### PR TITLE
Small fixes for iac

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -19,7 +19,7 @@ from ggshield.scan import ScanCollection
 from ggshield.scan.scannable_errors import handle_scan_error
 
 
-def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
+def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[str]:
     invalid_excluded_policies = [
         policy_id for policy_id in value if not validate_policy_id(policy_id)
     ]
@@ -27,6 +27,7 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
         raise ValueError(
             f"The policies {invalid_excluded_policies} do not match the pattern '{POLICY_ID_PATTERN.pattern}'"
         )
+    return value
 
 
 @click.command()

--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -40,7 +40,6 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> None:
     "minimum_severity",
     type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
     help="Minimum severity of the policies",
-    default="LOW",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose display mode.")
 @click.option(

--- a/ggshield/output/text/message.py
+++ b/ggshield/output/text/message.py
@@ -182,6 +182,13 @@ def iac_vulnerability_location(
     return msg.getvalue()
 
 
+def iac_vulnerability_location_failed(
+    line_start: int,
+    line_end: int,
+) -> str:
+    return f"\nFailed to read from the original file.\nThe incident was found between lines {line_start} and {line_end}\n"  # noqa: E501
+
+
 def policy_break_header(
     issue_n: int, policy_breaks: List[PolicyBreak], ignore_sha: str
 ) -> str:


### PR DESCRIPTION
fix(iac): fix ignore-policy click option

fix(iac): add default behavior in case files are not found to display for the text output handler, to prevent complete failure

fix(iac): remove default CLI input to minimum-severity to avoid overriding config files