### PR TITLE
Rework docker scan output, unskip tests on Windows

### DIFF
--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -158,7 +158,11 @@ def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Fil
         if len(file_content) > MAX_FILE_SIZE * 0.95:
             continue
 
+        # layer_filename is "<some_uuid>/layer.tar". We only keep "<some_uuid>"
+        layer_name = os.path.dirname(layer_filename)
+
+        # Do not use os.path.join() for the filename argument: we always want Unix path
+        # separators here
         yield File.from_bytes(
-            raw_document=file_content,
-            filename=os.path.join(archive.name, layer_filename, file_info.name),  # type: ignore
+            raw_document=file_content, filename=f"{layer_name}:/{file_info.name}"
         )

--- a/tests/scan/test_scan_docker.py
+++ b/tests/scan/test_scan_docker.py
@@ -9,7 +9,6 @@ from ggshield.scan.docker import (
     _should_scan_layer,
     get_files_from_docker_archive,
 )
-from tests.conftest import skipwindows
 
 
 DOCKER_EXAMPLE_PATH = Path(__file__).parent.parent / "data" / "docker-example.tar.xz"
@@ -78,7 +77,6 @@ class TestDockerScan:
         with pytest.raises(InvalidDockerArchiveException, match=match):
             _get_config(tarfile)
 
-    @skipwindows
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
@@ -86,13 +84,10 @@ class TestDockerScan:
         files = get_files_from_docker_archive(image_path)
 
         expected_files = {
-            "Dockerfile or build-args": None,  # noqa: E501
-            image_path
-            / "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc/layer.tar/app/file_one": "Hello, I am the first file!\n",  # noqa: E501
-            image_path
-            / "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_three.sh": "echo Life is beautiful.\n",  # noqa: E501
-            image_path
-            / "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
+            "Dockerfile or build-args": None,
+            "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc:/app/file_one": "Hello, I am the first file!\n",  # noqa: E501
+            "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f:/app/file_three.sh": "echo Life is beautiful.\n",  # noqa: E501
+            "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f:/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
         }
 
         assert set(files.files) == {str(file_path) for file_path in expected_files}


### PR DESCRIPTION
## Context

Some docker tests are currently skipped on Windows (see #168). They are skipped because path separator issues (`\` vs `/`) make them fail.

This PR fixes this.

## What has been done

- Decide that Docker output paths are always Unix. This is not always true (there are Windows-based Docker images), but extracting this information requires too much work.
- Simplify the output: do not report the archive name, it is the path to a temporary archive, which is gone by the time the command ends.

The second point means that before the output looked like this:

```
️  ⚔️  ️  1 incident has been found in file /tmp/tmpai92kygzggshield/archive.tar/fdcab29fec3e99c1bb251f62ec1064ba2e32682bcf70da7d0d16d7cc2e0f6dd7/layer.tar/etc/config.py

>>> Incident 1(Secrets detection): Generic High Entropy Secret (Validity: Cannot Check)  (Ignore with SHA: a4d3db3514f2547b9f7be3fa42c5db5eccd681ad0db515c661ff8652629291a5) (1 occurrence)
4 | db_password = r"f1jer3iojnionvbfAZ"
5 | 
6 | byte_api_key = b"fre***********reg"
                     |_____apikey____|
7 | f_string_password = f"we'dBetterIgnore{os.environ['DB_PASSWORD']}That0rNot"
8 | 

```

And now it looks like this:

```
️  ⚔️  ️  1 incident has been found in file fdcab29fec3e99c1bb251f62ec1064ba2e32682bcf70da7d0d16d7cc2e0f6dd7:/etc/config.py

>>> Incident 1(Secrets detection): Generic High Entropy Secret (Validity: Cannot Check)  (Ignore with SHA: a4d3db3514f2547b9f7be3fa42c5db5eccd681ad0db515c661ff8652629291a5) (1 occurrence)
4 | db_password = r"f1jer3iojnionvbfAZ"
5 | 
6 | byte_api_key = b"fre***********reg"
                     |_____apikey____|
7 | f_string_password = f"we'dBetterIgnore{os.environ['DB_PASSWORD']}That0rNot"
8 | 
```
