### PR TITLE
Plalanne/ /bring back mode header

### DIFF
--- a/ggshield/cmd/scan/archive.py
+++ b/ggshield/cmd/scan/archive.py
@@ -48,9 +48,8 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.matches_ignore,
-                banlisted_detectors=config.banlisted_detectors,
                 all_policies=config.all_policies,
-                verbose=config.verbose,
+                banlisted_detectors=config.banlisted_detectors,
                 on_file_chunk_scanned=update_progress,
             )
 

--- a/ggshield/cmd/scan/archive.py
+++ b/ggshield/cmd/scan/archive.py
@@ -8,6 +8,7 @@ import click
 
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
+from ggshield.core.utils import SupportedScanMode
 from ggshield.output import OutputHandler
 from ggshield.scan import Files, Result, ScanCollection
 
@@ -49,6 +50,7 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
                 cache=ctx.obj["cache"],
                 matches_ignore=config.matches_ignore,
                 all_policies=config.all_policies,
+                mode_header=SupportedScanMode.ARCHIVE.value,
                 banlisted_detectors=config.banlisted_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/cmd/scan/path.py
+++ b/ggshield/cmd/scan/path.py
@@ -37,9 +37,8 @@ def path_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.matches_ignore,
-            banlisted_detectors=config.banlisted_detectors,
             all_policies=config.all_policies,
-            verbose=config.verbose,
+            banlisted_detectors=config.banlisted_detectors,
         )
         scan = ScanCollection(id=" ".join(paths), type="path_scan", results=results)
 

--- a/ggshield/cmd/scan/path.py
+++ b/ggshield/cmd/scan/path.py
@@ -3,7 +3,7 @@ from typing import List
 import click
 
 from ggshield.core.file_utils import get_files_from_paths
-from ggshield.core.utils import handle_exception
+from ggshield.core.utils import SupportedScanMode, handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanCollection
 
@@ -38,6 +38,7 @@ def path_cmd(
             cache=ctx.obj["cache"],
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
+            mode_header=SupportedScanMode.PATH.value,
             banlisted_detectors=config.banlisted_detectors,
         )
         scan = ScanCollection(id=" ".join(paths), type="path_scan", results=results)

--- a/ggshield/cmd/scan/precommit.py
+++ b/ggshield/cmd/scan/precommit.py
@@ -3,7 +3,7 @@ from typing import List
 import click
 
 from ggshield.core.git_shell import check_git_dir
-from ggshield.core.utils import handle_exception
+from ggshield.core.utils import SupportedScanMode, handle_exception
 from ggshield.output import TextOutputHandler
 from ggshield.scan import Commit, ScanCollection
 
@@ -28,6 +28,7 @@ def precommit_cmd(
             cache=ctx.obj["cache"],
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
+            mode_header=SupportedScanMode.PRE_COMMIT.value,
             banlisted_detectors=config.banlisted_detectors,
         )
 

--- a/ggshield/cmd/scan/precommit.py
+++ b/ggshield/cmd/scan/precommit.py
@@ -28,7 +28,6 @@ def precommit_cmd(
             cache=ctx.obj["cache"],
             matches_ignore=config.matches_ignore,
             all_policies=config.all_policies,
-            verbose=config.verbose,
             banlisted_detectors=config.banlisted_detectors,
         )
 

--- a/ggshield/cmd/scan/pypi.py
+++ b/ggshield/cmd/scan/pypi.py
@@ -107,9 +107,8 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.matches_ignore,
-                banlisted_detectors=config.banlisted_detectors,
                 all_policies=config.all_policies,
-                verbose=config.verbose,
+                banlisted_detectors=config.banlisted_detectors,
                 on_file_chunk_scanned=update_progress,
             )
         scan = ScanCollection(id=package_name, type="path_scan", results=results)

--- a/ggshield/cmd/scan/pypi.py
+++ b/ggshield/cmd/scan/pypi.py
@@ -10,6 +10,7 @@ import click
 
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
+from ggshield.core.utils import SupportedScanMode
 from ggshield.output import OutputHandler
 from ggshield.scan import Files, Result, ScanCollection
 
@@ -108,6 +109,7 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
                 cache=ctx.obj["cache"],
                 matches_ignore=config.matches_ignore,
                 all_policies=config.all_policies,
