### PR TITLE
feat: print "No secrets have been found" when no secrets are found 

### DIFF
--- a/ggshield/output/text/text_output_handler.py
+++ b/ggshield/output/text/text_output_handler.py
@@ -49,13 +49,12 @@ class TextOutputHandler(OutputHandler):
             for result in scan.results:
                 scan_buf.write(self.process_result(result))
         else:
-            if self.verbose:
-                has_results = False
-                if scan.scans:
-                    has_results = any(x.results for x in scan.scans)
+            has_results = False
+            if scan.scans:
+                has_results = any(x.results for x in scan.scans)
 
-                if not has_results:
-                    scan_buf.write(no_leak_message())
+            if not has_results:
+                scan_buf.write(no_leak_message())
 
         if scan.scans:
             for sub_scan in scan.scans:

--- a/tests/cmd/scan/test_path.py
+++ b/tests/cmd/scan/test_path.py
@@ -32,11 +32,15 @@ class TestPathScan:
         Path("file2").write_text("This is a file with no secrets.")
 
     @my_vcr.use_cassette("test_scan_file")
-    def test_scan_file(self, cli_fs_runner):
+    @pytest.mark.parametrize("verbose", [True, False])
+    def test_scan_file(self, cli_fs_runner, verbose):
         Path("file").write_text("This is a file with no secrets.")
         assert os.path.isfile("file")
 
-        result = cli_fs_runner.invoke(cli, ["-v", "scan", "path", "file"])
+        if verbose:
+            result = cli_fs_runner.invoke(cli, ["-v", "scan", "path", "file"])
+        else:
+            result = cli_fs_runner.invoke(cli, ["scan", "path", "file"])
         assert not result.exception
         assert "No secrets have been found" in result.output
 


### PR DESCRIPTION
Print "No secrets have been found" when no secrets are found even in non verbose mode.

### Testing
- Added a test to check the output without the verbose tag

### Issue
- Closes #117 