### PR TITLE
fix(iac): add iac scan tests + few fixes on the iac integration

### DIFF
--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -74,8 +74,10 @@ class IaCGGClient(GGClient):
             "post",
             endpoint="iacscan",
             extra_headers=extra_headers,
-            data={
+            files={
                 "directory": directory,
+            },
+            data={
                 "scan_parameters": IaCScanParametersSchema().dumps(scan_parameters),
             },
         )

--- a/ggshield/output/json/iac_json_output_handler.py
+++ b/ggshield/output/json/iac_json_output_handler.py
@@ -8,7 +8,7 @@ from ggshield.scan.scannable import ScanCollection
 
 class IaCJSONOutputHandler(OutputHandler):
     def _process_scan_impl(self, scan: ScanCollection) -> str:
-        scan_dict = self.create_scan_dict(scan)
+        scan_dict = IaCJSONOutputHandler.create_scan_dict(scan)
         text = IaCJSONScanResultSchema().dumps(scan_dict)
         return cast(str, text)
 
@@ -19,11 +19,14 @@ class IaCJSONOutputHandler(OutputHandler):
                 "id": scan.id,
                 "type": scan.type,
                 "total_incidents": 0,
+                "entities_with_incidents": [],
             }
         scan_dict: Dict[str, Any] = IaCScanResultSchema().dump(scan.iac_result)
-        scan_dict["total_incidents"] = len(scan.iac_result.entities_with_incidents)
+        scan_dict["total_incidents"] = 0
 
         for entity in scan_dict["entities_with_incidents"]:
-            entity["total_incidents"] = len(entity["incidents"])
+            total_incidents = len(entity["incidents"])
+            entity["total_incidents"] = total_incidents
+            scan_dict["total_incidents"] += total_incidents
 
         return scan_dict

--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-import marshmallow_dataclass
 from marshmallow import fields, post_dump
 from pygitguardian.models import BaseSchema, Match, MatchSchema
 
-from ggshield.iac.models import IaCFileResult, IaCScanResult, IaCScanResultSchema
+from ggshield.iac.models import IaCFileResultSchema, IaCScanResultSchema
 
 
 class ExtendedMatchSchema(MatchSchema):
@@ -102,17 +100,10 @@ class JSONScanCollectionSchema(BaseSchema):
     secrets_engine_version = fields.String(required=False)
 
 
-@dataclass
-class IaCJSONFileResult(IaCFileResult):
-    total_incidents: int = 0
+class IaCJSONFileResultSchema(IaCFileResultSchema):  # type: ignore
+    total_incidents = fields.Integer(default=0)
 
 
-@dataclass
-class IaCJSONScanResult(IaCScanResult):
-    entities_with_incidents: List[IaCJSONFileResult] = field(default_factory=list)
-    total_incidents: int = 0
-
-
-IaCJSONScanResultSchema = marshmallow_dataclass.class_schema(
-    IaCJSONScanResult, IaCScanResultSchema
-)
+class IaCJSONScanResultSchema(IaCScanResultSchema):  # type: ignore
+    entities_with_incidents = fields.List(fields.Nested(IaCJSONFileResultSchema))
+    total_incidents = fields.Integer(default=0)

--- a/ggshield/output/text/iac_text_output_handler.py
+++ b/ggshield/output/text/iac_text_output_handler.py
@@ -13,6 +13,7 @@ from .message import (
     iac_engine_version,
     iac_vulnerability_header,
     iac_vulnerability_location,
+    no_iac_vulnerabilities,
 )
 
 
@@ -32,7 +33,8 @@ class IaCTextOutputHandler(OutputHandler):
                         Path(scan.id) / file_result.filename, file_result
                     )
                 )
