### PR TITLE
Implement ggshield web oauth flow

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,13 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-ggshield = { editable = true, path = "." }
+appdirs = ">=1.4.4,<1.5.0"
 click = ">=8.0,<8.1"
+ggshield = { editable = true, path = "." }
+oauthlib = "~=3.2"
 pygitguardian = ">=1.3.4,<1.4.0"
 pyyaml = ">=6.0,<6.1"
 python-dotenv = ">=0.19.1,<0.20.0"
-appdirs = ">=1.4.4,<1.5.0"
 
 [dev-packages]
 black = "==22.3.0"
@@ -28,5 +29,7 @@ snapshottest = "*"
 types-PyYAML = "*"
 types-requests = "*"
 types-appdirs = "*"
+types-oauthlib = "*"
+typing-extensions = "*"
 vcrpy = "*"
 pyfakefs = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "58386306476116acaaa7610c9bd04c3271428c99d478888c1d5c67c7796a538a"
+            "sha256": "eb83578dd60a3e3d7181b4c79f32740599c9f5caf907d8087b772170875d51fd"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -65,6 +65,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.15.0"
         },
+        "oauthlib": {
+            "hashes": [
+                "sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2",
+                "sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe"
+            ],
+            "index": "pypi",
+            "version": "==3.2.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -83,11 +91,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "python-dotenv": {
             "hashes": [
@@ -585,11 +593,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c",
-                "sha256:9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650"
+                "sha256:62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752",
+                "sha256:bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.28"
+            "version": "==3.0.29"
         },
         "ptyprocess": {
             "hashes": [
@@ -647,11 +655,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pytest": {
             "hashes": [
@@ -718,11 +726,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:41aface2e85b517c3a466b4689b8055c02cd2e623461f09af7d93f3da65c4709",
-                "sha256:88fafba4abc2f047e08a188fd4bbc10b0e464592c37b514c19f8f8f88d94450b"
+                "sha256:26ead7d1f93efc0f8c804d9fafafbe4a44b179580a7105754b245155f9af05a8",
+                "sha256:47c7b0c0f8fc10eec4cf1e71c6fdadf8decaa74ffa087e68cd1c20db7ad6a592"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==61.3.1"
+            "version": "==62.1.0"
         },
         "six": {
             "hashes": [
@@ -792,6 +800,14 @@
             "index": "pypi",
             "version": "==1.4.2"
         },
+        "types-oauthlib": {
+            "hashes": [
+                "sha256:010c980847cf9b2e3ed3afd74dcdfb70b4e86117abad84b4125f57f935a764eb",
+                "sha256:a3582161089dc217068aab2567d72a5120f70eef56b222c63d767dc426bb1734"
+            ],
+            "index": "pypi",
+            "version": "==3.1.6"
+        },
         "types-pyyaml": {
             "hashes": [
                 "sha256:2fd21310870addfd51db621ad9f3b373f33ee3cbb81681d70ef578760bd22d35",
@@ -820,7 +836,7 @@
                 "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
                 "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
             ],
-            "markers": "python_version < '3.10'",
+            "index": "pypi",
             "version": "==4.1.1"
         },
         "vcrpy": {
@@ -833,11 +849,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66",
-                "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"
+                "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a",
+                "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.14.0"
+            "version": "==20.14.1"
         },
         "wasmer": {
             "hashes": [

--- a/ggshield/auth.py
+++ b/ggshield/auth.py
@@ -2,6 +2,7 @@ import click
 
 from .client import retrieve_client
 from .config import AccountConfig, InstanceConfig
+from .oauth import OAuthClient
 from .utils import clean_url
 
 
@@ -9,7 +10,7 @@ from .utils import clean_url
 @click.option(
     "--method",
     required=True,
-    type=click.Choice(["token"]),
+    type=click.Choice(["token", "web"]),
     help="Authentication method.",
 )
 @click.option(
@@ -74,7 +75,8 @@ def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
         instance_config.account = account_config
         config.save()
         click.echo("Authentication was successful.")
-
+    elif method == "web":
+        OAuthClient(config, instance).oauth_process()
     return 0
 
 

--- a/ggshield/auth.py
+++ b/ggshield/auth.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 
 from .client import retrieve_client
@@ -21,7 +23,14 @@ from .utils import clean_url
 )
 @click.pass_context
 def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
-    """Authenticate to your GitGuardian account."""
+    """
+    Authenticate to your GitGuardian account.
+
+    Use `--method token` to authenticate using an existing token.
+
+    Use `--method web` to let ggshield authenticate through your web browser and
+    generate a token for you. Note: This is experimental for now.
+    """
     config = ctx.obj["config"]
 
     if instance:
@@ -76,7 +85,10 @@ def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
         config.save()
         click.echo("Authentication was successful.")
     elif method == "web":
-        OAuthClient(config, instance).oauth_process()
+        if os.getenv("IS_WEB_AUTH_ENABLED", False):
+            OAuthClient(config, instance).oauth_process()
+        else:
+            raise click.ClickException("The web auth login method is not enabled.")
     return 0
 
 

--- a/ggshield/oauth.py
+++ b/ggshield/oauth.py
@@ -1,0 +1,290 @@
+import os
+import urllib.parse as urlparse
+import webbrowser
+from base64 import urlsafe_b64encode
+from datetime import datetime
+from hashlib import sha256
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, Optional, Type
+
+import click
+import requests
+from oauthlib.oauth2 import OAuth2Error, WebApplicationClient
+
+from .client import retrieve_client
+from .config import AccountConfig, Config
+
+
+CLIENT_ID = "ggshield_oauth"
+SCOPE = "scan"
+REDIRECT_PORT = 1234
+
+
+class OAuthClient:
+    """
+    Helper class to handle the OAuth authentication flow
+    the logic is divided in 2 steps:
+    - open the browser on GitGuardian login screen and run a local server to wait for callback
+    - handle the oauth callback to exchange an authorization code against a valid access token
+    """
+
+    def __init__(self, config: Config, instance: str) -> None:
+        self.config = config
+        self.instance = instance
+        self._oauth_client = WebApplicationClient(CLIENT_ID)
+
+        self._handler_wrapper = RequestHandlerWrapper(oauth_client=self)
+        self._access_token: Optional[str] = None
+        self.server: Optional[HTTPServer] = None
+
+        self._generate_pkce_pair()
+
+    def oauth_process(self) -> None:
+        """
+        Handle the whole oauth process which includes
+        - opening the user's webbrowser to GitGuardian login page
+        - open a server and wait for the callback processing
+        """
+        # enable redirection to http://localhost
+        os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = str(True)
+
+        self._token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
+
+        self._prepare_server()
+        self._redirect_to_login()
+        self._wait_for_callback()
+        click.echo(f"Created Personal Access Token {self._token_name}")
+
+    def process_callback(self, callback_url: str) -> None:
+        """
+        This function runs within the request handler do_GET method.
+        It takes the url of the callback request as argument and does
+        - Extract the authorization code
+        - Exchange the code against an access token with GitGuardian's api
+        - Validate the new token against GitGuardian's api
+        - Save the token in configuration
+        Any error during this process will raise a OAuthError
+        """
+        authorization_code = self._get_code(callback_url)
+        self._claim_token(authorization_code)
+        token_data = self._validate_access_token()
+        self._save_token(token_data)
+
+    def _generate_pkce_pair(self) -> None:
+        """
+        Generate a code verifier (random string) and its sha encoded version to be used
+        for the pkce checking process
+        """
+        self.code_verifier = self._oauth_client.create_code_verifier(128)  # type: ignore
+        self.code_challenge = (
+            urlsafe_b64encode(sha256(self.code_verifier.encode()).digest())
+            .decode()
+            .rstrip("=")
+        )
+
+    def _redirect_to_login(self) -> None:
+        """
+        Open the user's browser to the GitGuardian ggshield authentication page
+        """
+        static_params = {
+            "auth_mode": "ggshield_login",
+            "utm_source": "cli",
+            "utm_medium": "login",
+            "utm_campaign": "ggshield",
+        }
+        request_uri = self._oauth_client.prepare_request_uri(
+            uri=urlparse.urljoin(self.dashboard_url, "auth/login"),
+            redirect_uri=self.redirect_uri,
+            scope=SCOPE,
+            code_challenge=self.code_challenge,
+            code_challenge_method="S256",
+            **static_params,
+        )
+        click.echo(
+            f"To complete the login process, follow the instructions from {request_uri}.\n"
+            "Opening your web browser now..."
+        )
+        webbrowser.open_new_tab(request_uri)
+
+    def _prepare_server(self) -> None:
+        try:
+            self.server = HTTPServer(
+                # only consider requests from localhost on the predetermined port
+                ("127.0.0.1", REDIRECT_PORT),
+                # attache the wrapped request handler
+                self._handler_wrapper.request_handler,
+            )
+        except OSError:
+            raise click.ClickException(f"Port {REDIRECT_PORT} is already in use.")
+
+    def _wait_for_callback(self) -> None:
+        """
+        Wait to receive and process the authorization callback on the local server.
+        This actually catches HTTP requests made on the previously opened server.
+        The callback processing logic is implementend in the request handler class
+        and the `process_callback` method
+        """
+        try:
+            while not self._handler_wrapper.complete:
+                # Wait for callback on localserver including an authorization code
+                # any matchin request will get processed by the request handler and
+                # the `process_callback` function
+                self.server.handle_request()  # type: ignore
+        except KeyboardInterrupt:
+            raise click.ClickException("Aborting")
+
+        if self._handler_wrapper.error_message is not None:
+            # if no error message is attached, the process is considered successful
+            raise click.ClickException(self._handler_wrapper.error_message)
+
+    def _get_code(self, uri: str) -> str:
+        """
+        extract the authorization from the incoming request URI
+        if no code can be extracted, return None
+        """
+        try:
+            authorization_code = self._oauth_client.parse_request_uri_response(uri).get(
+                "code"
+            )
+        except OAuth2Error:
+            authorization_code = None
+        if authorization_code is None:
+            raise OAuthError("Invalid code received from the callback.")
+        return authorization_code  # type: ignore
+
+    def _claim_token(self, authorization_code: str) -> None:
+        """
+        Exchange the authorization code with a valid access token using GitGuardian public api.
+        If no valid token could be retrieved, exit the authentication process with an error message
+        """
+
+        request_params = {"name": self._token_name}
+
+        request_body = self._oauth_client.prepare_request_body(
+            code=authorization_code,
+            redirect_uri=self.redirect_uri,
+            code_verifier=self.code_verifier,
+            body=urlparse.urlencode(request_params),
+        )
+
+        response = requests.post(
+            urlparse.urljoin(self.api_url, "oauth/token"),
+            request_body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        if not response.ok:
+            raise OAuthError("Cannot create a token.")
+
+        self._access_token = response.json()["key"]
+        self.config.auth_config.current_token = self._access_token
+
+    def _validate_access_token(self) -> Dict[str, Any]:
+        """
+        Validate the token using GitGuardian public api.
+        If the token is not valid, exit the authentication process with an error message.
+        """
+        response = retrieve_client(self.config).get(endpoint="token")
+        if not response.ok:
+            raise OAuthError("The created token is invalid.")
+        return response.json()  # type: ignore
+
+    def _save_token(self, api_token_data: Dict[str, Any]) -> None:
+        """
+        Save the new token in the configuration.
+        """
+        account_config = AccountConfig(
+            account_id=api_token_data["account_id"],
+            token=self._access_token,  # type: ignore
+            expire_at=api_token_data.get("expire_at"),
+            token_name=api_token_data.get("name", ""),
+            type=api_token_data.get("type", ""),
+        )
+        instance_config = self.config.auth_config.instances[self.instance]
+        instance_config.account = account_config
+        self.config.save()
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://localhost:{REDIRECT_PORT}"
+
+    @property
+    def dashboard_url(self) -> str:
+        return self.config.dashboard_url
+
+    @property
+    def api_url(self) -> str:
+        return self.config.api_url
+
+
+class RequestHandlerWrapper:
+    """
+    Utilitary class to link the server and the request handler.
+    This allows to kill the server from the request processing.
+    """
+
+    oauth_client: OAuthClient
+    # tells the server to stop listening to requests
+    complete: bool
+    # error encountered while processing the callback
+    # if None, the process is considered successful
+    error_message: Optional[str] = None
+
+    def __init__(self, oauth_client: OAuthClient) -> None:
+        self.oauth_client = oauth_client
+        self.complete = False
+        self.error_message = None
+
+    @property
+    def request_handler(self) -> Type[BaseHTTPRequestHandler]:
+        class RequestHandler(BaseHTTPRequestHandler):
+            def do_GET(self_) -> None:
+                """
+                This function process every GET request received by the server.
+                Non-root request are skipped.
+                If an authorization code can be extracted from the URI, attach it to the handler
+                so it can be retrieved after the request is processed, then kill the server.
+                """
+                callback_url: str = self_.path
+                parsed_url = urlparse.urlparse(callback_url)
+                if parsed_url.path == "/":
+                    try:
+                        self.oauth_client.process_callback(callback_url)
+                    except OAuthError as error:
+                        self_._end_request()
+                        # attach error message to the handler wrapper instance
+                        self.error_message = error.message
+                    else:
+                        self_._end_request(
+                            urlparse.urljoin(
+                                self.oauth_client.dashboard_url, "authenticated"
+                            ),
+                        )
+
+                    # indicate to the serve to stop
+                    self.complete = True
+
+            def _end_request(self_, redirect_url: Optional[str] = None) -> None:
+                """
+                End the current request. If a redirect url is provided,
+                the response will be a redirection to this url.
+                If not the response will be a user error 400
+                """
+                status_code = 301 if redirect_url is not None else 400
+                self_.send_response(status_code)
+
+                if redirect_url is not None:
+                    self_.send_header("Location", redirect_url)
+                self_.end_headers()
+
+        return RequestHandler
+
+
+class OAuthError(Exception):
+    """
+    Exception raised during the authorization exchange code process
+    Its message is caught and will be raised again as a click Exception
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -36,6 +36,11 @@ def tmp_config(monkeypatch, tmp_path):
     monkeypatch.setattr("ggshield.config.get_auth_config_dir", lambda: str(tmp_path))
 
 
+@pytest.fixture()
+def enable_web_auth(monkeypatch):
+    monkeypatch.setenv("IS_WEB_AUTH_ENABLED", True)
+
+
 class TestAuthLoginToken:
     VALID_TOKEN_PAYLOAD = {**_TOKEN_RESPONSE_PAYLOAD}
     INVALID_TOKEN_PAYLOAD = {"detail": "Invalid API key."}
@@ -168,6 +173,17 @@ class TestAuthLoginToken:
 
 
 class TestAuthLoginWeb:
+    def test_auth_login_web_not_enabled(self, cli_fs_runner):
+        """
+        GIVEN -
+        WHEN the ggshield web login feature flag is off
+        THEN it is not possible to login using the web method
+        """
+        cmd = ["auth", "login", "--method=web"]
+        result = cli_fs_runner.invoke(cli, cmd, color=False, catch_exceptions=True)
+        assert result.exit_code == 1
+        assert result.output == "Error: The web auth login method is not enabled.\n"
+
     @pytest.mark.parametrize(
         ["port_used_count", "authorization_code", "is_exchange_ok", "is_token_valid"],
         [
@@ -187,6 +203,7 @@ class TestAuthLoginWeb:
         is_token_valid,
         monkeypatch,
         cli_fs_runner,
+        enable_web_auth,
     ):
         """
         GIVEN a valid API token


### PR DESCRIPTION
Implement ggshield login auth "web" method which implement the OAuth2 flow.
The core logic is implemented in `OAuthClient.oauth_process()`. In short it does
* redirect to GitGuarian login page (with ggshield options)
* open a local server to start listening
* retrieve the code from the call to localhost
* validate the token and retrieve its data
* save the token to the config
* open a tab to the "authenticated" page