### PR TITLE
Fix _NO_SECRET fixture being ignored

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,16 +420,20 @@ index 0000000..b80e3df
     + _ONE_LINE_AND_MULTILINE_PATCH_CONTENT
 )
 
-_NO_SECRET = (
-    "diff --git a/test.txt b/test.txt\n"
-    "new file mode 100644\n"
-    "index 0000000..b80e3df\n"
-    "--- /dev/null\n"
-    "+++ b/test\n"
-    "@@ -0,0 +1 @@\n"
-    "+this is a patch without secret\n"
-)
+_NO_SECRET_PATCH = """commit 9537b6343a81f88d471e93f20ffb2e2665bbab00
+Author: GitGuardian Owl <owl@example.com>
+Date:   Thu Aug 18 18:20:21 2022 +0200
 
+A message
+
+:000000 100644 0000000 e965047 A\0test\0\0diff --git a/test b/test
+new file mode 100644
+index 0000000..b80e3df
+--- /dev/null
++++ b/test
+@@ -0,0 +1 @@
++this is a patch without secret
+"""
 
 _SECRET_RAW_FILE = '+sg_key = "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";\n'
 

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -10,7 +10,7 @@ from ggshield.output.json.schemas import JSONScanCollectionSchema
 from ggshield.scan import Commit, ScanCollection
 from tests.conftest import (
     _MULTIPLE_SECRETS_PATCH,
-    _NO_SECRET,
+    _NO_SECRET_PATCH,
     _ONE_LINE_AND_MULTILINE_PATCH,
     _SINGLE_ADD_PATCH,
     _SINGLE_DELETE_PATCH,
@@ -91,7 +91,7 @@ SCHEMA_WITH_INCIDENTS = S(
         ("simple_secret", UNCHECKED_SECRET_PATCH, 1),
         ("test_scan_file_secret_with_validity", VALID_SECRET_PATCH, 1),
         ("one_line_and_multiline_patch", _ONE_LINE_AND_MULTILINE_PATCH, 1),
-        ("no_secret", _NO_SECRET, 0),
+        ("no_secret", _NO_SECRET_PATCH, 0),
         ("single_add", _SINGLE_ADD_PATCH, 1),
         ("single_delete", _SINGLE_DELETE_PATCH, 1),
         ("single_move", _SINGLE_MOVE_PATCH, 1),

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -8,7 +8,7 @@ from ggshield.core.utils import Filemode, SupportedScanMode
 from ggshield.scan import Commit, File, Files
 from tests.conftest import (
     _MULTIPLE_SECRETS_PATCH,
-    _NO_SECRET,
+    _NO_SECRET_PATCH,
     _ONE_LINE_AND_MULTILINE_PATCH,
     GG_TEST_TOKEN,
     UNCHECKED_SECRET_PATCH,
@@ -50,7 +50,7 @@ _EXPECT_NO_SECRET = {
         ),
         (
             "no_secret",
-            _NO_SECRET,
+            _NO_SECRET_PATCH,
             ExpectedScan(
                 exit_code=0, matches=0, first_match=None, want=_EXPECT_NO_SECRET
             ),


### PR DESCRIPTION
- Turn `_NO_SECRET` fixture into a proper patch, with header
- Rename it to `_NO_SECRET_PATCH` for consistency