### PR TITLE
fix: send verbose messages to stderr

### DIFF
--- a/ggshield/cmd/scan/archive.py
+++ b/ggshield/cmd/scan/archive.py
@@ -1,4 +1,5 @@
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
@@ -37,7 +38,7 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
         )
 
         with click.progressbar(
-            length=len(files.files), label="Scanning"
+            length=len(files.files), label="Scanning", file=sys.stderr
         ) as progressbar:
 
             def update_progress(chunk: List[Dict[str, Any]]) -> None:

--- a/ggshield/cmd/scan/ci.py
+++ b/ggshield/cmd/scan/ci.py
@@ -25,7 +25,8 @@ def jenkins_range(verbose: bool) -> List[str]:  # pragma: no cover
 
     if verbose:
         click.echo(
-            f"\tGIT_COMMIT: {head_commit}" f"\nGIT_PREVIOUS_COMMIT: {previous_commit}"
+            f"\tGIT_COMMIT: {head_commit}" f"\nGIT_PREVIOUS_COMMIT: {previous_commit}",
+            err=True,
         )
 
     if previous_commit:
@@ -51,7 +52,8 @@ def travis_range(verbose: bool) -> List[str]:  # pragma: no cover
 
     if verbose:
         click.echo(
-            f"TRAVIS_COMMIT_RANGE: {commit_range}" f"\nTRAVIS_COMMIT: {commit_sha}"
+            f"TRAVIS_COMMIT_RANGE: {commit_range}" f"\nTRAVIS_COMMIT: {commit_sha}",
+            err=True,
         )
 
     if commit_range:
@@ -74,7 +76,7 @@ def travis_range(verbose: bool) -> List[str]:  # pragma: no cover
 def bitbucket_pipelines_range(verbose: bool) -> List[str]:  # pragma: no cover
     commit_sha = os.getenv("BITBUCKET_COMMIT", "HEAD")
     if verbose:
-        click.echo(f"BITBUCKET_COMMIT: {commit_sha}")
+        click.echo(f"BITBUCKET_COMMIT: {commit_sha}", err=True)
 
     commit_list = get_list_commit_SHA("{}~1...".format(commit_sha))
     if commit_list:
@@ -101,7 +103,9 @@ def circle_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
     commit_sha = os.getenv("CIRCLE_SHA1", "HEAD")
 
     if verbose:
-        click.echo(f"CIRCLE_RANGE: {compare_range}\nCIRCLE_SHA1: {commit_sha}")
+        click.echo(
+            f"CIRCLE_RANGE: {compare_range}\nCIRCLE_SHA1: {commit_sha}", err=True
+        )
 
     if compare_range and not compare_range.startswith("..."):
         commit_list = get_list_commit_SHA(compare_range)
@@ -129,7 +133,8 @@ def gitlab_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
         click.echo(
             f"CI_MERGE_REQUEST_TARGET_BRANCH_NAME: {merge_request_target_branch}\n"
             f"CI_COMMIT_BEFORE_SHA: {before_sha}\n"
-            f"CI_COMMIT_SHA: {commit_sha}"
+            f"CI_COMMIT_SHA: {commit_sha}",
+            err=True,
         )
 
     if before_sha and before_sha != EMPTY_SHA:
@@ -170,7 +175,8 @@ def github_actions_range(verbose: bool) -> List[str]:  # pragma: no cover
             f"github_push_base_sha: {push_base_sha}\n"
             f"github_pull_base_sha: {pull_req_base_sha}\n"
             f"github_default_branch: {default_branch}\n"
-            f"github_head_sha: {head_sha}"
+            f"github_head_sha: {head_sha}",
+            err=True,
         )
 
     if push_before_sha and push_before_sha != EMPTY_SHA:
@@ -213,7 +219,7 @@ def drone_range(verbose: bool) -> List[str]:  # pragma: no cover
     before_sha = os.getenv("DRONE_COMMIT_BEFORE")
 
     if verbose:
-        click.echo(f"DRONE_COMMIT_BEFORE: {before_sha}\n")
+        click.echo(f"DRONE_COMMIT_BEFORE: {before_sha}\n", err=True)
 
     if before_sha and before_sha != EMPTY_SHA:
         commit_list = get_list_commit_SHA("{}..".format(before_sha))
@@ -231,7 +237,7 @@ def azure_range(verbose: bool) -> List[str]:  # pragma: no cover
     head_commit = os.getenv("BUILD_SOURCEVERSION")
 
     if verbose:
-        click.echo(f"BUILD_SOURCEVERSION: {head_commit}\n")
+        click.echo(f"BUILD_SOURCEVERSION: {head_commit}\n", err=True)
 
     if head_commit:
         commit_list = get_list_commit_SHA("{}~1...".format(head_commit))
