### PR TITLE
pre-commit fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         stages: [push]
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: ggshield
         language_version: python3

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   entry: ggshield
   description: Runs ggshield to detect hardcoded secrets, security vulnerabilities and policy breaks.
   stages: [commit]
-  args: ['scan', 'pre-commit']
+  args: ['secret', 'scan', 'pre-commit']
   language: python
 - id: docker-ggshield
   name: GitGuardian Shield (pre-commit,docker)
@@ -14,7 +14,7 @@
   name: GitGuardian Shield (pre-push)
   entry: ggshield
   description: Runs ggshield to detect hardcoded secrets, security vulnerabilities and policy breaks.
-  args: ['scan', 'pre-push']
+  args: ['secret', 'scan', 'pre-push']
   stages: [push]
   pass_filenames: false
   language: python

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Only metadata such as call time, request size and scan mode is stored from scans
       - [Updating](#updating)
 - [Initial setup](#initial-setup)
 - [Command reference](#command-reference)
-  - [auth commands](#auth-commands)
-  - [config commands](#config-commands)
-  - [secret scan commands](#secret-scan-commands)
+  - [Auth commands](#auth-commands)
+  - [Config commands](#config-commands)
+  - [Secret scan commands](#secret-scan-commands)
     - [`secret scan ci`: scan each commit since the last build in your CI](#secret-scan-ci-scan-each-commit-since-the-last-build-in-your-ci)
     - [`secret scan commit-range`: scan each commit in the given commit range](#secret-scan-commit-range-scan-each-commit-in-the-given-commit-range)
     - [`secret scan path`: scan files or directories with the recursive option](#secret-scan-path-scan-files-or-directories-with-the-recursive-option)
@@ -153,6 +153,7 @@ Commands:
   quota       Show quotas overview.
   secret      Commands to work with secrets.
 ```
+
 ## Auth commands
 
 See [the manual](https://docs.gitguardian.com/internal-repositories-monitoring/ggshield/reference/auth/overview) for information about the auth commands.

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Create a `.pre-commit-config.yaml` file in your root repository:
 ```yaml
 repos:
   - repo: https://github.com/gitguardian/ggshield
-    rev: main
+    rev: v1.12.0
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
While preparing an upcoming presentation, I found out a few issues with our pre-commit setup. This PR fixes them.

- The doc suggests using `rev: main`, but pre-commit warns if we do so, with a message like this:
```
[WARNING] The 'rev' field of repo 'https://github.com/gitguardian/ggshield' appears to be a
mutable reference (moving tag / branch).  Mutable references are never updated after first
install and are not supported.  See
https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.
Hint: `pre-commit autoupdate` often fixes this.
```

- Update the version of ggshield we use to 1.12.0.

- Update the hook commands to use `ggshield secret scan (...)` instead of `ggshield scan (...)`.

(The PR also updates the toc, which was outdated, causing doctoc to complain)