### PR TITLE
Workaround TestPreReceive::test_timeout flakiness (#192)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,10 @@ skipwindows = pytest.mark.skipif(
 )
 
 
+def is_macos():
+    return platform.system() == "Darwin"
+
+
 DATA_PATH = Path(__file__).parent.absolute() / "data"
 
 


### PR DESCRIPTION
This PR works around the flakiness of `TestPreReceive::test_timeout` on macOS by increasing the timeout. Not the best fix in the world, but it should help with false failures.