### PR TITLE
docs: add brew command for easy install on :apple: macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,15 @@ GITGUARDIAN_API_KEY=<GitGuardian API Key>
 
 # Installation
 
-## On MacOs
+## On MacOS
 ### Using Homebrew
 
-You can install ggshield using homebrew by running the following command:
+You can install ggshield using Homebrew by running the following command:
 
 ```shell
 $ brew install gitguardian/tap/ggshield
 ```
+
 ## On other Operating Systems
 ### Using pip
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ GITGUARDIAN_API_KEY=<GitGuardian API Key>
 
 # Installation
 
+## On MacOs
+### Using Homebrew
+
+You can install ggshield using homebrew by running the following command:
+
+```shell
+$ brew install gitguardian/tap/ggshield
+```
+## On other Operating Systems
+### Using pip
+
 Install and update using `pip`:
 
 ```shell


### PR DESCRIPTION
## Description
Add documentation to install `ggshield` using Homebrew on MacOs