### PR TITLE
feat(iac): add new classes to handle response from the client endpoint

### DIFF
--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -1,8 +1,14 @@
+from typing import Dict, Optional, Union
+
 import click
 import urllib3
 from pygitguardian import GGClient
+from pygitguardian.client import is_ok, load_detail
+from pygitguardian.models import Detail
 from requests import Session
 
+from ..iac.models import IaCScanResult
+from ..iac.models.iac_scan_parameters import IaCScanParameters, IaCScanParametersSchema
 from .config import Config
 from .config.errors import UnknownInstanceError
 from .constants import DEFAULT_DASHBOARD_URL
@@ -36,7 +42,7 @@ def create_client(
     """
     session = create_session(allow_self_signed=allow_self_signed)
     try:
-        return GGClient(
+        return IaCGGClient(
             api_key=api_key,
             base_uri=api_url,
             user_agent="ggshield",
@@ -54,3 +60,32 @@ def create_session(allow_self_signed: bool = False) -> Session:
         urllib3.disable_warnings()
         session.verify = False
     return session
+
+
+class IaCGGClient(GGClient):
+    def directory_scan(
+        self,
+        directory: bytes,
+        scan_parameters: IaCScanParameters,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Union[Detail, IaCScanResult]:
+
+        resp = self.request(
+            "post",
+            endpoint="iacscan",
+            extra_headers=extra_headers,
+            data={
+                "directory": directory,
+                "scan_parameters": IaCScanParametersSchema().dumps(scan_parameters),
+            },
+        )
+
+        result: Union[Detail, IaCScanResult]
+        if is_ok(resp):
+            result = IaCScanResult.SCHEMA.load(resp.json())
+        else:
+            result = load_detail(resp)
+
+        result.status_code = resp.status_code
+
+        return result

--- a/ggshield/iac/models/__init__.py
+++ b/ggshield/iac/models/__init__.py
@@ -1,0 +1,13 @@
+from ggshield.iac.models.iac_scan_parameters import (
+    IaCScanParameters,
+    IaCScanParametersSchema,
+)
+from ggshield.iac.models.iac_scan_result import IaCScanResult, IaCScanResultSchema
+
+
+__all__ = [
+    "IaCScanResult",
+    "IaCScanResultSchema",
+    "IaCScanParameters",
+    "IaCScanParametersSchema",
+]

--- a/ggshield/iac/models/iac_scan_parameters.py
+++ b/ggshield/iac/models/iac_scan_parameters.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import marshmallow_dataclass
+from pygitguardian.models import Base, BaseSchema
+
+
+@dataclass
+class IaCScanParameters(Base):
+    ignored_policies: List[str] = field(default_factory=list)
+    minimum_severity: Optional[str] = None
+
+
+IaCScanParametersSchema = marshmallow_dataclass.class_schema(
+    IaCScanParameters, BaseSchema
+)

--- a/ggshield/iac/models/iac_scan_result.py
+++ b/ggshield/iac/models/iac_scan_result.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List
+
+import marshmallow_dataclass
+from pygitguardian.models import Base, BaseSchema
+
+
+@dataclass
+class IaCScanResult(Base):
+    iac_engine_version: str
+    entities_with_incidents: List["IaCVulnerability"]
+    id: str = ""
+    type: str = ""
+
+
+@dataclass
+class IaCVulnerability:
+    filename: str
+    policy: str
+    policy_id: str
+    line_end: int
+    line_start: int
+    description: str
+    documentation_url: str
+    component: str = ""
+    severity: str = ""
+    ignore_sha: str = ""
+
+
+IaCScanResultSchema = marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)
+IaCVulnerabilitiesSchema = marshmallow_dataclass.class_schema(IaCVulnerability)

--- a/tests/cmd/test_status.py
+++ b/tests/cmd/test_status.py
@@ -43,7 +43,7 @@ def test_api_status(cassette, json_output, snapshot, cli_fs_runner):
 def test_ssl_verify(cli_fs_runner, verify):
     cmd = ["api-status"] if verify else ["--allow-self-signed", "api-status"]
 
-    with mock.patch("ggshield.core.client.GGClient") as client_mock:
+    with mock.patch("ggshield.core.client.IaCGGClient") as client_mock:
         cli_fs_runner.invoke(cli, cmd)
         _, kwargs = client_mock.call_args
         assert kwargs["session"].verify == verify

--- a/tests/iac/test_models.py
+++ b/tests/iac/test_models.py
@@ -1,0 +1,57 @@
+import pytest
+
+from ggshield.iac.models import IaCScanResult, IaCScanResultSchema
+from ggshield.iac.models.iac_scan_parameters import (
+    IaCScanParameters,
+    IaCScanParametersSchema,
+)
+
+
+class TestModel:
+    @pytest.mark.parametrize(
+        "schema_klass, expected_klass, instance_data",
+        [
+            (
+                IaCScanResultSchema,
+                IaCScanResult,
+                {
+                    "id": "myid",
+                    "type": "type",
+                    "iac_engine_version": "version",
+                    "entities_with_incidents": [
+                        {
+                            "filename": "myfilename",
+                            "policy": "mypolicy,",
+                            "policy_id": "mypolicyid",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "mydescription",
+                            "documentation_url": "mydoc",
+                            "component": "mycomponent",
+                            "severity": "myseverity",
+                            "ignore_sha": "mysha",
+                            "some_extra_field": "extra",
+                        }
+                    ],
+                },
+            ),
+            (
+                IaCScanParametersSchema,
+                IaCScanParameters,
+                {"ignored_policies": ["pol1", "pol2"], "minimum_severity": "LOW"},
+            ),
+        ],
+    )
+    def test_schema_loads(self, schema_klass, expected_klass, instance_data):
+        """
+        GIVEN the right kwargs and an extra field in dict format
+        WHEN loading using the schema
+        THEN the extra field is not taken into account
+            AND the result should be an instance of the expected class
+        """
+        schema = schema_klass()
+
+        data = {**instance_data, "field": "extra"}
+
+        obj = schema.load(data)
+        assert isinstance(obj, expected_klass)


### PR DESCRIPTION
In order to be able to call the API and handle the results, we:
- inherit the GGClient, adding a method to call the iacscan endpoint and create the IAC Client to call
- add classes for an IaC scan result and vulnerability with the 
- add a scan parameters class which is passed to the client when doing the request to ignore some policies/severities

### Testing
- Added a test to check deserialization of the introduced classes
- Currently missing a test for the client, will be added when we define the API response and get cassettes