### PR TITLE
Scan CI fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,6 @@ runs:
   args:
     - ggshield
     - -v
+    - secret
     - scan
     - ci

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -263,7 +263,9 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
         if not (
             os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")
         ):
-            raise click.ClickException("--ci should only be used in a CI environment.")
+            raise click.ClickException(
+                "`secret scan ci` should only be used in a CI environment."
+            )
 
         if os.getenv("GITLAB_CI"):
             commit_list = gitlab_ci_range(config.verbose)
@@ -292,7 +294,7 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
         else:
             raise click.ClickException(
                 f"Current CI is not detected or supported."
-                f"Must be one of [{' | '.join([ci.value for ci in SupportedCI])}]"
+                f" Supported CIs: {', '.join([ci.value for ci in SupportedCI])}."
             )
 
         add_extra_header(ctx, "Ci-Mode", ci_mode.name)


### PR DESCRIPTION
This PR cleans a few things I noticed while fixing #294:

- Use `ggshield secret scan` in our local action.
- Improve wording of CI messages, in particular do not talk about a `--ci` option: it does not exist anymore.