### PR TITLE
Do not crash if we receive an unsupported validity check

### DIFF
--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -105,12 +105,20 @@ def display_error(msg: str) -> None:
 
 
 _VALIDITY_TEXT_FOR_ID = {
-    "cannot_check": "Cannot Check",
-    "invalid": "Invalid",
     "unknown": "Unknown",
+    # cannot_check is the old ID for secrets for which there are no checkers
+    "cannot_check": "Cannot Check",
+    "no_checker": "No Checker",
+    "failed_to_check": "Failed to Check",
+    "not_checked": "Not Checked",
+    "invalid": "Invalid",
     "valid": "Valid",
 }
 
 
 def translate_validity(validity_id: Optional[str]) -> str:
-    return _VALIDITY_TEXT_FOR_ID[validity_id or "unknown"]
+    if validity_id is None:
+        validity_id = "unknown"
+    # If we don't have a text for the validity_id, return it as is. We assume the text
+    # of the ID is more valuable than a generic "Unknown" string
+    return _VALIDITY_TEXT_FOR_ID.get(validity_id, validity_id)

--- a/tests/core/test_text_utils.py
+++ b/tests/core/test_text_utils.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import pytest
 
-from ggshield.core.text_utils import Line, LineCategory
+from ggshield.core.text_utils import Line, LineCategory, translate_validity
 
 
 def test_line_validation():
@@ -48,3 +50,17 @@ def test_line_validation():
 def test_build_line_count(input: Line, padding: int, want: str) -> None:
     result = input.build_line_count(padding)
     assert result == want
+
+
+@pytest.mark.parametrize(
+    "validity_id, expected",
+    [
+        ("unknown", "Unknown"),
+        (None, "Unknown"),
+        ("valid", "Valid"),
+        ("unexpected_status", "unexpected_status"),
+    ],
+)
+def test_translate_validity(validity_id: Optional[str], expected: str):
+    result = translate_validity(validity_id)
+    assert result == expected


### PR DESCRIPTION
Make our code more future proof: if a validity id is not known, return it instead of raising an exception.
