### PR TITLE
Bring back support for GITGUARDIAN_API_URL

### DIFF
--- a/.gitguardian.example.yml
+++ b/.gitguardian.example.yml
@@ -23,8 +23,6 @@ exit-zero: false # default: false
 
 verbose: false # default: false
 
-instance: https://api.gitguardian.com
-
 # Maximum commits to scan in a hook.
 max-commits-for-hook: 50 # default: 50
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,12 @@ exit-zero: false # default: false
 # By default only secrets are detected. Use all-policies to toggle this behaviour.
 all-policies: false # default: false
 
-instance: https://api.gitguardian.com
+# GitGuardian instance URL.
+# Only useful when using an on-premise GitGuardian instance.
+instance: https://dashboard.gitguardian.com
+
+# GitGuardian API URL. Deduced from `instance` if not set.
+api-url: https://api.gitguardian.com
 
 verbose: false # default: false
 ```
@@ -473,9 +478,9 @@ Reference of current environment variables supported by ggshield:
 
 - `GITGUARDIAN_API_KEY`: API Key for the GitGuardian API. Use this if you don't want to use the `ggshield auth` commands.
 
-- `GITGUARDIAN_INSTANCE`: Custom URL of the GitGuardian dashboard. The API URL will be inferred from it.
+- `GITGUARDIAN_INSTANCE`: Custom URL of the GitGuardian dashboard.
 
-- `GITGUARDIAN_API_URL`: Custom URL for the scanning API. Deprecated, use `GITGUARDIAN_INSTANCE` instead.
+- `GITGUARDIAN_API_URL`: Custom URL for the scanning API.
 
 - `GITGUARDIAN_DONT_LOAD_ENV`: If set to any value, environment variables won't be loaded from a file.
 

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -6,8 +6,7 @@ import click
 from ggshield.core.config.auth_config import AuthConfig
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import get_attr_mapping
-from ggshield.core.constants import DEFAULT_DASHBOARD_URL
-from ggshield.core.utils import api_to_dashboard_url, clean_url, dashboard_to_api_url
+from ggshield.core.utils import clean_url, dashboard_to_api_url
 
 
 class Config:
@@ -76,22 +75,8 @@ class Config:
         if self._cmdline_instance_name:
             return self._cmdline_instance_name
 
-        try:
-            return os.environ["GITGUARDIAN_INSTANCE"]
-        except KeyError:
-            pass
-
-        try:
-            name = os.environ["GITGUARDIAN_API_URL"]
-        except KeyError:
-            pass
-        else:
-            return api_to_dashboard_url(name, warn=True)
-
-        if self.user_config.instance:
-            return self.user_config.instance
-
-        return DEFAULT_DASHBOARD_URL
+        assert self.user_config.instance
+        return self.user_config.instance
 
     def set_cmdline_instance_name(self, name: str) -> None:
         """
@@ -112,8 +97,10 @@ class Config:
         The API URL to use to use the API
         It's the API URL from the configured instance
         """
-        # TODO change when instance_name can be a name instead of just a URL
-        return dashboard_to_api_url(self.instance_name)
+        if self._cmdline_instance_name:
+            return dashboard_to_api_url(self._cmdline_instance_name)
+        assert self.user_config.api_url
+        return self.user_config.api_url
 
     @property
     def dashboard_url(self) -> str:

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -288,6 +288,8 @@ def clean_url(url: str, warn: bool = False) -> ParseResult:
     (optionally with a warning).
     """
     parsed_url = urlparse(url)
+    if parsed_url.scheme != "https":
+        raise click.ClickException(f"Invalid scheme for URL '{url}', expected HTTPS")
     if parsed_url.path.endswith("/"):
         parsed_url = parsed_url._replace(path=parsed_url.path[:-1])
     if parsed_url.path.endswith("/v1"):
@@ -303,10 +305,6 @@ def dashboard_to_api_url(dashboard_url: str, warn: bool = False) -> str:
     handles the SaaS edge case where the host changes instead of the path
     """
     parsed_url = clean_url(dashboard_url, warn=warn)
-    if parsed_url.scheme != "https":
-        raise click.ClickException(
-            f"Invalid scheme for dashboard URL '{dashboard_url}', expected HTTPS"
-        )
     if any(parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
         if parsed_url.path:
             raise click.ClickException(
@@ -328,10 +326,6 @@ def api_to_dashboard_url(api_url: str, warn: bool = False) -> str:
     handles the SaaS edge case where the host changes instead of the path
     """
     parsed_url = clean_url(api_url, warn=warn)
-    if parsed_url.scheme != "https":
-        raise click.ClickException(
-            f"Invalid scheme for API URL '{api_url}', expected HTTPS"
-        )
     if parsed_url.netloc.endswith(".gitguardian.com"):  # SaaS
         if parsed_url.path:
             raise click.ClickException(

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -293,7 +293,7 @@ def clean_url(url: str, warn: bool = False) -> ParseResult:
     if parsed_url.path.endswith("/v1"):
         parsed_url = parsed_url._replace(path=parsed_url.path[:-3])
         if warn:
-            display_warning("Unexpected /v1 path in your URL configuration")
+            display_warning(f"Ignoring unnecessary /v1 path in '{url}'")
     return parsed_url
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -561,9 +561,8 @@ class TestConfig:
         WHEN loading the config
         THEN writes a warning to stderr
         """
-        monkeypatch.setitem(
-            os.environ, "GITGUARDIAN_API_URL", "https://api.gitguardian.com/v1"
-        )
+        original_api_url = "https://api.gitguardian.com/v1"
+        monkeypatch.setitem(os.environ, "GITGUARDIAN_API_URL", original_api_url)
         config = Config()
         api_url = config.api_url
         out, err = capsys.readouterr()
@@ -571,7 +570,7 @@ class TestConfig:
         sys.stderr.write(err)
 
         assert api_url == "https://api.gitguardian.com"
-        assert "Unexpected /v1 path in your URL configuration" in err
+        assert f"Ignoring unnecessary /v1 path in '{original_api_url}'" in err
 
     def test_v1_in_api_url_local_config(self, capsys, local_config_path):
         """
@@ -579,12 +578,13 @@ class TestConfig:
         WHEN loading the config
         THEN writes a warning to stderr
         """
+        original_api_url = "https://api.gitguardian.com/v1"
         write_yaml(
             local_config_path,
             {
                 "verbose": False,
                 "show_secrets": True,
-                "api_url": "https://api.gitguardian.com/v1",
+                "api_url": original_api_url,
             },
         )
 
@@ -595,7 +595,7 @@ class TestConfig:
         sys.stderr.write(err)
 
         assert api_url == "https://api.gitguardian.com"
-        assert "Unexpected /v1 path in your URL configuration" in err
+        assert f"Ignoring unnecessary /v1 path in '{original_api_url}'" in err
 
     def test_v1_in_api_url_global_config(self, capsys, global_config_path):
         """
@@ -603,12 +603,13 @@ class TestConfig:
         WHEN loading the config
         THEN writes a warning to stderr
         """
+        original_api_url = "https://api.gitguardian.com/v1"
         write_yaml(
             global_config_path,
             {
                 "verbose": False,
                 "show_secrets": True,
-                "api_url": "https://api.gitguardian.com/v1",
+                "api_url": original_api_url,
             },
         )
 
@@ -617,7 +618,7 @@ class TestConfig:
         sys.stdout.write(out)
         sys.stderr.write(err)
 
-        assert "Unexpected /v1 path in your URL configuration" in err
+        assert f"Ignoring unnecessary /v1 path in '{original_api_url}'" in err
 
     def test_updating_config_not_from_default_local_config_path(
         self, local_config_path

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -111,7 +111,7 @@ def test_retrieve_client_invalid_api_url():
     url = "no-scheme.com"
     with pytest.raises(
         click.ClickException,
-        match=f"Invalid scheme for API URL '{url}', expected HTTPS",
+        match=f"Invalid scheme for URL '{url}', expected HTTPS",
     ):
         with mock.patch.dict(os.environ, {"GITGUARDIAN_API_URL": url}):
             create_client_from_config(Config())


### PR DESCRIPTION
## Description

This PR "un-deprecates" the `$GITGUARDIAN_API_URL` environment variable. When it is set, we no longer try to turn it into a dashboard URL and back into an API URL.

It also reworks some tests to make them easier to understand.

Best reviewed commit by commit.
