### PR TITLE
Fix command documentation and messages

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -59,13 +59,13 @@ def validate_login_path(
     "--instance",
     required=False,
     type=str,
-    help="URL of the instance to authenticate to.",
+    help="URL of the instance to authenticate against.",
 )
 @click.option(
     "--sso-url",
     required=False,
     type=str,
-    help="URL of the instance to authenticate to on a pre-selected SAML SSO page.",
+    help="Instance URL to authenticate with on a pre-selected SAML SSO page.",
 )
 @click.option(
     "--token-name",
@@ -78,7 +78,7 @@ def validate_login_path(
     required=False,
     type=click.IntRange(0),
     default=None,
-    help="Amount of days before the token expires. 0 means the token never expires.",
+    help="Number of days before the token expires. 0 means the token never expires.",
 )
 @click.pass_context
 def login_cmd(
@@ -90,12 +90,16 @@ def login_cmd(
     sso_url: Optional[str],
 ) -> int:
     """
-    Authenticate to your GitGuardian account.
+    Authenticate with a GitGuardian workspace.
+    A successful authentication results in a personal access token.
+    This token is stored in your configuration and used to authenticate your future requests.
 
-    Use `--method token` to authenticate using an existing token.
+    The default authentication method is "web".
+    ggshield launches a web browser to authenticate you to your GitGuardian workspace,
+    then automatically generates a token on your behalf.
 
-    Use `--method web` to let ggshield authenticate through your web browser and
-    generate a token for you. Note: This is experimental for now.
+    Alternatively, you can use `--method token` to authenticate using an already existing token.
+    The minimum required scope for the token is `scan`.
     """
     config = ctx.obj["config"]
 

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -51,7 +51,8 @@ def validate_login_path(
 @click.command()
 @click.option(
     "--method",
-    required=True,
+    required=False,
+    default="web",
     type=click.Choice(["token", "web"]),
     help="Authentication method.",
 )

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -23,15 +23,18 @@ REVOKE_FAIL_MESSAGE = (
     "--revoke/--no-revoke",
     is_flag=True,
     default=True,
-    help="Whether the token should be revoked before being removed from the config.",
+    help="Whether the token should be revoked on logout before being removed from the configuration.",
 )
 @click.option("--all", "all_", is_flag=True, help="Iterate over every saved tokens.")
 @click.pass_context
 def logout_cmd(ctx: click.Context, instance: str, revoke: bool, all_: bool) -> int:
     """
-    Delete saved authentication details for the specified instance (or default instance if not specified)
-    By default, this will also try to revoke found tokens unless --no-revoke is specified.\n
-    If --all is specified, it will iterate over all instances.
+    Remove authentication for a GitGuardian instance.
+    A successful logout results in the deletion of personal access token stored in the configuration.
+    By default, the token will be revoked unless `--no-revoke` option is specified.
+
+    If not specified, ggshield will logout from the default instance.
+    The `--all` option can be used if you want to logout from all your GitGuardian instances.
     """
     config = ctx.obj["config"]
 

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -22,8 +22,8 @@ def config_get_command(
     ctx: click.Context, field_name: str, instance_url: Optional[str]
 ) -> int:
     """
-    Get the value of the specified parameter.
-    If --instance is passed, retrieve the value for this specific instance
+    Print the value of the given configuration key.
+    If --instance is passed, retrieve the value for this specific instance.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -9,7 +9,7 @@ from .constants import DATETIME_FORMAT
 @click.pass_context
 def config_list_cmd(ctx: click.Context) -> int:
     """
-    List all auth configurations.
+    Print the list of configuration keys and values.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -15,14 +15,14 @@ from .constants import FIELD_OPTIONS
     required=False,
     type=str,
     metavar="URL",
-    help="URL of the instance to set the config.",
+    help="URL of the instance to set the configuration.",
 )
 @click.pass_context
 def config_set_command(
     ctx: click.Context, field_name: str, value: str, instance: Optional[str]
 ) -> int:
     """
-    Set the value of a specific field in the auth config.
+    Update the value of the given configuration key.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -15,7 +15,7 @@ from .constants import FIELD_OPTIONS
     required=False,
     type=str,
     metavar="URL",
-    help="URL of the instance to unset the config.",
+    help="URL of the instance to unset the configuration.",
 )
 @click.option("--all", "all_", is_flag=True, help="Iterate over every saved tokens.")
 @click.pass_context
@@ -23,8 +23,8 @@ def config_unset_command(
     ctx: click.Context, field_name: str, instance_url: Optional[str], all_: bool
 ) -> int:
     """
-    This command removes a parameter value from the auth config.
-    if --all is passed, it iterates over all auth configs.
+    Remove the value of the given configuration key.
+    If --all is passed, it iterates over all auth configs.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -102,16 +102,7 @@ class OAuthClient:
         self._prepare_server()
         self._redirect_to_login()
         self._wait_for_callback()
-
-        message = f"Created Personal Access Token {self._token_name} "
-
-        assert self.instance_config.account is not None
-        expire_at = self.instance_config.account.expire_at
-        if expire_at is not None:
-            message += "expiring on " + get_pretty_date(expire_at)
-        else:
-            message += "with no expiry"
-        click.echo(message)
+        self._print_login_success()
 
     def process_callback(self, callback_url: str) -> None:
         """
@@ -160,7 +151,8 @@ class OAuthClient:
             **static_params,
         )
         click.echo(
-            f"To complete the login process, follow the instructions from {request_uri}.\n"
+            f"Complete the login process at:\n"
+            f"  {request_uri}.\n"
             "Opening your web browser now..."
         )
         webbrowser.open_new_tab(request_uri)
@@ -338,6 +330,28 @@ class OAuthClient:
             message += "without an expiry date"
         click.echo(message)
         return True
+
+    def _print_login_success(self) -> None:
+        """
+        Output the login success message
+        """
+        assert self.instance_config.account is not None
+        expire_at = self.instance_config.account.expire_at
+
+        if expire_at is not None:
+            str_date = get_pretty_date(expire_at)
+        else:
+            str_date = "never"
+
+        message = (
+            "Success! You are now authenticated.\n"
+            "The personal access token has been created and stored in your ggshield config.\n\n"
+            f"token name: {self._token_name}\n"
+            f"token expiration date: {str_date}\n\n"
+            'You do not need to run "ggshield auth login" again. Future requests will automatically use the token.'
+        )
+
+        click.echo(message)
 
     def get_server_error_message(self, error_code: str) -> str:
         """

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -370,12 +370,19 @@ class TestAuthLoginWeb:
         self._assert_post_payload()
         self._client_get_mock.assert_called_once()
 
-        message = f"\nCreated Personal Access Token {self._generated_token_name} "
-
         if self._lifetime is None:
-            message += "with no expiry\n"
+            str_date = "never"
         else:
-            message += "expiring on " + get_pretty_date(self._get_expiry_date()) + "\n"
+            str_date = get_pretty_date(self._get_expiry_date())
+
+        message = (
+            "Success! You are now authenticated.\n"
+            "The personal access token has been created and stored in your ggshield config.\n\n"
+            f"token name: {self._generated_token_name}\n"
+            f"token expiration date: {str_date}\n\n"
+            'You do not need to run "ggshield auth login" again. Future requests will automatically use the token.\n'
+        )
+
         assert output.endswith(message)
 
         self._assert_config("mysupertoken")

--- a/tests/cmd/auth/test_logout.py
+++ b/tests/cmd/auth/test_logout.py
@@ -32,7 +32,11 @@ class TestAuthLogout:
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url)
 
         assert exit_code == 1, output
-        assert output == f"Error: No token found for instance {instance_url}.\n"
+        assert output == (
+            f"Error: No token found for instance {instance_url}\n"
+            "First try to login by running:\n"
+            "  ggshield auth login\n"
+        )
 
     @pytest.mark.parametrize("instance_url", (None, "https://some-gg-instance.com"))
     @pytest.mark.parametrize("revoke", (True, False))
@@ -70,12 +74,17 @@ class TestAuthLogout:
         assert exit_code == 0, output
         instance_url = instance_url or "https://dashboard.gitguardian.com"
 
-        expected_output = f"Logged out from instance {instance_url}\n"
+        expected_output = f"Successfully logged out for instance {instance_url}\n\n"
 
         if revoke:
-            expected_output = (
-                f"Personal Access Token {token_name} has been revoked\n"
-                + expected_output
+            expected_output += (
+                "Your personal access token has been revoked and removed "
+                "from your configuration.\n"
+            )
+        else:
+            expected_output += (
+                "Your personal access token has been removed "
+                "from your configuration.\n"
             )
 
         assert output == expected_output
@@ -101,8 +110,10 @@ class TestAuthLogout:
 
         assert exit_code == 1, output
         assert output == (
-            "Error: Logout failed due to an error when revoking the token, "
-            "you can skip revocation with --no-revoke to bypass\n"
+            "Error: Could not perform the logout command "
+            "because your token is already revoked or invalid.\n"
+            "Please try with the following command:\n"
+            "  ggshield auth logout --no-revoke\n"
         )
 
     def test_logout_server_error(self, monkeypatch, cli_fs_runner):
@@ -125,8 +136,10 @@ class TestAuthLogout:
 
         assert exit_code == 1, output
         assert output == (
-            "Error: Logout failed due to an error when revoking the token, "
-            "you can skip revocation with --no-revoke to bypass\n"
+            "Error: Could not perform the logout command "
+            "because your token is already revoked or invalid.\n"
+            "Please try with the following command:\n"
+            "  ggshield auth logout --no-revoke\n"
         )
 
     def test_logout_all(self, monkeypatch, cli_fs_runner):


### PR DESCRIPTION
* fix documentations appearing with  `--help` commands
* adjust message (and error messages) to be more explicit and readable to the users
* for auth login command, make `--method web` default (thus optional to specify)