### PR TITLE
fix(filter): stop to list FS to exclude files to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ paths-ignore:
 ```
 
 ```sh
-ggshield scan --exclude dir/subdir path -r dir
+ggshield scan --exclude dir/subdir/** path -r dir
 ```
 
 ## Ignoring a secret

--- a/ggshield/ci.py
+++ b/ggshield/ci.py
@@ -301,7 +301,7 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
             commit_list=commit_list,
             output_handler=ctx.obj["output_handler"],
             verbose=config.verbose,
-            filter_set=ctx.obj["filter_set"],
+            exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
             scan_id=" ".join(commit_list),

--- a/ggshield/cmd.py
+++ b/ggshield/cmd.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import os
 import sys
-from pathlib import Path
 from typing import Any, List, Optional, Type, cast
 
 import click
@@ -10,7 +9,7 @@ from .ci import ci_cmd
 from .config import CONTEXT_SETTINGS, Cache, Config, load_dot_env
 from .dev_scan import path_cmd, range_cmd, repo_cmd
 from .docker import docker_archive_cmd, docker_name_cmd
-from .filter import path_filter_set
+from .filter import init_exclusion_regexes
 from .hook_cmd import precommit_cmd, prepush_cmd
 from .ignore import ignore
 from .install import install
@@ -129,7 +128,7 @@ def scan(
     if not ignore_default_excludes and not ctx.obj["config"].ignore_default_excludes:
         paths_ignore.update(IGNORED_DEFAULT_PATTERNS)
 
-    ctx.obj["filter_set"] = path_filter_set(Path(os.getcwd()), paths_ignore)
+    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(paths_ignore)
     config: Config = ctx.obj["config"]
 
     if show_secrets is not None:

--- a/ggshield/filter.py
+++ b/ggshield/filter.py
@@ -3,13 +3,20 @@ import math
 import operator
 import re
 from collections import OrderedDict
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set
 
+import click
 from pygitguardian.models import Match, PolicyBreak, ScanResult
 
 
 REGEX_MATCH_HIDE = re.compile(r"[^+\-\s]")
+REGEX_SPECIAL_CHARS = set(".^$+*?{}()[]\\|")
+INVALID_PATTERNS_REGEX = re.compile(
+    r"(\*\*\*)"  # the "***" sequence is not valid
+    r"|(\*\*[^/])"  # a "**" sequence must be immediately followed by a "/"
+    r"|([^/]\*\*)"  # a "**" sequence must be either at the start of the string or
+    # immediately preceded by a "/"
+)
 
 MAXIMUM_CENSOR_LENGTH = 60
 
@@ -118,7 +125,37 @@ def leak_dictionary_by_ignore_sha(
     return sha_dict
 
 
-def path_filter_set(top_dir: Path, paths_ignore: Iterable[str]) -> Set[str]:
+def translate_user_pattern(pattern: str) -> str:
+    """
+    Translate the user pattern into a regex. This function assumes that the given
+    pattern is valid and has been normalized beforehand.
+    """
+
+    # Escape each special character
+    pattern = "".join(
+        f"\\{char}" if char in REGEX_SPECIAL_CHARS else char for char in pattern
+    )
+
+    # Handle start/end of pattern
+    if pattern[-1] != "/":
+        pattern += "$"
+    if pattern[0] == "/":
+        pattern = "^" + pattern[1:]
+    else:
+        pattern = "(^|/)" + pattern
+
+    # Replace * and ** sequences
+    pattern = re.sub(r"\\\*\\\*/", "([^/]+/)*", pattern)
+    pattern = re.sub(r"\\\*", "([^/]+)", pattern)
+
+    return pattern
+
+
+def is_pattern_valid(pattern: str) -> bool:
+    return bool(pattern) and not INVALID_PATTERNS_REGEX.search(pattern)
+
+
+def init_exclusion_regexes(paths_ignore: Iterable[str]) -> Set[re.Pattern]:
     """
     filter_set creates a set of paths of the ignored
     entries from 3 sources:
@@ -126,11 +163,16 @@ def path_filter_set(top_dir: Path, paths_ignore: Iterable[str]) -> Set[str]:
     files in .git
     files ignore in .gitignore
     """
-    filters = set()
-    for ignored in paths_ignore:
-        filters.update({str(target) for target in top_dir.glob(ignored)})
+    res = set()
+    for path in paths_ignore:
+        if not is_pattern_valid(path):
+            raise click.ClickException(f"{path} is not a valid exclude pattern.")
+        res.add(re.compile(translate_user_pattern(path)))
+    return res
 
-    return filters
+
+def is_filepath_excluded(filepath: str, exclusion_regexes: Set[re.Pattern]) -> bool:
+    return any(r.search(filepath) for r in exclusion_regexes)
 
 
 def censor_match(match: Match) -> str:

--- a/ggshield/hook_cmd.py
+++ b/ggshield/hook_cmd.py
@@ -27,7 +27,7 @@ def precommit_cmd(
     )
     try:
         check_git_dir()
-        results = Commit(filter_set=ctx.obj["filter_set"]).scan(
+        results = Commit(exclusion_regexes=ctx.obj["exclusion_regexes"]).scan(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.matches_ignore,
@@ -135,7 +135,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             commit_list=commit_list,
             output_handler=ctx.obj["output_handler"],
             verbose=config.verbose,
-            filter_set=ctx.obj["filter_set"],
+            exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
             scan_id=" ".join(commit_list),

--- a/ggshield/pre_receive_cmd.py
+++ b/ggshield/pre_receive_cmd.py
@@ -144,7 +144,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 commit_list=commit_list,
                 output_handler=ctx.obj["output_handler"],
                 verbose=config.verbose,
-                filter_set=ctx.obj["filter_set"],
+                exclusion_regexes=ctx.obj["exclusion_regexes"],
                 matches_ignore=config.matches_ignore,
                 all_policies=config.all_policies,
                 scan_id=" ".join(commit_list),

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -1,9 +1,9 @@
-import os
 from collections import namedtuple
 
 import pytest
 
 from ggshield.config import MAX_FILE_SIZE
+from ggshield.filter import init_exclusion_regexes
 from ggshield.scan import Commit
 from ggshield.utils import Filemode, SupportedScanMode
 from tests.conftest import (
@@ -158,7 +158,7 @@ def test_patch_separation_ignore():
     c = Commit()
     c._patch = PATCH_SEPARATION
     file_to_ignore = ".env"
-    c.filter_set = {os.path.join(os.getcwd(), file_to_ignore)}
+    c.exclusion_regexes = init_exclusion_regexes([file_to_ignore])
     files = list(c.get_files())
 
     assert len(files) == 3


### PR DESCRIPTION
ggshield supports to exclude some files from scan using exclude
patterns.  Those patterns can be set using cli arguments, configuration
file and there are default excluded patterns as well.

We used to list all the files matching those patterns using glob in
order to filter out files to scan. We recently added some default
patterns to ignore and it leds us to realize the performance issue with
this approach: FS listing is very slow and it does not scale.

We now use regex to check if a file path is included in the exclude
patterns.