### PR TITLE
Simplify and improve scanning API

### DIFF
--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -49,7 +49,7 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,
-                mode_header=SupportedScanMode.ARCHIVE.value,
+                scan_mode=SupportedScanMode.ARCHIVE,
                 ignored_detectors=config.secret.ignored_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -8,7 +8,7 @@ import click
 
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
-from ggshield.core.utils import SupportedScanMode
+from ggshield.core.utils import ScanMode
 from ggshield.output import OutputHandler
 from ggshield.scan import Files, ScanCollection
 
@@ -49,7 +49,7 @@ def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,
-                scan_mode=SupportedScanMode.ARCHIVE,
+                scan_mode=ScanMode.ARCHIVE,
                 ignored_detectors=config.secret.ignored_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -308,7 +308,6 @@ def ci_cmd(ctx: click.Context) -> int:
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            scan_id=" ".join(commit_list),
             mode_header=mode_header,
             ignored_detectors=config.secret.ignored_detectors,
         )

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -308,7 +308,7 @@ def ci_cmd(ctx: click.Context) -> int:
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            mode_header=mode_header,
+            scan_mode=mode_header,
             ignored_detectors=config.secret.ignored_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -6,12 +6,7 @@ import click
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.extra_headers import add_extra_header
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
-from ggshield.core.utils import (
-    EMPTY_SHA,
-    SupportedCI,
-    SupportedScanMode,
-    handle_exception,
-)
+from ggshield.core.utils import EMPTY_SHA, ScanMode, SupportedCI, handle_exception
 from ggshield.scan.repo import scan_commit_range
 
 
@@ -295,7 +290,7 @@ def ci_cmd(ctx: click.Context) -> int:
 
         add_extra_header(ctx, "Ci-Mode", ci_mode.name)
 
-        mode_header = f"{SupportedScanMode.CI.value}/{ci_mode.value}"
+        mode_header = f"{ScanMode.CI.value}/{ci_mode.value}"
 
         if config.verbose:
             click.echo(f"Commits to scan: {len(commit_list)}", err=True)

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -44,7 +44,6 @@ def docker_name_cmd(ctx: click.Context, name: str, docker_timeout: int) -> int:
                 cache=ctx.obj["cache"],
                 verbose=config.verbose,
                 matches_ignore=config.secret.ignored_matches,
-                scan_id=name,
                 ignored_detectors=config.secret.ignored_detectors,
             )
 

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -31,7 +31,6 @@ def docker_archive_cmd(
             cache=ctx.obj["cache"],
             verbose=config.verbose,
             matches_ignore=config.secret.ignored_matches,
-            scan_id=str(archive),
             ignored_detectors=config.secret.ignored_detectors,
         )
 

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -37,7 +37,7 @@ def path_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.secret.ignored_matches,
-            mode_header=SupportedScanMode.PATH.value,
+            scan_mode=SupportedScanMode.PATH,
             ignored_detectors=config.secret.ignored_detectors,
         )
         scan = ScanCollection(id=" ".join(paths), type="path_scan", results=results)

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -3,7 +3,7 @@ from typing import List
 import click
 
 from ggshield.core.file_utils import get_files_from_paths
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import ScanMode, handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanCollection
 
@@ -37,7 +37,7 @@ def path_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.PATH,
+            scan_mode=ScanMode.PATH,
             ignored_detectors=config.secret.ignored_detectors,
         )
         scan = ScanCollection(id=" ".join(paths), type="path_scan", results=results)

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -3,7 +3,7 @@ from typing import List
 import click
 
 from ggshield.core.git_shell import check_git_dir
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import ScanMode, handle_exception
 from ggshield.output import TextOutputHandler
 from ggshield.scan import Commit, ScanCollection
 
