### PR TITLE
fix: remove verbose flag and change args order

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
         --all-policies                Present fails of all policies (Filenames, FileExtensions,
                                       Secret Detection). By default, only Secret Detection is shown.
         --exit-zero                   Always return a 0 (non-error) status code, even if incidents are found.
-        -v, --verbose                 Verbose display mode.
         -b, --banlist-detector TEXT   Exclude results from a detector.
     required: false
 
@@ -28,5 +27,6 @@ runs:
     - -v
     - secret
     - scan
-    - ci
     - ${{ inputs.args }}
+    - ci
+


### PR DESCRIPTION
- Remove the verbose option, already hard-coded in the args.
- Re-order the args