### PR TITLE
Do not duplicate pygitguardian upload-limit constant

### DIFF
--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -1,8 +1,6 @@
 import os
 
 
-# max file size to accept
-MAX_FILE_SIZE = 1048576
 # max files size to create a tar from
 MAX_TAR_CONTENT_SIZE = 30 * 1024 * 1024
 

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Iterable, Iterator, List, Set, Union
 
 import click
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
-from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.filter import is_filepath_excluded
 from ggshield.core.git_shell import git_ls, is_git_dir
 from ggshield.scan import File, Files
@@ -94,9 +94,12 @@ def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterator[F
             continue
 
         file_size = os.path.getsize(path)
-        if file_size > MAX_FILE_SIZE:
+        if file_size > DOCUMENT_SIZE_THRESHOLD_BYTES:
             if verbose:
-                click.echo(f"ignoring file over 1MB: {path}", err=True)
+                click.echo(
+                    f"ignoring file over {DOCUMENT_SIZE_THRESHOLD_BYTES:,} bytes: {path}",
+                    err=True,
+                )
             continue
         if path.endswith(BINARY_FILE_EXTENSIONS):
             if verbose:

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -10,9 +10,9 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import click
 from pygitguardian import GGClient
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.cache import Cache
-from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.text_utils import display_info
 from ggshield.core.types import IgnoredMatch
 from ggshield.core.utils import ScanMode
@@ -165,7 +165,7 @@ def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Fil
         if not file_info.isfile():
             continue
 
-        if file_info.size > MAX_FILE_SIZE * 0.95:
+        if file_info.size > DOCUMENT_SIZE_THRESHOLD_BYTES * 0.95:
             continue
 
         if not _validate_filepath(

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -18,11 +18,11 @@ from typing import (
 
 import click
 from pygitguardian import GGClient
-from pygitguardian.config import MULTI_DOCUMENT_LIMIT
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MULTI_DOCUMENT_LIMIT
 from pygitguardian.models import Detail, ScanResult
 
 from ggshield.core.cache import Cache
-from ggshield.core.constants import CPU_COUNT, MAX_FILE_SIZE
+from ggshield.core.constants import CPU_COUNT
 from ggshield.core.extra_headers import generate_command_id, get_extra_headers
 from ggshield.core.filter import (
     is_filepath_excluded,
@@ -388,7 +388,7 @@ def _parse_patch(
             document = diff[end_of_headers + 1 :]
 
             file_size = len(document.encode("utf-8"))
-            if file_size > MAX_FILE_SIZE * 0.90:
+            if file_size > DOCUMENT_SIZE_THRESHOLD_BYTES * 0.90:
                 continue
 
             if document:

--- a/tests/core/test_file_utils.py
+++ b/tests/core/test_file_utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.file_utils import generate_files_from_paths
 
@@ -39,7 +40,10 @@ def test_generate_files_from_paths(
     ["filename", "creator"],
     [
         ("a_binary_file.tar", lambda x: x.write_text("Uninteresting")),
-        ("big_file", lambda x: x.write_text(2_000_000 * " ")),
+        (
+            "big_file",
+            lambda x: x.write_text((DOCUMENT_SIZE_THRESHOLD_BYTES + 12) * " "),
+        ),
         ("i_am_a_dir", lambda x: x.mkdir()),
     ],
 )

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 
 import pytest
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
-from ggshield.core.constants import MAX_FILE_SIZE
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.utils import Filemode, ScanMode
 from ggshield.scan import Commit, File, Files
@@ -220,7 +220,7 @@ index 0000000..0000000
 @@ -0,0 +1,112 @@
 CHECK_ENVIRONMENT=true
     """
-    c._patch += "a" * MAX_FILE_SIZE
+    c._patch += "a" * DOCUMENT_SIZE_THRESHOLD_BYTES
     files = list(c.get_files())
 
     assert len(files) == 0


### PR DESCRIPTION
Use pygitguardian `DOCUMENT_SIZE_THRESHOLD_BYTES` constant instead of duplicating its value in core.constants.

Avoids head-scratching when one increases this value and wonders why the changes have no effects...
