### PR TITLE
Add a helper message for iac scan command

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -76,6 +76,9 @@ def scan_cmd(
     json: bool,
     directory: Path,
 ) -> int:
+    """
+    Scan a directory for IaC vulnerabilities.
+    """
     update_context(
         ctx, exit_zero, minimum_severity, verbose, ignore_policies, ignore_paths, json
     )


### PR DESCRIPTION
Add a IaC scan helper message.

The help commands results are now:
```
> ggshield iac --help
Usage: ggshield iac [OPTIONS] COMMAND [ARGS]...

  Commands to work with infrastructure as code.

Options:
  -h, --help  Show this message and exit.

Commands:
  scan  Scan a directory for IaC vulnerabilities.
```

```
> ggshield iac scan --help
Usage: ggshield iac scan [OPTIONS] DIRECTORY

  Scan a directory for IaC vulnerabilities.

Options:
  --exit-zero                     Always return 0 (non-error) status code.
  --minimum-severity [LOW|MEDIUM|HIGH|CRITICAL]
                                  Minimum severity of the policies
  -v, --verbose                   Verbose display mode.
  --ignore-policy, --ipo TEXT     Policies to exclude from the results.
  --ignore-path, --ipa PATH       Do not scan the specified paths.
  --json                          JSON output.
  -h, --help                      Show this message and exit.
```