-
+            if len(scan.iac_result.entities_with_incidents) == 0:
+                scan_buf.write(no_iac_vulnerabilities())
         return scan_buf.getvalue()
 
     def process_iac_file_result(

--- a/ggshield/output/text/message.py
+++ b/ggshield/output/text/message.py
@@ -380,6 +380,13 @@ def no_leak_message() -> str:
     return format_text("\nNo secrets have been found\n", STYLE["no_secret"])
 
 
+def no_iac_vulnerabilities() -> str:
+    """
+    Build a message if no IaC vulnerabilities were found.
+    """
+    return format_text("\nNo incidents have been found\n", STYLE["no_secret"])
+
+
 def get_lines_to_display(
     flat_matches_dict: Dict[int, List[Match]], lines: List, nb_lines: int
 ) -> Set[int]:

--- a/tests/cassettes/test_iac_scan_empty_directory.yaml
+++ b/tests/cassettes/test_iac_scan_empty_directory.yaml
@@ -1,12 +1,13 @@
 interactions:
 - request:
     body: !!binary |
-      LS0zODdkYWIyMzBkODIyZTk3ZDdiOTE1OGNjOGYwZjllNw0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      LS1lOWJlNDk2MDFmYjdiN2FjZThmNmU1YmYwODJlZTQyOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
       Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0zODdkYWIyMzBkODIyZTk3ZDdiOTE1
-      OGNjOGYwZjllNw0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
-      cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAChuaYgL/7cEBDQAAAMKg909tDjegAAAA
-      AAAAAAAAgDcDmt4dJwAoAAANCi0tMzg3ZGFiMjMwZDgyMmU5N2Q3YjkxNThjYzhmMGY5ZTctLQ0K
+      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJNRURJVU0ifQ0KLS1lOWJlNDk2MDFmYjdiN2FjZThm
+      NmU1YmYwODJlZTQyOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJl
+      Y3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAeAKfYgL/7cEBDQAAAMKg909tDjeg
+      AAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tZTliZTQ5NjAxZmI3YjdhY2U4ZjZlNWJmMDgyZWU0Mjkt
+      LQ0K
     headers:
       Accept:
       - '*/*'
@@ -15,9 +16,9 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '342'
+      - '345'
       Content-Type:
-      - multipart/form-data; boundary=387dab230d822e97d7b9158cc8f0f9e7
+      - multipart/form-data; boundary=e9be49601fb7b7ace8f6e5bf082ee429
       GGShield-Command-Path:
       - cli iac scan
       GGShield-Version:
@@ -28,22 +29,26 @@ interactions:
     uri: https://api.gitguardian.com/v1/iacscan
   response:
     body:
-      string: '{"detail": "Not found (404)"}'
+      string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[]}'
     headers:
       Access-Control-Expose-Headers:
       - X-App-Version
+      Allow:
+      - POST, OPTIONS
       Connection:
       - keep-alive
       Content-Length:
-      - '29'
+      - '86'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jun 2022 14:30:34 GMT
+      - Tue, 07 Jun 2022 07:47:06 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
+      Vary:
+      - Cookie
       X-App-Version:
       - 3751cc90
       X-Content-Type-Options:
@@ -51,11 +56,12 @@ interactions:
       - nosniff
       X-Frame-Options:
       - DENY
