### PR TITLE
Fix crash when scanning a non-local image

### DIFF
--- a/ggshield/docker.py
+++ b/ggshield/docker.py
@@ -63,9 +63,10 @@ def docker_save_to_tmp(image_name: str, destination_path: Path, timeout: int) ->
             docker_pull_image(image_name, timeout)
 
             docker_save_to_tmp(image_name, destination_path, timeout)
-        raise click.ClickException(
-            f"Unable to save docker archive:\nError: {err_string}"
-        )
+        else:
+            raise click.ClickException(
+                f"Unable to save docker archive:\nError: {err_string}"
+            )
     except subprocess.TimeoutExpired:
         raise click.ClickException('Command "{}" timed out'.format(" ".join(command)))
 


### PR DESCRIPTION
If we run `ggshield scan docker <image>` and `<image>` is not available locally, `ggshield` downloads it first.

I broke this feature when I made other Docker fixes: ggshield currently raises an exception at the end of the download.
    
Fix that and add tests to cover this case to ensure that cannot go undetected anymore.

Fixes #181.

cc @Sayrus
