### PR TITLE
Improve docker filesystem banlist

### DIFF
--- a/tests/cmd/scan/test_docker.py
+++ b/tests/cmd/scan/test_docker.py
@@ -6,11 +6,7 @@ import click
 import pytest
 
 from ggshield.cmd.main import cli
-from ggshield.scan.docker import (
-    DEFAULT_EXTENSION_BANLIST,
-    DEFAULT_FS_BANLIST,
-    _validate_filepath,
-)
+from ggshield.scan.docker import _validate_filepath
 from ggshield.scan.scannable import File, Files, ScanCollection
 from tests.conftest import (
     _SIMPLE_SECRET,
@@ -34,6 +30,9 @@ class TestDockerUtils:
             ["/usr/bin/secret.py", False],
             ["usr/bin/secret.py", False],
             ["/my/file/secret.py", True],
+            ["/my/file/usr/bin/secret.py", True],
+            ["/usr/share/nginx/secret.py", True],
+            ["/gems/secret.py", True],
             ["/npm-bis/secret.py", True],
             ["/banned/extension/secret.md", False],
             ["/banned/extension/secret.html", False],
@@ -45,8 +44,6 @@ class TestDockerUtils:
         assert (
             _validate_filepath(
                 filepath=filepath,
-                extension_banlist=DEFAULT_EXTENSION_BANLIST,
-                filepath_banlist=DEFAULT_FS_BANLIST,
             )
             is valid
         )

--- a/tests/cmd/scan/test_docker.py
+++ b/tests/cmd/scan/test_docker.py
@@ -6,6 +6,11 @@ import click
 import pytest
 
 from ggshield.cmd.main import cli
+from ggshield.scan.docker import (
+    DEFAULT_EXTENSION_BANLIST,
+    DEFAULT_FS_BANLIST,
+    _validate_filepath,
+)
 from ggshield.scan.scannable import File, Files, ScanCollection
 from tests.conftest import (
     _SIMPLE_SECRET,
@@ -20,6 +25,31 @@ DOCKER_EXAMPLE_PATH = DATA_PATH / "docker-example.tar.xz"
 DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
     DATA_PATH / "docker-incomplete-manifest-example.tar.xz"
 )
+
+
+class TestDockerUtils:
+    @pytest.mark.parametrize(
+        "filepath, valid",
+        (
+            ["/usr/bin/secret.py", False],
+            ["usr/bin/secret.py", False],
+            ["/my/file/secret.py", True],
+            ["/npm-bis/secret.py", True],
+            ["/banned/extension/secret.md", False],
+            ["/banned/extension/secret.html", False],
+            ["/banned/extension/secret.css", False],
+            ["/banned/extension/secret.other", True],
+        ),
+    )
+    def test_docker_filepath_validation(self, filepath, valid):
+        assert (
+            _validate_filepath(
+                filepath=filepath,
+                extension_banlist=DEFAULT_EXTENSION_BANLIST,
+                filepath_banlist=DEFAULT_FS_BANLIST,
+            )
+            is valid
+        )
 
 
 class TestDockerCMD:


### PR DESCRIPTION
In this PR, we do mainly two things :  
- Improve the existing way we "pre-validate" filepath before sending them to the API.  
- Modify a bit the banlist to fix #193.  
  - We now allow some very specific cases of `/usr/` filepath when the file relates to nginx. 
  - We allow `/gems` filepath, as it introduces a low volume of results with some interesting results.  
  - I tried to identify some other rules that we could change : I think this is outside the scope of this issue, and it would require some more work.
  
  