### PR TITLE
Fix Azure Pipelines example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,9 @@ jobs:
   - job: GitGuardianShield
     pool:
       vmImage: 'ubuntu-latest'
-    container: gitguardian/ggshield:latest
+    container:
+      image: gitguardian/ggshield:latest
+      options: -u 0
     steps:
       - script: ggshield scan ci
         env:


### PR DESCRIPTION
Azure Pipelines expects the Docker container to start as root. They then run `useradd -m -u 1001 vsts_azpcontainer` in the container to create a matching non-root user.

This fails with ggshield Docker container because it starts as its own non-privileged user, which is not allowed to run `useradd`.

Tell Azure Pipelines to start the container as root (with `-u 0`) to avoid that issue.