### PR TITLE
fix(ci): unbreak Cloudsmith upload

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -208,6 +208,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Download packages
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The CI job to upload packages to Cloudsmith was missing the step to checkout the code (doh!).

This PR adds it.