### PR TITLE
Publish deb and rpm packages on Cloudsmith

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: "packages/ggshield-*.pyz;packages/ggshield_*.deb;packages/ggshield-*.rpm"
+          file: 'packages/ggshield-*.pyz;packages/ggshield_*.deb;packages/ggshield-*.rpm'
           release_id: ${{ steps.create_release.outputs.id }}
           overwrite: true
           verbose: true
@@ -202,3 +202,21 @@ jobs:
           git tag ${{ steps.tags.outputs.tag }}
           git push
           git push --tags
+
+  push_to_cloudsmith:
+    needs: build_packages
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+
+      - name: Install Cloudsmith CLI
+        run: pip install cloudsmith-cli
+
+      - name: Push to Cloudsmith
+        run: |
+          scripts/push-to-cloudsmith
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ GITGUARDIAN_API_KEY=<GitGuardian API Key>
 
 # Installation
 
-## On MacOS
+## macOS
 
 ### Using Homebrew
 
@@ -99,7 +99,16 @@ You can install ggshield using Homebrew by running the following command:
 $ brew install gitguardian/tap/ggshield
 ```
 
-## On other Operating Systems
+## Linux packages
+
+Deb and RPM packages are available on [Cloudsmith](https://cloudsmith.io/~gitguardian/repos/ggshield/packages/).
+
+Setup instructions:
+
+- [Deb packages](https://cloudsmith.io/~gitguardian/repos/ggshield/setup/#formats-deb)
+- [RPM packages](https://cloudsmith.io/~gitguardian/repos/ggshield/setup/#formats-rpm)
+
+## Other Operating Systems
 
 ### Using pip
 
@@ -109,7 +118,7 @@ Install and update using `pip`:
 $ pip install ggshield
 ```
 
-ggshield supports **Python 3.6 and newer**.
+ggshield supports **Python 3.7 and newer**.
 
 The package should run on MacOS, Linux and Windows.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,7 @@
-This directory contains script to help with ggshield development.
+This directory contains scripts to help with ggshield development.
 
-- update-pipfile-lock: Update Pipfile.lock, using the oldest supported version of Python
+- update-pipfile-lock/update-pipfile-lock: Update Pipfile.lock, using the oldest supported version of Python.
+
+- build-packages/build-packages: Build .pyz, .deb and .rpm packages.
+
+- push-to-cloudsmith: Publish the .deb and .rpm built by build-packages to Cloudsmith.

--- a/scripts/build-packages/build-packages
+++ b/scripts/build-packages/build-packages
@@ -12,6 +12,7 @@ set -euo pipefail
 
 cd $(dirname $0)
 NFPM_YAML_TMPL=$PWD/nfpm.yaml.tmpl
+GGSHIELD_WRAPPER=$PWD/ggshield-wrapper
 
 # Move to the work-tree root
 cd $(git rev-parse --show-toplevel)
