### PR TITLE
Fix GitLab Web UI showing empty error messages

### DIFF
--- a/ggshield/output/__init__.py
+++ b/ggshield/output/__init__.py
@@ -1,6 +1,12 @@
+from .gitlab_webui import GitLabWebUIOutputHandler
 from .json import JSONOutputHandler
 from .output_handler import OutputHandler
 from .text import TextOutputHandler
 
 
-__all__ = ["TextOutputHandler", "OutputHandler", "JSONOutputHandler"]
+__all__ = [
+    "GitLabWebUIOutputHandler",
+    "JSONOutputHandler",
+    "OutputHandler",
+    "TextOutputHandler",
+]

--- a/ggshield/output/gitlab_webui/__init__.py
+++ b/ggshield/output/gitlab_webui/__init__.py
@@ -1,0 +1,4 @@
+from .gitlab_webui_output_handler import GitLabWebUIOutputHandler
+
+
+__all__ = ["GitLabWebUIOutputHandler"]

--- a/ggshield/output/gitlab_webui/gitlab_webui_output_handler.py
+++ b/ggshield/output/gitlab_webui/gitlab_webui_output_handler.py
@@ -1,0 +1,61 @@
+from pygitguardian.models import PolicyBreak
+
+from ggshield.filter import censor_match
+from ggshield.output.output_handler import OutputHandler
+from ggshield.scan import ScanCollection
+from ggshield.text_utils import pluralize, translate_validity
+
+
+def format_policy_break(policy_break: PolicyBreak) -> str:
+    """Returns a string with the policy name, validity and a comma-separated,
+    double-quoted, censored version of all `policy_break` matches.
+
+    Looks like this:
+
+    PayPal OAuth2 Keys (Validity: Valid, id="aa*******bb", secret="cc******dd")
+    """
+    match_str = ", ".join(
+        f'{x.match_type}: "{censor_match(x)}"' for x in policy_break.matches
+    )
+    validity = translate_validity(policy_break.validity)
+    return f"{policy_break.break_type} (Validity: {validity}, {match_str})"
+
+
+class GitLabWebUIOutputHandler(OutputHandler):
+    """
+    Terse OutputHandler optimized for GitLab Web UI, because GitLab Web UI only shows
+    lines starting with GL-HOOK-ERR.
+
+    See https://docs.gitlab.com/ee/administration/server_hooks.html#custom-error-messages
+    """
+
+    def __init__(self, show_secrets: bool = False) -> None:
+        super().__init__(show_secrets=show_secrets, verbose=False)
+
+    def _process_scan_impl(self, scan_collection: ScanCollection) -> str:
+        results = list(scan_collection.get_all_results())
+        if not results:
+            return ""
+
+        policy_breaks = []
+        for result in results:
+            policy_breaks += result.scan.policy_breaks
+
+        # Use a set to ensure we do not report duplicate incidents.
+        # (can happen when the secret is present in both the old and the new version of
+        # the document)
+        formatted_policy_breaks = {format_policy_break(x) for x in policy_breaks}
+
+        break_count = len(formatted_policy_breaks)
+        summary_str = f"{break_count} {pluralize('incident', break_count)}"
+
+        # Putting each policy break on its own line would be more readable, but we can't
+        # do this because of a bug in GitLab Web IDE which causes newline characters to
+        # be shown as "<br>"
+        # https://gitlab.com/gitlab-org/gitlab/-/issues/350349
+        breaks_str = ", ".join(formatted_policy_breaks)
+
+        return (
+            f"GL-HOOK-ERR: ggshield found {summary_str} in these changes: {breaks_str}."
+            " The commit has been rejected."
+        )

--- a/ggshield/output/text/message.py
+++ b/ggshield/output/text/message.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Set, Tuple
 from pygitguardian.client import VERSIONS
 from pygitguardian.models import HealthCheckResponse, Match, PolicyBreak
 
-from ggshield.text_utils import STYLE, Line, format_text, pluralize
+from ggshield.text_utils import STYLE, Line, format_text, pluralize, translate_validity
 
 
 ICON_BY_OS = {"posix": "🛡️  ⚔️  🛡️ ", "default": ">>>"}
