### PR TITLE
Never run standalone mode. fixes exit 1 on interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,6 @@ after the specified value. Set to 0 to disable the timeout
 
 GITGUARDIAN_MAX_COMMITS_FOR_HOOK: if set to an int, `ggshield scan pre-receive` and `ggshield scan pre-push`
 will not scan more than the specified value of commits in a single scan.
-
-GITGUARDIAN_CRASH_LOG: If set to True, ggshield will display a full traceback
-when crashing
 ```
 
 ## On-premises configuration

--- a/ggshield/cmd.py
+++ b/ggshield/cmd.py
@@ -226,11 +226,8 @@ def cli(
 
 
 def cli_wrapper() -> int:
-    standalone_mode = not (
-        os.getenv("GITGUARDIAN_CRASH_LOG", "False").lower() == "true"
-    )
     try:
-        return_code: int = cli.main(standalone_mode=standalone_mode)
+        return_code: int = cli.main(standalone_mode=False)
     except click.exceptions.Abort:
         return_code = 0
 


### PR DESCRIPTION
`export GITGUARDIAN_TIMEOUT=2`

`echo 86c47dda8f279cea8cba8384040e14672f9aa7ab\nHEAD\nmain\n | ggshield scan pre-receive`