### PR TITLE
Add a GGShield-Command-Id HTTP header

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, Sequence, Type
 
 import click
 
-from ggshield import __version__
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.extra_headers import get_extra_headers
@@ -149,13 +148,7 @@ def iac_scan(ctx: click.Context, directory: Path) -> Optional[IaCScanResult]:
     scan = client.directory_scan(
         tar,
         scan_parameters,
-        {
-            "GGShield-Version": __version__,
-            "GGShield-Command-Path": ctx.command_path
-            if ctx is not None
-            else "external",
-            **get_extra_headers(ctx),
-        },
+        get_extra_headers(ctx),
     )
 
     if not scan.success or not isinstance(scan, IaCScanResult):

--- a/ggshield/core/extra_headers.py
+++ b/ggshield/core/extra_headers.py
@@ -2,6 +2,8 @@ from typing import Dict, Optional
 
 import click
 
+from ggshield import __version__
+
 
 def add_extra_header(ctx: Optional[click.Context], key: str, value: str) -> None:
     """
@@ -22,15 +24,19 @@ def add_extra_header(ctx: Optional[click.Context], key: str, value: str) -> None
 
 def get_extra_headers(ctx: Optional[click.Context]) -> Dict[str, str]:
     """
-    Returns the extra headers stored in the command's context.
-    Adds the prefix "GGShield-" to the header's names.
+    Returns the extra headers to send in HTTP requests.
+    Adds the "GGShield-" prefix to the header's names.
     """
-    if (
-        ctx is not None
-        and isinstance(ctx.obj, dict)
-        and isinstance(ctx.obj.get("headers"), dict)
-    ):
-        return {
-            str(key): f"GGShield-{value}" for key, value in ctx.obj["headers"].items()
-        }
-    return {}
+
+    command_path = ctx.command_path if ctx is not None else "external"
+
+    headers = {
+        "Version": __version__,
+        "Command-Path": command_path,
+    }
+    if ctx is not None and isinstance(ctx.obj, dict):
+        context_headers = ctx.obj.get("headers")
+        if context_headers:
+            headers = {**headers, **context_headers}
+
+    return {f"GGShield-{key}": str(value) for key, value in headers.items()}

--- a/ggshield/core/extra_headers.py
+++ b/ggshield/core/extra_headers.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict, Optional
 
 import click
@@ -22,9 +23,12 @@ def add_extra_header(ctx: Optional[click.Context], key: str, value: str) -> None
         ctx.obj["headers"][key] = value
 
 
-def get_extra_headers(ctx: Optional[click.Context]) -> Dict[str, str]:
+def get_extra_headers(
+    ctx: Optional[click.Context], command_id: Optional[str] = None
+) -> Dict[str, str]:
     """
     Returns the extra headers to send in HTTP requests.
+    If `command_id` is not None, a `GGShield-Command-Id` header will be sent.
     Adds the "GGShield-" prefix to the header's names.
     """
 
@@ -34,9 +38,19 @@ def get_extra_headers(ctx: Optional[click.Context]) -> Dict[str, str]:
         "Version": __version__,
         "Command-Path": command_path,
     }
+    if command_id:
+        headers["Command-Id"] = command_id
+
     if ctx is not None and isinstance(ctx.obj, dict):
         context_headers = ctx.obj.get("headers")
         if context_headers:
             headers = {**headers, **context_headers}
 
     return {f"GGShield-{key}": str(value) for key, value in headers.items()}
+
+
+def generate_command_id() -> str:
+    """
+    Returns an opaque ID used to identify multiple API calls belonging to the same command
+    """
+    return str(uuid.uuid4())

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -11,6 +11,7 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.constants import CPU_COUNT
+from ggshield.core.extra_headers import generate_command_id
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import STYLE, display_error, format_text
 from ggshield.core.types import IgnoredMatch
@@ -65,6 +66,7 @@ def scan_commit(
     verbose: bool,
     matches_ignore: Iterable[IgnoredMatch],
     mode_header: str,
+    command_id: str,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:  # pragma: no cover
     try:
@@ -73,6 +75,7 @@ def scan_commit(
             cache=cache,
             matches_ignore=matches_ignore,
             mode_header=mode_header,
+            command_id=command_id,
             ignored_detectors=ignored_detectors,
         )
     except Exception as exc:
@@ -106,6 +109,9 @@ def scan_commit_range(
     :param commit_list: List of commits sha to scan
     :param verbose: Display successfull scan's message
     """
+
+    command_id = generate_command_id()
+
     return_code = 0
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=min(CPU_COUNT, 4)
@@ -119,6 +125,7 @@ def scan_commit_range(
                 verbose,
                 matches_ignore,
                 mode_header,
+                command_id,
                 ignored_detectors,
             )
             for sha in commit_list

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -36,6 +36,7 @@ def test_request_headers(scan_mock: Mock, client):
         {
             "GGShield-Version": __version__,
             "GGShield-Command-Path": "foo bar",
+            "GGShield-Command-Id": ANY,
             "mode": "test",
         },
     )


### PR DESCRIPTION
## Description

This MR adds a new HTTP header, used for server-side debugging: `GGShield-Command-Id`. This header makes it possible to group all API calls generated by a single ggshield command.

## What has been done

- Reduce duplication in HTTP header handling code (this is #233).
- Add the necessary API to the `extra_headers` module to generate command_ids and send them.
- Use this API in the `scan.repo` module.
