### PR TITLE
Improvements to --debug

### DIFF
--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any, List, Optional
 
 import click
+import pygitguardian
 
 from ggshield.cmd.auth import auth_group
 from ggshield.cmd.config import config_group
@@ -132,6 +133,7 @@ def cli(
         config.allow_self_signed = allow_self_signed
 
     logger.debug("args=%s", sys.argv)
+    logger.debug("py-gitguardian=%s", pygitguardian.__version__)
 
 
 @cli.result_callback()

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -22,7 +22,9 @@ from ggshield.core.text_utils import display_warning
 from ggshield.core.utils import load_dot_env
 
 
-LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s:%(funcName)s:%(lineno)d %(message)s"
+LOG_FORMAT = (
+    "%(asctime)s %(levelname)s %(thread)d %(name)s:%(funcName)s:%(lineno)d %(message)s"
+)
 
 logger = logging.getLogger(__name__)
 

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -47,8 +47,24 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> None:
     sys.exit(exit_code)
 
 
-def setup_debug_logs() -> None:
-    logging.basicConfig(filename=None, level=logging.DEBUG, format=LOG_FORMAT)
+def setup_debug_logs(debug: bool) -> None:
+    """Configure Python logger. Disable messages up to logging.ERROR level by default.
+
+    The reason we disable error messages is that we call logging.error() in addition to
+    showing user-friendly error messages, but we don't want the error logs to show up
+    with the user-friendly error messages, unless --debug has been set.
+    """
+    level = logging.DEBUG if debug else logging.CRITICAL
+
+    if sys.version_info[:2] < (3, 8):
+        # Simulate logging.basicConfig() `force` argument, introduced in Python 3.8
+        root = logging.getLogger()
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+            handler.close()
+        logging.basicConfig(filename=None, level=level, format=LOG_FORMAT)
+    else:
+        logging.basicConfig(filename=None, level=level, format=LOG_FORMAT, force=True)
 
 
 @click.group(
@@ -93,10 +109,9 @@ def cli(
     load_dot_env()
     ctx.ensure_object(dict)
 
-    if debug:
-        # If --debug is set, setup logs *now*, otherwise log commands for the
-        # creation of the Config instance will be ignored
-        setup_debug_logs()
+    # If --debug is set, setup logs *now*, otherwise log commands for the
+    # creation of the Config instance will be ignored
+    setup_debug_logs(debug is True)
 
     config = Config(config_path)
 
@@ -105,7 +120,7 @@ def cli(
     elif config.debug:
         # if --debug is not set, but `debug` is set in the configuration file,
         # we still have to setup logs
-        setup_debug_logs()
+        setup_debug_logs(True)
 
     ctx.obj["config"] = config
     ctx.obj["cache"] = Cache()

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from typing import List, Optional, Tuple
@@ -7,6 +8,9 @@ import click
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, handle_exception
 from ggshield.scan.repo import scan_commit_range
+
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -85,6 +89,7 @@ def collect_from_stdin() -> Tuple[str, str]:
     Collect pre-commit variables from stdin.
     """
     prepush_input = sys.stdin.read().split()
+    logger.debug("input=%s", prepush_input)
     if len(prepush_input) < 4:
         # Then it's either a tag or a deletion event
         local_commit = EMPTY_SHA
@@ -93,6 +98,7 @@ def collect_from_stdin() -> Tuple[str, str]:
         local_commit = prepush_input[1].strip()
         remote_commit = prepush_input[3].strip()
 
+    logger.debug("refs=(%s, %s)", local_commit, remote_commit)
     return (local_commit, remote_commit)
 
 
@@ -109,4 +115,5 @@ def collect_from_precommit_env() -> Tuple[Optional[str], Optional[str]]:
         local_commit = os.getenv("PRE_COMMIT_FROM_REF", None)
         remote_commit = os.getenv("PRE_COMMIT_TO_REF", None)
 
+    logger.debug("refs=(%s, %s)", local_commit, remote_commit)
     return (local_commit, remote_commit)

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 from functools import lru_cache
@@ -8,6 +9,8 @@ import click
 
 
 COMMAND_TIMEOUT = 45
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(None)
@@ -86,6 +89,7 @@ def shell(command: List[str], timeout: int = COMMAND_TIMEOUT) -> str:
     env["LANG"] = "C"
 
     try:
+        logger.debug("command=%s", command)
         result = subprocess.run(
             command,
             check=True,

--- a/ggshield/scan/scannable_errors.py
+++ b/ggshield/scan/scannable_errors.py
@@ -1,3 +1,4 @@
+import logging
 from ast import literal_eval
 from typing import Dict, List
 
@@ -7,7 +8,11 @@ from pygitguardian.models import Detail
 from ggshield.core.text_utils import STYLE, display_error, format_text, pluralize
 
 
+logger = logging.getLogger(__name__)
+
+
 def handle_scan_chunk_error(detail: Detail, chunk: List[Dict[str, str]]) -> None:
+    logger.error("status_code=%d detail=%s", detail.status_code, detail.detail)
     if detail.status_code == 401:
         raise click.UsageError(detail.detail)
 
@@ -46,6 +51,7 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[Dict[str, str]]) -> None
 
 
 def handle_scan_error(detail: Detail) -> None:
+    logger.error("status_code=%d detail=%s", detail.status_code, detail.detail)
     if detail.status_code == 401:
         raise click.UsageError(detail.detail)
     display_error("\nError scanning.")


### PR DESCRIPTION
This PR makes --debug more useful by:

- Logging the thread ID: this ensures we know which log messages go together
- Logging git commands and scan errors