### PR TITLE
fix(ci): fix commit range for gitlab merge request pipelines

### DIFF
--- a/ggshield/ci.py
+++ b/ggshield/ci.py
@@ -123,10 +123,24 @@ def circle_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
 def gitlab_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
     before_sha = os.getenv("CI_COMMIT_BEFORE_SHA")
     commit_sha = os.getenv("CI_COMMIT_SHA", "HEAD")
+    merge_request_target_branch = os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
+
     if verbose:
-        click.echo(f"CI_COMMIT_BEFORE_SHA: {before_sha}\nCI_COMMIT_SHA: {commit_sha}")
+        click.echo(
+            f"CI_MERGE_REQUEST_TARGET_BRANCH_NAME: {merge_request_target_branch}\n"
+            f"CI_COMMIT_BEFORE_SHA: {before_sha}\n"
+            f"CI_COMMIT_SHA: {commit_sha}"
+        )
+
     if before_sha and before_sha != EMPTY_SHA:
         commit_list = get_list_commit_SHA("{}~1...".format(before_sha))
+        if commit_list:
+            return commit_list
+
+    if merge_request_target_branch and merge_request_target_branch != EMPTY_SHA:
+        commit_list = get_list_commit_SHA(
+            "origin/{}...".format(merge_request_target_branch)
+        )
         if commit_list:
             return commit_list
 
@@ -137,6 +151,7 @@ def gitlab_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
     raise click.ClickException(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
+        f"  CI_MERGE_REQUEST_TARGET_BRANCH_NAME: {merge_request_target_branch}\n"
         f"  CI_COMMIT_BEFORE_SHA: {before_sha}\n"
         f"  CI_COMMIT_SHA: {commit_sha}"
     )

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,63 @@
+from typing import Dict
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ggshield.ci import EMPTY_SHA, gitlab_ci_range
+
+
+@patch("ggshield.ci.get_list_commit_SHA")
+@patch("ggshield.ci.check_git_dir")
+@pytest.mark.parametrize(
+    "env,expected_parameter",
+    [
+        ({"CI_COMMIT_BEFORE_SHA": "before_sha"}, "before_sha~1..."),
+        (
+            {
+                "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+                "CI_COMMIT_SHA": "commit_sha",
+            },
+            "commit_sha~1...",
+        ),
+        (
+            {
+                "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+                "HEAD": "HEAD",
+            },
+            "HEAD~1...",
+        ),
+        (
+            {
+                "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+                "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "mr_target_branch_name",
+            },
+            "origin/mr_target_branch_name...",
+        ),
+        (
+            {
+                "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+                "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": EMPTY_SHA,
+                "CI_COMMIT_SHA": "commit_sha",
+            },
+            "commit_sha~1...",
+        ),
+        ({"CI_COMMIT_SHA": "commit_sha"}, "commit_sha~1..."),
+        ({"HEAD": "head_sha"}, "HEAD~1..."),
+    ],
+)
+def test_gitab_ci_range(
+    _: Mock,
+    get_list_mock: Mock,
+    monkeypatch,
+    env: Dict[str, str],
+    expected_parameter: str,
+):
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    get_list_mock.return_value = ["a"] * 51
+
+    gitlab_ci_range(verbose=False)
+    get_list_mock.assert_called_once_with(expected_parameter)


### PR DESCRIPTION
Gitlab CI does not set CI_COMMIT_BEFORE_SHA environment variable for
merge request pipelines. Using only the CI_COMMIT_SHA one does not allow
to compute the merge request commits range. The only environment
variable we can rely on is CI_MERGE_REQUEST_TARGET_BRANCH_NAME.