### PR TITLE
fix(dev_dependencies): remove types-click from pre-comits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          [
-            types-requests,
-            types-pyyaml,
-            types-click,
-            types-appdirs,
-            types-oauthlib,
-          ]
+          [types-requests, types-pyyaml, types-appdirs, types-oauthlib, click]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1


### PR DESCRIPTION
Remove `types-click` from pre-commit. 

I suspect the package is no longer necessary (and cause bugs):
There is no `click` folder in https://github.com/python/typeshed/tree/master/stubs  (so the link in https://pypi.org/project/types-click/#history is dead).

I have tried adding `types-click` as a dev-dependency, but it somehow requires `ipython` ??? (see https://github.com/GitGuardian/ggshield/runs/6452203176?check_suite_focus=true)