### PR TITLE
fix(ci): stop to tag every Docker images as latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
 
-  dockerhub-latest:
+  dockerhub-unstable:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -99,9 +99,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: gitguardian/ggshield
-          tags: latest
+          tags: unstable
 
-  github_packages-latest:
+  github_packages-unstable:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -116,13 +116,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           repository: gitguardian/ggshield/ggshield
-          tags: latest
+          tags: unstable
 
   scanning-released:
     name: GitGuardian scan
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: [dockerhub-latest]
+    needs: [dockerhub-unstable]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -89,6 +89,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: gitguardian/ggshield
           tag_with_ref: true
+          tags: latest
 
   push_to_github_packages:
     name: Push Docker image to GitHub Packages
@@ -105,6 +106,7 @@ jobs:
           registry: docker.pkg.github.com
           repository: gitguardian/ggshield/ggshield
           tag_with_ref: true
+          tags: latest
 
   push_to_tap:
     needs: pypi


### PR DESCRIPTION
We tagged every Docker images we built as latest. It makes every merges
we did a release for our customers using latest Docker images.

This commit now makes the CI to tag images built on a merge into the
main branch as unstable instead of latest. We continue to tag Docker
images built for a release with the corresponding git tag and we add the
latest tag.