@@ -54,6 +55,7 @@ run_nfpm() {
     local nfpm_yaml=$(mktemp --tmpdir nfpm-XXXXX.yaml)
     sed \
         -e "s,@VERSION@,$VERSION," \
+        -e "s,@GGSHIELD_WRAPPER@,$GGSHIELD_WRAPPER," \
         -e "s,@GGSHIELD_PYZ@,$GGSHIELD_PYZ," \
         "$NFPM_YAML_TMPL" > "$nfpm_yaml"
 

--- a/scripts/build-packages/ggshield-wrapper
+++ b/scripts/build-packages/ggshield-wrapper
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This wrapper looks for a recent enough Python interpreter and exits with a
+# user-friendly message if it can't find one.
+# This is useful when the `python3` interpreter is too old, but the system
+# has a more recent `python3.x` interpreter installed.
+
+# The minimum Python version we need
+MAJOR=3
+MINOR=7
+
+GGSHIELD_PYZ=/usr/lib/ggshield/ggshield.pyz
+
+POSSIBLE_PYTHONS=\
+"python311 python3.11
+python310 python3.10
+python39 python3.9
+python38 python3.8
+python37 python3.7
+python3
+python
+"
+
+is_python_usable() {
+    local python_cmd=$1
+    if ! command -v "$python_cmd" > /dev/null ; then
+        return 1
+    fi
+    $python_cmd -c "import sys; sys.exit(0 if sys.version_info >= ($MAJOR, $MINOR) else 1)"
+}
+
+for python_cmd in $POSSIBLE_PYTHONS ; do
+    if is_python_usable "$python_cmd" ; then
+        exec "$python_cmd" $GGSHIELD_PYZ "$@"
+    fi
+done
+
+echo "Error: could not find a usable Python interpreter. ggshield needs at least Python $MAJOR.$MINOR." >&2
+exit 1

--- a/scripts/build-packages/nfpm.yaml.tmpl
+++ b/scripts/build-packages/nfpm.yaml.tmpl
@@ -16,8 +16,12 @@ depends:
   - git
   - python3
 contents:
-  - src: @GGSHIELD_PYZ@
+  - src: @GGSHIELD_WRAPPER@
     dst: /usr/bin/ggshield
+    file_info:
+      mode: 0755
+  - src: @GGSHIELD_PYZ@
+    dst: /usr/lib/ggshield/ggshield.pyz
     file_info:
       mode: 0755
   - src: README.md

--- a/scripts/push-to-cloudsmith
+++ b/scripts/push-to-cloudsmith
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OWNER_REPO_DISTRO_RELEASE=gitguardian/ggshield/any-distro/any-version
+
+die() {
+    echo $* >&2
+    exit 1
+}
+
+if [ -z "${CLOUDSMITH_API_KEY:-}" ] ; then
+    die '$CLOUDSMITH_API_KEY is not set'
+fi
+
+for package in packages/*.{rpm,deb} ; do
+    case "$package" in
+        *.deb)
+            cloudsmith push deb $OWNER_REPO_DISTRO_RELEASE "$package"
+            ;;
+        *.rpm)
+            cloudsmith push rpm $OWNER_REPO_DISTRO_RELEASE "$package"
+            ;;
+        *)
+            die "Should not happen"
+            ;;
+    esac
+done


### PR DESCRIPTION
## Description

This PR adds a script to publish packages on Cloudsmith and make the tag workflow call this script.

It also makes our package a bit more robust in situations where the default `python3` interpreter is too old.

## Demonstration

Installing the package in a Fedora container.

Start the container:
```
$ docker run -it --rm -e GITGUARDIAN_API_KEY -v $PWD:/src fedora
```

Run Cloudsmith setup script:
```
[root@7fc7a79dbf5b /]# curl -1sLf 'https://dl.cloudsmith.io/public/gitguardian/ggshield/setup.rpm.sh' | bash
Executing the  setup script for the 'gitguardian/ggshield' repository ...

   OK: Checking for required executable 'curl' ...
   OK: Checking for required executable 'rpm' ...
   OK: Detecting your OS distribution and release using system methods ...
 ^^^^: ... Detected/provided for your OS/distribution, version and architecture:
 >>>>:
 >>>>: ... distro=fedora  version=35  codename=Container  arch=x86_64
 >>>>:
   OK: Importing 'gitguardian/ggshield' repository GPG keys into rpm ...
   OK: Checking for available package manager (DNF/Microdnf/YUM/Zypper) ...
 ^^^^: ... Detected package manager as 'dnf'
 NOPE: Checking for dnf dependency 'yum-utils' ...
   OK: Attempting to install 'yum-utils' ...
 NOPE: Checking for dnf dependency 'dnf-plugin-config-manager' ...
   OK: Attempting to install 'dnf-plugin-config-manager' ...
   OK: Checking if upstream install config is OK ...
   OK: Fetching 'gitguardian/ggshield' repository configuration ...
   OK: Installing 'gitguardian/ggshield' repository via dnf ...
  RUN: Updating the dnf cache to fetch the new repository metadata ...Importing GPG key 0x55FE38C6:
 Userid     : "Cloudsmith Package (gitguardian/ggshield) <support@cloudsmith.io>"
 Fingerprint: 91F4 8E57 79C6 D559 F0BE 479F 6739 F7C6 55FE 38C6
 From       : https://dl.cloudsmith.io/public/gitguardian/ggshield/gpg.6739F7C655FE38C6.key
Importing GPG key 0x55FE38C6:
 Userid     : "Cloudsmith Package (gitguardian/ggshield) <support@cloudsmith.io>"
 Fingerprint: 91F4 8E57 79C6 D559 F0BE 479F 6739 F7C6 55FE 38C6
 From       : https://dl.cloudsmith.io/public/gitguardian/ggshield/gpg.6739F7C655FE38C6.key
Importing GPG key 0x55FE38C6:
 Userid     : "Cloudsmith Package (gitguardian/ggshield) <support@cloudsmith.io>"
 Fingerprint: 91F4 8E57 79C6 D559 F0BE 479F 6739 F7C6 55FE 38C6
 From       : https://dl.cloudsmith.io/public/gitguardian/ggshield/gpg.6739F7C655FE38C6.key
   OK: Updating the dnf cache to fetch the new repository metadata ...
   OK: The repository has been installed successfully - You're ready to rock!
```

Install ggshield:

```
[root@7fc7a79dbf5b /]# yum install ggshield
gitguardian-ggshield                                                              929  B/s | 648  B     00:00
gitguardian-ggshield-noarch                                                       957  B/s | 648  B     00:00
gitguardian-ggshield-source                                                       955  B/s | 648  B     00:00
Dependencies resolved.
==================================================================================================================
 Package                        Architecture   Version                         Repository                    Size
==================================================================================================================
Installing:
 ggshield                       x86_64         1.11.0-1                        gitguardian-ggshield         1.5 M
Installing dependencies:
 git                            x86_64         2.35.1-1.fc35                   updates                       67 k
 git-core                       x86_64         2.35.1-1.fc35                   updates                      3.9 M
 git-core-doc                   noarch         2.35.1-1.fc35                   updates                      2.4 M
 groff-base                     x86_64         1.22.4-8.fc35                   fedora                       1.0 M
[...]
 util-linux-core                x86_64         2.37.4-1.fc35                   updates                      433 k
Installing weak dependencies:
 perl-IO-Socket-SSL             noarch         2.072-1.fc35                    fedora                       217 k
 perl-Mozilla-CA                noarch         20211001-1.fc35                 updates                       12 k
 perl-NDBM_File                 x86_64         1.15-486.fc35                   updates                       27 k

Transaction Summary
==================================================================================================================
Install  79 Packages

Total download size: 21 M
Installed size: 82 M
Is this ok [y/N]: y
Downloading Packages:
(1/79): libcbor-0.7.0-4.fc35.x86_64.rpm                                           637 kB/s |  56 kB     00:00
(2/79): libedit-3.1-40.20210910cvs.fc35.x86_64.rpm                                991 kB/s | 105 kB     00:00
(3/79): libfido2-1.8.0-1.fc35.x86_64.rpm                                          2.0 MB/s |  81 kB     00:00
(4/79): libutempter-1.2.1-5.fc35.x86_64.rpm                                       1.1 MB/s |  26 kB     00:00
[...]
(76/79): perl-libs-5.34.1-486.fc35.x86_64.rpm                                     9.9 MB/s | 2.1 MB     00:00
(77/79): util-linux-2.37.4-1.fc35.x86_64.rpm                                       13 MB/s | 2.2 MB     00:00
(78/79): util-linux-core-2.37.4-1.fc35.x86_64.rpm                                 2.4 MB/s | 433 kB     00:00
(79/79): ggshield-1.11.0-1.x86_64.rpm                                             2.3 MB/s | 1.5 MB     00:00
------------------------------------------------------------------------------------------------------------------
Total                                                                             7.6 MB/s |  21 MB     00:02
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                          1/1
  Installing       : util-linux-core-2.37.4-1.fc35.x86_64                                                    1/79
  Running scriptlet: util-linux-core-2.37.4-1.fc35.x86_64                                                    1/79
  Installing       : libfdisk-2.37.4-1.fc35.x86_64                                                           2/79
  Installing       : less-590-2.fc35.x86_64                                                                  3/79
[...]
  Verifying        : perl-vars-1.05-486.fc35.noarch                                                         76/79
  Verifying        : util-linux-2.37.4-1.fc35.x86_64                                                        77/79
  Verifying        : util-linux-core-2.37.4-1.fc35.x86_64                                                   78/79
  Verifying        : ggshield-1.11.0-1.x86_64                                                               79/79

Installed:
  ggshield-1.11.0-1.x86_64                               git-2.35.1-1.fc35.x86_64
  git-core-2.35.1-1.fc35.x86_64                          git-core-doc-2.35.1-1.fc35.noarch
  groff-base-1.22.4-8.fc35.x86_64                        less-590-2.fc35.x86_64
  libcbor-0.7.0-4.fc35.x86_64                            libedit-3.1-40.20210910cvs.fc35.x86_64
[...]
  perl-overloading-0.02-486.fc35.noarch                  perl-parent-1:0.238-478.fc35.noarch
  perl-podlators-1:4.14-478.fc35.noarch                  perl-subs-1.04-486.fc35.noarch
  perl-vars-1.05-486.fc35.noarch                         util-linux-2.37.4-1.fc35.x86_64
  util-linux-core-2.37.4-1.fc35.x86_64

Complete!
```

Use ggshield:

```
[root@7fc7a79dbf5b /]# ggshield quota
Quota available: 882
Quota used in the last 30 days: 118
Total Quota of the workspace: 1000

[root@7fc7a79dbf5b /]# ggshield scan path /etc/nsswitch.conf

[root@7fc7a79dbf5b /]#
```
