### PR TITLE
feat(iac): handle config file for iac

### DIFF
--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -23,12 +23,28 @@ from ggshield.core.utils import api_to_dashboard_url
 
 
 @dataclass
+class IaCConfig:
+    """
+    Holds the iac config as defined .gitguardian.yaml files
+    (local and global).
+    """
+
+    ignored_paths: Set[str] = field(default_factory=set)
+    ignored_policies: Set[str] = field(default_factory=set)
+    minimum_severity: str = "LOW"
+
+
+IaCConfigSchema = marshmallow_dataclass.class_schema(IaCConfig)
+
+
+@dataclass
 class UserConfig:
     """
     Holds all ggshield settings defined by the user in the .gitguardian.yaml files
     (local and global).
     """
 
+    iac: IaCConfig = field(default_factory=IaCConfig)
     instance: Optional[str] = None
     all_policies: bool = False
     exit_zero: bool = False

--- a/tests/core/config/test_user_config.py
+++ b/tests/core/config/test_user_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from ggshield.core.config import Config
 from ggshield.core.config.errors import ParseError
+from ggshield.core.config.user_config import IaCConfig
 from tests.conftest import write_text, write_yaml
 
 
@@ -85,3 +86,49 @@ class TestUserConfig:
             {"match": "one", "name": ""},
             {"match": "two", "name": ""},
         ]
+
+    def test_iac_config(self, cli_fs_runner, local_config_path):
+        write_yaml(
+            local_config_path,
+            {
+                "iac": {
+                    "ignored_paths": ["mypath"],
+                    "ignored_policies": ["mypolicy"],
+                    "minimum_severity": "myseverity",
+                }
+            },
+        )
+        config = Config()
+        assert isinstance(config.iac, IaCConfig)
+        assert config.iac.ignored_paths == {"mypath"}
+        assert config.iac.ignored_policies == {"mypolicy"}
+        assert config.iac.minimum_severity == "myseverity"
+
+    def test_iac_config_options_inheritance(
+        self, cli_fs_runner, local_config_path, global_config_path
+    ):
+        write_yaml(
+            global_config_path,
+            {
+                "iac": {
+                    "ignored_paths": ["myglobalpath"],
+                    "ignored_policies": ["myglobalpolicy"],
+                    "minimum_severity": "myglobalseverity",
+                }
+            },
+        )
+        write_yaml(
+            local_config_path,
+            {
+                "iac": {
+                    "ignored_paths": ["mypath"],
+                    "ignored_policies": ["mypolicy"],
+                    "minimum_severity": "myseverity",
+                }
+            },
+        )
+        config = Config()
+        assert isinstance(config.iac, IaCConfig)
+        assert config.iac.ignored_paths == {"myglobalpath", "mypath"}
+        assert config.iac.ignored_policies == {"myglobalpolicy", "mypolicy"}
+        assert config.iac.minimum_severity == "myseverity"


### PR DESCRIPTION
- Allow setting iac settings by adding iac parameters to the user config file as described in the config file format v2 doc

### Testing
- Added unit tests for the loading of the config, global or local