+                mode_header=SupportedScanMode.PYPI.value,
                 banlisted_detectors=config.banlisted_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -222,6 +222,19 @@ class SupportedCI(Enum):
     AZURE = "AZURE PIPELINES"
 
 
+class SupportedScanMode(Enum):
+    REPO = "repo"
+    PATH = "path"
+    COMMIT_RANGE = "commit_range"
+    PRE_COMMIT = "pre_commit"
+    PRE_PUSH = "pre_push"
+    PRE_RECEIVE = "pre_receive"
+    CI = "ci"
+    DOCKER = "docker"
+    PYPI = "pypi"
+    ARCHIVE = "archive"
+
+
 json_output_option_decorator = click.option(
     "--json",
     "json_output",

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -252,9 +252,8 @@ def docker_scan_archive(
             cache=cache,
             matches_ignore=matches_ignore,
             all_policies=all_policies,
-            verbose=verbose,
-            on_file_chunk_scanned=update_progress,
             banlisted_detectors=banlisted_detectors,
+            on_file_chunk_scanned=update_progress,
         )
 
     return ScanCollection(id=scan_id, type="scan_docker_archive", results=results)

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -13,6 +13,7 @@ from pygitguardian import GGClient
 
 from ggshield.core.cache import Cache
 from ggshield.core.constants import MAX_FILE_SIZE
+from ggshield.core.utils import SupportedScanMode
 from ggshield.scan import ScanCollection
 from ggshield.scan.scannable import File, Files
 
@@ -252,6 +253,7 @@ def docker_scan_archive(
             cache=cache,
             matches_ignore=matches_ignore,
             all_policies=all_policies,
+            mode_header=SupportedScanMode.DOCKER.value,
             banlisted_detectors=banlisted_detectors,
             on_file_chunk_scanned=update_progress,
         )

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -71,9 +71,8 @@ def scan_commit(
         client=client,
         cache=cache,
         matches_ignore=matches_ignore,
-        banlisted_detectors=banlisted_detectors,
         all_policies=all_policies,
-        verbose=verbose,
+        banlisted_detectors=banlisted_detectors,
     )
 
     return ScanCollection(

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -14,7 +14,7 @@ from ggshield.core.constants import CPU_COUNT
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import handle_exception
+from ggshield.core.utils import SupportedScanMode, handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import Commit, ScanCollection
 
@@ -72,6 +72,7 @@ def scan_commit(
         cache=cache,
         matches_ignore=matches_ignore,
         all_policies=all_policies,
+        mode_header=SupportedScanMode.REPO.value,
         banlisted_detectors=banlisted_detectors,
     )
 

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -133,6 +133,7 @@ class Files:
         cache: Cache,
         matches_ignore: Iterable[IgnoredMatch],
         all_policies: bool,
+        mode_header: str,
         banlisted_detectors: Optional[Set[str]] = None,
         on_file_chunk_scanned: Callable[
             [List[Dict[str, Any]]], None
@@ -152,7 +153,7 @@ class Files:
                 executor.submit(
                     client.multi_content_scan,
                     chunk,
-                    self.extra_headers,
+                    {"mode": mode_header, **self.extra_headers},
                 ): chunk
                 for chunk in chunks
             }

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -133,7 +133,6 @@ class Files:
         cache: Cache,
         matches_ignore: Iterable[IgnoredMatch],
         all_policies: bool,
-        verbose: bool,
         banlisted_detectors: Optional[Set[str]] = None,
         on_file_chunk_scanned: Callable[
             [List[Dict[str, Any]]], None

--- a/tests/cmd/test_ignore.py
+++ b/tests/cmd/test_ignore.py
@@ -47,6 +47,7 @@ def test_cache_catches_last_found_secrets(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
+            mode_header="test",
         )
     assert config.matches_ignore == list()
 
@@ -83,6 +84,7 @@ def test_cache_catches_nothing(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
+            mode_header="test",
         )
 
         assert results == []
@@ -112,6 +114,7 @@ def test_cache_old_config_no_new_secret(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
+            mode_header="test",
         )
 
         assert results == []

--- a/tests/cmd/test_ignore.py
+++ b/tests/cmd/test_ignore.py
@@ -47,7 +47,6 @@ def test_cache_catches_last_found_secrets(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
-            verbose=False,
         )
     assert config.matches_ignore == list()
 
@@ -84,7 +83,6 @@ def test_cache_catches_nothing(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
-            verbose=False,
         )
 
         assert results == []
@@ -114,7 +112,6 @@ def test_cache_old_config_no_new_secret(client, isolated_fs):
             cache=cache,
             matches_ignore=config.matches_ignore,
             all_policies=True,
-            verbose=False,
         )
 
         assert results == []

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -77,7 +77,6 @@ def test_make_indices_patch(client, cache, name, content, is_patch, expected_ind
             cache=cache,
             matches_ignore={},
             all_policies=True,
-            verbose=False,
             banlisted_detectors=None,
         )
         result = results[0]

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -8,6 +8,7 @@ from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.utils import (
     MatchIndices,
+    SupportedScanMode,
     api_to_dashboard_url,
     dashboard_to_api_url,
     find_match_indices,
@@ -77,6 +78,7 @@ def test_make_indices_patch(client, cache, name, content, is_patch, expected_ind
             cache=cache,
             matches_ignore={},
             all_policies=True,
+            mode_header=SupportedScanMode.PATH.value,
             banlisted_detectors=None,
         )
         result = results[0]

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -61,7 +61,6 @@ def test_json_output(client, cache, name, input_patch, expected, snapshot):
             cache=cache,
             matches_ignore={},
             all_policies=True,
-            verbose=False,
             banlisted_detectors=None,
         )
 

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from ggshield.core.utils import Filemode
+from ggshield.core.utils import Filemode, SupportedScanMode
 from ggshield.output import JSONOutputHandler, OutputHandler
 from ggshield.output.json.schemas import JSONScanCollectionSchema
 from ggshield.scan import Commit, ScanCollection
@@ -61,6 +61,7 @@ def test_json_output(client, cache, name, input_patch, expected, snapshot):
             cache=cache,
             matches_ignore={},
             all_policies=True,
+            mode_header=SupportedScanMode.PATH.value,
             banlisted_detectors=None,
         )
 

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -25,13 +25,7 @@ def test_request_headers(scan_mock: Mock, client):
 
     with Context(Command("bar"), info_name="bar") as ctx:
         ctx.parent = Context(Group("foo"), info_name="foo")
-        c.scan(
-            client=client,
-            cache=Cache(),
-            matches_ignore={},
-            all_policies=True,
-            verbose=False,
-        )
+        c.scan(client=client, cache=Cache(), matches_ignore={}, all_policies=True)
     scan_mock.assert_called_with(
         ANY,
         {

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -25,11 +25,18 @@ def test_request_headers(scan_mock: Mock, client):
 
     with Context(Command("bar"), info_name="bar") as ctx:
         ctx.parent = Context(Group("foo"), info_name="foo")
-        c.scan(client=client, cache=Cache(), matches_ignore={}, all_policies=True)
+        c.scan(
+            client=client,
+            cache=Cache(),
+            matches_ignore={},
+            all_policies=True,
+            mode_header="test",
+        )
     scan_mock.assert_called_with(
         ANY,
         {
             "GGShield-Version": __version__,
             "GGShield-Command-Path": "foo bar",
+            "mode": "test",
         },
     )

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -4,7 +4,7 @@ import pytest
 
 from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.filter import init_exclusion_regexes
-from ggshield.core.utils import Filemode
+from ggshield.core.utils import Filemode, SupportedScanMode
 from ggshield.scan import Commit
 from tests.conftest import (
     _MULTIPLE_SECRETS,
@@ -68,7 +68,11 @@ def test_scan_patch(client, cache, name, input_patch, expected):
 
     with my_vcr.use_cassette(name):
         results = c.scan(
-            client=client, cache=cache, matches_ignore={}, all_policies=True
+            client=client,
+            cache=cache,
+            matches_ignore={},
+            all_policies=True,
+            mode_header=SupportedScanMode.PATH.value,
         )
         for result in results:
             if result.scan.policy_breaks:

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -68,11 +68,7 @@ def test_scan_patch(client, cache, name, input_patch, expected):
 
     with my_vcr.use_cassette(name):
         results = c.scan(
-            client=client,
-            cache=cache,
-            matches_ignore={},
-            all_policies=True,
-            verbose=False,
+            client=client, cache=cache, matches_ignore={}, all_policies=True
         )
         for result in results:
             if result.scan.policy_breaks:


### PR DESCRIPTION
In this PR, we re-introduce the "mode" header for API calls.  
This header can take several values depending on the type of scan launched.

**Note :** We also took advantage of this PR to remove a useless verbose parameter.