### PR TITLE
Skip auth if existing token

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -63,7 +63,7 @@ def login_cmd(
     except UnknownInstanceError:
         # account is initialized as None because the instance must exist in
         # the config before using the client
-        instance_config = InstanceConfig(account=None, url=instance)  # type: ignore
+        instance_config = InstanceConfig(account=None, url=instance)
         config.auth_config.instances.append(instance_config)
 
     if method == "token":

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -84,7 +84,7 @@ class OAuthClient:
         self._wait_for_callback()
 
         message = f"Created Personal Access Token {self._token_name} "
-        expire_at = self.instance_config.account.expire_at
+        expire_at = self.instance_config.account.expire_at  # type: ignore
         if expire_at is not None:
             message += "expiring on " + get_pretty_date(expire_at)
         else:

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -266,7 +266,7 @@ class OAuthClient:
 
     @property
     def instance_config(self) -> InstanceConfig:
-        return self.config.auth_config.instances[self.instance]
+        return self.config.auth_config.get_instance(self.instance)
 
     @property
     def default_token_lifetime(self) -> Optional[int]:


### PR DESCRIPTION
When using the web auth login method, if a token is found in the config for the current instance, skip the process with an explicit message.

This also include refactoring how the instance config are stored. instead of using a dict we know use a list.
This is not a real performance issue as the end users are not supposed to have many instances at once.
All the tests have been adapted to suit this new configuration file.