+      - SAMEORIGIN
       X-Secrets-Engine-Version:
       - 2.68.0
       X-XSS-Protection:
       - 1; mode=block
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_iac_scan_multiple_files.yaml
+++ b/tests/cassettes/test_iac_scan_multiple_files.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: !!binary |
+      LS05NmU4YzFjNzFiOTE2YTkwZjQ3NzM4MThkNjY5MmUyNQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS05NmU4YzFjNzFiOTE2YTkwZjQ3NzM4
+      MThkNjY5MmUyNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+      cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA8dCdYgL/7ZfNbqMwFEZZ8xSWH8DxH5As
+      Is2yyy66G1WWQ0yKajAyRkmn6ruPaSZtKtqu2kTT3MMCdG18F/BxDJmR2a9rvbsyem188i3QPR+d
+      KRXy9XqsM8oZT9AuOQFDH7SP7ZPLhM9RE+rGLFmeyYwu5nRBpCjyPONpAvx4al2qqrZGMRKq5Pvy
+      n8t9xuObtc86f808oyJhkstCZFTkLOZfsqxIED1l/hsdwl1thj93ut28My9Oq6qf9/xTb3o3+NIg
+      rLe90nalbN0H0xqPEV7ptTI73XTWYPSYItR5F1zpLFoifHVzc43TJ/hM/M8Q8D/4f+r/OVsUEOxL
+      8r84n/8Fyyb+j9PA/6f3f2vC1vl7pUur/DBaf7oHMJt4T48OLFGlbW+ONweHARzKDseByrtGdc6H
+      wwDnsRrcUe2lOnaN7UPt2n+LaGvddlymrNderawr7w/rM06YIEwSlsFOBPwP/v8q/xdyLiFOl+R/
+      fk7/T///cwH+P4P/e1MOvg4PauPd0H1i//Hy2Mh91PFvTMnzMaP4No4/RSWjFH3W4cNNRnjozGj4
+      un3u91b/02ZjIwgzAAAAAAAAAAAAAADAO/wFwGvkIAAoAAANCi0tOTZlOGMxYzcxYjkxNmE5MGY0
+      NzczODE4ZDY2OTJlMjUtLQ0K
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '759'
+      Content-Type:
+      - multipart/form-data; boundary=96e8c1c71b916a90f4773818d6692e25
+      GGShield-Command-Path:
+      - cli iac scan
+      GGShield-Version:
+      - 1.11.0
+      User-Agent:
+      - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+    method: POST
+    uri: https://api.gitguardian.com/v1/iacscan
+  response:
+    body:
+      string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
+        HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+        HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"}]},{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
+        egress traffic might lead to remote code execution.","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
+        egress means that the asset can download data from the whole web.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"},{"policy":"Unrestricted
+        ingress traffic leaves assets exposed to remote attacks.","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
+        security group has open ingress from all IPs, and on all ports. This means
+        that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
+        no port range is specified. This\nmeans that some applications running on
+        assets of this security group may be reached by\nexternal traffic, while they
+        are not expected to do so.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"}]}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-App-Version
+      Allow:
+      - POST, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 10:03:31 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Cookie
+      X-App-Version:
+      - 3751cc90
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Secrets-Engine-Version:
+      - 2.68.0
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1499'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
+++ b/tests/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: !!binary |
+      LS1hZjM2ZDY5NWRiNTU2ZWE0NTQ4MjViNjM0YWRiYzRiMw0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS1hZjM2ZDY5NWRiNTU2ZWE0NTQ4MjVi
+      NjM0YWRiYzRiMw0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+      cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAtMydYgL/7dOxbsIwFAXQzP6KJ39AcBzH
+      SQekjh27V1VkggNWCSDHUaEV/14HBoa2bDDAPRnylNi+g3XTSTp5fjW7F2vm1idXIU7+ewuRq/M8
+      fs+EzGRCu+QGhj4YH+OTxyQr6oLr7DTThSpEVUqVPslKq0qyBO6eM03dupVNQ3u1jLHUWp06Xmp9
+      6ro8dz7P8iRTUpW50lIXsf95WcT+i1v2vzMhLJ0dvpZmvfhjXVzWtvd3/8zbfjP4xhI3n33d22bw
+      Luzrhd8MW058Zua13Zluu7KcvhmRXcQd/XEkatzc17PVpvnoaUpvXKTHZyL4e/x/YAdGjC4l1H4Y
+      D/4dE/ZbG4/kbn3M4+xy2BiEMgMAAAAAAAAAAAAAAAAAAMBD+gH3QKahACgAAA0KLS1hZjM2ZDY5
+      NWRiNTU2ZWE0NTQ4MjViNjM0YWRiYzRiMy0tDQo=
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '599'
+      Content-Type:
+      - multipart/form-data; boundary=af36d695db556ea454825b634adbc4b3
+      GGShield-Command-Path:
+      - cli iac scan
+      GGShield-Version:
+      - 1.11.0
+      User-Agent:
+      - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+    method: POST
+    uri: https://api.gitguardian.com/v1/iacscan
+  response:
+    body:
+      string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
+        egress traffic might lead to remote code execution.","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
+        egress means that the asset can download data from the whole web.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"},{"policy":"Unrestricted
+        ingress traffic leaves assets exposed to remote attacks.","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
+        security group has open ingress from all IPs, and on all ports. This means
+        that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
+        no port range is specified. This\nmeans that some applications running on
+        assets of this security group may be reached by\nexternal traffic, while they
+        are not expected to do so.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"}]}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-App-Version
+      Allow:
+      - POST, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 09:45:27 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Cookie
+      X-App-Version:
+      - 3751cc90
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Secrets-Engine-Version:
+      - 2.68.0
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '1126'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_iac_scan_no_vulnerabilities.yaml
+++ b/tests/cassettes/test_iac_scan_no_vulnerabilities.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: !!binary |
+      LS04YWM3NDM2MGIwYzQ3OWJlODhmZTY1M2NkYWFlMDdiNA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS04YWM3NDM2MGIwYzQ3OWJlODhmZTY1
+      M2NkYWFlMDdiNA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+      cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAoc6dYgL/7dSxbsMgEAZgz34K5AcggLGt
+      DpE6duwbIEJwYgUHC2MlatV3L26atEM7JkPyfwv4Dt8N6KALunh+1ccXq9c2ZFfBTv5bGSvLn/0c
+      50xwnpFjdgPTGHVI7bPHJBrSx663S15XsmJPgje0rmUlRJ7B/eu0UW3nLI3t1XrMQ11L+bU2dX2a
+      dSEvM1/yKuNSyKaUjZAizX/ZVCwj7Jbz3+sYt52d3rZ6v/njXDrWtvd3/3mwo5+CsaTQh1HtbTz4
+      sFPaOBUmZwtSrPRa2aPuh/nrPSfEbtI/Izlbkla70abEEHz0xrtLoohmKFKiDb5Xgw/xnEivCyHR
+      /4pdonPX1D52fv9dRDvnD3MZ062DWjlvduf6XFBeUi4pr4r8Ay8WAAAAAAAAAAAAAAAAAAAAPKJP
+      Zv8szAAoAAANCi0tOGFjNzQzNjBiMGM0NzliZTg4ZmU2NTNjZGFhZTA3YjQtLQ0K
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '618'
+      Content-Type:
+      - multipart/form-data; boundary=8ac74360b0c479be88fe653cdaae07b4
+      GGShield-Command-Path:
+      - cli iac scan
+      GGShield-Version:
+      - 1.11.0
+      User-Agent:
+      - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+    method: POST
+    uri: https://api.gitguardian.com/v1/iacscan
+  response:
+    body:
+      string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-App-Version
+      Allow:
+      - POST, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 09:53:39 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Cookie
+      X-App-Version:
+      - 3751cc90
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Secrets-Engine-Version:
+      - 2.68.0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_iac_scan_single_vulnerability.yaml
+++ b/tests/cassettes/test_iac_scan_single_vulnerability.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: !!binary |
+      LS0zY2ViYTFhZDQwZWNiMzNkMzI1NDJjZDE4YzIwZDhkZA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+      IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0zY2ViYTFhZDQwZWNiMzNkMzI1NDJj
+      ZDE4YzIwZDhkZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+      cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgACSKaYgL/7dSxasMwEAZgzX4KoQdwJFmW
+      swQyZsyQ3SjOuRHIcZBlalr67nXwkKUdk0L6f4sOcXDD8V++ylfbvZt25E4U2UPIxW+vlIW517d/
+      JbXSjE/sCcYhuTiPZ/+TXvMu+Y42ypZG27XRZa6NrOYFZAxenndN3fpAeWofNuMWamuWjFfWLlnX
+      98wrWTBltLFGK6nUnP+i0iXj8pn571xKZ0/jx9ld3n7om9va9vX2n0Ua+jE2xIV7H2oXjnXwQ6IL
+      RcHF0Z1qmlx3DST4Z8b5Nfapb/rAN1zsDoe9yL5wJgAAAAAAAAAAAAAAAAAAAAD+0jctxjBEACgA
+      AA0KLS0zY2ViYTFhZDQwZWNiMzNkMzI1NDJjZDE4YzIwZDhkZC0tDQo=
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '554'
+      Content-Type:
+      - multipart/form-data; boundary=3ceba1ad40ecb33d32542cd18c20d8dd
+      GGShield-Command-Path:
+      - cli iac scan
+      GGShield-Version:
+      - 1.11.0
+      User-Agent:
+      - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+    method: POST
+    uri: https://api.gitguardian.com/v1/iacscan
+  response:
+    body:
+      string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
+        HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+        HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://gitguardian.com","ignore_sha":"shasha"}]}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-App-Version
+      Allow:
+      - POST, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '454'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 03 Jun 2022 15:00:27 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Cookie
+      X-App-Version:
+      - 3751cc90
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Secrets-Engine-Version:
+      - 2.68.0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cmd/iac/test_scan.py
+++ b/tests/cmd/iac/test_scan.py
@@ -1,6 +1,5 @@
 import json
 
