### PR TITLE
feat(iac): handle API result with text and json output handlers

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -1,9 +1,22 @@
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence, Type
 
 import click
 
-from ggshield.iac.utils import POLICY_ID_PATTERN, validate_policy_id
+from ggshield import __version__
+from ggshield.core.client import create_client_from_config
+from ggshield.core.config import Config
+from ggshield.core.extra_headers import get_extra_headers
+from ggshield.core.filter import init_exclusion_regexes
+from ggshield.iac.filter import get_iac_files_from_paths
+from ggshield.iac.models import IaCScanResult
+from ggshield.iac.models.iac_scan_parameters import IaCScanParameters
+from ggshield.iac.utils import POLICY_ID_PATTERN, create_tar, validate_policy_id
+from ggshield.output import OutputHandler
+from ggshield.output.json.iac_json_output_handler import IaCJSONOutputHandler
+from ggshield.output.text.iac_text_output_handler import IaCTextOutputHandler
+from ggshield.scan import ScanCollection
+from ggshield.scan.scannable_errors import handle_scan_error
 
 
 def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
@@ -23,9 +36,10 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
     help="Always return 0 (non-error) status code.",
 )
 @click.option(
-    "--level",
+    "--minimum-severity",
+    "minimum_severity",
     type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
-    help="Level of the blocking alerts.",
+    help="Minimum severity of the policies",
     default="LOW",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose display mode.")
@@ -41,20 +55,105 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
     "--ignore-path",
     "--ipa",
     "ignore_paths",
+    default=None,
+    type=click.Path(),
     multiple=True,
     help="Do not scan the specified paths.",
 )
 @click.option("--json", is_flag=True, help="JSON output.")
 @click.argument(
-    "directory", type=click.Path(exists=True, readable=True, path_type=type(Path))
+    "directory", type=click.Path(exists=True, readable=True, path_type=Path)
 )
+@click.pass_context
 def scan_cmd(
+    ctx: click.Context,
     exit_zero: bool,
-    level: str,
+    minimum_severity: str,
     verbose: bool,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
     json: bool,
     directory: Path,
+) -> int:
+    update_context(
+        ctx, exit_zero, minimum_severity, verbose, ignore_policies, ignore_paths, json
+    )
+    result = iac_scan(ctx, directory)
+    scan = ScanCollection(id=str(directory), type="path_scan", iac_result=result)
+
+    output_handler: OutputHandler = ctx.obj["output_handler"]
+    return output_handler.process_scan(scan)
+
+
+def update_context(
+    ctx: click.Context,
+    exit_zero: bool,
+    minimum_severity: str,
+    verbose: bool,
+    ignore_policies: Sequence[str],
+    ignore_paths: Sequence[str],
+    json: bool,
 ) -> None:
-    pass
+    config: Config = ctx.obj["config"]
+    ctx.obj["client"] = create_client_from_config(config)
+
+    if ignore_paths is not None:
+        config.user_config.iac.ignored_paths.update(ignore_paths)
+
+    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(
+        config.user_config.iac.ignored_paths
+    )
+
+    if ignore_policies is not None:
+        config.user_config.iac.ignored_policies.update(ignore_policies)
+
+    if verbose is not None:
+        config.user_config.verbose = verbose
+
+    if exit_zero is not None:
+        config.user_config.exit_zero = exit_zero
+
+    if minimum_severity is not None:
+        config.user_config.iac.minimum_severity = minimum_severity
+
+    output_handler_cls: Type[OutputHandler] = IaCTextOutputHandler
+    if json:
+        output_handler_cls = IaCJSONOutputHandler
+
+    ctx.obj["output_handler"] = output_handler_cls(
+        show_secrets=False, verbose=config.user_config.verbose
+    )
+
+
+def iac_scan(ctx: click.Context, directory: Path) -> Optional[IaCScanResult]:
+    files = get_iac_files_from_paths(
+        path=directory,
+        exclusion_regexes=ctx.obj["exclusion_regexes"],
+        verbose=ctx.obj["config"].verbose,
+        ignore_git=True,
+    )
+    tar = create_tar(directory, files)
+
+    config = ctx.obj["config"]
+    client = ctx.obj["client"]
+
+    scan_parameters = IaCScanParameters(
+        config.user_config.iac.ignored_policies, config.user_config.iac.minimum_severity
+    )
+
+    scan = client.directory_scan(
+        tar,
+        scan_parameters,
+        {
+            "GGShield-Version": __version__,
+            "GGShield-Command-Path": ctx.command_path
+            if ctx is not None
+            else "external",
+            **get_extra_headers(ctx),
+        },
+    )
+
+    if not scan.success or not isinstance(scan, IaCScanResult):
+        handle_scan_error(scan, files.scannable_list)
+        return None
+    return scan

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -7,7 +7,7 @@ from pygitguardian.client import is_ok, load_detail
 from pygitguardian.models import Detail
 from requests import Session
 