@@ -27,7 +27,7 @@ def precommit_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.PRE_COMMIT,
+            scan_mode=ScanMode.PRE_COMMIT,
             ignored_detectors=config.secret.ignored_detectors,
         )
 

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -27,7 +27,7 @@ def precommit_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             matches_ignore=config.secret.ignored_matches,
-            mode_header=SupportedScanMode.PRE_COMMIT.value,
+            scan_mode=SupportedScanMode.PRE_COMMIT,
             ignored_detectors=config.secret.ignored_detectors,
         )
 

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -82,7 +82,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            mode_header=SupportedScanMode.PRE_PUSH.value,
+            scan_mode=SupportedScanMode.PRE_PUSH,
             ignored_detectors=config.secret.ignored_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -6,12 +6,7 @@ from typing import List, Optional, Tuple
 import click
 
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
-from ggshield.core.utils import (
-    EMPTY_SHA,
-    EMPTY_TREE,
-    SupportedScanMode,
-    handle_exception,
-)
+from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, ScanMode, handle_exception
 from ggshield.scan.repo import scan_commit_range
 
 
@@ -82,7 +77,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.PRE_PUSH,
+            scan_mode=ScanMode.PRE_PUSH,
             ignored_detectors=config.secret.ignored_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -82,7 +82,6 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            scan_id=" ".join(commit_list),
             mode_header=SupportedScanMode.PRE_PUSH.value,
             ignored_detectors=config.secret.ignored_detectors,
         )

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -163,7 +163,6 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 verbose=config.verbose,
                 exclusion_regexes=ctx.obj["exclusion_regexes"],
                 matches_ignore=config.secret.ignored_matches,
-                scan_id=" ".join(commit_list),
                 mode_header=SupportedScanMode.PRE_RECEIVE.value,
                 ignored_detectors=config.secret.ignored_detectors,
             )

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -14,7 +14,7 @@ from ggshield.core.utils import (
     EMPTY_SHA,
     EMPTY_TREE,
     PRERECEIVE_TIMEOUT,
-    SupportedScanMode,
+    ScanMode,
     handle_exception,
 )
 from ggshield.output import GitLabWebUIOutputHandler
@@ -163,7 +163,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 verbose=config.verbose,
                 exclusion_regexes=ctx.obj["exclusion_regexes"],
                 matches_ignore=config.secret.ignored_matches,
-                scan_mode=SupportedScanMode.PRE_RECEIVE,
+                scan_mode=ScanMode.PRE_RECEIVE,
                 ignored_detectors=config.secret.ignored_detectors,
             )
             if return_code:

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -163,7 +163,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 verbose=config.verbose,
                 exclusion_regexes=ctx.obj["exclusion_regexes"],
                 matches_ignore=config.secret.ignored_matches,
-                mode_header=SupportedScanMode.PRE_RECEIVE.value,
+                scan_mode=SupportedScanMode.PRE_RECEIVE,
                 ignored_detectors=config.secret.ignored_detectors,
             )
             if return_code:

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -108,7 +108,7 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,
-                mode_header=SupportedScanMode.PYPI.value,
+                scan_mode=SupportedScanMode.PYPI,
                 ignored_detectors=config.secret.ignored_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -10,7 +10,7 @@ import click
 
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
-from ggshield.core.utils import SupportedScanMode
+from ggshield.core.utils import ScanMode
 from ggshield.output import OutputHandler
 from ggshield.scan import Files, ScanCollection
 
@@ -108,7 +108,7 @@ def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 matches_ignore=config.secret.ignored_matches,
-                scan_mode=SupportedScanMode.PYPI,
+                scan_mode=ScanMode.PYPI,
                 ignored_detectors=config.secret.ignored_detectors,
                 on_file_chunk_scanned=update_progress,
             )

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -31,7 +31,7 @@ def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            mode_header=SupportedScanMode.COMMIT_RANGE.value,
+            scan_mode=SupportedScanMode.COMMIT_RANGE,
             ignored_detectors=config.secret.ignored_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -31,7 +31,6 @@ def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            scan_id=commit_range,
             mode_header=SupportedScanMode.COMMIT_RANGE.value,
             ignored_detectors=config.secret.ignored_detectors,
         )

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -1,7 +1,7 @@
 import click
 
 from ggshield.core.git_shell import get_list_commit_SHA
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import ScanMode, handle_exception
 from ggshield.scan.repo import scan_commit_range
 
 
