### PR TITLE
Unbreak main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,23 +167,3 @@ jobs:
           registry: docker.pkg.github.com
           repository: gitguardian/ggshield/ggshield
           tags: unstable
-
-  scanning-released:
-    name: GitGuardian scan
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: [dockerhub-unstable]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # fetch all history so multiple commits can be scanned
-      - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@master
-        env:
-          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
-          GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-          GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}


### PR DESCRIPTION
Remove the `scanning-released` CI step. It uses the latest release of ggshield to scan our code. That does not work well when this repository .gitguardian.yaml files contains configuration keys that the latest release does not support.

Current breakage: https://github.com/GitGuardian/ggshield/runs/7425018269?check_suite_focus=true.

See #304 for more details.