@@ -147,14 +147,6 @@ def flatten_policy_breaks_by_line(
     return flat_match_dict
 
 
-_validity_translate = {
-    "cannot_check": "Cannot Check",
-    "invalid": "Invalid",
-    "unknown": "Unknown",
-    "valid": "Valid",
-}
-
-
 def policy_break_header(
     issue_n: int, policy_breaks: List[PolicyBreak], ignore_sha: str
 ) -> str:
@@ -162,7 +154,7 @@ def policy_break_header(
     Build a header for the policy break.
     """
     validity_msg = (
-        f" (Validity: {format_text( _validity_translate[policy_breaks[0].validity], STYLE['nb_secrets'])}) "
+        f" (Validity: {format_text(translate_validity(policy_breaks[0].validity), STYLE['nb_secrets'])}) "
         if policy_breaks[0].validity
         else ""
     )

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -48,6 +48,14 @@ class ScanCollection(NamedTuple):
             return [scan for scan in self.scans if scan.results]
         return []
 
+    def get_all_results(self) -> Iterable[Result]:
+        """Returns an iterable on all results and sub-scan results"""
+        if self.results:
+            yield from self.results
+        if self.scans:
+            for scan in self.scans:
+                yield from scan.results
+
 
 class File:
     """Class representing a simple file."""

--- a/ggshield/text_utils.py
+++ b/ggshield/text_utils.py
@@ -105,3 +105,15 @@ def format_line_count(line_count: Union[int, None], padding: int) -> str:
 
 def display_error(msg: str) -> None:
     click.echo(format_text(msg, STYLE["error"]), err=True)
+
+
+_VALIDITY_TEXT_FOR_ID = {
+    "cannot_check": "Cannot Check",
+    "invalid": "Invalid",
+    "unknown": "Unknown",
+    "valid": "Valid",
+}
+
+
+def translate_validity(validity_id: Optional[str]) -> str:
+    return _VALIDITY_TEXT_FOR_ID[validity_id or "unknown"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,8 +114,9 @@ VALID_SECRET = (
 
 _SIMPLE_SECRET = UNCHECKED_SECRET
 
-_SIMPLE_SECRET_PATCH = """@@ -0,0 +1 @@
-+github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
+_SIMPLE_SECRET_TOKEN = "368ac3edf9e850d1c0ff9d6c526496f8237ddf91"
+_SIMPLE_SECRET_PATCH = f"""@@ -0,0 +1 @@
++github_token: {_SIMPLE_SECRET_TOKEN}
 """
 _SIMPLE_SECRET_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
     {
@@ -126,7 +127,7 @@ _SIMPLE_SECRET_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                 "policy": "Secrets Detection",
                 "matches": [
                     {
-                        "match": "368ac3edf9e850d1c0ff9d6c526496f8237ddf91",  # noqa
+                        "match": _SIMPLE_SECRET_TOKEN,
                         "type": "apikey",
                         "index_start": 29,
                         "index_end": 69,
@@ -152,7 +153,7 @@ _SIMPLE_SECRET_WITH_FILENAME_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                 "policy": "Secrets Detection",
                 "matches": [
                     {
-                        "match": "368ac3edf9e850d1c0ff9d6c526496f8237ddf91",  # noqa
+                        "match": _SIMPLE_SECRET_TOKEN,  # noqa
                         "type": "apikey",
                         "index_start": 29,
                         "index_end": 69,

--- a/tests/output/test_gitlab_webui_output.py
+++ b/tests/output/test_gitlab_webui_output.py
@@ -1,0 +1,23 @@
+from pygitguardian.models import Match, PolicyBreak
+
+from ggshield.output.gitlab_webui.gitlab_webui_output_handler import format_policy_break
+
+
+def test_format_policy_break():
+    policy = PolicyBreak(
+        "PayPal",
+        "Secrets detection",
+        "valid",
+        [
+            Match("AZERTYUIOP", "client_id", line_start=123),
+            Match("abcdefghijk", "client_secret", line_start=456),
+        ],
+    )
+    out = format_policy_break(policy)
+
+    assert policy.break_type in out
+    assert "Validity: Valid" in out
+    for match in policy.matches:
+        assert match.match_type in out
+        # match value itself must be obfuscated
+        assert match.match not in out


### PR DESCRIPTION
## Description

This PR detects if the pre-receive hook is running from GitLab Web UI. If it is the case, it uses a shorter error message, prefixed with what GitLab expects so that the message shows up in the UI instead of disabling the hook completely.

It also deprecates the --web option, which is no longer useful.

## Issue

https://github.com/GitGuardian/ggshield/issues/151

## Screenshots

Web UI:

![webui](https://user-images.githubusercontent.com/91945295/154977538-caf13092-343b-4600-a742-5f394c9ea9d1.png)

Web IDE:

![image](https://user-images.githubusercontent.com/91945295/154527572-39f9e69c-4284-4219-9bef-d7956455e4f6.png)

Not the pinnacle of design and user-friendliness, but GitLab UI does not allow any better.