### PR TITLE
Ignore env var when login token method

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import click
 
 from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
-from ggshield.core.client import create_client_from_config
+from ggshield.core.client import create_client
 from ggshield.core.config import AccountConfig, Config
 from ggshield.core.oauth import OAuthClient
 from ggshield.core.utils import clean_url
@@ -119,7 +119,8 @@ def login_cmd(
 
         config.auth_config.current_token = token
 
-        client = create_client_from_config(config)
+        # enforce using the token (and not use config default)
+        client = create_client(api_key=token, api_url=config.api_url)
         response = client.get(endpoint="token")
         if not response.ok:
             raise click.ClickException("Authentication failed with token.")


### PR DESCRIPTION

## What is the current bug behavior?

If `$GITGUARDIAN_API_KEY` is set to a valid token, then `ggshield auth login --method token` succeeds even if the entered token is invalid.

## What is the expected correct behavior?

`ggshield auth login --method token` should ignore the `$GITGUARDIAN_API_KEY` environment variable.

## Steps to reproduce

1. Set `$GITGUARDIAN_API_KEY` to a valid token
1. Run `ggshield auth login --method token`
1. Enter an invalid token
1. A `.config/ggshield/auth_config.yaml` file with the invalid token is created

# What was done

After the token is retrieved from the input, the API call to test it will use the token instead of the config's default token (which is the env variable by default if set).