### PR TITLE
Fix uncaught Exception when cache is created on a read-only FS

### DIFF
--- a/ggshield/config.py
+++ b/ggshield/config.py
@@ -286,7 +286,7 @@ class Cache:
 
         try:
             f = open(self.CACHE_FILENAME, "w")
-        except PermissionError:
+        except OSError:
             # Hotfix: for the time being we skip cache handling if permission denied
             return True
         else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,6 +172,22 @@ class TestCache:
             file_content = json.load(file)
             assert file_content == {"last_found_secrets": ["XXX"]}
 
+    def test_read_only_fs(self):
+        """
+        GIVEN a read-only file-system
+        WHEN save is called
+        THEN it shouldn't raise an exception
+        """
+        cache = Cache()
+        cache.update_cache(**{"last_found_secrets": {"XXX"}})
+        # don't use mock.patch decorator on the test, since Cache.__init__ also calls open
+        with patch("builtins.open") as open_mock:
+            # The read-only FS is simulated with patched builtin open raising an error
+            open_mock.side_effect = OSError("Read-only file system")
+            assert cache.save() is True
+            # Make sure our patched open was called
+            open_mock.assert_called_once()
+
     @pytest.mark.parametrize("with_entry", [True, False])
     @patch("ggshield.config.Config.CONFIG_LOCAL", [".gitguardian.yml"])
     def test_save_cache_first_time(self, isolated_fs, with_entry):


### PR DESCRIPTION
This PR fixes an issue when ggshield runs on a read-only filesystem, by catching more general `OSError` during cache write.