### PR TITLE
Fix error message in blank state (#201)

### DIFF
--- a/ggshield/client.py
+++ b/ggshield/client.py
@@ -3,7 +3,8 @@ import urllib3
 from pygitguardian import GGClient
 from requests import Session
 
-from .config import Config
+from .config import Config, UnknownInstanceError
+from .constants import DEFAULT_DASHBOARD_URL
 
 
 def retrieve_client(config: Config) -> GGClient:
@@ -13,12 +14,25 @@ def retrieve_client(config: Config) -> GGClient:
         session.verify = False
 
     try:
+        api_key = config.api_key
+        api_url = config.api_url
+    except UnknownInstanceError as e:
+        if e.instance == DEFAULT_DASHBOARD_URL:
+            # This can happen when the user first tries the app and has not gone through
+            # the authentication procedure yet. In this case, replace the error message
+            # complaining about an unknown instance with a more user-friendly one.
+            raise click.ClickException("GitGuardian API key is needed.")
+        else:
+            raise
+
+    try:
         return GGClient(
-            api_key=config.api_key,
-            base_uri=config.api_url,
+            api_key=api_key,
+            base_uri=api_url,
             user_agent="ggshield",
             timeout=60,
             session=session,
         )
     except ValueError as e:
+        # Can be raised by pygitguardian
         raise click.ClickException(f"Failed to create API client. {e}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,12 +7,12 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from click import ClickException
 
 from ggshield.config import (
     AccountConfig,
     Config,
     InstanceConfig,
+    UnknownInstanceError,
     get_auth_config_filepath,
     replace_in_keys,
 )
@@ -476,7 +476,7 @@ class TestConfig:
         config = Config()
         config.current_instance = "toto"
 
-        with pytest.raises(ClickException, match="Unrecognized instance: 'toto'"):
+        with pytest.raises(UnknownInstanceError, match="Unknown instance: 'toto'"):
             config.api_key
 
     @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,37 @@ def test_retrieve_client_invalid_api_key():
             retrieve_client(Config())
 
 
+def test_retrieve_client_blank_state(isolated_fs):
+    """
+    GIVEN a blank state (no config, no environment variable)
+    WHEN retrieve_client() is called
+    THEN the exception message is user-friendly for new users
+    """
+    with pytest.raises(
+        click.ClickException,
+        match="GitGuardian API key is needed",
+    ):
+        with mock.patch.dict(os.environ, clear=True):
+            retrieve_client(Config())
+
+
+def test_retrieve_client_unknown_custom_dashboard_url(isolated_fs):
+    """
+    GIVEN an auth config telling the client to use a custom instance
+    WHEN retrieve_client() is called
+    AND the custom instance does not exist
+    THEN the exception message mentions the instance name
+    """
+    with pytest.raises(
+        click.ClickException,
+        match="Unknown instance: 'https://example.com'",
+    ):
+        with mock.patch.dict(os.environ, clear=True):
+            config = Config()
+            config.auth_config.current_instance = "https://example.com"
+            retrieve_client(config)
+
+
 class TestAPIDashboardURL:
     @pytest.mark.parametrize(
         ["api_url", "dashboard_url"],


### PR DESCRIPTION
This ensures a first-time user trying to scan without having setup authentication first won't get that error message:

> Unrecognized instance 'https://dashboard.gitguardian.com'

Fixes #201.