### PR TITLE
Fix scan stopping when encountering a file containing a 0 byte

### DIFF
--- a/ggshield/path.py
+++ b/ggshield/path.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Iterable, List, Set, Union
+from typing import Iterable, Iterator, List, Set, Union
 
 import click
 
@@ -86,8 +86,8 @@ def get_filepaths(
     return targets
 
 
-def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterable[File]:
-    """Generate a list of scannable files from a list of filepaths."""
+def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterator[File]:
+    """Loop on filepaths and return an iterator on scannable files."""
     for path in paths:
         if os.path.isdir(path) or not os.path.exists(path):
             continue
@@ -101,10 +101,7 @@ def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterable[F
             if verbose:
                 click.echo(f"ignoring binary file extension: {path}")
             continue
-        with open(path, "r") as file:
-            try:
-                content = file.read()
-                if content:
-                    yield File(content, file.name, file_size)
-            except UnicodeDecodeError:
-                pass
+        with open(path, "rb") as file:
+            content = file.read()
+            if content:
+                yield File.from_bytes(content, file.name)

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -82,11 +82,7 @@ def _get_config(archive: tarfile.TarFile) -> Tuple[Dict, Dict, File]:
     return (
         manifest,
         json.loads(config_file_content),
-        File(
-            config_file_content,
-            filename="Dockerfile or build-args",  # noqa: E501
-            filesize=config_file_info.size,
-        ),
+        File(config_file_content, filename="Dockerfile or build-args"),
     )
 
 

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -158,17 +158,11 @@ def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Fil
         if file is None:
             continue
 
-        file_content_raw = file.read()
-        if len(file_content_raw) > MAX_FILE_SIZE * 0.95:
+        file_content = file.read()
+        if len(file_content) > MAX_FILE_SIZE * 0.95:
             continue
 
-        file_content = (
-            file_content_raw.decode(errors="replace")
-            .replace("\0", " ")  # null character, not replaced by replace
-            .replace("\uFFFD", " ")  # replacement character
-        )
-        yield File(
-            document=file_content,
-            filename=os.path.join(archive.name, layer_filename, file_info.name),  # type: ignore # noqa
-            filesize=file_info.size,
+        yield File.from_bytes(
+            raw_document=file_content,
+            filename=os.path.join(archive.name, layer_filename, file_info.name),  # type: ignore
         )

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -61,11 +61,10 @@ class ScanCollection(NamedTuple):
 class File:
     """Class representing a simple file."""
 
-    def __init__(self, document: str, filename: str, filesize: Optional[int] = None):
+    def __init__(self, document: str, filename: str):
         self.document = document
         self.filename = filename
         self.filemode = Filemode.FILE
-        self.filesize = filesize if filesize else len(self.document.encode("utf-8"))
 
     @staticmethod
     def from_bytes(raw_document: bytes, filename: str) -> "File":
@@ -91,14 +90,8 @@ class File:
 class CommitFile(File):
     """Class representing a commit file."""
 
-    def __init__(
-        self,
-        document: str,
-        filename: str,
-        filemode: Filemode,
-        filesize: Optional[int] = None,
-    ):
-        super().__init__(document, filename, filesize)
+    def __init__(self, document: str, filename: str, filemode: Filemode):
+        super().__init__(document, filename)
         self.filemode = filemode
 
 
@@ -309,4 +302,4 @@ class Commit(Files):
                 continue
 
             if document:
-                yield CommitFile(document, filename, filemode, file_size)
+                yield CommitFile(document, filename, filemode)

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -67,6 +67,15 @@ class File:
         self.filemode = Filemode.FILE
         self.filesize = filesize if filesize else len(self.document.encode("utf-8"))
 
+    @staticmethod
+    def from_bytes(raw_document: bytes, filename: str) -> "File":
+        document = (
+            raw_document.decode(errors="replace")
+            .replace("\0", " ")  # errors="replace" keeps `\0`, remove it
+            .replace("\uFFFD", " ")  # replacement character
+        )
+        return File(document, filename)
+
     @property
     def scan_dict(self) -> Dict[str, Any]:
         """Return a payload compatible with the scanning API."""

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from ggshield.path import generate_files_from_paths
+
+
+@pytest.mark.parametrize(
+    ["filename", "input_content", "expected_content"],
+    [
+        ("normal.txt", "Normal", "Normal"),
+        ("0-inside.txt", "Ins\0de", "Ins de"),
+    ],
+)
+def test_generate_files_from_paths(
+    tmp_path, filename: str, input_content: str, expected_content: str
+):
+    """
+    GIVEN a file
+    WHEN calling generate_files_from_paths() on it
+    THEN it returns the expected File instance
+    AND the content of the File instance is what is expected
+    """
+    path = tmp_path / filename
+    Path(path).write_text(input_content)
+
+    files = list(generate_files_from_paths([str(path)], verbose=False))
+
+    file = files[0]
+    assert file.filename == str(path)
+    assert file.document == expected_content
+
+    assert len(files) == 1
+
+
+@pytest.mark.parametrize(
+    ["filename", "creator"],
+    [
+        ("a_binary_file.tar", lambda x: x.write_text("Uninteresting")),
+        ("big_file", lambda x: x.write_text(2_000_000 * " ")),
+        ("i_am_a_dir", lambda x: x.mkdir()),
+    ],
+)
+def test_generate_files_from_paths_skips_files(
+    tmp_path, filename: str, creator: Callable[[Path], None]
+):
+    """
+    GIVEN a file which should be skipped
+    WHEN calling generate_files_from_paths() on it
+    THEN it should return an empty list
+    """
+    path = tmp_path / filename
+    creator(path)
+
+    files = list(generate_files_from_paths([str(path)], verbose=False))
+
+    assert files == []


### PR DESCRIPTION
## Context

This PR fixes #155.

## What has been done

I moved the decoding code used when reading files inside Docker images to a `File.from_bytes()` static method and then replaced the code used to decode files from the file system with `Files.from_bytes()`.

While working on the `File` class I realized it contains a `filesize` field, which is never used, so I removed it.