### PR TITLE
fix(ci) no secret found no more displayed if secrets found

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -18,5 +18,6 @@ paths-ignore:
   - LICENSE
   - .dockerignore
   - .gitignore
+  - .env
 show-secrets: false
 verbose: false

--- a/ggshield/output/text/text_output.py
+++ b/ggshield/output/text/text_output.py
@@ -54,10 +54,7 @@ class TextHandler(OutputHandler):
             if self.verbose:
                 has_results = False
                 if scan.scans:
-                    for sub_scan in scan.scans:
-                        if sub_scan.results:
-                            has_results = True
-                            break
+                    has_results = any(x.results for x in scan.scans)
 
                 if not has_results:
                     scan_buf.write(no_leak_message())

--- a/ggshield/output/text/text_output.py
+++ b/ggshield/output/text/text_output.py
@@ -52,7 +52,15 @@ class TextHandler(OutputHandler):
                 scan_buf.write(self.process_result(result))
         else:
             if self.verbose:
-                scan_buf.write(no_leak_message())
+                has_results = False
+                if scan.scans:
+                    for sub_scan in scan.scans:
+                        if sub_scan.results:
+                            has_results = True
+                            break
+
+                if not has_results:
+                    scan_buf.write(no_leak_message())
 
         if scan.scans:
             for sub_scan in scan.scans:


### PR DESCRIPTION
This PR fixes https://github.com/GitGuardian/ggshield/issues/116

A scan can be composed of a list of subscans. In this case, found secrets are not listed in the main scan.results list, but in sub scans results. This PR proposes to test if any sub scan has a result in order to trigger the "no secret found" message.