### PR TITLE
Add auth login optional params for web method

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -1,5 +1,3 @@
-import os
-
 import click
 
 from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
@@ -90,8 +88,5 @@ def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
     check_instance_has_enabled_flow(config=config)
 
     if method == "web":
-        if os.getenv("IS_WEB_AUTH_ENABLED", False):
-            OAuthClient(config, instance).oauth_process()
-        else:
-            raise click.ClickException("The web auth login method is not enabled.")
+        OAuthClient(config, instance).oauth_process()
     return 0

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -20,8 +20,14 @@ from ggshield.core.utils import clean_url
     type=str,
     help="URL of the instance to authenticate to.",
 )
+@click.option(
+    "--token-name",
+    required=False,
+    type=str,
+    help="Name of new token.",
+)
 @click.pass_context
-def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
+def login_cmd(ctx: click.Context, method: str, instance: str, token_name: str) -> int:
     """
     Authenticate to your GitGuardian account.
 
@@ -88,5 +94,5 @@ def login_cmd(ctx: click.Context, method: str, instance: str) -> int:
     check_instance_has_enabled_flow(config=config)
 
     if method == "web":
-        OAuthClient(config, instance).oauth_process()
+        OAuthClient(config, instance).oauth_process(token_name=token_name)
     return 0

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
@@ -26,8 +28,21 @@ from ggshield.core.utils import clean_url
     type=str,
     help="Name of new token.",
 )
+@click.option(
+    "--lifetime",
+    required=False,
+    type=click.IntRange(0),
+    default=None,
+    help="Amount of days before the token expires. 0 means the token never expires.",
+)
 @click.pass_context
-def login_cmd(ctx: click.Context, method: str, instance: str, token_name: str) -> int:
+def login_cmd(
+    ctx: click.Context,
+    method: str,
+    instance: str,
+    token_name: Optional[str],
+    lifetime: Optional[int],
+) -> int:
     """
     Authenticate to your GitGuardian account.
 
@@ -94,5 +109,7 @@ def login_cmd(ctx: click.Context, method: str, instance: str, token_name: str) -
     check_instance_has_enabled_flow(config=config)
 
     if method == "web":
-        OAuthClient(config, instance).oauth_process(token_name=token_name)
+        OAuthClient(config, instance).oauth_process(
+            token_name=token_name, lifetime=lifetime
+        )
     return 0

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -45,7 +45,7 @@ class OAuthClient:
 
         self._generate_pkce_pair()
 
-    def oauth_process(self) -> None:
+    def oauth_process(self, token_name: Optional[str] = None) -> None:
         """
         Handle the whole oauth process which includes
         - opening the user's webbrowser to GitGuardian login page
@@ -54,7 +54,9 @@ class OAuthClient:
         # enable redirection to http://localhost
         os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = str(True)
 
-        self._token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
+        if token_name is None:
+            token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
+        self._token_name = token_name
 
         self._prepare_server()
         self._redirect_to_login()

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -351,6 +351,10 @@ class RequestHandlerWrapper:
                     self_.send_header("Location", redirect_url)
                 self_.end_headers()
 
+            def log_message(self, format: str, *args: Any) -> None:
+                """Silence log message"""
+                return
+
         return RequestHandler
 
 

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -43,11 +43,6 @@ def tmp_config(monkeypatch, tmp_path):
     )
 
 
-@pytest.fixture()
-def enable_web_auth(monkeypatch):
-    monkeypatch.setenv("IS_WEB_AUTH_ENABLED", True)
-
-
 class TestAuthLoginToken:
     VALID_TOKEN_PAYLOAD = {**_TOKEN_RESPONSE_PAYLOAD}
     INVALID_TOKEN_PAYLOAD = {"detail": "Invalid API key."}
@@ -188,23 +183,6 @@ class TestAuthLoginToken:
 
 
 class TestAuthLoginWeb:
-    def test_auth_login_web_not_enabled(self, cli_fs_runner, monkeypatch):
-        """
-        GIVEN -
-        WHEN the ggshield web login feature flag is off
-        THEN it is not possible to login using the web method
-        """
-        check_instance_has_enabled_flow_mock = Mock()
-        monkeypatch.setattr(
-            "ggshield.cmd.auth.login.check_instance_has_enabled_flow",
-            check_instance_has_enabled_flow_mock,
-        )
-
-        cmd = ["auth", "login", "--method=web"]
-        result = cli_fs_runner.invoke(cli, cmd, color=False, catch_exceptions=True)
-        assert result.exit_code == 1
-        assert result.output == "Error: The web auth login method is not enabled.\n"
-
     @pytest.mark.parametrize(
         ["port_used_count", "authorization_code", "is_exchange_ok", "is_token_valid"],
         [

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -184,18 +184,33 @@ class TestAuthLoginToken:
 
 class TestAuthLoginWeb:
     @pytest.mark.parametrize(
-        ["port_used_count", "authorization_code", "is_exchange_ok", "is_token_valid"],
         [
-            (0, "some_valid_authorization_code", True, True),
-            (1, "some_valid_authorization_code", True, True),
-            (1000, "some_valid_authorization_code", True, True),
-            (0, "some_valid_authorization_code", False, False),
-            (0, "some_valid_authorization_code", True, False),
-            (0, None, True, True),  # invalid authorization code from callback
+            "token_name",
+            "port_used_count",
+            "authorization_code",
+            "is_exchange_ok",
+            "is_token_valid",
+        ],
+        [
+            # valid case
+            ("test token", 0, "some_valid_authorization_code", True, True),
+            # default token name
+            (None, 0, "some_valid_authorization_code", True, True),
+            # first port already used
+            ("test token", 1, "some_valid_authorization_code", True, True),
+            # all ports already used
+            ("test token", 1000, "some_valid_authorization_code", True, True),
+            # can't get token from server
+            ("test token", 0, "some_valid_authorization_code", False, False),
+            # invalid token from server
+            ("test token", 0, "some_valid_authorization_code", True, False),
+            # invalid authorization code from callback
+            ("test token", 0, None, True, True),
         ],
     )
     def test_auth_login_web_default_instance(
         self,
+        token_name,
         port_used_count,
         authorization_code,
         is_exchange_ok,
@@ -223,7 +238,6 @@ class TestAuthLoginWeb:
             or not is_token_valid
         )
 
-        token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
         token = "mysupertoken"
         config = Config()
         assert len(config.auth_config.instances) == 0
@@ -280,6 +294,12 @@ class TestAuthLoginWeb:
 
         # run cli command
         cmd = ["auth", "login", "--method=web"]
+        if token_name is not None:
+            cmd.append(f"--token-name={token_name}")
+        else:
+            token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
+
+        # run cli command
         result = cli_fs_runner.invoke(cli, cmd, color=False, catch_exceptions=True)
 
         check_instance_has_enabled_flow_mock.assert_called_once()


### PR DESCRIPTION
- refactor tests into separate test functions
- handle optional parameters for the auth login web method
  - token name
  - lifetime of the token (in days)
- make sure that these value are included in the state passed to the authentication server and that they are returned unchanged in the callback url
- make the server silent so it doesn't log incoming http requests
- remove the feature flag for more clarity (as requested by @agateau-gg )