@@ -31,7 +31,7 @@ def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
             verbose=config.verbose,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.COMMIT_RANGE,
+            scan_mode=ScanMode.COMMIT_RANGE,
             ignored_detectors=config.secret.ignored_detectors,
         )
     except Exception as error:

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -35,7 +35,6 @@ def repo_cmd(ctx: click.Context, repository: str) -> int:  # pragma: no cover
             output_handler=ctx.obj["output_handler"],
             config=config,
             repo_path=repository,
-            scan_id=repository,
         )
 
     if REGEX_GIT_URL.match(repository):
@@ -47,7 +46,6 @@ def repo_cmd(ctx: click.Context, repository: str) -> int:  # pragma: no cover
                 output_handler=ctx.obj["output_handler"],
                 config=config,
                 repo_path=tmpdirname,
-                scan_id=repository,
             )
 
     if any(host in repository for host in ("gitlab.com", "github.com")):

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -215,7 +215,7 @@ class SupportedCI(Enum):
     AZURE = "AZURE PIPELINES"
 
 
-class SupportedScanMode(Enum):
+class ScanMode(Enum):
     REPO = "repo"
     PATH = "path"
     COMMIT_RANGE = "commit_range"

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -15,7 +15,7 @@ from ggshield.core.cache import Cache
 from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.text_utils import display_info
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import SupportedScanMode
+from ggshield.core.utils import ScanMode
 from ggshield.scan import ScanCollection
 from ggshield.scan.scannable import File, Files
 
