### PR TITLE
Various fixes related to ggshield auth and config commands

### DIFF
--- a/ggshield/cmd/auth/utils.py
+++ b/ggshield/cmd/auth/utils.py
@@ -1,4 +1,5 @@
 import click
+from requests import ConnectionError
 
 from ggshield.core.client import create_session
 from ggshield.core.config import Config
@@ -21,7 +22,11 @@ def check_instance_has_enabled_flow(config: Config) -> None:
 
     # don't use gitguardian client because the request should not include the token
     session = create_session(config.allow_self_signed)
-    response = session.get(urljoin(config.api_url, "/v1/metadata"), timeout=30)
+
+    try:
+        response = session.get(urljoin(config.api_url, "/v1/metadata"), timeout=30)
+    except ConnectionError:
+        raise click.ClickException("Invalid GitGuardian instance url.")
 
     if response.status_code == 404:
         raise click.ClickException(VERSION_TOO_LOW_MESSAGE)

--- a/ggshield/cmd/config/__init__.py
+++ b/ggshield/cmd/config/__init__.py
@@ -15,4 +15,4 @@ from .config_unset import config_unset_command
     }
 )
 def config_group() -> None:
-    """Commands to manage auth config."""
+    """Commands to manage configuration."""

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -43,12 +43,3 @@ def config_list_cmd(ctx: click.Context) -> int:
 
     click.echo(message[:-2])
     return 0
-
-
-@click.group(
-    commands={
-        "list": config_list_cmd,
-    }
-)
-def auth_config_group() -> None:
-    """Commands to manage auth config."""

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -331,7 +331,7 @@ class OAuthClient:
         if account is None or not account.token or self.instance_config.expired:
             return False
 
-        message = "ggshield is already athenticated "
+        message = "ggshield is already authenticated "
         if account.expire_at:
             message += "until " + get_pretty_date(account.expire_at)
         else:

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -52,6 +52,8 @@ IGNORED_DEFAULT_WILDCARDS = [
     "**/*.sops",
 ]
 
+GITGUARDIAN_DOMAINS = ["gitguardian.com", "gitguardian.tech"]
+
 
 class Filemode(Enum):
     """
@@ -307,7 +309,7 @@ def dashboard_to_api_url(dashboard_url: str, warn: bool = False) -> str:
         raise click.ClickException(
             f"Invalid scheme for dashboard URL '{dashboard_url}', expected HTTPS"
         )
-    if parsed_url.netloc.endswith(".gitguardian.com"):  # SaaS
+    if any(parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
         if parsed_url.path:
             raise click.ClickException(
                 f"Invalid dashboard URL '{dashboard_url}', got an unexpected path '{parsed_url.path}'"

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -207,7 +207,7 @@ class TestAuthLoginWeb:
         self._webbrowser_open_mock.assert_not_called()
 
         self._assert_last_print(
-            output, "ggshield is already athenticated without an expiry date"
+            output, "ggshield is already authenticated without an expiry date"
         )
 
     @pytest.mark.parametrize("instance_url", [None, "https://some_instance.com"])
@@ -234,7 +234,7 @@ class TestAuthLoginWeb:
         self._webbrowser_open_mock.assert_not_called()
 
         self._assert_last_print(
-            output, f"ggshield is already athenticated until {str_date} 2100"
+            output, f"ggshield is already authenticated until {str_date} 2100"
         )
 
     def test_no_port_available_exits_error(self, cli_fs_runner, monkeypatch):


### PR DESCRIPTION
* handle ConnectionError (unresolved host) when checking if ggshield flow is enabled. e.g. `gghsield auth login --method web --instance https://fake-host.com"
* recognize gitguardian.tech domain as gitguardian own domain (to allow logging in with gghsield on https://dashboard.staging.gitguardian.tech)
* fix `auth config` command documentation
* remove unused code