@@ -292,7 +298,7 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
         add_extra_header(ctx, "Ci-Mode", ci_mode.name)
 
         if config.verbose:
-            click.echo(f"Commits to scan: {len(commit_list)}")
+            click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 
         return scan_commit_range(
             client=ctx.obj["client"],

--- a/ggshield/cmd/scan/prepush.py
+++ b/ggshield/cmd/scan/prepush.py
@@ -23,12 +23,13 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
         local_commit, remote_commit = collect_from_stdin()
 
     if local_commit == EMPTY_SHA:
-        click.echo("Deletion event or nothing to scan.")
+        click.echo("Deletion event or nothing to scan.", err=True)
         return 0
 
     if remote_commit == EMPTY_SHA:
         click.echo(
-            f"New tree event. Scanning last {config.max_commits_for_hook} commits."
+            f"New tree event. Scanning last {config.max_commits_for_hook} commits.",
+            err=True,
         )
         before = EMPTY_TREE
         after = local_commit
@@ -47,18 +48,20 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             "Unable to get commit range.\n"
             f"  before: {before}\n"
             f"  after: {after}\n"
-            "Skipping pre-push hook\n"
+            "Skipping pre-push hook\n",
+            err=True,
         )
         return 0
 
     if len(commit_list) > config.max_commits_for_hook:
         click.echo(
-            f"Too many commits. Scanning last {config.max_commits_for_hook} commits\n"
+            f"Too many commits. Scanning last {config.max_commits_for_hook} commits\n",
+            err=True,
         )
         commit_list = commit_list[-config.max_commits_for_hook :]
 
     if config.verbose:
-        click.echo(f"Commits to scan: {len(commit_list)}")
+        click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 
     try:
         check_git_dir()

--- a/ggshield/cmd/scan/prereceive.py
+++ b/ggshield/cmd/scan/prereceive.py
@@ -92,7 +92,10 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
         output_handler = GitLabWebUIOutputHandler(show_secrets=config.show_secrets)
 
     if get_breakglass_option():
-        click.echo("SKIP: breakglass detected. Skipping GitGuardian pre-receive hook.")
+        click.echo(
+            "SKIP: breakglass detected. Skipping GitGuardian pre-receive hook.",
+            err=True,
+        )
         return 0
 
     args = sys.stdin.read().strip().split()
@@ -103,7 +106,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
     commit_list = []
 
     if after == EMPTY_SHA:
-        click.echo("Deletion event or nothing to scan.")
+        click.echo("Deletion event or nothing to scan.", err=True)
         return 0
 
     if before == EMPTY_SHA:
@@ -115,10 +118,11 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
         if not commit_list:
             before = EMPTY_TREE
             click.echo(
-                f"New tree event. Scanning last {config.max_commits_for_hook} commits."
+                f"New tree event. Scanning last {config.max_commits_for_hook} commits.",
+                err=True,
             )
             commit_list = get_list_commit_SHA(
-                f"--max-count={config.max_commits_for_hook+1} {EMPTY_TREE} {after}"
+                f"--max-count={config.max_commits_for_hook+1} {EMPTY_TREE} {after}",
             )
     else:
         commit_list = get_list_commit_SHA(
@@ -130,18 +134,20 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
             "Unable to get commit range.\n"
             f"  before: {before}\n"
             f"  after: {after}\n"
-            "Skipping pre-receive hook\n"
+            "Skipping pre-receive hook\n",
+            err=True,
         )
         return 0
 
     if len(commit_list) > config.max_commits_for_hook:
         click.echo(
-            f"Too many commits. Scanning last {config.max_commits_for_hook} commits\n"
+            f"Too many commits. Scanning last {config.max_commits_for_hook} commits\n",
+            err=True,
         )
         commit_list = commit_list[-config.max_commits_for_hook :]
 
     if config.verbose:
-        click.echo(f"Commits to scan: {len(commit_list)}")
+        click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 
     try:
         with ExitAfter(get_prereceive_timeout()):
@@ -167,7 +173,8 @@ you can set up ggshield in your pre commit:
 https://docs.gitguardian.com/internal-repositories-monitoring/integrations/git_hooks/pre_commit
 
 Use it carefully: if those secrets are false positives and you still want your push to pass, run:
-'git push -o breakglass'"""
+'git push -o breakglass'""",
+                    err=True,
                 )
             return return_code
     except TimeoutError:

--- a/ggshield/cmd/scan/pypi.py
+++ b/ggshield/cmd/scan/pypi.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Set
@@ -27,14 +28,15 @@ def save_package_to_tmp(temp_dir: str, package_name: str) -> None:
     ]
 
     try:
-        click.echo("Downloading pip package... ", nl=False)
+        click.echo("Downloading pip package... ", nl=False, err=True)
         subprocess.run(
             command,
             check=True,
-            stderr=subprocess.PIPE,
+            stdout=sys.stderr,
+            stderr=sys.stderr,
             timeout=PYPI_DOWNLOAD_TIMEOUT,
         )
