### PR TITLE
Add --debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Options:
                           config files.
   -v, --verbose           Verbose display mode.
   --allow-self-signed     Ignore ssl verification.
+  --debug                 Show debug information.
   --version               Show the version and exit.
   -h, --help              Show this message and exit.
 
@@ -482,6 +483,8 @@ secret:
 If you have a v1 configuration file, you can run `ggshield config migrate` to let ggshield migrate it for you. The command modifies the configuration file in place, but it keeps the previous version as a `.gitguardian.yaml.old` file.
 
 Alternatively, you can follow these steps to migrate your configuration file manually:
+
+debug: false # default: false
 
 1. Add a `version: 2` entry.
 2. If the configuration file contains an `all-policies` key, remove it: it's no longer supported.

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import logging
 import re
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set
@@ -24,6 +25,9 @@ from ggshield.core.utils import REGEX_HEADER_INFO, Filemode
 from ..core.extra_headers import get_extra_headers
 from ..iac.models import IaCScanResult
 from .scannable_errors import handle_scan_chunk_error
+
+
+logger = logging.getLogger(__name__)
 
 
 class Result(NamedTuple):
@@ -89,6 +93,9 @@ class File:
             "filemode": self.filemode,
         }
 
+    def __repr__(self) -> str:
+        return f"<File filename={self.filename} filemode={self.filemode}>"
+
     def has_extensions(self, extensions: Set[str]) -> bool:
         """Returns True iff the file has one of the given extensions."""
         file_extensions = Path(self.filename).suffixes
@@ -134,6 +141,10 @@ class Files:
             **extra_headers,
         }
 
+    def __repr__(self) -> str:
+        files = list(self.files.values())
+        return f"<Files files={files}>"
+
     def apply_filter(self, filter_func: Callable[[File], bool]) -> "Files":
         return Files([file for file in self.files.values() if filter_func(file)])
 
@@ -151,6 +162,7 @@ class Files:
             [List[Dict[str, Any]]], None
         ] = lambda chunk: None,
     ) -> List[Result]:
+        logger.debug("self=%s", self)
         cache.purge()
         scannable_list = self.scannable_list
         results = []
@@ -316,3 +328,7 @@ class Commit(Files):
 
             if document:
                 yield CommitFile(document, filename, filemode)
+
+    def __repr__(self) -> str:
+        files = list(self.files.values())
+        return f"<Commit sha={self.sha} files={files}>"


### PR DESCRIPTION
To help with customer support, this PR adds a `--debug` option to log the following info:

- path of loaded config files
- command line arguments
- filename and filemode (added, removed, modified) of scanned documents
- sha of scanned commits
- scan exit code