### PR TITLE
feat(scan): do not create ggshield cache when scan pre-receive

### DIFF
--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -3,20 +3,11 @@ from typing import List
 
 import click
 
-from ggshield.core.cache import Cache
+from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.extra_headers import add_extra_header
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA, SupportedCI, handle_exception
 from ggshield.scan.repo import scan_commit_range
-
-
-class ReadOnlyCache(Cache):
-    """
-    A version of Cache which does not write anything to the disk.
-    """
-
-    def save(self) -> None:  # pragma: no cover
-        return None
 
 
 def jenkins_range(verbose: bool) -> List[str]:  # pragma: no cover

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Type
 
 import click
 
+from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_shell import get_list_commit_SHA
 from ggshield.core.text_utils import display_error
 from ggshield.core.utils import (
@@ -155,7 +156,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
         with ExitAfter(get_prereceive_timeout()):
             return_code = scan_commit_range(
                 client=ctx.obj["client"],
-                cache=ctx.obj["cache"],
+                cache=ReadOnlyCache(),
                 commit_list=commit_list,
                 output_handler=output_handler,
                 verbose=config.verbose,

--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -94,3 +94,12 @@ class Cache:
                         match=get_ignore_sha(policy_break),
                     )
                 )
+
+
+class ReadOnlyCache(Cache):
+    """
+    A version of Cache which does not write anything to the disk.
+    """
+
+    def save(self) -> None:  # pragma: no cover
+        return None


### PR DESCRIPTION
Issue #306 
Like it is done for `scan ci`, we do not want to create cache when running `scan pre-receive`

Tested manually using the doc/pre-receive.sample script :
After committing a secret, run `echo "HEAD <recent-commit-ID> <unused-arg>" | sh doc/pre-receive.sample`
No cache file .cache_ggshield is created