### PR TITLE
update number of types of secrets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/gitguardian/ggshield/main?style=for-the-badge)](https://www.codefactor.io/repository/github/gitguardian/ggshield)
 [![Codecov](https://img.shields.io/codecov/c/github/GitGuardian/ggshield?style=for-the-badge)](https://codecov.io/gh/GitGuardian/ggshield/)
 
-ggshield is a CLI application that runs in your local environment or in a CI environment to help you detect more than 300 types of secrets, as well as other potential security vulnerabilities or policy breaks.
+ggshield is a CLI application that runs in your local environment or in a CI environment to help you detect more than 350+ types of secrets, as well as other potential security vulnerabilities or policy breaks.
 
 ggshield uses our [public API](https://api.gitguardian.com/doc) through [py-gitguardian](https://github.com/GitGuardian/py-gitguardian) to scan and detect potential secrets on files and other text content.
 


### PR DESCRIPTION
Per Jérémy Lanfranchi, the number of things ggshields scans for is now over 350, this update is just to change that one number in the README. 