### PR TITLE
fix(config): fix api/dashboard URLs parsing not handling params and queries

### DIFF
--- a/ggshield/config.py
+++ b/ggshield/config.py
@@ -16,7 +16,7 @@ from ggshield.constants import (
     LOCAL_CONFIG_PATHS,
 )
 from ggshield.types import IgnoredMatch
-from ggshield.utils import api_to_dashboard_url, dashboard_to_api_url
+from ggshield.utils import api_to_dashboard_url, clean_url, dashboard_to_api_url
 
 
 def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> None:
@@ -148,11 +148,13 @@ class UserConfig(YAMLFileConfig):
         api_url = os.getenv("GITGUARDIAN_API_URL")
         dashboard_url = os.getenv("GITGUARDIAN_URL")
         if api_url is not None:
+            clean_url(api_url, warn=True)
             if dashboard_url is None:
                 dashboard_url = api_to_dashboard_url(api_url)
             self.api_url = api_url
             self.dashboard_url = dashboard_url
         elif dashboard_url is not None:
+            clean_url(dashboard_url, warn=True)
             api_url = dashboard_to_api_url(dashboard_url)
             self.api_url = api_url
             self.dashboard_url = dashboard_url
@@ -162,6 +164,10 @@ class UserConfig(YAMLFileConfig):
         URLs should always be both set together to make sure they belong
         to the same instance
         """
+        if "dashboard_url" in data:
+            clean_url(data["dashboard_url"], warn=True)
+        if "api_url" in data:
+            clean_url(data["api_url"], warn=True)
         if "dashboard_url" in data and "api_url" not in data:
             data["api_url"] = dashboard_to_api_url(data["dashboard_url"])
         elif "dashboard_url" not in data and "api_url" in data:

--- a/ggshield/utils.py
+++ b/ggshield/utils.py
@@ -285,9 +285,9 @@ def dashboard_to_api_url(dashboard_url: str) -> str:
     Convert a dashboard URL to an API URL.
     handles the SaaS edge case where the host changes instead of the path
     """
-    if dashboard_url.endswith("/"):
-        dashboard_url = dashboard_url[:-1]
     parsed_url = urlparse(dashboard_url)