-import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
@@ -8,7 +7,7 @@ from tests.conftest import my_vcr
 
 
 class TestScanIac:
-    @pytest.mark.skip("To reenable when we have valid cassettes")
+    @my_vcr.use_cassette("test_iac_scan_empty_directory")
     def test_scan_valid_args(self, cli_fs_runner: CliRunner) -> None:
         """
         GIVEN valid arguments to the iac scan command
@@ -27,7 +26,7 @@ class TestScanIac:
                 "--ignore-policy",
                 "GG_IAC_0002",
                 "--ignore-path",
-                ".",
+                "**",
                 ".",
             ],
         )
@@ -84,10 +83,10 @@ class TestScanIac:
         )
         assert "Error scanning. Results may be incomplete." in result.stderr
         assert "404:Not found (404)" in result.stderr
-        assert json.loads(result.stdout) == json.loads(
-            '{"entities_with_incidents": [], '
-            '"iac_engine_version": "", '
-            '"id": ".", '
-            '"total_incidents": 0, '
-            '"type": "path_scan"}'
-        )
+        assert json.loads(result.stdout) == {
+            "entities_with_incidents": [],
+            "iac_engine_version": "",
+            "id": ".",
+            "total_incidents": 0,
+            "type": "path_scan",
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -452,6 +452,36 @@ index 2ace9c7..4c7699d 100644
 \\ No newline at end of file
 """
 
