### PR TITLE
chore(gitlab-ci): remove unused definition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,0 @@
-include:
-  - project: 'gg-code/sre/gitguardian-oss'
-    file: '/ggshield.yml'


### PR DESCRIPTION
This file was previously used to Gitlab CI internally. Nowadays, GitHub Actions are used instead of gitguardian-oss.