### PR TITLE
Minor changes after source-tree reorganization

### DIFF
--- a/ggshield/cmd/auth/__init__.py
+++ b/ggshield/cmd/auth/__init__.py
@@ -5,4 +5,4 @@ from .login import login_cmd
 
 @click.group(commands={"login": login_cmd})
 def auth_group() -> None:
-    """Command to manage authentication."""
+    """Commands to manage authentication."""

--- a/ggshield/cmd/auth/__init__.py
+++ b/ggshield/cmd/auth/__init__.py
@@ -4,5 +4,5 @@ from .login import login_cmd
 
 
 @click.group(commands={"login": login_cmd})
-def auth() -> None:
+def auth_group() -> None:
     """Command to manage authentication."""

--- a/ggshield/cmd/ignore.py
+++ b/ggshield/cmd/ignore.py
@@ -15,7 +15,7 @@ from ggshield.core.config import Config
 @click.pass_context
 def ignore_cmd(ctx: click.Context, last_found: bool) -> int:
     """
-    Command to ignore some secrets.
+    Ignore some secrets.
     """
 
     if last_found:

--- a/ggshield/cmd/ignore.py
+++ b/ggshield/cmd/ignore.py
@@ -13,7 +13,7 @@ from ggshield.core.config import Config
     help="Ignore secrets found in the last ggshield scan run",
 )
 @click.pass_context
-def ignore(ctx: click.Context, last_found: bool) -> int:
+def ignore_cmd(ctx: click.Context, last_found: bool) -> int:
     """
     Command to ignore some secrets.
     """

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -25,7 +25,7 @@ from ggshield.core.git_shell import GIT_PATH, check_git_dir, check_git_installed
 )
 @click.option("--force", "-f", is_flag=True, help="Force override")
 @click.option("--append", "-a", is_flag=True, help="Append to existing script")
