### PR TITLE
Fix SSO wrongly not matching with instance url

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -11,7 +11,7 @@ from ggshield.core.utils import clean_url
 
 
 def validate_login_path(
-    config: Config, instance: Optional[str], sso_url: Optional[str]
+    instance: Optional[str], sso_url: Optional[str]
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Validate that the SSO URL and the instance refer to the same instance if they are both defined,
@@ -39,7 +39,7 @@ def validate_login_path(
     if instance is None:
         return sso_instance, sso_login_path
 
-    config_parsed_url = clean_url(config.dashboard_url)
+    config_parsed_url = clean_url(instance)
     if (
         config_parsed_url.scheme != sso_parsed_url.scheme
         or config_parsed_url.netloc != sso_parsed_url.netloc
@@ -66,7 +66,7 @@ def validate_login_path(
     "--sso-url",
     required=False,
     type=str,
-    help="Instance URL to authenticate with on a pre-selected SAML SSO page.",
+    help="URL of your SSO login page to force the authentication flow through your workspace SSO.",
 )
 @click.option(
     "--token-name",
@@ -147,9 +147,7 @@ def login_cmd(
         return 0
 
     if method == "web":
-        instance, login_path = validate_login_path(
-            config, instance=instance, sso_url=sso_url
-        )
+        instance, login_path = validate_login_path(instance=instance, sso_url=sso_url)
         if instance:
             config.set_cmdline_instance_name(instance)
         defined_instance = config.instance_name

--- a/ggshield/cmd/auth/utils.py
+++ b/ggshield/cmd/auth/utils.py
@@ -10,7 +10,7 @@ VERSION_TOO_LOW_MESSAGE = "Your GitGuardian dashboard version is too low, upgrad
 DISABLED_FLOW_MESSAGE = "Your GitGuardian dashboard does not authorize this command, contact your administrator."
 CONNECTION_ERROR_MESSAGE = (
     "Could not connect to GitGuardian.\n"
-    "Please check your internet connection or if the specified URL is correct."
+    "Please check your internet connection and if the specified URL is correct."
 )
 
 

--- a/ggshield/cmd/auth/utils.py
+++ b/ggshield/cmd/auth/utils.py
@@ -8,6 +8,10 @@ from ggshield.core.utils import urljoin
 
 VERSION_TOO_LOW_MESSAGE = "Your GitGuardian dashboard version is too low, upgrade to be able to use this command."
 DISABLED_FLOW_MESSAGE = "Your GitGuardian dashboard does not authorize this command, contact your administrator."
+CONNECTION_ERROR_MESSAGE = (
+    "Could not connect to GitGuardian.\n"
+    "Please check your internet connection or if the specified URL is correct."
+)
 
 
 def check_instance_has_enabled_flow(config: Config) -> None:
@@ -26,7 +30,7 @@ def check_instance_has_enabled_flow(config: Config) -> None:
     try:
         response = session.get(urljoin(config.api_url, "/v1/metadata"), timeout=30)
     except ConnectionError:
-        raise click.ClickException("Invalid GitGuardian instance url.")
+        raise click.ClickException(CONNECTION_ERROR_MESSAGE)
 
     if response.status_code == 404:
         raise click.ClickException(VERSION_TOO_LOW_MESSAGE)

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -12,6 +12,7 @@ def config_list_cmd(ctx: click.Context) -> int:
     Print the list of configuration keys and values.
     """
     config: Config = ctx.obj["config"]
+    default_token_lifetime = config.auth_config.default_token_lifetime
 
     message = ""
     for instance in config.auth_config.instances:
@@ -30,9 +31,15 @@ def config_list_cmd(ctx: click.Context) -> int:
         else:
             workspace_id = token = token_name = expiry = "not set"  # type: ignore
 
+        _default_token_lifetime = (
+            instance.default_token_lifetime
+            if instance.default_token_lifetime is not None
+            else default_token_lifetime
+        )
+
         message_lines = [
             f"[{instance_name}]",
-            f"default_token_lifetime: {instance.default_token_lifetime}",
+            f"default_token_lifetime: {_default_token_lifetime}",
             f"workspace_id: {workspace_id}",
             f"url: {instance.url}",
             f"token: {token}",

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -363,6 +363,8 @@ class OAuthClient:
                 "Maximum number of personal access tokens reached. Could not provision a new personal access token.\n"
                 f"Go to your workspace to manage your tokens: {url}"
             )
+        elif error_code == "invalid_saml":
+            return "The given SSO URL is invalid."
         return f"An unknown server error has occurred (error code: {error_code})."
 
     @property

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -829,6 +829,10 @@ class TestLoginUtils:
                 ),
             ),
             (
+                "invalid_saml",
+                "The given SSO URL is invalid.",
+            ),
+            (
                 "invalid_error_code",
                 "An unknown server error has occurred (error code: invalid_error_code).",
             ),

--- a/tests/cmd/auth/test_login.py
+++ b/tests/cmd/auth/test_login.py
@@ -747,6 +747,11 @@ class TestAuthLoginWeb:
                 "dashboard.gitguardian.com",
             ],
             [
+                "https://some-gg-instance.com",
+                "https://some-gg-instance.com/auth/sso/1e0f7890-2293-4b2d-8aa8-f6f0e8e92274",
+                "some-gg-instance.com",
+            ],
+            [
                 None,
                 "https://custom.gitguardian.com/auth/sso/1e0f7890-2293-4b2d-8aa8-f6f0e8e92274",
                 "custom.gitguardian.com",

--- a/tests/cmd/auth/test_logout.py
+++ b/tests/cmd/auth/test_logout.py
@@ -111,7 +111,7 @@ class TestAuthLogout:
         assert exit_code == 1, output
         assert output == (
             "Error: Could not connect to GitGuardian.\n"
-            "Please check your internet connection or if the specified URL is correct.\n"
+            "Please check your internet connection and if the specified URL is correct.\n"
         )
 
     def test_logout_server_error(self, monkeypatch, cli_fs_runner):

--- a/tests/cmd/auth/test_logout.py
+++ b/tests/cmd/auth/test_logout.py
@@ -110,10 +110,8 @@ class TestAuthLogout:
 
         assert exit_code == 1, output
         assert output == (
-            "Error: Could not perform the logout command "
-            "because your token is already revoked or invalid.\n"
-            "Please try with the following command:\n"
-            "  ggshield auth logout --no-revoke\n"
+            "Error: Could not connect to GitGuardian.\n"
+            "Please check your internet connection or if the specified URL is correct.\n"
         )
 
     def test_logout_server_error(self, monkeypatch, cli_fs_runner):


### PR DESCRIPTION
* Fix SSO wrongly not matching witn instance url (it happened if the url of the instance was not the default one)
* update logout error message if no network