### PR TITLE
feat(scan): Do not abort repo scan if a commit fails to scan

### DIFF
--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -10,7 +10,7 @@ from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.utils import SupportedScanMode
 from ggshield.output import OutputHandler
-from ggshield.scan import Files, Result, ScanCollection
+from ggshield.scan import Files, ScanCollection
 
 
 @click.command()
@@ -45,7 +45,7 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
             def update_progress(chunk: List[Dict[str, Any]]) -> None:
                 progressbar.update(len(chunk))
 
-            results: List[Result] = files.scan(
+            results = files.scan(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -12,7 +12,7 @@ from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.utils import SupportedScanMode
 from ggshield.output import OutputHandler
-from ggshield.scan import Files, Result, ScanCollection
+from ggshield.scan import Files, ScanCollection
 
 
 PYPI_DOWNLOAD_TIMEOUT = 30
@@ -104,7 +104,7 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
             def update_progress(chunk: List[Dict[str, Any]]) -> None:
                 progressbar.update(len(chunk))
 
-            results: List[Result] = files.scan(
+            results = files.scan(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,

--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -87,12 +87,22 @@ class JSONResultSchema(BaseSchema):
     total_occurrences = fields.Integer(required=True)
 
 
+class JSONErrorSchema(BaseSchema):
+    class JSONErrorFileSchema(BaseSchema):
+        mode = fields.String(required=True)
+        filename = fields.String(required=True)
+
+    files = fields.List(fields.Nested(JSONErrorFileSchema))
+    description = fields.String(required=True)
+
+
 class JSONScanCollectionSchema(BaseSchema):
     id = fields.String()
     type = fields.String()
     results = fields.List(
         fields.Nested(JSONResultSchema), data_key="entities_with_incidents"
     )
+    errors = fields.List(fields.Nested(JSONErrorSchema))
     scans = fields.List(fields.Nested(lambda: JSONScanCollectionSchema()))
     extra_info = fields.Dict(keys=fields.Str(), values=fields.Str())
     total_incidents = fields.Integer(required=True)

--- a/ggshield/output/output_handler.py
+++ b/ggshield/output/output_handler.py
@@ -49,8 +49,8 @@ class OutputHandler(ABC):
 
     @staticmethod
     def _get_exit_code(scan: ScanCollection) -> int:
-        if scan.results:
+        if scan.has_results:
             return 1
-        if scan.scans and any(x.results for x in scan.scans):
+        if scan.scans and any(x.has_results for x in scan.scans):
             return 1
         return 0

--- a/ggshield/scan/__init__.py
+++ b/ggshield/scan/__init__.py
@@ -1,4 +1,4 @@
-from .scannable import Commit, File, Files, Result, ScanCollection
+from .scannable import Commit, File, Files, Result, Results, ScanCollection
 
 
 __all__ = [
@@ -6,5 +6,6 @@ __all__ = [
     "File",
     "Files",
     "Result",
+    "Results",
     "ScanCollection",
 ]

--- a/tests/cmd/scan/test_prereceive.py
+++ b/tests/cmd/scan/test_prereceive.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
 from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, Filemode
-from ggshield.scan import Result, ScanCollection
+from ggshield.scan import Result, Results, ScanCollection
 from tests.conftest import (
     _SIMPLE_SECRET_PATCH,
     _SIMPLE_SECRET_PATCH_SCAN_RESULT,
@@ -161,14 +161,17 @@ class TestPreReceive:
         scan_commit_mock.return_value = ScanCollection(
             new_sha,
             type="commit",
-            results=[
-                Result(
-                    _SIMPLE_SECRET_PATCH,
-                    Filemode.MODIFY,
-                    "server.conf",
-                    _SIMPLE_SECRET_PATCH_SCAN_RESULT,
-                )
-            ],
+            results=Results(
+                results=[
+                    Result(
+                        _SIMPLE_SECRET_PATCH,
+                        Filemode.MODIFY,
+                        "server.conf",
+                        _SIMPLE_SECRET_PATCH_SCAN_RESULT,
+                    )
+                ],
+                errors=[],
+            ),
         )
 
         result = cli_fs_runner.invoke(

--- a/tests/cmd/test_ignore.py
+++ b/tests/cmd/test_ignore.py
@@ -80,7 +80,7 @@ def test_cache_catches_nothing(client, isolated_fs):
             mode_header="test",
         )
 
-        assert results == []
+        assert results.results == []
         assert config.secret.ignored_matches == FOUND_SECRETS
         assert cache.last_found_secrets == []
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -80,7 +80,7 @@ def test_make_indices_patch(client, cache, name, content, is_patch, expected_ind
             mode_header=SupportedScanMode.PATH.value,
             ignored_detectors=None,
         )
-        result = results[0]
+        result = results.results[0]
 
     lines = get_lines_from_content(
         content=result.content,

--- a/tests/output/test_text_output.py
+++ b/tests/output/test_text_output.py
@@ -11,7 +11,7 @@ from ggshield.output.text.message import (
     _file_info_default_decoration,
 )
 from ggshield.scan import Result
-from ggshield.scan.scannable import ScanCollection
+from ggshield.scan.scannable import Results, ScanCollection
 from tests.conftest import (
     _MULTI_SECRET_ONE_LINE_PATCH,
     _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
@@ -111,7 +111,7 @@ def test_leak_message(result_input, snapshot, show_secrets, verbose):
             ScanCollection(
                 id="scan",
                 type="test",
-                results=[new_result],
+                results=Results(results=[new_result], errors=[]),
                 optional_header="> This is an example header",
             )
         )

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -73,7 +73,7 @@ def test_scan_patch(client, cache, name, input_patch, expected):
             matches_ignore={},
             mode_header=SupportedScanMode.PATH.value,
         )
-        for result in results:
+        for result in results.results:
             if result.scan.policy_breaks:
                 assert len(result.scan.policy_breaks[0].matches) == expected.matches
                 if expected.first_match:


### PR DESCRIPTION
closes #267 

When an error occurs when scanning a commit, `ggshield` will no longer stop. The error is printed in stderr and included in the JSON output.

I changed the timeout to 0.3s to force errors during the scan, here an example of the JSON output:
```json
{
  "id": "hello-gg",
  "type": "commit-range",
  "scans": [
    {
      "id": "5be496155e6c6a86199a744903a42419983d2592",
      "type": "commit",
      "errors": [
        {
          "files": [
            {
              "mode": "NEW",
              "filename": "test.py"
            }
          ],
          "description": "HTTPSConnectionPool(host='api.gitguardian.com', port=443): Read timed out. (read timeout=0.3)"
        }
      ],
      "extra_info": {
        "author": "Samuel Guillaume",
        "email": "sguillaume@dev.dev",
        "date": "Mon Aug 16 16:41:06 2021 +0200"
      },
      "total_incidents": 0,
      "total_occurrences": 0
    }
  ],
  "total_incidents": 0,
  "total_occurrences": 0
}
```