### PR TITLE
fix(patch_parsing): lines starting with backslash

### DIFF
--- a/ggshield/utils.py
+++ b/ggshield/utils.py
@@ -147,6 +147,9 @@ def get_lines_from_patch(content: str, filemode: Filemode) -> Iterable[Line]:
             line_pre_index = pre_index
             line_content = line[1:]
             category = LineCategory.deletion
+        elif line_type == "\\":
+            # This type of line should'nt contain any secret; no need to set indices
+            line_content = line[1:]
 
         if line_type and line_content is not None:
             yield Line(

--- a/tests/cassettes/no_newline_before_secret.yaml
+++ b/tests/cassettes/no_newline_before_secret.yaml
@@ -1,0 +1,70 @@
+interactions:
+  - request:
+      body:
+        '[{"filename": "artifactory", "document": "@@ -1,3 +1,3 @@\n some line\n
+        some other line\n-deleted line\n\\ No newline at end of file\n+sg_key = \"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\"\n\\
+        No newline at end of file\n"}]'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '252'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.3.1 (Linux;py3.8.10)
+        mode:
+          - path
+      method: POST
+      uri: https://api.gitguardian.com/v1/multiscan
+    response:
+      body:
+        string:
+          '[{"policy_break_count":1,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[{"type":"SendGrid
+          Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":97,"index_end":165,"line_start":6,"line_end":6}]}]}]'
+      headers:
+        Access-Control-Expose-Headers:
+          - X-App-Version
+        Allow:
+          - POST, OPTIONS
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '331'
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 17 Nov 2021 11:11:16 GMT
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Server:
+          - nginx
+        Set-Cookie:
+          - AWSALB=4FG+2Mt83SZODePsQZtBFwdLgScrPJKtba9B4SgrrrJ5Gd0RXgTqzgX3Fq7c0Wc5fWuhPQYwbDVoW3cQHIleD3WvNAjzlKlKcbIZpnQ8nMsANxhTtmQVVz6ve7wp;
+            Expires=Wed, 24 Nov 2021 11:11:16 GMT; Path=/
+          - AWSALBCORS=4FG+2Mt83SZODePsQZtBFwdLgScrPJKtba9B4SgrrrJ5Gd0RXgTqzgX3Fq7c0Wc5fWuhPQYwbDVoW3cQHIleD3WvNAjzlKlKcbIZpnQ8nMsANxhTtmQVVz6ve7wp;
+            Expires=Wed, 24 Nov 2021 11:11:16 GMT; Path=/; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        Vary:
+          - Cookie
+        X-App-Version:
+          - 1.31.0-rc.3
+        X-Content-Type-Options:
+          - nosniff
+          - nosniff
+        X-Frame-Options:
+          - DENY
+          - SAMEORIGIN
+        X-Secrets-Engine-Version:
+          - 2.52.1
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,6 +400,20 @@ _SINGLE_DELETE_PATCH = (
     " something\n"
     '-sg_key = "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";\n'  # noqa
 )
+_PATCH_WITH_NONEWLINE_BEFORE_SECRET = """
+diff --git a/artifactory b/artifactory
+index 2ace9c7..4c7699d 100644
+--- a/artifactory
++++ b/artifactory
+@@ -1,3 +1,3 @@
+ some line
+ some other line
+-deleted line
+\\ No newline at end of file
++sg_key = "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"
+\\ No newline at end of file
+"""
+
 
 my_vcr = vcr.VCR(
     cassette_library_dir=join(dirname(realpath(__file__)), "cassettes"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from ggshield.utils import (
     get_lines_from_content,
 )
 from tests.conftest import (
+    _PATCH_WITH_NONEWLINE_BEFORE_SECRET,
     _SECRET_RAW_FILE,
     _SINGLE_ADD_PATCH,
     _SINGLE_DELETE_PATCH,
@@ -46,6 +47,13 @@ from tests.conftest import (
             _SECRET_RAW_FILE,
             False,
             [MatchIndices(0, 0, 11, 80)],
+            id="file",
+        ),
+        pytest.param(
+            "no_newline_before_secret",
+            _PATCH_WITH_NONEWLINE_BEFORE_SECRET,
+            True,
+            [MatchIndices(5, 5, 10, 79)],
             id="file",
         ),
     ],


### PR DESCRIPTION
Handles bug encountered due to the presence of `\ No newline at end of file` in patches, that were not handled