+_IAC_SINGLE_VULNERABILITY = """
+resource "aws_alb_listener" "bad_example" {
+  protocol = "HTTP"
+}
+"""
+
+_IAC_MULTIPLE_VULNERABILITIES = """
+resource "aws_security_group" "bad_example" {
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+ resource "aws_security_group_rule" "bad_example" {
+  type = "ingress"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+"""
+
+_IAC_NO_VULNERABILITIES = """
+resource "aws_network_acl_rule" "bad_example" {
+  egress         = false
+  protocol       = "tcp"
+  from_port      = 22
+  to_port        = 22
+  rule_action    = "allow"
+  cidr_block     = "12.13.14.15"
+}
+"""
 
 my_vcr = vcr.VCR(
     cassette_library_dir=join(dirname(realpath(__file__)), "cassettes"),

--- a/tests/output/test_iac_json_output.py
+++ b/tests/output/test_iac_json_output.py
@@ -1,0 +1,174 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from click.testing import CliRunner, Result
+
+from ggshield.cmd.main import cli
+from tests.conftest import (
+    _IAC_MULTIPLE_VULNERABILITIES,
+    _IAC_NO_VULNERABILITIES,
+    _IAC_SINGLE_VULNERABILITY,
+    my_vcr,
+)
+
+
+@my_vcr.use_cassette("test_iac_scan_single_vulnerability")
+def test_display_single_vulnerabilities(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_single_vulnerability.tf").write_text(_IAC_SINGLE_VULNERABILITY)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "--json",
+            "tmp",
+        ],
+    )
+
+    json_result = load_json(result)
+    assert_iac_version_displayed(json_result, 1)
+    assert_file_single_vulnerability_displayed(json_result)
+
+
+@my_vcr.use_cassette("test_iac_scan_multiple_vulnerabilities")
+def test_display_multiple_vulnerabilities(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_multiple_vulnerabilities.tf").write_text(
+        _IAC_MULTIPLE_VULNERABILITIES
+    )
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "--json",
+            "tmp",
+        ],
+    )
+
+    json_result = load_json(result)
+    assert_iac_version_displayed(json_result, 2)
+    assert_file_multiple_vulnerabilities_displayed(json_result)
+
+
+@my_vcr.use_cassette("test_iac_scan_no_vulnerabilities")
+def test_display_no_vulnerability(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_no_vulnerabilities.tf").write_text(_IAC_NO_VULNERABILITIES)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "--json",
+            "tmp",
+        ],
+    )
+
+    json_result = load_json(result)
+    assert_iac_version_displayed(json_result, 0)
+    assert len(json_result["entities_with_incidents"]) == 0
+
+
+@my_vcr.use_cassette("test_iac_scan_multiple_files")
+def test_display_multiple_files(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_single_vulnerability.tf").write_text(_IAC_SINGLE_VULNERABILITY)
+    Path("tmp/iac_file_multiple_vulnerabilities.tf").write_text(
+        _IAC_MULTIPLE_VULNERABILITIES
+    )
+    Path("tmp/iac_file_no_vulnerabilities.tf").write_text(_IAC_NO_VULNERABILITIES)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "--json",
+            "tmp",
+        ],
+    )
+
+    json_result = load_json(result)
+    assert_iac_version_displayed(json_result, 3)
+    assert_file_single_vulnerability_displayed(json_result)
+    assert_file_multiple_vulnerabilities_displayed(json_result)
+
+
+def load_json(result: Result) -> Dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+def assert_iac_version_displayed(json_result: Dict[str, Any], total_incidents: int):
+    assert json_result["iac_engine_version"] == "1.1.0"
+    assert json_result["type"] == "path_scan"
+    assert json_result["id"] == ""
+    assert json_result["total_incidents"] == total_incidents
+
+
+def assert_file_single_vulnerability_displayed(json_result: Dict[str, Any]):
+    file_result = [
+        file_result
+        for file_result in json_result["entities_with_incidents"]
+        if file_result["filename"] == "iac_file_single_vulnerability.tf"
+    ]
+    assert len(file_result) == 1
+    assert file_result[0] == {
+        "filename": "iac_file_single_vulnerability.tf",
+        "incidents": [
+            {
+                "policy": "Plain HTTP is used",
+                "policy_id": "GG_IAC_0001",
+                "line_end": 3,
+                "line_start": 3,
+                "description": "Plain HTTP should not be used, it is unencrypted. HTTPS should be used instead.",
+                "documentation_url": "https://gitguardian.com",
+                "component": "aws_alb_listener.bad_example",
+                "severity": "HIGH",
+                "ignore_sha": "shasha",
+            }
+        ],
+        "total_incidents": 1,
+    }
+
+
+def assert_file_multiple_vulnerabilities_displayed(json_result: Dict[str, Any]):
+    file_result = [
+        file_result
+        for file_result in json_result["entities_with_incidents"]
+        if file_result["filename"] == "iac_file_multiple_vulnerabilities.tf"
+    ]
+    assert len(file_result) == 1
+    assert file_result[0] == {
+        "filename": "iac_file_multiple_vulnerabilities.tf",
+        "incidents": [
+            {
+                "policy": "Unrestricted egress traffic might lead to remote code execution.",
+                "policy_id": "GG_IAC_0002",
+                "line_end": 4,
+                "line_start": 4,
+                "description": "Open egress means that the asset can download data from the whole web.",
+                "documentation_url": "https://gitguardian.com",
+                "component": "aws_security_group.bad_example",
+                "severity": "HIGH",
+                "ignore_sha": "shasha",
+            },
+            {
+                "policy": "Unrestricted ingress traffic leaves assets exposed to remote attacks.",
+                "policy_id": "GG_IAC_0003",
+                "line_end": 10,
+                "line_start": 10,
+                "description": "A security group has open ingress from all IPs, and on all ports. This means that the\nassets in this security group are exposed to the whole web.\n\nFurthermore, no port range is specified. This\nmeans that some applications running on assets of this security group may be reached by\nexternal traffic, while they are not expected to do so.",  # noqa: E501
+                "documentation_url": "https://gitguardian.com",
+                "component": "aws_security_group_rule.bad_example",
+                "severity": "HIGH",
+                "ignore_sha": "shasha",
+            },
+        ],
+        "total_incidents": 2,
+    }

