### PR TITLE
Modify multi-thread value for ggshield secret scan commands

### DIFF
--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -8,6 +8,9 @@ from ggshield.output import OutputHandler
 from ggshield.scan import ScanCollection
 
 
+SCAN_CMD_THREADS = 10
+
+
 @click.command()
 @click.argument(
     "paths", nargs=-1, type=click.Path(exists=True, resolve_path=True), required=True
@@ -45,6 +48,7 @@ def path_cmd(
             matches_ignore=config.secret.ignored_matches,
             scan_context=scan_context,
             ignored_detectors=config.secret.ignored_detectors,
+            scan_threads=SCAN_CMD_THREADS,
         )
         scan = ScanCollection(id=" ".join(paths), type="path_scan", results=results)
 

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -1,10 +1,5 @@
-import os
-
-
 # max files size to create a tar from
 MAX_TAR_CONTENT_SIZE = 30 * 1024 * 1024
-
-CPU_COUNT = os.cpu_count() or 1
 
 CACHE_FILENAME = "./.cache_ggshield"
 GLOBAL_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", ".gitguardian.yaml"]

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -10,13 +10,16 @@ from pygitguardian import GGClient
 
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
-from ggshield.core.constants import CPU_COUNT
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import STYLE, display_error, format_text
 from ggshield.core.types import IgnoredMatch
 from ggshield.core.utils import ScanContext, handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import Commit, Results, ScanCollection
+
+
+COMMIT_THREADS = 10
+SCAN_THREADS = 4
 
 
 @contextmanager
@@ -71,6 +74,7 @@ def scan_commit(
             matches_ignore=matches_ignore,
             scan_context=scan_context,
             ignored_detectors=ignored_detectors,
+            scan_threads=SCAN_THREADS,
         )
     except Exception as exc:
         results = Results.from_exception(exc)
@@ -102,9 +106,7 @@ def scan_commit_range(
     :param verbose: Display successfull scan's message
     """
 
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=min(CPU_COUNT, 4)
-    ) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=COMMIT_THREADS) as executor:
 
         future_to_process = [
             executor.submit(

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -10,7 +10,6 @@ from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MULTI_DOCUMENT_L
 from pygitguardian.models import Detail, ScanResult
 
 from ggshield.core.cache import Cache
-from ggshield.core.constants import CPU_COUNT
 from ggshield.core.extra_headers import get_headers
 from ggshield.core.filter import (
     is_filepath_excluded,
@@ -260,6 +259,7 @@ class Files:
         on_file_chunk_scanned: Callable[
             [List[Dict[str, Any]]], None
         ] = lambda chunk: None,
+        scan_threads: int = 4,
     ) -> Results:
         logger.debug("self=%s command_id=%s", self, scan_context.command_id)
         cache.purge()
@@ -273,7 +273,7 @@ class Files:
         headers = get_headers(scan_context)
 
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=min(CPU_COUNT, 4), thread_name_prefix="content_scan"
+            max_workers=scan_threads, thread_name_prefix="content_scan"
         ) as executor:
             future_to_scan = {
                 executor.submit(


### PR DESCRIPTION
To speed up the `ggshield secret scan repo` and `path` commands, we want to modify the number of threads that are used:
- for `ggshield secret scan path` we will use 10 `scan_thread`s to scan chunks of files in parallel
- for `ggshield secret scan repo` we will use 10 `commit_thread`s to parallelize commits and 4 `scan_thread`s to scan chunks.