### PR TITLE
fix(user_config): #278 Don't fail on unknown keys for user config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,14 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          [types-requests, types-pyyaml, types-appdirs, types-oauthlib, click]
+          [
+            types-requests,
+            types-pyyaml,
+            types-appdirs,
+            types-oauthlib,
+            click,
+            marshmallow-dataclass,
+          ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -20,6 +20,7 @@ from ggshield.core.constants import (
     GLOBAL_CONFIG_FILENAMES,
     LOCAL_CONFIG_PATHS,
 )
+from ggshield.core.text_utils import display_warning
 from ggshield.core.types import IgnoredMatch, IgnoredMatchSchema
 from ggshield.core.utils import api_to_dashboard_url
 from ggshield.iac.utils import POLICY_ID_PATTERN, validate_policy_id
@@ -34,7 +35,7 @@ class BaseConfig:
     @pre_load(pass_many=False)
     def filter_fields(cls, data: Dict, **kwargs: Any) -> Dict:
         """
-        Remove and alert on unknown field.
+        Remove and alert on unknown fields.
         """
         field_names = {field_.name for field_ in fields(cls)}
         filtered_fields = {}
@@ -42,7 +43,7 @@ class BaseConfig:
             if key in field_names:
                 filtered_fields[key] = item
             else:
-                click.echo("Unrecognized key in config: {}".format(key))
+                display_warning("Unrecognized key in config: {}".format(key))
 
         return filtered_fields
 

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -30,7 +30,7 @@ CURRENT_CONFIG_VERSION = 2
 
 
 @marshmallow_dataclass.dataclass
-class BaseConfig:
+class FilteredConfig:
     @classmethod
     @pre_load(pass_many=False)
     def filter_fields(cls, data: Dict, **kwargs: Any) -> Dict:
@@ -49,7 +49,7 @@ class BaseConfig:
 
 
 @marshmallow_dataclass.dataclass
-class SecretConfig(BaseConfig):
+class SecretConfig(FilteredConfig):
     """
     Holds all user-defined secret-specific settings
     """
@@ -83,7 +83,7 @@ def validate_policy_ids(values: Iterable[str]) -> None:
 
 
 @marshmallow_dataclass.dataclass
-class IaCConfig(BaseConfig):
+class IaCConfig(FilteredConfig):
     """
     Holds the iac config as defined .gitguardian.yaml files
     (local and global).
@@ -97,7 +97,7 @@ class IaCConfig(BaseConfig):
 
 
 @marshmallow_dataclass.dataclass
-class UserConfig(BaseConfig):
+class UserConfig(FilteredConfig):
     """
     Holds all ggshield settings defined by the user in the .gitguardian.yaml files
     (local and global).

--- a/ggshield/core/types.py
+++ b/ggshield/core/types.py
@@ -1,13 +1,33 @@
-from typing import Optional
+from dataclasses import fields
+from typing import Any, Dict, Optional
 
 import marshmallow_dataclass
-from marshmallow import EXCLUDE
+from marshmallow.decorators import pre_load
+
+from ggshield.core.text_utils import display_warning
 
 
 @marshmallow_dataclass.dataclass
-class IgnoredMatch:
-    class Meta:
-        unknown = EXCLUDE
+class FilteredConfig:
+    @classmethod
+    @pre_load(pass_many=False)
+    def filter_fields(cls, data: Dict, **kwargs: Any) -> Dict:
+        """
+        Remove and alert on unknown fields.
+        """
+        field_names = {field_.name for field_ in fields(cls)}
+        filtered_fields = {}
+        for key, item in data.items():
+            if key in field_names:
+                filtered_fields[key] = item
+            else:
+                display_warning("Unrecognized key in config: {}".format(key))
+
+        return filtered_fields
+
+
+@marshmallow_dataclass.dataclass
+class IgnoredMatch(FilteredConfig):
 
     match: str
     name: Optional[str] = None

--- a/ggshield/core/types.py
+++ b/ggshield/core/types.py
@@ -1,11 +1,14 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import marshmallow_dataclass
+from marshmallow import EXCLUDE
 
 
-@dataclass
+@marshmallow_dataclass.dataclass
 class IgnoredMatch:
+    class Meta:
+        unknown = EXCLUDE
+
     match: str
     name: Optional[str] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+plugins = ["marshmallow_dataclass.mypy"]
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/tests/core/config/test_user_config.py
+++ b/tests/core/config/test_user_config.py
@@ -249,7 +249,7 @@ class TestUserConfig:
                 "iac": {"ignored_paths": ["myglobalpath"], "iac_unknown": [""]},
                 "secret": {
                     "secret_invalid_key": "invalid key",
-                    "matches_ignore": [
+                    "ignored-matches": [
                         {"name": "", "match": "one", "match_invalid_key": "two"},
                     ],
                 },
@@ -260,3 +260,4 @@ class TestUserConfig:
         assert "Unrecognized key in config: root_unknown" in captured.err
         assert "Unrecognized key in config: iac_unknown" in captured.err
         assert "Unrecognized key in config: secret_invalid_key" in captured.err
+        assert "Unrecognized key in config: match_invalid_key" in captured.err

--- a/tests/core/config/test_user_config.py
+++ b/tests/core/config/test_user_config.py
@@ -234,3 +234,24 @@ class TestUserConfig:
         assert config.iac.ignored_paths == {"myglobalpath", "mypath"}
         assert config.iac.ignored_policies == {"GG_IAC_0001", "GG_IAC_0002"}
         assert config.iac.minimum_severity == "myseverity"
+
+    def test_user_config_unknown_keys(self, local_config_path, capsys):
+        """
+        GIVEN a config containing unknown keys
+        WHEN deserializing it
+        THEN the keys are ignored and a warning is raised
+        """
+        write_yaml(
+            local_config_path,
+            {
+                "version": 2,
+                "root_unknown": "false key",
+                "iac": {"ignored_paths": ["myglobalpath"], "iac_unknown": [""]},
+                "secret": {"secret_invalid_key": "invalid key"},
+            },
+        )
+        UserConfig.load(local_config_path)
+        captured = capsys.readouterr()
+        assert "Unrecognized key in config: root_unknown" in captured.out
+        assert "Unrecognized key in config: iac_unknown" in captured.out
+        assert "Unrecognized key in config: secret_invalid_key" in captured.out

--- a/tests/core/config/test_user_config.py
+++ b/tests/core/config/test_user_config.py
@@ -239,7 +239,7 @@ class TestUserConfig:
         """
         GIVEN a config containing unknown keys
         WHEN deserializing it
-        THEN the keys are ignored and a warning is raised
+        THEN the keys are ignored and a warning is raised for config keys
         """
         write_yaml(
             local_config_path,
@@ -247,7 +247,12 @@ class TestUserConfig:
                 "version": 2,
                 "root_unknown": "false key",
                 "iac": {"ignored_paths": ["myglobalpath"], "iac_unknown": [""]},
-                "secret": {"secret_invalid_key": "invalid key"},
+                "secret": {
+                    "secret_invalid_key": "invalid key",
+                    "matches_ignore": [
+                        {"name": "", "match": "one", "match_invalid_key": "two"},
+                    ],
+                },
             },
         )
         UserConfig.load(local_config_path)

--- a/tests/core/config/test_user_config.py
+++ b/tests/core/config/test_user_config.py
@@ -257,6 +257,6 @@ class TestUserConfig:
         )
         UserConfig.load(local_config_path)
         captured = capsys.readouterr()
-        assert "Unrecognized key in config: root_unknown" in captured.out
-        assert "Unrecognized key in config: iac_unknown" in captured.out
-        assert "Unrecognized key in config: secret_invalid_key" in captured.out
+        assert "Unrecognized key in config: root_unknown" in captured.err
+        assert "Unrecognized key in config: iac_unknown" in captured.err
+        assert "Unrecognized key in config: secret_invalid_key" in captured.err


### PR DESCRIPTION
- Add a base config class to handle pre_load and output message with unknown keys in config
- Add marshmallow_dataclass plugin for mypy

Please note that we don't raise a warning for additional fields in IgnoredMatches. I thought those are less important since they don't change the behaviour of the scan and can be a very long output in the case of a faulty copy/paste. This can be changed if you think it is better to raise the warning.

 Close #278