@@ -264,7 +264,7 @@ def docker_scan_archive(
             client=client,
             cache=cache,
             matches_ignore=matches_ignore,
-            scan_mode=SupportedScanMode.DOCKER,
+            scan_mode=ScanMode.DOCKER,
             ignored_detectors=ignored_detectors,
             on_file_chunk_scanned=update_progress,
         )

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -250,7 +250,6 @@ def docker_scan_archive(
     cache: Cache,
     verbose: bool,
     matches_ignore: Iterable[IgnoredMatch],
-    scan_id: str,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:
     files = get_files_from_docker_archive(archive)
@@ -270,4 +269,4 @@ def docker_scan_archive(
             on_file_chunk_scanned=update_progress,
         )
 
-    return ScanCollection(id=scan_id, type="scan_docker_archive", results=results)
+    return ScanCollection(id=str(archive), type="scan_docker_archive", results=results)

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -264,7 +264,7 @@ def docker_scan_archive(
             client=client,
             cache=cache,
             matches_ignore=matches_ignore,
-            mode_header=SupportedScanMode.DOCKER.value,
+            scan_mode=SupportedScanMode.DOCKER,
             ignored_detectors=ignored_detectors,
             on_file_chunk_scanned=update_progress,
         )

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import Iterable, Iterator, List, Optional, Set
+from typing import Iterable, Iterator, List, Optional, Set, Union
 
 import click
 from pygitguardian import GGClient
@@ -50,7 +50,7 @@ def scan_repo_path(
                 verbose=config.verbose,
                 exclusion_regexes=set(),
                 matches_ignore=config.secret.ignored_matches,
-                mode_header=SupportedScanMode.PATH.value,
+                scan_mode=SupportedScanMode.PATH,
                 ignored_detectors=config.secret.ignored_detectors,
             )
     except Exception as error:
@@ -63,7 +63,7 @@ def scan_commit(
     cache: Cache,
     verbose: bool,
     matches_ignore: Iterable[IgnoredMatch],
-    mode_header: str,
+    scan_mode: Union[SupportedScanMode, str],
     command_id: str,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:  # pragma: no cover
@@ -72,7 +72,7 @@ def scan_commit(
             client=client,
             cache=cache,
             matches_ignore=matches_ignore,
-            mode_header=mode_header,
+            scan_mode=scan_mode,
             command_id=command_id,
             ignored_detectors=ignored_detectors,
         )
@@ -96,7 +96,7 @@ def scan_commit_range(
     verbose: bool,
     exclusion_regexes: Set[re.Pattern],
     matches_ignore: Iterable[IgnoredMatch],
-    mode_header: str,
+    scan_mode: Union[SupportedScanMode, str],
     ignored_detectors: Optional[Set[str]] = None,
 ) -> int:  # pragma: no cover
     """
@@ -121,7 +121,7 @@ def scan_commit_range(
                 cache,
                 verbose,
                 matches_ignore,
-                mode_header,
+                scan_mode,
                 command_id,
                 ignored_detectors,
             )

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -15,7 +15,7 @@ from ggshield.core.extra_headers import generate_command_id
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import STYLE, display_error, format_text
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import SupportedScanMode, handle_exception
+from ggshield.core.utils import ScanMode, handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import Commit, Results, ScanCollection
 
@@ -50,7 +50,7 @@ def scan_repo_path(
                 verbose=config.verbose,
                 exclusion_regexes=set(),
                 matches_ignore=config.secret.ignored_matches,
-                scan_mode=SupportedScanMode.PATH,
+                scan_mode=ScanMode.PATH,
                 ignored_detectors=config.secret.ignored_detectors,
             )
     except Exception as error:
@@ -63,7 +63,7 @@ def scan_commit(
     cache: Cache,
     verbose: bool,
     matches_ignore: Iterable[IgnoredMatch],
-    scan_mode: Union[SupportedScanMode, str],
+    scan_mode: Union[ScanMode, str],
     command_id: str,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:  # pragma: no cover
@@ -96,7 +96,7 @@ def scan_commit_range(
     verbose: bool,
     exclusion_regexes: Set[re.Pattern],
     matches_ignore: Iterable[IgnoredMatch],
-    scan_mode: Union[SupportedScanMode, str],
+    scan_mode: Union[ScanMode, str],
     ignored_detectors: Optional[Set[str]] = None,
 ) -> int:  # pragma: no cover
     """

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -36,7 +36,6 @@ def scan_repo_path(
     output_handler: OutputHandler,
     config: Config,
     repo_path: str,
-    scan_id: str,
 ) -> int:  # pragma: no cover
     try:
         with cd(repo_path):
@@ -51,7 +50,6 @@ def scan_repo_path(
                 verbose=config.verbose,
                 exclusion_regexes=set(),
                 matches_ignore=config.secret.ignored_matches,
-                scan_id=scan_id,
                 mode_header=SupportedScanMode.PATH.value,
                 ignored_detectors=config.secret.ignored_detectors,
             )
@@ -98,7 +96,6 @@ def scan_commit_range(
     verbose: bool,
     exclusion_regexes: Set[re.Pattern],
     matches_ignore: Iterable[IgnoredMatch],
-    scan_id: str,
     mode_header: str,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> int:  # pragma: no cover
@@ -147,6 +144,6 @@ def scan_commit_range(
                 scans.append(scan_collection)
 
         return_code = output_handler.process_scan(
-            ScanCollection(id=scan_id, type="commit-range", scans=scans)
+            ScanCollection(id=command_id, type="commit-range", scans=scans)
         )
     return return_code

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -3,7 +3,18 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import click
 from pygitguardian import GGClient
@@ -21,7 +32,7 @@ from ggshield.core.filter import (
 from ggshield.core.git_shell import GIT_PATH, shell
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import REGEX_HEADER_INFO, Filemode
+from ggshield.core.utils import REGEX_HEADER_INFO, Filemode, SupportedScanMode
 
 from ..iac.models import IaCScanResult
 from .scannable_errors import handle_scan_chunk_error
@@ -256,7 +267,7 @@ class Files:
         client: GGClient,
         cache: Cache,
         matches_ignore: Iterable[IgnoredMatch],
-        mode_header: str,
+        scan_mode: Union[SupportedScanMode, str],
         command_id: Optional[str] = None,
         ignored_detectors: Optional[Set[str]] = None,
         on_file_chunk_scanned: Callable[
@@ -277,7 +288,9 @@ class Files:
         context = click.get_current_context(silent=True)
 
         headers = get_extra_headers(context, command_id=command_id)
-        headers["mode"] = mode_header
+        headers["mode"] = (
+            scan_mode.value if isinstance(scan_mode, SupportedScanMode) else scan_mode
+        )
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=min(CPU_COUNT, 4), thread_name_prefix="content_scan"

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -32,7 +32,7 @@ from ggshield.core.filter import (
 from ggshield.core.git_shell import GIT_PATH, shell
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import REGEX_HEADER_INFO, Filemode, SupportedScanMode
+from ggshield.core.utils import REGEX_HEADER_INFO, Filemode, ScanMode
 
 from ..iac.models import IaCScanResult
 from .scannable_errors import handle_scan_chunk_error
@@ -267,7 +267,7 @@ class Files:
         client: GGClient,
         cache: Cache,
         matches_ignore: Iterable[IgnoredMatch],
-        scan_mode: Union[SupportedScanMode, str],
+        scan_mode: Union[ScanMode, str],
         command_id: Optional[str] = None,
         ignored_detectors: Optional[Set[str]] = None,
         on_file_chunk_scanned: Callable[
@@ -289,7 +289,7 @@ class Files:
 
         headers = get_extra_headers(context, command_id=command_id)
         headers["mode"] = (
-            scan_mode.value if isinstance(scan_mode, SupportedScanMode) else scan_mode
+            scan_mode.value if isinstance(scan_mode, ScanMode) else scan_mode
         )
 
         with concurrent.futures.ThreadPoolExecutor(

--- a/tests/cmd/scan/test_ci.py
+++ b/tests/cmd/scan/test_ci.py
@@ -141,8 +141,8 @@ def test_ci_cmd_uses_right_mode_header(
     args = scan_commit_range_mock.call_args
 
     # TODO: When Python 3.7 is dropped, we can use the `args.kwargs` syntax
-    # assert args.kwargs["mode_header"] == expected_mode
-    assert args[1]["mode_header"] == expected_mode
+    # assert args.kwargs["scan_mode"] == expected_mode
+    assert args[1]["scan_mode"] == expected_mode
 
 
 @patch("ggshield.cmd.secret.scan.ci.check_git_dir")

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -113,7 +113,6 @@ class TestPrepush:
             verbose=True,
             exclusion_regexes=ANY,
             matches_ignore=ANY,
-            scan_id=ANY,
             mode_header="pre_push",
             ignored_detectors=set(),
         )

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -10,7 +10,7 @@ from ggshield.core.utils import (
     EMPTY_SHA,
     EMPTY_TREE,
     IGNORED_DEFAULT_WILDCARDS,
-    SupportedScanMode,
+    ScanMode,
 )
 from tests.conftest import assert_invoke_ok
 
@@ -118,7 +118,7 @@ class TestPrepush:
             verbose=True,
             exclusion_regexes=ANY,
             matches_ignore=ANY,
-            scan_mode=SupportedScanMode.PRE_PUSH,
+            scan_mode=ScanMode.PRE_PUSH,
             ignored_detectors=set(),
         )
         assert_invoke_ok(result)

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -6,7 +6,12 @@ from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
 from ggshield.core.filter import init_exclusion_regexes
-from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, IGNORED_DEFAULT_WILDCARDS
+from ggshield.core.utils import (
+    EMPTY_SHA,
+    EMPTY_TREE,
+    IGNORED_DEFAULT_WILDCARDS,
+    SupportedScanMode,
+)
 from tests.conftest import assert_invoke_ok
 
 
@@ -113,7 +118,7 @@ class TestPrepush:
             verbose=True,
             exclusion_regexes=ANY,
             matches_ignore=ANY,
-            mode_header="pre_push",
+            scan_mode=SupportedScanMode.PRE_PUSH,
             ignored_detectors=set(),
         )
         assert_invoke_ok(result)

--- a/tests/cmd/test_ignore.py
+++ b/tests/cmd/test_ignore.py
@@ -7,6 +7,7 @@ from ggshield.cmd.secret.ignore import ignore_last_found
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.types import IgnoredMatch
+from ggshield.core.utils import SupportedScanMode
 from ggshield.scan import Commit
 from tests.conftest import _MULTIPLE_SECRETS_PATCH, my_vcr
 
@@ -43,7 +44,7 @@ def test_cache_catches_last_found_secrets(client, isolated_fs):
             client=client,
             cache=cache,
             matches_ignore=config.secret.ignored_matches,
-            mode_header="test",
+            scan_mode=SupportedScanMode.COMMIT_RANGE,
         )
     assert config.secret.ignored_matches == list()
 
@@ -77,7 +78,7 @@ def test_cache_catches_nothing(client, isolated_fs):
             client=client,
             cache=cache,
             matches_ignore=config.secret.ignored_matches,
-            mode_header="test",
+            scan_mode=SupportedScanMode.COMMIT_RANGE,
         )
 
         assert results.results == []

--- a/tests/cmd/test_ignore.py
+++ b/tests/cmd/test_ignore.py
@@ -7,7 +7,7 @@ from ggshield.cmd.secret.ignore import ignore_last_found
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import SupportedScanMode
+from ggshield.core.utils import ScanMode
 from ggshield.scan import Commit
 from tests.conftest import _MULTIPLE_SECRETS_PATCH, my_vcr
 
@@ -44,7 +44,7 @@ def test_cache_catches_last_found_secrets(client, isolated_fs):
             client=client,
             cache=cache,
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.COMMIT_RANGE,
+            scan_mode=ScanMode.COMMIT_RANGE,
         )
     assert config.secret.ignored_matches == list()
 
@@ -78,7 +78,7 @@ def test_cache_catches_nothing(client, isolated_fs):
             client=client,
             cache=cache,
             matches_ignore=config.secret.ignored_matches,
-            scan_mode=SupportedScanMode.COMMIT_RANGE,
+            scan_mode=ScanMode.COMMIT_RANGE,
         )
 
         assert results.results == []

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -87,7 +87,7 @@ def test_make_indices_patch(
             client=client,
             cache=cache,
             matches_ignore={},
-            mode_header=SupportedScanMode.PATH.value,
+            scan_mode=SupportedScanMode.PATH,
             ignored_detectors=None,
         )
         result = results.results[0]

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -11,7 +11,7 @@ from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.utils import (
     MatchIndices,
-    SupportedScanMode,
+    ScanMode,
     api_to_dashboard_url,
     dashboard_to_api_url,
     find_match_indices,
@@ -87,7 +87,7 @@ def test_make_indices_patch(
             client=client,
             cache=cache,
             matches_ignore={},
-            scan_mode=SupportedScanMode.PATH,
+            scan_mode=ScanMode.PATH,
             ignored_detectors=None,
         )
         result = results.results[0]

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -117,7 +117,7 @@ def test_json_output(client, cache, name, input_patch, expected_exit_code):
             client=client,
             cache=cache,
             matches_ignore={},
-            mode_header=SupportedScanMode.PATH.value,
+            scan_mode=SupportedScanMode.PATH,
             ignored_detectors=None,
         )
 

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_voluptuous import Partial, S
 from voluptuous import Optional, validators
 
-from ggshield.core.utils import Filemode, SupportedScanMode
+from ggshield.core.utils import Filemode, ScanMode
 from ggshield.output import JSONOutputHandler, OutputHandler
 from ggshield.output.json.schemas import JSONScanCollectionSchema
 from ggshield.scan import Commit, ScanCollection
@@ -117,7 +117,7 @@ def test_json_output(client, cache, name, input_patch, expected_exit_code):
             client=client,
             cache=cache,
             matches_ignore={},
-            scan_mode=SupportedScanMode.PATH,
+            scan_mode=ScanMode.PATH,
             ignored_detectors=None,
         )
 

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -5,6 +5,7 @@ from click import Command, Context, Group
 
 from ggshield import __version__
 from ggshield.core.cache import Cache
+from ggshield.core.utils import SupportedScanMode
 from ggshield.scan import Commit
 from ggshield.scan.repo import cd
 from tests.conftest import UNCHECKED_SECRET_PATCH
@@ -29,7 +30,7 @@ def test_request_headers(scan_mock: Mock, client):
             client=client,
             cache=Cache(),
             matches_ignore={},
-            mode_header="test",
+            scan_mode=SupportedScanMode.PATH,
         )
     scan_mock.assert_called_with(
         ANY,
@@ -37,6 +38,6 @@ def test_request_headers(scan_mock: Mock, client):
             "GGShield-Version": __version__,
             "GGShield-Command-Path": "foo bar",
             "GGShield-Command-Id": ANY,
-            "mode": "test",
+            "mode": "path",
         },
     )

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -5,7 +5,7 @@ from click import Command, Context, Group
 
 from ggshield import __version__
 from ggshield.core.cache import Cache