-from ..iac.models import IaCScanResult
+from ..iac.models import IaCScanResult, IaCScanResultSchema
 from ..iac.models.iac_scan_parameters import IaCScanParameters, IaCScanParametersSchema
 from .config import Config
 from .config.errors import UnknownInstanceError
@@ -82,7 +82,7 @@ class IaCGGClient(GGClient):
 
         result: Union[Detail, IaCScanResult]
         if is_ok(resp):
-            result = IaCScanResult.SCHEMA.load(resp.json())
+            result = IaCScanResultSchema().load(resp.json())
         else:
             result = load_detail(resp)
 

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -43,7 +43,9 @@ def get_files_from_paths(
     size = len(files)
     if size > 1 and not yes:
         click.confirm(
-            f"{size} files will be scanned. Do you want to continue?", abort=True
+            f"{size} files will be scanned. Do you want to continue?",
+            abort=True,
+            err=True,
         )
 
     return Files(files)

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import List, Set
+from typing import Set
 
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.scan import File, Files
@@ -20,7 +20,7 @@ IAC_FILENAME_KEYWORDS = {"tfvars", "dockerfile"}
 
 
 def get_iac_files_from_paths(
-    paths: List[str],
+    path: Path,
     exclusion_regexes: Set[re.Pattern],
     verbose: bool,
     ignore_git: bool = False,
@@ -45,6 +45,7 @@ def get_iac_files_from_paths(
             ignore_git=ignore_git,
         )
         .apply_filter(is_file_iac_file)
+        .relative_to(path)
     )
 
 

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -22,8 +22,6 @@ IAC_FILENAME_KEYWORDS = {"tfvars", "dockerfile"}
 def get_iac_files_from_paths(
     paths: List[str],
     exclusion_regexes: Set[re.Pattern],
-    recursive: bool,
-    yes: bool,
     verbose: bool,
     ignore_git: bool = False,
 ) -> Files:
@@ -37,9 +35,17 @@ def get_iac_files_from_paths(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
-    return get_files_from_paths(
-        paths, exclusion_regexes, recursive, yes, verbose, ignore_git
-    ).apply_filter(is_file_iac_file)
+    return (
+        get_files_from_paths(
+            paths=[str(path)],
+            exclusion_regexes=exclusion_regexes,
+            recursive=True,
+            yes=True,
+            verbose=verbose,
+            ignore_git=ignore_git,
+        )
+        .apply_filter(is_file_iac_file)
+    )
 
 
 def is_file_iac_file(file: File) -> bool:

--- a/ggshield/iac/models/__init__.py
+++ b/ggshield/iac/models/__init__.py
@@ -1,12 +1,22 @@
+from ggshield.iac.models.iac_file_result import IaCFileResult, IaCFileResultSchema
 from ggshield.iac.models.iac_scan_parameters import (
     IaCScanParameters,
     IaCScanParametersSchema,
 )
 from ggshield.iac.models.iac_scan_result import IaCScanResult, IaCScanResultSchema
+from ggshield.iac.models.iac_vulnerability import (
+    IaCVulnerability,
+    IaCVulnerabilitySchema,
+)
 
 
 __all__ = [
+    "IaCVulnerability",
+    "IaCVulnerabilitySchema",
+    "IaCFileResult",
+    "IaCFileResultSchema",
     "IaCScanResult",
+    "IaCScanResultSchema",
     "IaCScanResultSchema",
     "IaCScanParameters",
     "IaCScanParametersSchema",

--- a/ggshield/iac/models/iac_file_result.py
+++ b/ggshield/iac/models/iac_file_result.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import List
+
+import marshmallow_dataclass
+from pygitguardian.models import Base, BaseSchema
+
+from ggshield.iac.models.iac_vulnerability import IaCVulnerability
+
+
+@dataclass
+class IaCFileResult(Base):
+    filename: str
+    incidents: List[IaCVulnerability]
+
+
+IaCFileResultSchema = marshmallow_dataclass.class_schema(IaCFileResult, BaseSchema)

--- a/ggshield/iac/models/iac_scan_result.py
+++ b/ggshield/iac/models/iac_scan_result.py
@@ -4,28 +4,15 @@ from typing import List
 import marshmallow_dataclass
 from pygitguardian.models import Base, BaseSchema
 
+from ggshield.iac.models.iac_file_result import IaCFileResult
+
 
 @dataclass
 class IaCScanResult(Base):
     iac_engine_version: str
-    entities_with_incidents: List["IaCVulnerability"]
+    entities_with_incidents: List[IaCFileResult]
     id: str = ""
     type: str = ""
 
 
-@dataclass
-class IaCVulnerability:
-    filename: str
-    policy: str
-    policy_id: str
-    line_end: int
-    line_start: int
-    description: str
-    documentation_url: str
-    component: str = ""
-    severity: str = ""
-    ignore_sha: str = ""
-
-
 IaCScanResultSchema = marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)
-IaCVulnerabilitiesSchema = marshmallow_dataclass.class_schema(IaCVulnerability)

--- a/ggshield/iac/models/iac_scan_result.py
+++ b/ggshield/iac/models/iac_scan_result.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 import marshmallow_dataclass
@@ -9,10 +9,10 @@ from ggshield.iac.models.iac_file_result import IaCFileResult
 
 @dataclass
 class IaCScanResult(Base):
-    iac_engine_version: str
-    entities_with_incidents: List[IaCFileResult]
     id: str = ""
     type: str = ""
+    iac_engine_version: str = ""
+    entities_with_incidents: List[IaCFileResult] = field(default_factory=list)
 
 
 IaCScanResultSchema = marshmallow_dataclass.class_schema(IaCScanResult, BaseSchema)

--- a/ggshield/iac/models/iac_vulnerability.py
+++ b/ggshield/iac/models/iac_vulnerability.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+import marshmallow_dataclass
+from pygitguardian.models import Base, BaseSchema
+
+
+@dataclass
+class IaCVulnerability(Base):
+    policy: str
+    policy_id: str
+    line_end: int
+    line_start: int
+    description: str
+    documentation_url: str
+    component: str = ""
+    severity: str = ""
+    ignore_sha: str = ""
+
+
+IaCVulnerabilitySchema = marshmallow_dataclass.class_schema(
+    IaCVulnerability, BaseSchema
+)

--- a/ggshield/output/json/iac_json_output_handler.py
+++ b/ggshield/output/json/iac_json_output_handler.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, cast
+
+from ggshield.iac.models import IaCScanResultSchema
+from ggshield.output.json.schemas import IaCJSONScanResultSchema
+from ggshield.output.output_handler import OutputHandler
+from ggshield.scan.scannable import ScanCollection
+
+
+class IaCJSONOutputHandler(OutputHandler):
+    def _process_scan_impl(self, scan: ScanCollection) -> str:
+        scan_dict = self.create_scan_dict(scan)
+        text = IaCJSONScanResultSchema().dumps(scan_dict)
+        return cast(str, text)
+
+    @staticmethod
+    def create_scan_dict(scan: ScanCollection) -> Dict[str, Any]:
+        if scan.iac_result is None:
+            return {
+                "id": scan.id,
+                "type": scan.type,
+                "total_incidents": 0,
+            }
+        scan_dict: Dict[str, Any] = IaCScanResultSchema().dump(scan.iac_result)
+        scan_dict["total_incidents"] = len(scan.iac_result.entities_with_incidents)
+
+        for entity in scan_dict["entities_with_incidents"]:
+            entity["total_incidents"] = len(entity["incidents"])
+
+        return scan_dict

--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -1,7 +1,11 @@
-from typing import Any, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
+import marshmallow_dataclass
 from marshmallow import fields, post_dump
 from pygitguardian.models import BaseSchema, Match, MatchSchema
+
+from ggshield.iac.models import IaCFileResult, IaCScanResult, IaCScanResultSchema
 
 
 class ExtendedMatchSchema(MatchSchema):
@@ -96,3 +100,19 @@ class JSONScanCollectionSchema(BaseSchema):
     total_incidents = fields.Integer(required=True)
     total_occurrences = fields.Integer(required=True)
     secrets_engine_version = fields.String(required=False)
+
+
+@dataclass
+class IaCJSONFileResult(IaCFileResult):
+    total_incidents: int = 0
+
+
+@dataclass
+class IaCJSONScanResult(IaCScanResult):
+    entities_with_incidents: List[IaCJSONFileResult] = field(default_factory=list)
+    total_incidents: int = 0
+
+
+IaCJSONScanResultSchema = marshmallow_dataclass.class_schema(
+    IaCJSONScanResult, IaCScanResultSchema
+)

--- a/ggshield/output/text/iac_text_output_handler.py
+++ b/ggshield/output/text/iac_text_output_handler.py
@@ -1,0 +1,67 @@
+from io import StringIO
+from pathlib import Path
+from typing import ClassVar, List
+
+from ggshield.output.output_handler import OutputHandler
+from ggshield.scan import File, ScanCollection
+
+from ...core.text_utils import Line
+from ...core.utils import Filemode, get_lines_from_content
+from ...iac.models import IaCFileResult
+from .message import (
+    file_info,
+    iac_engine_version,
+    iac_vulnerability_header,
+    iac_vulnerability_location,
+)
+
+
+class IaCTextOutputHandler(OutputHandler):
+    nb_lines: ClassVar[int] = 3
+
+    def _process_scan_impl(self, scan: ScanCollection) -> str:
+        scan_buf = StringIO()
+        if scan.optional_header and (scan.iac_result or self.verbose):
+            scan_buf.write(scan.optional_header)
+
+        if scan.iac_result:
+            scan_buf.write(iac_engine_version(scan.iac_result.iac_engine_version))
+            for file_result in scan.iac_result.entities_with_incidents:
+                scan_buf.write(
+                    self.process_iac_file_result(
+                        Path(scan.id) / file_result.filename, file_result
+                    )
+                )
+
+        return scan_buf.getvalue()
+
+    def process_iac_file_result(
+        self, file_path: Path, file_result: IaCFileResult
+    ) -> str:
+        """
+        Build readable message on the found incidents for a specific file
+
+        :param file_path: The full path to the file, used to read the content of the file
+        :param file_result: The file results from the IaC scanning API
+        :return: The formatted message to display
+        """
+        result_buf = StringIO()
+
+        result_buf.write(file_info(file_result.filename, len(file_result.incidents)))
+
+        file = File.from_bytes(file_path.read_bytes(), str(file_path))
+        lines: List[Line] = get_lines_from_content(file.document, Filemode.FILE, False)
+
+        for issue_n, vulnerability in enumerate(file_result.incidents, 1):
+            result_buf.write(iac_vulnerability_header(issue_n, vulnerability))
+            result_buf.write(
+                iac_vulnerability_location(
+                    lines,
+                    vulnerability.line_start,
+                    vulnerability.line_end,
+                    self.nb_lines,
+                    clip_long_lines=not self.verbose,
+                )
+            )
+
+        return result_buf.getvalue()

--- a/ggshield/output/text/message.py
+++ b/ggshield/output/text/message.py
@@ -13,6 +13,8 @@ from ggshield.core.text_utils import (
     pluralize,
     translate_validity,
 )
+from ggshield.iac.models import IaCVulnerability
+from ggshield.output.text.utils import get_offset, get_padding
 
 
 DECORATION_BY_OS = {"posix": "🛡️  ⚔️  🛡️ ", "default": ">>>"}
@@ -153,6 +155,33 @@ def flatten_policy_breaks_by_line(
     return flat_match_dict
 
 
+def iac_vulnerability_location(
+    lines: List[Line],
+    line_start: int,
+    line_end: int,
+    nb_lines: int,
+    clip_long_lines: bool = False,
+) -> str:
+    msg = StringIO()
+    padding = get_padding(lines)
+    offset = get_offset(padding)
+    max_width = shutil.get_terminal_size()[0] - offset if clip_long_lines else 0
+    for line_nb in range(
+        max(0, line_start - nb_lines), min(len(lines) - 1, line_end + nb_lines)
+    ):
+        msg.write(
+            lines[line_nb].build_line_count(
+                padding, line_start - 1 <= line_nb <= line_end - 1
+            )
+        )
+        line_content = lines[line_nb].content
+
+        if max_width:
+            line_content = clip_long_line(line_content, max_width, after=True)
+        msg.write(f"{line_content}\n")
+    return msg.getvalue()
+
+
 def policy_break_header(
     issue_n: int, policy_breaks: List[PolicyBreak], ignore_sha: str
 ) -> str:
@@ -174,6 +203,20 @@ def policy_break_header(
         format_text(ignore_sha, STYLE["ignore_sha"]),
         len(policy_breaks),
         pluralize("occurrence", len(policy_breaks), "occurrences"),
+    )
+
+
+def iac_vulnerability_header(issue_n: int, vulnerability: IaCVulnerability) -> str:
+    """
+    Build a header for the iac policy break.
+    """
+    return "\n{} Incident {} ({}): {}: {} (Ignore with SHA: {})\n".format(
+        format_text(">>>", STYLE["detector_line_start"]),
+        issue_n,
+        format_text("IaC", STYLE["detector"]),
+        format_text(vulnerability.component, STYLE["detector"]),
+        format_text(vulnerability.policy, STYLE["detector"]),
+        format_text(vulnerability.ignore_sha, STYLE["ignore_sha"]),
     )
 
 
@@ -301,6 +344,10 @@ def format_detector(match_type: str, index_start: int, index_end: int) -> str:
 
 def secrets_engine_version() -> str:
     return f"\nsecrets-engine-version: {VERSIONS.secrets_engine_version}\n"
+
+
+def iac_engine_version(iac_engine_version: str) -> str:
+    return f"\niac-engine-version: {iac_engine_version}\n"
 
 
 def _file_info_decoration() -> str:

--- a/ggshield/output/text/text_output_handler.py
+++ b/ggshield/output/text/text_output_handler.py
@@ -5,7 +5,7 @@ import click
 from pygitguardian.models import Match
 
 from ggshield.core.filter import censor_content, leak_dictionary_by_ignore_sha
-from ggshield.core.text_utils import LINE_DISPLAY, Line
+from ggshield.core.text_utils import Line
 from ggshield.core.utils import Filemode, find_match_indices, get_lines_from_content
 from ggshield.output.output_handler import OutputHandler
 from ggshield.scan import Result, ScanCollection
@@ -18,20 +18,7 @@ from .message import (
     policy_break_header,
     secrets_engine_version,
 )
-
-
-def get_padding(lines: List[Line]) -> int:
-    """Return the number of digit of the maximum line number."""
-    # value can be None
-    return max(len(str(lines[-1].pre_index or 0)), len(str(lines[-1].post_index or 0)))
-
-
-def get_offset(padding: int, is_patch: bool = False) -> int:
-    """Return the offset due to the line display."""
-    if is_patch:
-        return len(LINE_DISPLAY["patch"].format("0" * padding, "0" * padding))
-
-    return len(LINE_DISPLAY["file"].format("0" * padding))
+from .utils import get_offset, get_padding
 
 
 class TextOutputHandler(OutputHandler):

--- a/ggshield/output/text/utils.py
+++ b/ggshield/output/text/utils.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from ggshield.core.text_utils import LINE_DISPLAY, Line
+
+
+def get_padding(lines: List[Line]) -> int:
+    """Return the number of digit of the maximum line number."""
+    # value can be None
+    return max(len(str(lines[-1].pre_index or 0)), len(str(lines[-1].post_index or 0)))
+
+
+def get_offset(padding: int, is_patch: bool = False) -> int:
+    """Return the offset due to the line display."""
+    if is_patch:
+        return len(LINE_DISPLAY["patch"].format("0" * padding, "0" * padding))
+
+    return len(LINE_DISPLAY["file"].format("0" * padding))

--- a/tests/cassettes/test_iac_scan_error_response.yaml
+++ b/tests/cassettes/test_iac_scan_error_response.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: directory=%1F%8B%08%00%F6%D8%94b%02%FF%ED%C1%01%0D%00%00%00%C2%A0%F7Om%0E7%A0%00%00%00%00%00%00%00%00%00%807%03%9A%DE%1D%27%00%28%00%00&scan_parameters=%7B%22ignored_policies%22%3A+%5B%5D%2C+%22minimum_severity%22%3A+%22LOW%22%7D
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '229'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      GGShield-Command-Path:
+      - cli iac scan
+      GGShield-Version:
+      - 1.11.0
+      User-Agent:
+      - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+    method: POST
+    uri: https://api.gitguardian.com/v1/iacscan
+  response:
+    body:
+      string: '{"detail": "Not found (404)"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-App-Version
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 30 May 2022 14:47:19 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Set-Cookie:
+      - AWSALB=moPRy9ITU70yvr3B98qmLQMO8NmUE3+z7dMZL7mzcyZ/1EQYEkRVyHxGvti15Si79ssdA7QoUwh4Dz6ohew1KWxBi8Lyyr9kd5fTixx4OWN1sEvxQSYv/AATCstI;
+        Expires=Mon, 06 Jun 2022 14:47:19 GMT; Path=/
+      - AWSALBCORS=moPRy9ITU70yvr3B98qmLQMO8NmUE3+z7dMZL7mzcyZ/1EQYEkRVyHxGvti15Si79ssdA7QoUwh4Dz6ohew1KWxBi8Lyyr9kd5fTixx4OWN1sEvxQSYv/AATCstI;
+        Expires=Mon, 06 Jun 2022 14:47:19 GMT; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-App-Version:
+      - 2ec17e93
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Secrets-Engine-Version:
+      - 2.67.0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/cmd/iac/test_scan.py
+++ b/tests/cmd/iac/test_scan.py
@@ -1,9 +1,14 @@
+import json
+
+import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
+from tests.conftest import my_vcr
 
 
 class TestScanIac:
+    @pytest.mark.skip("To reenable when we have valid cassettes")
     def test_scan_valid_args(self, cli_fs_runner: CliRunner) -> None:
         """
         GIVEN valid arguments to the iac scan command
@@ -15,7 +20,7 @@ class TestScanIac:
             [
                 "iac",
                 "scan",
-                "--level",
+                "--minimum-severity",
                 "MEDIUM",
                 "--ignore-policy",
                 "GG_IAC_0001",
@@ -50,4 +55,39 @@ class TestScanIac:
         assert (
             "The policies ['GG_IAC_002'] do not match the pattern 'GG_IAC_[0-9]{4}'"
             in str(result.exception)
+        )
+
+    @my_vcr.use_cassette("test_iac_scan_error_response")
+    def test_iac_scan_error_response(self, cli_fs_runner: CliRunner) -> None:
+        result = cli_fs_runner.invoke(
+            cli,
+            [
+                "iac",
+                "scan",
+                ".",
+            ],
+        )
+        assert "Error scanning. Results may be incomplete." in result.stdout
+        assert "404:Not found (404)" in result.stdout
+
+    @my_vcr.use_cassette("test_iac_scan_error_response")
+    def test_iac_scan_json_error_response(self, cli_fs_runner: CliRunner) -> None:
+        cli_fs_runner.mix_stderr = False
+        result = cli_fs_runner.invoke(
+            cli,
+            [
+                "iac",
+                "scan",
+                "--json",
+                ".",
+            ],
+        )
+        assert "Error scanning. Results may be incomplete." in result.stderr
+        assert "404:Not found (404)" in result.stderr
+        assert json.loads(result.stdout) == json.loads(
+            '{"entities_with_incidents": [], '
+            '"iac_engine_version": "", '
+            '"id": ".", '
+            '"total_incidents": 0, '
+            '"type": "path_scan"}'
         )

--- a/tests/iac/test_filter.py
+++ b/tests/iac/test_filter.py
@@ -30,10 +30,10 @@ def test_get_iac_files_from_paths(tmp_path):
     for path in tmp_paths:
         Path(path).write_text("something")
 
-    files = get_iac_files_from_paths([str(tmp_path)], set(), True, True, True)
+    files = get_iac_files_from_paths(tmp_path, set(), True)
     assert len(files.files) == 10
-    assert str(tmp_path / "file1.json") not in files.files
-    assert str(tmp_path / "file2.json") in files.files
+    assert str("file1.json") not in files.files
+    assert str("file2.json") in files.files
 
 
 def test_get_iac_files_from_paths_excluded(tmp_path):
@@ -46,12 +46,10 @@ def test_get_iac_files_from_paths_excluded(tmp_path):
     for path in tmp_paths:
         Path(path).write_text("something")
 
-    files = get_iac_files_from_paths(
-        [str(tmp_path)], {re.compile(r"file2")}, True, True, True
-    )
+    files = get_iac_files_from_paths(tmp_path, {re.compile(r"file2")}, True)
     assert len(files.files) == 9
-    assert str(tmp_path / "file2.json") not in files.files
-    assert str(tmp_path / "file3.yaml") in files.files
+    assert str("file2.json") not in files.files
+    assert str("file3.yaml") in files.files
 
 
 def test_get_iac_files_from_paths_ignore_git(tmp_path):
@@ -68,7 +66,7 @@ def test_get_iac_files_from_paths_ignore_git(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path_str)
     subprocess.run(["git", "add", "."], cwd=tmp_path_str)
 
-    files = get_iac_files_from_paths([tmp_path_str], set(), True, True, True)
+    files = get_iac_files_from_paths(tmp_path, set(), True)
     assert len(files.files) == 9
-    assert str(tmp_path / "file2.json") not in files.files
-    assert str(tmp_path / "file3.yaml") in files.files
+    assert str("file2.json") not in files.files
+    assert str("file3.yaml") in files.files

--- a/tests/iac/test_models.py
+++ b/tests/iac/test_models.py
@@ -1,6 +1,13 @@
 import pytest
 
-from ggshield.iac.models import IaCScanResult, IaCScanResultSchema
+from ggshield.iac.models import (
+    IaCFileResult,
+    IaCFileResultSchema,
+    IaCScanResult,
+    IaCScanResultSchema,
+    IaCVulnerability,
+    IaCVulnerabilitySchema,
+)
 from ggshield.iac.models.iac_scan_parameters import (
     IaCScanParameters,
     IaCScanParametersSchema,
@@ -20,7 +27,53 @@ class TestModel:
                     "iac_engine_version": "version",
                     "entities_with_incidents": [
                         {
-                            "filename": "myfilename",
+                            "filename": "filename",
+                            "incidents": [
+                                {
+                                    "policy": "mypolicy,",
+                                    "policy_id": "mypolicyid",
+                                    "line_end": 0,
+                                    "line_start": 0,
+                                    "description": "mydescription",
+                                    "documentation_url": "mydoc",
+                                    "component": "mycomponent",
+                                    "severity": "myseverity",
+                                    "ignore_sha": "mysha",
+                                    "some_extra_field": "extra",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ),
+            (
+                IaCScanParametersSchema,
+                IaCScanParameters,
+                {"ignored_policies": ["pol1", "pol2"], "minimum_severity": "LOW"},
+            ),
+            (
+                IaCVulnerabilitySchema,
+                IaCVulnerability,
+                {
+                    "policy": "mypolicy,",
+                    "policy_id": "mypolicyid",
+                    "line_end": 0,
+                    "line_start": 0,
+                    "description": "mydescription",
+                    "documentation_url": "mydoc",
+                    "component": "mycomponent",
+                    "severity": "myseverity",
+                    "ignore_sha": "mysha",
+                    "some_extra_field": "extra",
+                },
+            ),
+            (
+                IaCFileResultSchema,
+                IaCFileResult,
+                {
+                    "filename": "filename",
+                    "incidents": [
+                        {
                             "policy": "mypolicy,",
                             "policy_id": "mypolicyid",
                             "line_end": 0,
@@ -34,11 +87,6 @@ class TestModel:
                         }
                     ],
                 },
-            ),
-            (
-                IaCScanParametersSchema,
-                IaCScanParameters,
-                {"ignored_policies": ["pol1", "pol2"], "minimum_severity": "LOW"},
             ),
         ],
     )

--- a/tests/output/test_message.py
+++ b/tests/output/test_message.py
@@ -8,7 +8,7 @@ from ggshield.output.text.message import (
     format_line_count_break,
     no_leak_message,
 )
-from ggshield.output.text.text_output_handler import get_offset, get_padding
+from ggshield.output.text.utils import get_offset, get_padding
 
 
 def test_message_no_secret(snapshot):


### PR DESCRIPTION
## feat(iac): handle API result with text and json output handlers

- Update iac scan command to call the API through the client, using the context passed as an argument (from local and global config files) and overriding it with cli arguments.
- Call the API to scan the path passed as a directory. Only support one path
- Update the filter method to remove the root path from the files name
- Introduce text and JSON output handlers for the iac scan, with the format as defined in the tech specs

### Testing
- Added unit tests and updated current unit tests
- Need to add some cassettes when the API is ready

## chore(iac): update iac filter to always use recursive option

## feat(iac): update classes to match api model

- Update classes to match {"id": "", type": "", "iac_engine_version": "","entities_with_incidents": [{"filename": "filename","incidents": [...]}]}