### PR TITLE
Fix ggshield secret scan repo crashes on repositories containing files with a 0 bytes in them

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ appdirs = ">=1.4.4,<1.5.0"
 click = ">=8.0,<8.1"
 ggshield = { editable = true, path = "." }
 oauthlib = "~=3.2"
-pygitguardian = ">=1.3.4,<1.4.0"
+pygitguardian = ">=1.3.5,<1.4.0"
 pyyaml = ">=6.0,<6.1"
 python-dotenv = ">=0.19.1,<0.20.0"
 

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -69,11 +69,7 @@ class File:
 
     @staticmethod
     def from_bytes(raw_document: bytes, filename: str) -> "File":
-        document = (
-            raw_document.decode(errors="replace")
-            .replace("\0", " ")  # errors="replace" keeps `\0`, remove it
-            .replace("\uFFFD", " ")  # replacement character
-        )
+        document = raw_document.decode(errors="replace")
         return File(document, filename)
 
     @property

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -9,12 +9,12 @@ from ggshield.core.file_utils import generate_files_from_paths
 @pytest.mark.parametrize(
     ["filename", "input_content", "expected_content"],
     [
-        ("normal.txt", "Normal", "Normal"),
-        ("0-inside.txt", "Ins\0de", "Ins de"),
+        ("normal.txt", b"Normal", "Normal"),
+        ("invalid-utf8-start-byte.txt", b"Hello\x81World", "Hello\uFFFDWorld"),
     ],
 )
 def test_generate_files_from_paths(
-    tmp_path, filename: str, input_content: str, expected_content: str
+    tmp_path, filename: str, input_content: bytes, expected_content: str
 ):
     """
     GIVEN a file
@@ -23,7 +23,7 @@ def test_generate_files_from_paths(
     AND the content of the File instance is what is expected
     """
     path = tmp_path / filename
-    Path(path).write_text(input_content)
+    Path(path).write_bytes(input_content)
 
     files = list(generate_files_from_paths([str(path)], verbose=False))
 

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -11,6 +11,7 @@ from ggshield.core.file_utils import generate_files_from_paths
     [
         ("normal.txt", b"Normal", "Normal"),
         ("invalid-utf8-start-byte.txt", b"Hello\x81World", "Hello\uFFFDWorld"),
+        ("zero-bytes-are-kept.txt", b"Zero\0byte", "Zero\0byte"),
     ],
 )
 def test_generate_files_from_paths(


### PR DESCRIPTION
Since version 1.3.5, py-gitguardian takes care of cleaning input documents by replacing `0` bytes. no need to do it ourselves.

Also, don't replace replacement characters: they do not cause problems and are a better fit than a space.

Fixes #264