-from ggshield.core.utils import SupportedScanMode
+from ggshield.core.utils import ScanMode
 from ggshield.scan import Commit
 from ggshield.scan.repo import cd
 from tests.conftest import UNCHECKED_SECRET_PATCH
@@ -30,7 +30,7 @@ def test_request_headers(scan_mock: Mock, client):
             client=client,
             cache=Cache(),
             matches_ignore={},
-            scan_mode=SupportedScanMode.PATH,
+            scan_mode=ScanMode.PATH,
         )
     scan_mock.assert_called_with(
         ANY,

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -4,7 +4,7 @@ import pytest
 
 from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.filter import init_exclusion_regexes
-from ggshield.core.utils import Filemode, SupportedScanMode
+from ggshield.core.utils import Filemode, ScanMode
 from ggshield.scan import Commit, File, Files
 from tests.conftest import (
     _MULTIPLE_SECRETS_PATCH,
@@ -72,7 +72,7 @@ def test_scan_patch(client, cache, name, input_patch, expected):
             client=client,
             cache=cache,
             matches_ignore={},
-            scan_mode=SupportedScanMode.PATH,
+            scan_mode=ScanMode.PATH,
         )
         for result in results.results:
             if result.scan.policy_breaks:

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -72,7 +72,7 @@ def test_scan_patch(client, cache, name, input_patch, expected):
             client=client,
             cache=cache,
             matches_ignore={},
-            mode_header=SupportedScanMode.PATH.value,
+            scan_mode=SupportedScanMode.PATH,
         )
         for result in results.results:
             if result.scan.policy_breaks:


### PR DESCRIPTION
## Description

This PR improves our scanning API with the following changes:

- Remove the `scan_id` argument from `scan_repo_path()` and `scan_commit_range()`. Reducing the number of arguments of these functions improves readability.
- Rename the SupportedScanMode enum to ScanMode.
- Rename the `mode_header` argument to `scan_mode`, and make it accept either a ScanMode or an str. It would have been better to make it only a ScanMode, but we need the str format for the CI mode.