### PR TITLE
Add auth logout command

### DIFF
--- a/ggshield/cmd/auth/__init__.py
+++ b/ggshield/cmd/auth/__init__.py
@@ -1,8 +1,9 @@
 import click
 
 from .login import login_cmd
+from .logout import logout_cmd
 
 
-@click.group(commands={"login": login_cmd})
+@click.group(commands={"login": login_cmd, "logout": logout_cmd})
 def auth_group() -> None:
     """Commands to manage authentication."""

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -1,0 +1,81 @@
+import click
+from requests.exceptions import ConnectionError
+
+from ggshield.core.client import create_client
+from ggshield.core.config import Config
+from ggshield.core.utils import dashboard_to_api_url
+
+
+REVOKE_FAIL_MESSAGE = (
+    "Logout failed due to an error when revoking the token, "
+    "you can skip revocation with --no-revoke to bypass"
+)
+
+
+@click.command()
+@click.option(
+    "--instance",
+    required=False,
+    type=str,
+    help="URL of the instance to logout from.",
+)
+@click.pass_context
+def logout_cmd(ctx: click.Context, instance: str) -> int:
+    """
+    Delete saved authentication details for the specified instance (or default instance if not specified)
+    By default, this will also try to revoke found tokens unless --no-revoke is specified.\n
+    If --all is specified, it will iterate over all instances.
+    """
+
+    config = ctx.obj["config"]
+
+    if not instance:
+        instance = config.instance_name
+
+    check_account_config_exists(config, instance)
+    revoke_token(config, instance)
+    logout(config, instance)
+    return 0
+
+
+def check_account_config_exists(config: Config, instance_url: str) -> None:
+    instance = config.auth_config.get_instance(instance_url)
+    if instance.account is None:
+        raise click.ClickException(f"No token found for instance {instance_url}.")
+
+
+def revoke_token(config: Config, instance_url: str) -> None:
+
+    instance = config.auth_config.get_instance(instance_url)
+
+    assert instance.account is not None
+    token = instance.account.token
+    token_name = instance.account.token_name
+
+    client = create_client(
+        token,
+        dashboard_to_api_url(instance_url),
+        allow_self_signed=config.allow_self_signed,
+    )
+    try:
+        response = client.post(endpoint="token/revoke")
+    except ConnectionError:
+        raise click.ClickException(REVOKE_FAIL_MESSAGE)
+
+    if response.status_code != 204:
+        raise click.ClickException(REVOKE_FAIL_MESSAGE)
+
+    click.echo(f"Personal Access Token {token_name} has been revoked")
+
+
+def logout(config: Config, instance: str) -> None:
+    instance_config = config.auth_config.get_instance(instance)
+    account_config = instance_config.account
+
+    assert account_config is not None
+
+    instance_config.account = None
+    config.auth_config.set_instance(instance_config)
+    config.save()
+
+    click.echo(f"Logged out from instance {instance}")

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -19,8 +19,14 @@ REVOKE_FAIL_MESSAGE = (
     type=str,
     help="URL of the instance to logout from.",
 )
+@click.option(
+    "--revoke/--no-revoke",
+    is_flag=True,
+    default=True,
+    help="Whether the token should be revoked before being removed from the config.",
+)
 @click.pass_context
-def logout_cmd(ctx: click.Context, instance: str) -> int:
+def logout_cmd(ctx: click.Context, instance: str, revoke: bool) -> int:
     """
     Delete saved authentication details for the specified instance (or default instance if not specified)
     By default, this will also try to revoke found tokens unless --no-revoke is specified.\n
@@ -33,7 +39,8 @@ def logout_cmd(ctx: click.Context, instance: str) -> int:
         instance = config.instance_name
 
     check_account_config_exists(config, instance)
-    revoke_token(config, instance)
+    if revoke:
+        revoke_token(config, instance)
     logout(config, instance)
     return 0
 

--- a/ggshield/core/config.py
+++ b/ggshield/core/config.py
@@ -249,7 +249,9 @@ class InstanceConfig:
         assert (
             len(accounts) == 1
         ), "Each GitGuardian instance should have exactly one account"
-        data["account"] = AccountConfig(**data.pop("accounts")[0])
+
+        account = data.pop("accounts")[0]
+        data["account"] = AccountConfig(**account) if account is not None else None
         return cls(**data)
 
     def to_dict(self) -> Union[List, Dict]:
@@ -352,6 +354,15 @@ class AuthConfig(YAMLFileConfig):
                 return instance
         else:
             raise UnknownInstanceError(instance=instance_name)
+
+    def set_instance(self, instance_config: InstanceConfig) -> None:
+        instance_name = instance_config.url
+        for i, instance in enumerate(self.instances):
+            if instance.url == instance_name or instance.name == instance_name:
+                self.instances[i] = instance_config
+                break
+        else:
+            self.instances.append(instance_config)
 
     def get_instance_token(self, instance_name: str) -> str:
         """

--- a/tests/cmd/auth/utils.py
+++ b/tests/cmd/auth/utils.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Optional
+
+from ggshield.core.config import AccountConfig, Config, InstanceConfig
+
+
+def prepare_config(
+    instance_url: Optional[str] = None,
+    token_name: Optional[str] = None,
+    expiry_date: Optional[datetime] = None,
+    with_account: Optional[bool] = True,
+):
+    """
+    Helper to save a token in the configuration
+    """
+    instance_url = instance_url or "https://dashboard.gitguardian.com"
+    token_name = token_name or "some token name"
+
+    if with_account:
+        account_config = AccountConfig(
+            account_id=1,
+            token="some token",
+            expire_at=expiry_date,
+            token_name=token_name,
+            type="",
+        )
+    else:
+        account_config = None
+
+    instance_config = InstanceConfig(
+        account=account_config,
+        url=instance_url,
+    )
+    config = Config()
+    config.auth_config.instances.append(instance_config)
+    config.save()


### PR DESCRIPTION
Add the `logout` command to ggshield client. It will delete the local configuration and attempt to revoke the token at the same time.

- implement the command `ggshield auth logout`
- it should remove the local configuration
- if `--instance` is not specified, it will resort to the default one
- it should revoke the old token by default unless `--no-revoke` option is passed
- if the `--all` option is passed, it will iterate over all found configs (`--instance` is ignored in this case)