### PR TITLE
fix: fix docker output breaking json redirection

### DIFF
--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -7,6 +7,7 @@ from pygitguardian.models import PolicyBreak
 
 from ggshield.core.constants import CACHE_FILENAME
 from ggshield.core.filter import get_ignore_sha
+from ggshield.core.text_utils import display_warning
 
 
 SECRETS_CACHE_KEY = "last_found_secrets"
@@ -47,7 +48,7 @@ class Cache:
             self.last_found_secrets = kwargs.pop(SECRETS_CACHE_KEY)
         if kwargs:
             for key in kwargs.keys():
-                click.echo(f'Unrecognized key in cache "{key}"')
+                display_warning(f'Unrecognized key in cache "{key}"')
 
     def to_dict(self) -> Dict[str, Any]:
         return {SECRETS_CACHE_KEY: self.last_found_secrets}

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -9,6 +9,7 @@ import yaml
 from appdirs import user_config_dir
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME
+from ggshield.core.text_utils import display_error
 
 
 def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> None:
@@ -36,7 +37,7 @@ def load_yaml(path: str, raise_exc: bool = False) -> Optional[Dict[str, Any]]:
             if raise_exc:
                 raise click.ClickException(message) from e
             else:
-                click.echo(message)
+                display_error(message)
                 return None
         else:
             replace_in_keys(data, old_char="-", new_char="_")

--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -109,6 +109,10 @@ def display_warning(msg: str) -> None:
     click.echo(format_text(msg, STYLE["warning"]), err=True)
 
 
+def display_info(msg: str, nl: bool = True) -> None:
+    click.echo(msg, nl=nl, err=True)
+
+
 _VALIDITY_TEXT_FOR_ID = {
     "unknown": "Unknown",
     # cannot_check is the old ID for secrets for which there are no checkers

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -12,7 +12,7 @@ from pygitguardian.models import Match
 from ggshield.core.constants import ON_PREMISE_API_URL_PATH_PREFIX
 
 from .git_shell import get_git_root, is_git_dir
-from .text_utils import Line, LineCategory, display_error
+from .text_utils import Line, LineCategory, display_error, display_warning
 
 
 REGEX_PATCH_HEADER = re.compile(
@@ -293,9 +293,7 @@ def clean_url(url: str, warn: bool = False) -> ParseResult:
     if parsed_url.path.endswith("/v1"):
         parsed_url = parsed_url._replace(path=parsed_url.path[:-3])
         if warn:
-            click.echo(
-                "[Warning] unexpected /v1 path in your URL configuration", err=True
-            )
+            display_warning("Unexpected /v1 path in your URL configuration")
     return parsed_url
 
 

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -13,6 +13,7 @@ from pygitguardian import GGClient
 
 from ggshield.core.cache import Cache
 from ggshield.core.constants import MAX_FILE_SIZE
+from ggshield.core.text_utils import display_info
 from ggshield.core.utils import SupportedScanMode
 from ggshield.scan import ScanCollection
 from ggshield.scan.scannable import File, Files
@@ -219,18 +220,18 @@ def docker_save_to_tmp(image_name: str, destination_path: Path, timeout: int) ->
     command = ["docker", "save", image_name, "-o", str(destination_path)]
 
     try:
-        click.echo("Saving docker image... ", nl=False)
+        display_info("Saving docker image... ", nl=False)
         subprocess.run(
             command,
             check=True,
             stderr=subprocess.PIPE,
             timeout=timeout,
         )
-        click.echo("OK")
+        display_info("OK")
     except subprocess.CalledProcessError as exc:
         err_string = str(exc.stderr)
         if "No such image" in err_string or "reference does not exist" in err_string:
-            click.echo("need to download image first")
+            display_info("need to download image first")
             docker_pull_image(image_name, timeout)
 
             docker_save_to_tmp(image_name, destination_path, timeout)

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -30,7 +30,7 @@ class TestCache:
 
         Cache()
         captured = capsys.readouterr()
-        assert "Unrecognized key in cache" in captured.out
+        assert "Unrecognized key in cache" in captured.err
 
     def test_save_cache(self, cli_fs_runner):
         with open(".cache_ggshield", "w") as file:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -88,7 +88,7 @@ class TestUserConfig:
         sys.stdout.write(out)
         sys.stderr.write(err)
 
-        assert f"Parsing error while reading {local_config_path}:" in out
+        assert f"Parsing error while reading {local_config_path}:" in err
 
     def test_display_options(self, cli_fs_runner, local_config_path):
         write_yaml(local_config_path, {"verbose": True, "show_secrets": True})
@@ -245,7 +245,7 @@ class TestAuthConfig:
         sys.stdout.write(out)
         sys.stderr.write(err)
 
-        assert f"Parsing error while reading {get_auth_config_filepath()}:" in out
+        assert f"Parsing error while reading {get_auth_config_filepath()}:" in err
 
     def test_token_not_expiring(self):
         """
@@ -571,7 +571,7 @@ class TestConfig:
         sys.stderr.write(err)
 
         assert api_url == "https://api.gitguardian.com"
-        assert "[Warning] unexpected /v1 path in your URL configuration" in err
+        assert "Unexpected /v1 path in your URL configuration" in err
 
     def test_v1_in_api_url_local_config(self, capsys, local_config_path):
         """
@@ -595,7 +595,7 @@ class TestConfig:
         sys.stderr.write(err)
 
         assert api_url == "https://api.gitguardian.com"
-        assert "[Warning] unexpected /v1 path in your URL configuration" in err
+        assert "Unexpected /v1 path in your URL configuration" in err
 
     def test_v1_in_api_url_global_config(self, capsys, global_config_path):
         """
@@ -617,7 +617,7 @@ class TestConfig:
         sys.stdout.write(out)
         sys.stderr.write(err)
 
-        assert "[Warning] unexpected /v1 path in your URL configuration" in err
+        assert "Unexpected /v1 path in your URL configuration" in err
 
     def test_updating_config_not_from_default_local_config_path(
         self, local_config_path


### PR DESCRIPTION
Print progress info on stderr so that we can pipe ggshield output to tools consuming json from stdin.

Before:
```
$ ggshield secret scan --json docker ubuntu:20.04 | jq
parse error: Invalid numeric literal at line 1, column 7
Scanning  [####################################]  100%          
Error: [Errno 32] Broken pipe
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

After:
```
$ ggshield secret scan --json docker ubuntu:20.04 | jq      
Saving docker image... OK
Scanning  [####################################]  100%          
{
  "id": "ubuntu:20.04",
  "type": "scan_docker_archive",
  "total_incidents": 0,
  "total_occurrences": 0
}
```