--- a/tests/output/test_iac_text_output.py
+++ b/tests/output/test_iac_text_output.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+from click.testing import CliRunner, Result
+
+from ggshield.cmd.main import cli
+from tests.conftest import (
+    _IAC_MULTIPLE_VULNERABILITIES,
+    _IAC_NO_VULNERABILITIES,
+    _IAC_SINGLE_VULNERABILITY,
+    my_vcr,
+)
+
+
+@my_vcr.use_cassette("test_iac_scan_single_vulnerability")
+def test_display_single_vulnerabilities(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_single_vulnerability.tf").write_text(_IAC_SINGLE_VULNERABILITY)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "tmp",
+        ],
+    )
+
+    assert_iac_version_displayed(result)
+    assert_file_single_vulnerability_displayed(result)
+
+
+@my_vcr.use_cassette("test_iac_scan_multiple_vulnerabilities")
+def test_display_multiple_vulnerabilities(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_multiple_vulnerabilities.tf").write_text(
+        _IAC_MULTIPLE_VULNERABILITIES
+    )
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "tmp",
+        ],
+    )
+
+    assert_iac_version_displayed(result)
+    assert_file_multiple_vulnerabilities_displayed(result)
+    assert_no_failures_displayed(result)
+
+
+@my_vcr.use_cassette("test_iac_scan_no_vulnerabilities")
+def test_display_no_vulnerability(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_no_vulnerabilities.tf").write_text(_IAC_NO_VULNERABILITIES)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "tmp",
+        ],
+    )
+
+    assert_iac_version_displayed(result)
+    assert "No incidents have been found" in result.stdout
+    assert_no_failures_displayed(result)
+
+
+@my_vcr.use_cassette("test_iac_scan_multiple_files")
+def test_display_multiple_files(cli_fs_runner: CliRunner):
+    Path("tmp/").mkdir(exist_ok=True)
+    Path("tmp/iac_file_single_vulnerability.tf").write_text(_IAC_SINGLE_VULNERABILITY)
+    Path("tmp/iac_file_multiple_vulnerabilities.tf").write_text(
+        _IAC_MULTIPLE_VULNERABILITIES
+    )
+    Path("tmp/iac_file_no_vulnerabilities.tf").write_text(_IAC_NO_VULNERABILITIES)
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+            "tmp",
+        ],
+    )
+
+    assert_iac_version_displayed(result)
+    assert_file_single_vulnerability_displayed(result)
+    assert_file_multiple_vulnerabilities_displayed(result)
+    assert_no_failures_displayed(result)
+
+
+def assert_iac_version_displayed(result: Result):
+    assert "iac-engine-version: 1.1.0" in result.stdout
+
+
+def assert_no_failures_displayed(result: Result):
+    assert "Error scanning. Results may be incomplete." not in result.stdout
+
+
+def assert_file_single_vulnerability_displayed(result: Result):
+    assert (
+        "1 incident has been found in file iac_file_single_vulnerability.tf"
+        in result.stdout
+    )
+    assert (
+        ">>> Incident 1 (IaC): aws_alb_listener.bad_example: Plain HTTP is used (Ignore with SHA: shasha)"  # noqa: E501
+        in result.stdout
+    )
+    assert '2 | resource "aws_alb_listener" "bad_example" {' in result.stdout
+
+
+def assert_file_multiple_vulnerabilities_displayed(result: Result):
+    assert (
+        "2 incidents have been found in file iac_file_multiple_vulnerabilities.tf"
+        in result.stdout
+    )
+    assert (
+        ">>> Incident 1 (IaC): aws_security_group.bad_example: Unrestricted egress traffic might lead to remote code execution. (Ignore with SHA: shasha)"  # noqa: E501
+        in result.stdout
+    )
+    assert '2 | resource "aws_security_group" "bad_example" {' in result.stdout
+    assert (
+        ">>> Incident 2 (IaC): aws_security_group_rule.bad_example: Unrestricted ingress traffic leaves assets exposed to remote attacks. (Ignore with SHA: shasha)"  # noqa: E501
+        in result.stdout
+    )
+    assert '8 |  resource "aws_security_group_rule" "bad_example" {' in result.stdout


### PR DESCRIPTION
- Update json schemas to fix entities_with_incidents appearing in the incidents
- Update client to pass the bytes tar as files
- Fix total entities in json output
- Add a message when there are no vulnerabilities found for the iac text output
- Add cassettes tests for a file with a single vulnerability, a file with multiple vulnerabilities, a file with no vulnerabilities, multiple files, for the text output and the json output