-        click.echo("OK")
+        click.echo("OK", err=True)
 
     except subprocess.CalledProcessError:
         raise click.ClickException(f'Failed to download "{package_name}"')
@@ -95,7 +97,7 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
         )
 
         with click.progressbar(
-            length=len(files.files), label="Scanning"
+            length=len(files.files), label="Scanning", file=sys.stderr
         ) as progressbar:
 
             def update_progress(chunk: List[Dict[str, Any]]) -> None:

--- a/ggshield/cmd/scan/range.py
+++ b/ggshield/cmd/scan/range.py
@@ -21,7 +21,7 @@ def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
         if not commit_list:
             raise click.ClickException("invalid commit range")
         if config.verbose:
-            click.echo(f"Commits to scan: {len(commit_list)}")
+            click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 
         return scan_commit_range(
             client=ctx.obj["client"],

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -38,7 +38,7 @@ def get_files_from_paths(
 
     if verbose:
         for f in files:
-            click.echo(f"- {click.format_filename(f.filename)}")
+            click.echo(f"- {click.format_filename(f.filename)}", err=True)
 
     size = len(files)
     if size > 1 and not yes:
@@ -94,11 +94,11 @@ def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterator[F
         file_size = os.path.getsize(path)
         if file_size > MAX_FILE_SIZE:
             if verbose:
-                click.echo(f"ignoring file over 1MB: {path}")
+                click.echo(f"ignoring file over 1MB: {path}", err=True)
             continue
         if path.endswith(BINARY_FILE_EXTENSIONS):
             if verbose:
-                click.echo(f"ignoring binary file extension: {path}")
+                click.echo(f"ignoring binary file extension: {path}", err=True)
             continue
         with open(path, "rb") as file:
             content = file.read()

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -2,6 +2,7 @@ import json
 import os.path
 import re
 import subprocess
+import sys
 import tarfile
 from itertools import chain
 from pathlib import Path
@@ -239,7 +240,9 @@ def docker_scan_archive(
     banlisted_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:
     files = get_files_from_docker_archive(archive)
-    with click.progressbar(length=len(files.files), label="Scanning") as progressbar:
+    with click.progressbar(
+        length=len(files.files), label="Scanning", file=sys.stderr
+    ) as progressbar:
 
         def update_progress(chunk: List[Dict[str, Any]]) -> None:
             progressbar.update(len(chunk))

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import os
 import re
+import sys
 from contextlib import contextmanager
 from typing import Iterable, Iterator, List, Optional, Set
 
@@ -126,6 +127,7 @@ def scan_commit_range(
             iterable=concurrent.futures.as_completed(future_to_process),
             length=len(future_to_process),
             label=format_text("Scanning Commits", STYLE["progress"]),
+            file=sys.stderr,
         ) as completed_futures:
             for future in completed_futures:
                 scans.append(future.result())

--- a/tests/cmd/scan/test_docker.py
+++ b/tests/cmd/scan/test_docker.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -68,11 +69,13 @@ class TestDockerCMD:
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
+    @pytest.mark.parametrize("json_output", (False, True))
     def test_docker_scan_archive(
         self,
         get_files_mock: Mock,
         cli_fs_runner: click.testing.CliRunner,
         image_path: Path,
+        json_output: bool,
     ):
         assert image_path.exists()
 
@@ -80,15 +83,23 @@ class TestDockerCMD:
             files=[File(document=_SIMPLE_SECRET, filename="file_secret")]
         )
         with my_vcr.use_cassette("test_scan_file_secret"):
+            json_arg = ["--json"] if json_output else []
+            cli_fs_runner.mix_stderr = False
             result = cli_fs_runner.invoke(
                 cli,
                 [
                     "-v",
                     "scan",
+                    *json_arg,
                     "docker-archive",
                     str(image_path),
                 ],
             )
             get_files_mock.assert_called_once()
-            assert "1 incident has been found in file file_secret" in result.output
             assert result.exit_code == 1
+
+            if json_output:
+                output = json.loads(result.output)
+                assert len(output["entities_with_incidents"]) == 1
+            else:
+                assert "1 incident has been found in file file_secret" in result.output

--- a/tests/cmd/scan/test_pypi.py
+++ b/tests/cmd/scan/test_pypi.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Set
 from unittest.mock import Mock, patch
@@ -32,7 +33,8 @@ class TestPipDownload:
                     "--no-deps",
                 ],
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=sys.stderr,
+                stderr=sys.stderr,
                 timeout=PYPI_DOWNLOAD_TIMEOUT,
             )
 


### PR DESCRIPTION
Send verbose messages to stderr to fix `--json` and `--verbose` behavior.

Closes #157 