### PR TITLE
Fix GitGuardian metadata check during web authentication process

### DIFF
--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -33,11 +33,7 @@ def create_client(
     Implementation of create_client_from_config(). Exposed as a function for specific
     cases such as needing a GGClient instance while defining the config account.
     """
-    session = Session()
-    if allow_self_signed:
-        urllib3.disable_warnings()
-        session.verify = False
-
+    session = create_session(allow_self_signed=allow_self_signed)
     try:
         return GGClient(
             api_key=api_key,
@@ -49,3 +45,11 @@ def create_client(
     except ValueError as e:
         # Can be raised by pygitguardian
         raise click.ClickException(f"Failed to create API client. {e}")
+
+
+def create_session(allow_self_signed: bool = False) -> Session:
+    session = Session()
+    if allow_self_signed:
+        urllib3.disable_warnings()
+        session.verify = False
+    return session

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -9,12 +9,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, Optional, Type, no_type_check
 
 import click
-import requests
 from oauthlib.oauth2 import OAuth2Error, WebApplicationClient
 
 from ggshield.core.utils import urljoin
 
-from .client import create_client
+from .client import create_client, create_session
 from .config import AccountConfig, Config, InstanceConfig
 
 
@@ -214,7 +213,8 @@ class OAuthClient:
             body=urlparse.urlencode(request_params),
         )
 
-        response = requests.post(
+        session = create_session(self.config.allow_self_signed)
+        response = session.post(
             urljoin(self.api_url, "/v1/oauth/token"),
             request_body,
             headers={"Content-Type": "application/x-www-form-urlencoded"},

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -332,3 +332,23 @@ def api_to_dashboard_url(api_url: str, warn: bool = False) -> str:
             path=parsed_url.path[: -len(ON_PREMISE_API_URL_PATH_PREFIX)]
         )
     return parsed_url.geturl()
+
+
+def urljoin(url: str, *args: str) -> str:
+    """
+    concatenate each argument with a slash if not already existing.
+    unlike urllib.parse.urljoin, this will make sure each element
+    is separated by a slash e.g.
+    ('http://somesite.com/path1', 'path2') -> http://somesite.com/path1/path2
+    ('http://somesite.com/path1/', 'path2') -> http://somesite.com/path1/path2
+    ('http://somesite.com/path1', '/path2') -> http://somesite.com/path1/path2
+    """
+    if url[-1] == "/":
+        url = url[:-1]
+
+    for url_part in args:
+        if url_part[0] != "/":
+            url_part = "/" + url_part
+        url += url_part
+
+    return url

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -491,7 +491,7 @@ class TestAuthLoginWeb:
         """
 
         (url, payload), kwargs = self._client_post_mock.call_args_list[0]
-        assert url == "https://api.gitguardian.com/oauth/token"
+        assert url == "https://api.gitguardian.com/v1/oauth/token"
 
         request_body = urlparse.parse_qs(payload)
 
@@ -568,8 +568,8 @@ class TestAuthLoginWeb:
         THEN it succeeds if the version is high enough, and the preference is enabled
         """
 
-        def client_get_mock(*args, endpoint, **kwargs):
-            if endpoint == "metadata":
+        def client_get_mock(self_, url, **kwargs):
+            if url.endswith("/v1/metadata"):
                 return Mock(
                     ok=status_code < 400,
                     status_code=status_code,
@@ -584,7 +584,7 @@ class TestAuthLoginWeb:
                 )
             raise NotImplementedError
 
-        monkeypatch.setattr("ggshield.core.client.GGClient.get", client_get_mock)
+        monkeypatch.setattr("ggshield.core.client.Session.get", client_get_mock)
 
         if expected_error:
             with pytest.raises(ClickException, match=expected_error):

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -382,7 +382,7 @@ class TestAuthLoginWeb:
                 ),
             )
         )
-        monkeypatch.setattr("ggshield.core.oauth.requests.post", self._client_post_mock)
+        monkeypatch.setattr("ggshield.core.client.Session.post", self._client_post_mock)
 
         # mock api call to test the access token
         self._client_get_mock = Mock(


### PR DESCRIPTION
The request to check the metadata was including the token in the headers. However this endpoint is public and doesn't expect any.

* manually call "metadata" endpoint during the auth process to avoid passing the token
* implement a custom `urljoin` helper to allow joining non-slash-trailing url parts (otherwise it would squeeze the '/v1') 