### PR TITLE
fix: avoid output flood when scanning repo

### DIFF
--- a/ggshield/output/text/text_output_handler.py
+++ b/ggshield/output/text/text_output_handler.py
@@ -53,7 +53,7 @@ class TextOutputHandler(OutputHandler):
             if scan.scans:
                 has_results = any(x.results for x in scan.scans)
 
-            if not has_results:
+            if top and not has_results:
                 scan_buf.write(no_leak_message())
 
         if scan.scans:


### PR DESCRIPTION
Fixes #265 
Only display `no_leak_message()` when `ŧop=True` in `_process_scan_impl` 