### PR TITLE
Only show backtrace if GITGUARDIAN_CRASH_LOG is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ after the specified value. Set to 0 to disable the timeout
 
 GITGUARDIAN_MAX_COMMITS_FOR_HOOK: if set to an int, `ggshield scan pre-receive` and `ggshield scan pre-push`
 will not scan more than the specified value of commits in a single scan.
+
+GITGUARDIAN_CRASH_LOG: If set to True, ggshield will display a full traceback
+when crashing
 ```
 
 ## On-premises configuration

--- a/ggshield/cmd.py
+++ b/ggshield/cmd.py
@@ -227,13 +227,14 @@ def cli(
         ctx.obj["config"].allow_self_signed = allow_self_signed
 
 
-def cli_wrapper() -> int:
-    try:
-        return_code: int = cli.main(standalone_mode=False)
-    except click.exceptions.Abort:
-        return_code = 0
+def cli_wrapper(args: Optional[List[str]] = None) -> Any:
+    """
+    Wrapper around cli.main() to handle the GITGUARDIAN_CRASH_LOG variable.
 
-    return return_code
+    `args` is only used by unit-tests.
+    """
+    show_crash_log = os.getenv("GITGUARDIAN_CRASH_LOG", "False").lower() == "true"
+    return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)
 
 
 if __name__ == "__main__":

--- a/tests/test_crash_log.py
+++ b/tests/test_crash_log.py
@@ -1,0 +1,22 @@
+import os
+from unittest import mock
+
+import click.exceptions
+import pytest
+
+from ggshield.cmd import cli_wrapper
+
+
+CRASH_LOG_ENV = {"GITGUARDIAN_CRASH_LOG": "true"}
+
+
+def test_syntax_error_no_crash_log():
+    with pytest.raises(SystemExit) as e:
+        cli_wrapper(args=["foo"])
+    assert e.value.code != 0
+
+
+@mock.patch.dict(os.environ, CRASH_LOG_ENV)
+def test_syntax_error_crash_log():
+    with pytest.raises(click.exceptions.UsageError):
+        cli_wrapper(args=["foo"])


### PR DESCRIPTION
This reverts commit 69204a9ba9a919250b464748ca06774ccceec8c0 and provides a different way to ensure we exit with 0 in case a `pre-receive` hits the timeout.

Fixes #150.

Before:
```
$ ggshield foo
Traceback (most recent call last):
  File "/home/agateau/.local/bin/ggshield", line 8, in <module>
    sys.exit(cli_wrapper())
  File "/home/agateau/.local/pipx/venvs/ggshield/lib/python3.8/site-packages/ggshield/cmd.py", line 229, in cli_wrapper
    return_code: int = cli.main(standalone_mode=False)
  File "/home/agateau/.local/pipx/venvs/ggshield/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/agateau/.local/pipx/venvs/ggshield/lib/python3.8/site-packages/click/core.py", line 1653, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/home/agateau/.local/pipx/venvs/ggshield/lib/python3.8/site-packages/click/core.py", line 1717, in resolve_command
    ctx.fail(_("No such command {name!r}.").format(name=original_cmd_name))
  File "/home/agateau/.local/pipx/venvs/ggshield/lib/python3.8/site-packages/click/core.py", line 673, in fail
    raise UsageError(message, self)
click.exceptions.UsageError: No such command 'foo'.
```

After:
```
$ ggshield foo    
Usage: ggshield [OPTIONS] COMMAND [ARGS]...
Try 'ggshield -h' for help.

Error: No such command 'foo'.
```

After, with `GITGUARDIAN_CRASH_LOG`:
```
$ GITGUARDIAN_CRASH_LOG=True ggshield foo
Traceback (most recent call last):
  File "/home/agateau/src/ggshield/.venv/bin/ggshield", line 33, in <module>
    sys.exit(load_entry_point('ggshield', 'console_scripts', 'ggshield')())
  File "/home/agateau/src/ggshield/ggshield/cmd.py", line 237, in cli_wrapper
    return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)
  File "/home/agateau/src/ggshield/.venv/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/agateau/src/ggshield/.venv/lib/python3.8/site-packages/click/core.py", line 1653, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/home/agateau/src/ggshield/.venv/lib/python3.8/site-packages/click/core.py", line 1717, in resolve_command
    ctx.fail(_("No such command {name!r}.").format(name=original_cmd_name))
  File "/home/agateau/src/ggshield/.venv/lib/python3.8/site-packages/click/core.py", line 673, in fail
    raise UsageError(message, self)
click.exceptions.UsageError: No such command 'foo'.
```