### PR TITLE
feat(auth): implement the --sso-url parameter to specify a SSO page to use for authentication

### DIFF
--- a/ggshield/core/config.py
+++ b/ggshield/core/config.py
@@ -355,6 +355,16 @@ class AuthConfig(YAMLFileConfig):
         else:
             raise UnknownInstanceError(instance=instance_name)
 
+    def get_or_create_instance(self, instance_name: str) -> InstanceConfig:
+        try:
+            instance_config = self.get_instance(instance_name=instance_name)
+        except UnknownInstanceError:
+            # account is initialized as None because the instance must exist in
+            # the config before using the client
+            instance_config = InstanceConfig(account=None, url=instance_name)
+            self.instances.append(instance_config)
+        return instance_config
+
     def set_instance(self, instance_config: InstanceConfig) -> None:
         instance_name = instance_config.url
         for i, instance in enumerate(self.instances):

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -62,6 +62,7 @@ class OAuthClient:
         self._oauth_client = WebApplicationClient(CLIENT_ID)
         self._state = ""  # use the `state` property instead
         self._lifetime: Optional[int] = None
+        self._login_path = "auth/login"
 
         self._handler_wrapper = RequestHandlerWrapper(oauth_client=self)
         self._access_token: Optional[str] = None
@@ -71,7 +72,10 @@ class OAuthClient:
         self._generate_pkce_pair()
 
     def oauth_process(
-        self, token_name: Optional[str] = None, lifetime: Optional[int] = None
+        self,
+        token_name: Optional[str] = None,
+        lifetime: Optional[int] = None,
+        login_path: Optional[str] = None,
     ) -> None:
         """
         Handle the whole oauth process which includes
@@ -88,6 +92,8 @@ class OAuthClient:
         if token_name is None:
             token_name = "ggshield token " + datetime.today().strftime("%Y-%m-%d")
         self._token_name = token_name
+        if login_path is not None:
+            self._login_path = login_path
 
         if lifetime is None:
             lifetime = self.default_token_lifetime
@@ -145,7 +151,7 @@ class OAuthClient:
             "utm_campaign": "ggshield",
         }
         request_uri = self._oauth_client.prepare_request_uri(
-            uri=urljoin(self.dashboard_url, "auth/login"),
+            uri=urljoin(self.dashboard_url, self._login_path),
             redirect_uri=self.redirect_uri,
             scope=SCOPE,
             code_challenge=self.code_challenge,


### PR DESCRIPTION
This adds an optional `--sso-url` parameter to the `ggshield auth login` command. to use with `--method=web`.

- it handles the collision with a `--instance` declaring another host.
- it handles deducing the instance from the sso url if the instance is not specified in the command.