+    if parsed_url.path.endswith("/"):
+        parsed_url = parsed_url._replace(path=parsed_url.path[:-1])
     if parsed_url.scheme != "https":
         raise click.ClickException(
             f"Invalid scheme for dashboard URL '{dashboard_url}', expected HTTPS"
@@ -312,9 +312,9 @@ def api_to_dashboard_url(api_url: str) -> str:
     Convert an API URL to a dashboard URL.
     handles the SaaS edge case where the host changes instead of the path
     """
-    if api_url.endswith("/"):
-        api_url = api_url[:-1]
     parsed_url = urlparse(api_url)
+    if parsed_url.path.endswith("/"):
+        parsed_url = parsed_url._replace(path=parsed_url.path[:-1])
     if parsed_url.scheme != "https":
         raise click.ClickException(
             f"Invalid scheme for API URL '{api_url}', expected HTTPS"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,13 @@ from ggshield.client import retrieve_client
 from ggshield.config import Config
 from ggshield.scan import Commit
 from ggshield.scan.scannable import File, Files
-from ggshield.utils import MatchIndices, find_match_indices, get_lines_from_content
+from ggshield.utils import (
+    MatchIndices,
+    api_to_dashboard_url,
+    dashboard_to_api_url,
+    find_match_indices,
+    get_lines_from_content,
+)
 from tests.conftest import (
     _PATCH_WITH_NONEWLINE_BEFORE_SECRET,
     _SECRET_RAW_FILE,
@@ -119,3 +125,76 @@ def test_retrieve_client_invalid_api_key():
     with pytest.raises(click.ClickException, match="Invalid value for API Key"):
         with mock.patch.dict(os.environ, {"GITGUARDIAN_API_KEY": "\u2023"}):
             retrieve_client(Config())
+
+
+class TestAPIDashboardURL:
+    @pytest.mark.parametrize(
+        ["api_url", "dashboard_url"],
+        [
+            ["https://api.gitguardian.com", "https://dashboard.gitguardian.com"],
+            ["https://api.gitguardian.com/", "https://dashboard.gitguardian.com"],
+            [
+                "https://api.gitguardian.com/?foo=bar",
+                "https://dashboard.gitguardian.com?foo=bar",
+            ],
+            ["https://gitguardian.ovh/exposed", "https://gitguardian.ovh"],
+            ["https://gitguardian.ovh/exposed/", "https://gitguardian.ovh"],
+            [
+                "https://gitguardian.ovh/exposed/?foo=bar",
+                "https://gitguardian.ovh?foo=bar",
+            ],
+            [
+                "https://gitguardian.ovh/toto/exposed/?foo=bar",
+                "https://gitguardian.ovh/toto?foo=bar",
+            ],
+        ],
+    )
+    def test_api_to_dashboard_url(self, api_url, dashboard_url):
+        assert api_to_dashboard_url(api_url) == dashboard_url
+
+    @pytest.mark.parametrize(
+        ["dashboard_url", "api_url"],
+        [
+            ["https://dashboard.gitguardian.com", "https://api.gitguardian.com"],
+            ["https://dashboard.gitguardian.com/", "https://api.gitguardian.com"],
+            [
+                "https://dashboard.gitguardian.com/?foo=bar",
+                "https://api.gitguardian.com?foo=bar",
+            ],
+            ["https://gitguardian.ovh/", "https://gitguardian.ovh/exposed"],
+            ["https://gitguardian.ovh/", "https://gitguardian.ovh/exposed"],
+            [
+                "https://gitguardian.ovh/?foo=bar",
+                "https://gitguardian.ovh/exposed?foo=bar",
+            ],
+            [
+                "https://gitguardian.ovh/toto?foo=bar",
+                "https://gitguardian.ovh/toto/exposed?foo=bar",
+            ],
+        ],
+    )
+    def test_dashboard_to_api_url(self, dashboard_url, api_url):
+        assert dashboard_to_api_url(dashboard_url) == api_url
+
+    @pytest.mark.parametrize(
+        "api_url",
+        ["https://api.gitguardian.com/exposed", "https://api.gitguardian.com/toto"],
+    )
+    def test_unexpected_path_api_url(self, api_url):
+        with pytest.raises(
+            click.exceptions.ClickException, match="got an unexpected path"
+        ):
+            api_to_dashboard_url(api_url)
+
+    @pytest.mark.parametrize(
+        "dashboard_url",
+        [
+            "https://dashboard.gitguardian.com/exposed",
+            "https://dashboard.gitguardian.com/toto",
+        ],
+    )
+    def test_unexpected_path_dashboard_url(self, dashboard_url):
+        with pytest.raises(
+            click.exceptions.ClickException, match="got an unexpected path"
+        ):
+            api_to_dashboard_url(dashboard_url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,19 +133,24 @@ class TestAPIDashboardURL:
         [
             ["https://api.gitguardian.com", "https://dashboard.gitguardian.com"],
             ["https://api.gitguardian.com/", "https://dashboard.gitguardian.com"],
+            ["https://api.gitguardian.com/v1", "https://dashboard.gitguardian.com"],
             [
                 "https://api.gitguardian.com/?foo=bar",
                 "https://dashboard.gitguardian.com?foo=bar",
             ],
-            ["https://gitguardian.ovh/exposed", "https://gitguardian.ovh"],
-            ["https://gitguardian.ovh/exposed/", "https://gitguardian.ovh"],
+            ["https://example.com/exposed", "https://example.com"],
+            ["https://example.com/exposed/", "https://example.com"],
             [
-                "https://gitguardian.ovh/exposed/?foo=bar",
-                "https://gitguardian.ovh?foo=bar",
+                "https://example.com/exposed/?foo=bar",
+                "https://example.com?foo=bar",
             ],
             [
-                "https://gitguardian.ovh/toto/exposed/?foo=bar",
-                "https://gitguardian.ovh/toto?foo=bar",
+                "https://example.com/toto/exposed/?foo=bar",
+                "https://example.com/toto?foo=bar",
+            ],
+            [
+                "https://example.com/exposed/v1/?foo=bar",
+                "https://example.com?foo=bar",
             ],
         ],
     )
@@ -161,15 +166,15 @@ class TestAPIDashboardURL:
                 "https://dashboard.gitguardian.com/?foo=bar",
                 "https://api.gitguardian.com?foo=bar",
             ],
-            ["https://gitguardian.ovh/", "https://gitguardian.ovh/exposed"],
-            ["https://gitguardian.ovh/", "https://gitguardian.ovh/exposed"],
+            ["https://example.com/", "https://example.com/exposed"],
+            ["https://example.com/", "https://example.com/exposed"],
             [
-                "https://gitguardian.ovh/?foo=bar",
-                "https://gitguardian.ovh/exposed?foo=bar",
+                "https://example.com/?foo=bar",
+                "https://example.com/exposed?foo=bar",
             ],
             [
-                "https://gitguardian.ovh/toto?foo=bar",
-                "https://gitguardian.ovh/toto/exposed?foo=bar",
+                "https://example.com/toto?foo=bar",
+                "https://example.com/toto/exposed?foo=bar",
             ],
         ],
     )


### PR DESCRIPTION
The config refactoring break an Integration test in docker due to the GITGUARDIAN_API_URL format that highlighted a parsing issue. The trailing / being only cleaned if the URL had no params nor queries.

This MR fixes it and adds unit tests for the `dashboard_to_api_url` and `api_to_dashboard_url` to test these edge cases.

Also cleans a potential /v1 and warns about it.