-def install(mode: str, hook_type: str, force: bool, append: bool) -> int:
+def install_cmd(mode: str, hook_type: str, force: bool, append: bool) -> int:
     """Command to install a pre-commit or pre-push hook (local or global)."""
     return_code = (
         install_global(hook_type=hook_type, force=force, append=append)

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -26,7 +26,7 @@ from ggshield.core.git_shell import GIT_PATH, check_git_dir, check_git_installed
 @click.option("--force", "-f", is_flag=True, help="Force override")
 @click.option("--append", "-a", is_flag=True, help="Append to existing script")
 def install_cmd(mode: str, hook_type: str, force: bool, append: bool) -> int:
-    """Command to install a pre-commit or pre-push hook (local or global)."""
+    """Install a pre-commit or pre-push git hook (local or global)."""
     return_code = (
         install_global(hook_type=hook_type, force=force, append=append)
         if mode == "global"

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -5,18 +5,18 @@ from typing import Any, List, Optional
 
 import click
 
-from ggshield.cmd.auth import auth
-from ggshield.cmd.ignore import ignore
-from ggshield.cmd.install import install
-from ggshield.cmd.quota import quota
-from ggshield.cmd.scan import scan
-from ggshield.cmd.status import status
+from ggshield.cmd.auth import auth_group
+from ggshield.cmd.ignore import ignore_cmd
+from ggshield.cmd.install import install_cmd
+from ggshield.cmd.quota import quota_cmd
+from ggshield.cmd.scan import scan_group
+from ggshield.cmd.status import status_cmd
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.utils import load_dot_env
 
 
-@scan.result_callback()
+@scan_group.result_callback()
 @click.pass_context
 def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> None:
     """
@@ -33,12 +33,12 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> None:
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]},
     commands={
-        "scan": scan,
-        "auth": auth,
-        "install": install,
-        "ignore": ignore,
-        "quota": quota,
-        "api-status": status,
+        "scan": scan_group,
+        "auth": auth_group,
+        "install": install_cmd,
+        "ignore": ignore_cmd,
+        "quota": quota_cmd,
+        "api-status": status_cmd,
     },
 )
 @click.option(

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -13,7 +13,7 @@ from ggshield.output.text.message import format_quota_color
 @click.command()
 @json_output_option_decorator
 @click.pass_context
-def quota(ctx: click.Context, json_output: bool) -> int:
+def quota_cmd(ctx: click.Context, json_output: bool) -> int:
     """Command to show quotas overview."""
     client: GGClient = retrieve_client(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -14,7 +14,7 @@ from ggshield.output.text.message import format_quota_color
 @json_output_option_decorator
 @click.pass_context
 def quota_cmd(ctx: click.Context, json_output: bool) -> int:
-    """Command to show quotas overview."""
+    """Show quotas overview."""
     client: GGClient = retrieve_client(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()
 

--- a/ggshield/cmd/scan/__init__.py
+++ b/ggshield/cmd/scan/__init__.py
@@ -102,7 +102,7 @@ def scan_group(
     exclude: Optional[List[str]] = None,
     ignore_default_excludes: bool = False,
 ) -> int:
-    """Command to scan various contents."""
+    """Commands to scan various contents."""
     ctx.obj["client"] = retrieve_client(ctx.obj["config"])
     return_code = 0
 

--- a/ggshield/cmd/scan/__init__.py
+++ b/ggshield/cmd/scan/__init__.py
@@ -90,7 +90,7 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     help="Ignore excluded patterns by default. [default: False]",
 )
 @click.pass_context
-def scan(
+def scan_group(
     ctx: click.Context,
     show_secrets: bool,
     exit_zero: bool,

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -12,7 +12,7 @@ from ggshield.output.text.message import format_healthcheck_status
 
 @click.command()
 @click.pass_context
-def status(ctx: click.Context, json_output: bool) -> int:
+def status_cmd(ctx: click.Context, json_output: bool) -> int:
     """Command to show api status."""
     client: GGClient = retrieve_client(ctx.obj["config"])
     response: HealthCheckResponse = client.health_check()
@@ -35,4 +35,4 @@ def status(ctx: click.Context, json_output: bool) -> int:
     return 0
 
 
-status = json_output_option_decorator(status)
+status = json_output_option_decorator(status_cmd)

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -13,7 +13,7 @@ from ggshield.output.text.message import format_healthcheck_status
 @click.command()
 @click.pass_context
 def status_cmd(ctx: click.Context, json_output: bool) -> int:
-    """Command to show api status."""
+    """Show API status."""
     client: GGClient = retrieve_client(ctx.obj["config"])
     response: HealthCheckResponse = client.health_check()
 

--- a/tests/cmd/scan/test_docker.py
+++ b/tests/cmd/scan/test_docker.py
@@ -1,5 +1,3 @@
-import re
-import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -7,7 +5,6 @@ import click
 import pytest
 
 from ggshield.cmd.main import cli
-from ggshield.scan.docker import docker_pull_image, docker_save_to_tmp
 from ggshield.scan.scannable import File, Files, ScanCollection
 from tests.conftest import _SIMPLE_SECRET, DATA_PATH, my_vcr
 
@@ -16,135 +13,6 @@ DOCKER_EXAMPLE_PATH = DATA_PATH / "docker-example.tar.xz"
 DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
     DATA_PATH / "docker-incomplete-manifest-example.tar.xz"
 )
-
-DOCKER_TIMEOUT = 12
-
-
-class TestDockerPull:
-    def test_docker_pull_image_success(self):
-        with patch("subprocess.run") as call:
-            docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
-            call.assert_called_once_with(
-                ["docker", "pull", "ggshield-non-existant"],
-                check=True,
-                timeout=DOCKER_TIMEOUT,
-            )
-
-    def test_docker_pull_image_non_exist(self):
-        with patch(
-            "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=[])
-        ):
-            with pytest.raises(
-                click.exceptions.ClickException,
-                match='Image "ggshield-non-existant" not found',
-            ):
-                docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
-
-    def test_docker_pull_image_timeout(self):
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=[], timeout=DOCKER_TIMEOUT),
-        ):
-            with pytest.raises(
-                click.exceptions.ClickException,
-                match='docker pull ggshield-non-existant" timed out',
-            ):
-                docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
-
-
-class TestDockerSave:
-    TMP_ARCHIVE = Path("/tmp/as/archive.tar")
-
-    def test_docker_save_image_success(self):
-        with patch("subprocess.run") as call:
-            docker_save_to_tmp(
-                "ggshield-non-existant", self.TMP_ARCHIVE, DOCKER_TIMEOUT
-            )
-            call.assert_called_once_with(
-                [
-                    "docker",
-                    "save",
-                    "ggshield-non-existant",
-                    "-o",
-                    str(self.TMP_ARCHIVE),
-                ],
-                check=True,
-                stderr=-1,
-                timeout=DOCKER_TIMEOUT,
-            )
-
-    def test_docker_save_image_does_not_exist(self):
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.CalledProcessError(
-                1, cmd=[], stderr="reference does not exist".encode("utf-8")
-            ),
-        ):
-            with pytest.raises(
-                click.exceptions.ClickException,
-                match='Image "ggshield-non-existant" not found',
-            ):
-                docker_save_to_tmp(
-                    "ggshield-non-existant", self.TMP_ARCHIVE, DOCKER_TIMEOUT
-                )
-
-    def test_docker_save_image_need_pull(self):
-        """
-        GIVEN a Docker image we do not have locally
-        WHEN we try to save it
-        THEN we first pull it and then save it
-
-        This test expects the following calls to `docker` commands:
-
-        - docker save <image_name> -o <something>
-          -> Fake failure
-        - docker pull <image_name>
-          -> Fake success
-        - docker save <image_name> -o <something>
-          -> Fake success
-        """
-        with patch(
-            "subprocess.run",
-            side_effect=[
-                subprocess.CalledProcessError(
-                    1, cmd=[], stderr="reference does not exist".encode("utf-8")
-                ),
-                None,
-                None,
-            ],
-        ):
-            docker_save_to_tmp(
-                "ggshield-non-existant", self.TMP_ARCHIVE, DOCKER_TIMEOUT
-            )
-
-    def test_docker_save_image_fails(self):
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.CalledProcessError(
-                1, cmd=[], stderr="docker failed weirdly".encode("utf-8")
-            ),
-        ):
-            with pytest.raises(
-                click.exceptions.ClickException,
-                match="Unable to save docker archive:",
-            ):
-                docker_save_to_tmp(
-                    "ggshield-non-existant", self.TMP_ARCHIVE, DOCKER_TIMEOUT
-                )
-
-    def test_docker_save_image_timeout(self):
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=[], timeout=DOCKER_TIMEOUT),
-        ):
-            expected_msg = f'Command "docker save ggshield-non-existant -o {str(self.TMP_ARCHIVE)}" timed out'  # noqa: E501
-            with pytest.raises(
-                click.exceptions.ClickException,
-                match=re.escape(expected_msg),
-            ):
-                docker_save_to_tmp(
-                    "ggshield-non-existant", self.TMP_ARCHIVE, DOCKER_TIMEOUT
-                )
 
 
 class TestDockerCMD:


### PR DESCRIPTION
This PR is a follow-up to #207.

What has been done:

- Improve naming consistency inside the `cmd` package: all command functions end with `_cmd()`, all group functions end with `_group()`
- Improve help messages
- Move some cli-independent docker tests from tests.cmd.scan.test_docker to tests.scan.test_scan_docker
