### PR TITLE
No cache for scan ci

### DIFF
--- a/ggshield/ci.py
+++ b/ggshield/ci.py
@@ -5,8 +5,18 @@ import click
 
 from ggshield.utils import EMPTY_SHA, SupportedCI, SupportedScanMode, handle_exception
 
+from .config import Cache
 from .dev_scan import scan_commit_range
 from .git_shell import check_git_dir, get_list_commit_SHA
+
+
+class ReadOnlyCache(Cache):
+    """
+    A version of Cache which does not write anything to the disk.
+    """
+
+    def save(self) -> bool:  # pragma: no cover
+        return True
 
 
 def jenkins_range(verbose: bool) -> List[str]:  # pragma: no cover
@@ -272,7 +282,7 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
 
         return scan_commit_range(
             client=ctx.obj["client"],
-            cache=ctx.obj["cache"],
+            cache=ReadOnlyCache(),
             commit_list=commit_list,
             output_handler=ctx.obj["output_handler"],
             verbose=config.verbose,

--- a/ggshield/config.py
+++ b/ggshield/config.py
@@ -224,18 +224,8 @@ class Cache:
         else:
             super().__setattr__(name, value)
 
-    def create_empty_cache(self) -> None:
-        # Creates a new file
-        try:
-            with open(self.CACHE_FILENAME, "w"):
-                pass
-        except PermissionError:
-            # Hotfix: for the time being we skip cache handling if permission denied
-            pass
-
     def load_cache(self) -> bool:
         if not os.path.isfile(self.CACHE_FILENAME):
-            self.create_empty_cache()
             return True
 
         _cache: dict = {}
@@ -286,9 +276,6 @@ class Cache:
         return _cache
 
     def save(self) -> bool:
-        if not os.path.isfile(self.CACHE_FILENAME):
-            return False
-
         try:
             f = open(self.CACHE_FILENAME, "w")
         except PermissionError:


### PR DESCRIPTION
## Description

This PR makes sure the `scan ci` command does not create a cache file. This fixes #68 

## What has been done
- Do not create the cache file as soon as the Cache instance is created
- In `ci_cmd()`, call `scan_commit_range()` with the cache set to a "dummy" cache class which does not save to disk