### PR TITLE
feat(headers): Completely replace mode_header with Click context

### DIFF
--- a/ggshield/cmd/scan/prepush.py
+++ b/ggshield/cmd/scan/prepush.py
@@ -5,12 +5,7 @@ from typing import List, Optional, Tuple
 import click
 
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
-from ggshield.core.utils import (
-    EMPTY_SHA,
-    EMPTY_TREE,
-    SupportedScanMode,
-    handle_exception,
-)
+from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, handle_exception
 from ggshield.scan.repo import scan_commit_range
 
 
@@ -77,7 +72,6 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
             scan_id=" ".join(commit_list),
-            mode_header=SupportedScanMode.PRE_PUSH.value,
             banlisted_detectors=config.banlisted_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/scan/prereceive.py
+++ b/ggshield/cmd/scan/prereceive.py
@@ -13,7 +13,6 @@ from ggshield.core.utils import (
     EMPTY_SHA,
     EMPTY_TREE,
     PRERECEIVE_TIMEOUT,
-    SupportedScanMode,
     handle_exception,
 )
 from ggshield.output import GitLabWebUIOutputHandler
@@ -156,7 +155,6 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 matches_ignore=config.matches_ignore,
                 all_policies=config.all_policies,
                 scan_id=" ".join(commit_list),
-                mode_header=SupportedScanMode.PRE_RECEIVE.value,
                 banlisted_detectors=config.banlisted_detectors,
             )
             if return_code:

--- a/ggshield/cmd/scan/range.py
+++ b/ggshield/cmd/scan/range.py
@@ -1,7 +1,7 @@
 import click
 
 from ggshield.core.git_shell import get_list_commit_SHA
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import handle_exception
 from ggshield.scan.repo import scan_commit_range
 
 
@@ -33,7 +33,6 @@ def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
             scan_id=commit_range,
-            mode_header=SupportedScanMode.COMMIT_RANGE.value,
             banlisted_detectors=config.banlisted_detectors,
         )
     except Exception as error:

--- a/ggshield/core/extra_headers.py
+++ b/ggshield/core/extra_headers.py
@@ -1,0 +1,36 @@
+from typing import Dict, Optional
+
+import click
+
+
+def add_extra_header(ctx: Optional[click.Context], key: str, value: str) -> None:
+    """
+    Stores an extra header in the command's context.
+    Existing headers cannot be overwritten.
+    """
+    if ctx is None:
+        return
+
+    if not isinstance(ctx.obj, dict):
+        ctx.obj = {"headers": {}}
+    if "headers" not in ctx.obj:
+        ctx.obj["headers"] = {}
+
+    if key not in ctx.obj["headers"]:
+        ctx.obj["headers"][key] = value
+
+
+def get_extra_headers(ctx: Optional[click.Context]) -> Dict[str, str]:
+    """
+    Returns the extra headers stored in the command's context.
+    Adds the prefix "GGShield-" to the header's names.
+    """
+    if (
+        ctx is not None
+        and isinstance(ctx.obj, dict)
+        and isinstance(ctx.obj.get("headers"), dict)
+    ):
+        return {
+            str(key): f"GGShield-{value}" for key, value in ctx.obj["headers"].items()
+        }
+    return {}

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -222,19 +222,6 @@ class SupportedCI(Enum):
     AZURE = "AZURE PIPELINES"
 
 
-class SupportedScanMode(Enum):
-    REPO = "repo"
-    PATH = "path"
-    COMMIT_RANGE = "commit_range"
-    PRE_COMMIT = "pre_commit"
-    PRE_PUSH = "pre_push"
-    PRE_RECEIVE = "pre_receive"
-    CI = "ci"
-    DOCKER = "docker"
-    PYPI = "pypi"
-    ARCHIVE = "archive"
-
-
 json_output_option_decorator = click.option(
     "--json",
     "json_output",

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -13,7 +13,7 @@ from ggshield.core.constants import CPU_COUNT
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import Commit, ScanCollection
 
@@ -51,7 +51,6 @@ def scan_repo_path(
                 matches_ignore=config.matches_ignore,
                 all_policies=config.all_policies,
                 scan_id=scan_id,
-                mode_header=SupportedScanMode.REPO.value,
                 banlisted_detectors=config.banlisted_detectors,
             )
     except Exception as error:
@@ -65,7 +64,6 @@ def scan_commit(
     verbose: bool,
     matches_ignore: Iterable[IgnoredMatch],
     all_policies: bool,
-    mode_header: str,
     banlisted_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:  # pragma: no cover
     results = commit.scan(
@@ -96,7 +94,6 @@ def scan_commit_range(
     matches_ignore: Iterable[IgnoredMatch],
     all_policies: bool,
     scan_id: str,
-    mode_header: str,
     banlisted_detectors: Optional[Set[str]] = None,
 ) -> int:  # pragma: no cover
     """
@@ -119,7 +116,6 @@ def scan_commit_range(
                 verbose,
                 matches_ignore,
                 all_policies,
-                mode_header,
                 banlisted_detectors,
             )
             for sha in commit_list

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -20,6 +20,7 @@ from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.types import IgnoredMatch
 from ggshield.core.utils import REGEX_HEADER_INFO, Filemode
 
+from ..core.extra_headers import get_extra_headers
 from .scannable_errors import handle_scan_error
 
 
@@ -116,12 +117,14 @@ class Files:
         # get_current_context returns None if outside a click command.
         # It happens in the tests and if gg-shield is used as a library.
         context = click.get_current_context(silent=True)
+        extra_headers = get_extra_headers(context)
 
         command_path = context.command_path if context is not None else "external"
 
         return {
             "GGShield-Version": __version__,
             "GGShield-Command-Path": command_path,
+            **extra_headers,
         }
 
     def scan(

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -114,7 +114,6 @@ class TestPrepush:
             matches_ignore=ANY,
             all_policies=False,
             scan_id=ANY,
-            mode_header="pre_push",
             banlisted_detectors=set(),
         )
         assert "Commits to scan: 20" in result.output


### PR DESCRIPTION
`mode_header` was still present in the code even if it was unused.

It was used to pass details about the type of CI in the headers, I've replaced it by using `obj` in Click's context to pass info to the function building the headers.