### PR TITLE
Make prepush smarter

### DIFF
--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -116,7 +116,7 @@ fi
 
     with open(hook_path, mode) as f:
         if mode == "w":
-            f.write("#!/bin/bash\n")
+            f.write("#!/usr/bin/env bash\n")
 
         f.write(f'\n{local_hook_str}\nggshield secret scan {hook_type} "$@"\n')
         os.chmod(hook_path, 0o700)

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -118,7 +118,7 @@ fi
         if mode == "w":
             f.write("#!/bin/bash\n")
 
-        f.write(f"\n{local_hook_str}\nggshield secret scan {hook_type}\n")
+        f.write(f'\n{local_hook_str}\nggshield secret scan {hook_type} "$@"\n')
         os.chmod(hook_path, 0o700)
 
     click.echo(

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -5,7 +5,12 @@ from typing import List, Optional, Tuple
 
 import click
 
-from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
+from ggshield.core.git_shell import (
+    check_git_dir,
+    get_list_commit_SHA,
+    git,
+    is_valid_git_commit_ref,
+)
 from ggshield.core.utils import (
     EMPTY_SHA,
     EMPTY_TREE,
@@ -22,7 +27,7 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.argument("prepush_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: no cover
+def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:
     """
     scan as a pre-push git hook.
     """
@@ -30,7 +35,9 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
 
     local_commit, remote_commit = collect_from_precommit_env()
     if local_commit is None or remote_commit is None:
-        local_commit, remote_commit = collect_from_stdin()
+        remote_name = prepush_args[0]
+        local_commit, remote_commit = collect_from_stdin(remote_name)
+    logger.debug("refs=(%s, %s)", local_commit, remote_commit)
 
     if local_commit == EMPTY_SHA:
         click.echo("Deletion event or nothing to scan.", err=True)
@@ -95,22 +102,51 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
         return handle_exception(error, config.verbose)
 
 
-def collect_from_stdin() -> Tuple[str, str]:
+def find_branch_start(commit: str, remote: str) -> str:
+    """
+    Returns the first local-only commit of the branch
+    """
+    # List all ancestors of `commit` which are not in `remote`
+    # Based on _pre_push_ns() from pre-commit
+    #
+    # Note: The `--remotes` argument MUST be set using a `=`: `--remotes={remote}` works,
+    # but `--remotes {remote}` fails.
+    output = git(
+        [
+            "rev-list",
+            commit,
+            "--topo-order",
+            "--reverse",
+            "--not",
+            f"--remotes={remote}",
+        ]
+    )
+    ancestors = output.splitlines()
+    return ancestors[0]
+
+
+def collect_from_stdin(remote_name: str) -> Tuple[str, str]:
     """
     Collect pre-commit variables from stdin.
     """
-    prepush_input = sys.stdin.read().split()
+    prepush_input = sys.stdin.read().strip()
     logger.debug("input=%s", prepush_input)
-    if len(prepush_input) < 4:
-        # Then it's either a tag or a deletion event
-        local_commit = EMPTY_SHA
-        remote_commit = EMPTY_SHA
-    else:
-        local_commit = prepush_input[1].strip()
-        remote_commit = prepush_input[3].strip()
+    if not prepush_input:
+        # Happens when there's nothing to push
+        return (EMPTY_SHA, EMPTY_SHA)
 
-    logger.debug("refs=(%s, %s)", local_commit, remote_commit)
-    return (local_commit, remote_commit)
+    # TODO There can be more than one line here, for example when pushing multiple
+    # branches. We should support this.
+    line = prepush_input.splitlines()[0]
+    _, local_commit, _, remote_commit = line.split(maxsplit=3)
+
+    if is_valid_git_commit_ref(remote_commit):
+        # Pushing to an existing branch
+        return (local_commit, remote_commit)
+
+    # Pushing to a new branch
+    start_commit = find_branch_start(local_commit, remote_name)
+    return (local_commit, f"{start_commit}~1")
 
 
 def collect_from_precommit_env() -> Tuple[Optional[str], Optional[str]]:
@@ -126,5 +162,4 @@ def collect_from_precommit_env() -> Tuple[Optional[str], Optional[str]]:
         local_commit = os.getenv("PRE_COMMIT_FROM_REF", None)
         remote_commit = os.getenv("PRE_COMMIT_TO_REF", None)
 
-    logger.debug("refs=(%s, %s)", local_commit, remote_commit)
     return (local_commit, remote_commit)

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -43,15 +43,15 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:  # pragma: 
         )
         before = EMPTY_TREE
         after = local_commit
-        cmd_range = (
-            f"--max-count={config.max_commits_for_hook+1} {EMPTY_TREE} {local_commit}"
-        )
+        cmd_range = f"{EMPTY_TREE} {local_commit}"
     else:
         before = remote_commit
         after = local_commit
-        cmd_range = f"--max-count={config.max_commits_for_hook+1} {remote_commit}...{local_commit}"  # noqa
+        cmd_range = f"{remote_commit}...{local_commit}"
 
-    commit_list = get_list_commit_SHA(cmd_range)
+    commit_list = get_list_commit_SHA(
+        cmd_range, max_count=config.max_commits_for_hook + 1
+    )
 
     if not commit_list:
         click.echo(

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -117,7 +117,7 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
     if before == EMPTY_SHA:
         before = "HEAD"
         commit_list = get_list_commit_SHA(
-            f"--max-count={config.max_commits_for_hook+1} {before}...{after}"
+            f"{before}...{after}", max_count=config.max_commits_for_hook + 1
         )
 
         if not commit_list:
@@ -127,11 +127,11 @@ def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) ->
                 err=True,
             )
             commit_list = get_list_commit_SHA(
-                f"--max-count={config.max_commits_for_hook+1} {EMPTY_TREE} {after}",
+                f"{EMPTY_TREE} {after}", max_count=config.max_commits_for_hook + 1
             )
     else:
         commit_list = get_list_commit_SHA(
-            f"--max-count={config.max_commits_for_hook+1} {before}...{after}"
+            f"{before}...{after}", max_count=config.max_commits_for_hook + 1
         )
 
     if not commit_list:

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -101,6 +101,11 @@ def shell_split(command: List[str], **kwargs: Any) -> List[str]:
     return shell(command, **kwargs).split("\n")
 
 
+def git(command: List[str], timeout: int = COMMAND_TIMEOUT, check: bool = True) -> str:
+    """Calls git with the given arguments, returns stdout as a string"""
+    return shell([GIT_PATH] + command, timeout=timeout, check=check)
+
+
 def git_ls(wd: Optional[str] = None) -> List[str]:
     cmd = [GIT_PATH]
     if wd is not None:

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
 import pytest
@@ -13,7 +13,20 @@ from ggshield.core.utils import (
     ScanContext,
     ScanMode,
 )
+from ggshield.scan.repo import cd
 from tests.conftest import assert_invoke_ok
+from tests.repository import Repository
+
+
+def create_local_repo_with_remote(work_dir: Path) -> Repository:
+    remote_repo_path = work_dir / "remote"
+    remote_repo = Repository.create(remote_repo_path)
+    remote_repo.create_commit("initial commit")
+
+    local_repo_path = work_dir / "local"
+    local_repo = Repository.clone(str(remote_repo_path), local_repo_path)
+
+    return local_repo
 
 
 class TestPrepush:
@@ -61,37 +74,29 @@ class TestPrepush:
         assert len(kwargs["commit_list"]) == 50
         assert "Too many commits. Scanning last 50" in result.output
 
-    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
-    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
     @pytest.mark.parametrize(
-        ["env", "input"],
+        ["local_ref_env_var", "remote_ref_env_var"],
         [
             pytest.param(
-                {"PRE_COMMIT_SOURCE": "a" * 40, "PRE_COMMIT_ORIGIN": "b" * 40},
-                None,
+                "PRE_COMMIT_SOURCE",
+                "PRE_COMMIT_ORIGIN",
                 id="old env names",
             ),
             pytest.param(
-                {"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
-                None,
+                "PRE_COMMIT_FROM_REF",
+                "PRE_COMMIT_TO_REF",
                 id="new env names",
-            ),
-            pytest.param(
-                {},
-                f"main\n{'a'*40}\norigin/main\n{'b'*40}\n",
-                id="stdin input",
             ),
         ],
     )
     def test_prepush_pre_commit_framework(
         self,
-        check_dir_mock: Mock,
         scan_commit_range_mock: Mock,
-        get_list_mock: Mock,
+        tmp_path,
         cli_fs_runner: CliRunner,
-        env: Dict,
-        input: Optional[str],
+        local_ref_env_var: str,
+        remote_ref_env_var: str,
     ):
         """
         GIVEN a prepush range with 20 commits provided by the pre-commit framework
@@ -100,21 +105,25 @@ class TestPrepush:
         AND the `exclusion_regexes` argument of the scan_commit_range() call should
         match IGNORED_DEFAULT_WILDCARDS
         """
-        scan_commit_range_mock.return_value = 0
-        commit_list = ["a"] * 20
-        get_list_mock.return_value = commit_list
+        local_repo = create_local_repo_with_remote(tmp_path)
+        remote_sha = local_repo.get_top_sha()
+        shas = [local_repo.create_commit() for _ in range(20)]
 
-        result = cli_fs_runner.invoke(
-            cli, ["-v", "scan", "pre-push"], env=env, input=input
-        )
-        get_list_mock.assert_called_once_with(
-            "--max-count=51 " + "b" * 40 + "..." + "a" * 40
-        )
+        scan_commit_range_mock.return_value = 0
+
+        env = {local_ref_env_var: shas[-1], remote_ref_env_var: remote_sha}
+
+        with cd(str(local_repo.path)):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+                env=env,
+            )
 
         scan_commit_range_mock.assert_called_once_with(
             client=ANY,
             cache=ANY,
-            commit_list=commit_list,
+            commit_list=shas,
             output_handler=ANY,
             exclusion_regexes=ANY,
             matches_ignore=ANY,
@@ -152,7 +161,11 @@ class TestPrepush:
         THEN it should print nothing to scan and return 0
         """
 
-        result = cli_fs_runner.invoke(cli, ["-v", "scan", "pre-push"], input="")
+        result = cli_fs_runner.invoke(
+            cli,
+            ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+            input="",
+        )
         assert_invoke_ok(result)
         assert "Deletion event or nothing to scan.\n" in result.output
 
@@ -214,14 +227,11 @@ class TestPrepush:
         assert_invoke_ok(result)
         assert "Deletion event or nothing to scan.\n" in result.output
 
-    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
-    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
     def test_prepush_stdin_input_no_newline(
         self,
-        check_dir_mock: Mock,
         scan_commit_range_mock: Mock,
-        get_list_mock: Mock,
+        tmp_path,
         cli_fs_runner: CliRunner,
     ):
         """
@@ -229,17 +239,18 @@ class TestPrepush:
         WHEN the command is run
         THEN it should pass onto scan and return 0
         """
-        scan_commit_range_mock.return_value = 0
-        get_list_mock.return_value = ["a" for _ in range(20)]
+        local_repo = create_local_repo_with_remote(tmp_path)
+        remote_sha = local_repo.get_top_sha()
+        shas = [local_repo.create_commit() for _ in range(20)]
 
-        result = cli_fs_runner.invoke(
-            cli,
-            ["-v", "scan", "pre-push"],
-            input="refs/heads/main bfffbd925b1ce9298e6c56eb525b8d7211603c09 refs/heads/main 649061dcda8bff94e02adbaac70ca64cfb84bc78",  # noqa: E501
-        )
+        scan_commit_range_mock.return_value = 0
+
+        with cd(str(local_repo.path)):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+                input=f"refs/heads/main {shas[-1]} refs/heads/main {remote_sha}",
+            )
         assert_invoke_ok(result)
-        get_list_mock.assert_called_once_with(
-            "--max-count=51 649061dcda8bff94e02adbaac70ca64cfb84bc78...bfffbd925b1ce9298e6c56eb525b8d7211603c09"  # noqa: E501
-        )  # noqa: E501
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 20" in result.output

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -207,9 +207,7 @@ class TestPrepush:
             env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": EMPTY_SHA},
         )
         assert_invoke_ok(result)
-        get_list_mock.assert_called_once_with(
-            f"--max-count=51 {EMPTY_TREE} { 'a' * 40}"
-        )
+        get_list_mock.assert_called_once_with(f"{EMPTY_TREE} {'a' * 40}", max_count=51)
         scan_commit_range_mock.assert_called_once()
 
         assert "New tree event. Scanning last 50 commits" in result.output

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -274,12 +274,20 @@ class TestPrepush:
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 20" in result.output
 
+    @pytest.mark.parametrize(
+        ["called_with_pre_push_args"],
+        [
+            (True,),
+            (False,),
+        ],
+    )
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
     def test_prepush_new_branch(
         self,
         scan_commit_range_mock: Mock,
         tmp_path,
         cli_fs_runner: CliRunner,
+        called_with_pre_push_args: bool,
     ):
         """
         GIVEN a cloned repository
@@ -295,10 +303,13 @@ class TestPrepush:
 
         scan_commit_range_mock.return_value = 0
 
+        cmd = ["-v", "secret", "scan", "pre-push"]
+        if called_with_pre_push_args:
+            cmd.extend(["origin", local_repo.remote_url])
         with cd(str(local_repo.path)):
             result = cli_fs_runner.invoke(
                 cli,
-                ["-v", "secret", "scan", "pre-push", "origin", local_repo.remote_url],
+                cmd,
                 input=f"refs/heads/{branch} {shas[-1]} refs/heads/{branch} {EMPTY_SHA}\n",
             )
 

--- a/tests/cmd/scan/test_prepush.py
+++ b/tests/cmd/scan/test_prepush.py
@@ -40,7 +40,7 @@ class TestPrepush:
         get_list_mock.return_value = []
         result = cli_fs_runner.invoke(
             cli,
-            ["-v", "scan", "pre-push"],
+            ["-v", "secret", "scan", "pre-push"],
             env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
         )
         assert_invoke_ok(result)
@@ -65,7 +65,7 @@ class TestPrepush:
         get_list_mock.return_value = ["a"] * 51
         result = cli_fs_runner.invoke(
             cli,
-            ["-v", "scan", "pre-push"],
+            ["-v", "secret", "scan", "pre-push"],
             env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
         )
         assert_invoke_ok(result)
@@ -116,7 +116,14 @@ class TestPrepush:
         with cd(str(local_repo.path)):
             result = cli_fs_runner.invoke(
                 cli,
-                ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+                [
+                    "-v",
+                    "secret",
+                    "scan",
+                    "pre-push",
+                    "origin",
+                    "https://example.com/remote",
+                ],
                 env=env,
             )
 
@@ -129,7 +136,7 @@ class TestPrepush:
             matches_ignore=ANY,
             scan_context=ScanContext(
                 scan_mode=ScanMode.PRE_PUSH,
-                command_path="cli scan pre-push",
+                command_path="cli secret scan pre-push",
             ),
             ignored_detectors=set(),
         )
@@ -163,7 +170,14 @@ class TestPrepush:
 
         result = cli_fs_runner.invoke(
             cli,
-            ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+            [
+                "-v",
+                "secret",
+                "scan",
+                "pre-push",
+                "origin",
+                "https://example.com/remote",
+            ],
             input="",
         )
         assert_invoke_ok(result)
@@ -189,7 +203,7 @@ class TestPrepush:
 
         result = cli_fs_runner.invoke(
             cli,
-            ["-v", "scan", "pre-push"],
+            ["-v", "secret", "scan", "pre-push"],
             env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": EMPTY_SHA},
         )
         assert_invoke_ok(result)
@@ -221,7 +235,7 @@ class TestPrepush:
 
         result = cli_fs_runner.invoke(
             cli,
-            ["-v", "scan", "pre-push"],
+            ["-v", "secret", "scan", "pre-push"],
             env={"PRE_COMMIT_FROM_REF": EMPTY_SHA, "PRE_COMMIT_TO_REF": "a" * 40},
         )
         assert_invoke_ok(result)
@@ -248,7 +262,14 @@ class TestPrepush:
         with cd(str(local_repo.path)):
             result = cli_fs_runner.invoke(
                 cli,
-                ["-v", "scan", "pre-push", "origin", "https://example.com/remote"],
+                [
+                    "-v",
+                    "secret",
+                    "scan",
+                    "pre-push",
+                    "origin",
+                    "https://example.com/remote",
+                ],
                 input=f"refs/heads/main {shas[-1]} refs/heads/main {remote_sha}",
             )
         assert_invoke_ok(result)

--- a/tests/cmd/scan/test_prereceive.py
+++ b/tests/cmd/scan/test_prereceive.py
@@ -45,7 +45,7 @@ class TestPreReceive:
             input="bbbb\naaaa\norigin/main\n",
         )
         assert_invoke_ok(result)
-        get_list_mock.assert_called_once_with("--max-count=51 bbbb" + "..." + "aaaa")
+        get_list_mock.assert_called_once_with("bbbb...aaaa", max_count=51)
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 20" in result.output
 
@@ -71,7 +71,7 @@ class TestPreReceive:
             input="bbbb\naaaa\norigin/main\n",
         )
         assert_invoke_exited_with(result, 1)
-        get_list_mock.assert_called_once_with("--max-count=51 bbbb" + "..." + "aaaa")
+        get_list_mock.assert_called_once_with("bbbb...aaaa", max_count=51)
         scan_commit_range_mock.assert_called_once()
         assert (
             "if those secrets are false positives and you still want your push to pass, run:\n'git push -o breakglass'"
@@ -100,7 +100,7 @@ class TestPreReceive:
             input="bbbb\naaaa\norigin/main\n",
         )
         assert_invoke_ok(result)
-        get_list_mock.assert_called_once_with("--max-count=51 bbbb" + "..." + "aaaa")
+        get_list_mock.assert_called_once_with("bbbb...aaaa", max_count=51)
         scan_commit_range_mock.assert_not_called()
         assert (
             "Unable to get commit range.\n  before: bbbb\n  after: aaaa\nSkipping pre-receive hook\n\n"
@@ -189,7 +189,7 @@ class TestPreReceive:
             },
         )
         assert_invoke_exited_with(result, 1)
-        get_list_mock.assert_called_once_with(f"--max-count=51 {old_sha}...{new_sha}")
+        get_list_mock.assert_called_once_with(f"{old_sha}...{new_sha}", max_count=51)
         scan_commits_content_mock.assert_called_once()
         web_ui_lines = [
             x for x in result.output.splitlines() if x.startswith("GL-HOOK-ERR: ")
@@ -245,7 +245,7 @@ class TestPreReceive:
         assert "New tree event. Scanning last 20 commits" in result.output
         assert "Commits to scan: 20" in result.output
         assert get_list_mock.call_count == 2
-        get_list_mock.assert_called_with(f"--max-count=21 {EMPTY_TREE} { 'a' * 40}")
+        get_list_mock.assert_called_with(f"{EMPTY_TREE} {'a' * 40}", max_count=21)
         scan_commit_range_mock.assert_called_once()
 
     @patch("ggshield.cmd.secret.scan.prereceive.get_list_commit_SHA")
@@ -273,7 +273,7 @@ class TestPreReceive:
 
         assert_invoke_ok(result)
         assert get_list_mock.call_count == 1
-        get_list_mock.assert_called_with(f"--max-count=51 HEAD...{ 'a' * 40}")
+        get_list_mock.assert_called_with(f"HEAD...{'a' * 40}", max_count=51)
         scan_commit_range_mock.assert_called_once()
 
     @patch("ggshield.cmd.secret.scan.prereceive.get_list_commit_SHA")
@@ -303,7 +303,7 @@ class TestPreReceive:
         assert "New tree event. Scanning last 50 commits" in result.output
         assert "Commits to scan: 50" in result.output
         assert get_list_mock.call_count == 2
-        get_list_mock.assert_called_with(f"--max-count=51 {EMPTY_TREE} { 'a' * 40}")
+        get_list_mock.assert_called_with(f"{EMPTY_TREE} { 'a' * 40}", max_count=51)
         scan_commit_range_mock.assert_called_once()
 
     @patch("ggshield.cmd.secret.scan.prereceive.get_list_commit_SHA")
@@ -351,8 +351,9 @@ class TestPreReceive:
         )
         assert_invoke_ok(result)
         get_list_mock.assert_called_once_with(
-            "--max-count=51 649061dcda8bff94e02adbaac70ca64cfb84bc78...bfffbd925b1ce9298e6c56eb525b8d7211603c09"  # noqa: E501
-        )  # noqa: E501
+            "649061dcda8bff94e02adbaac70ca64cfb84bc78...bfffbd925b1ce9298e6c56eb525b8d7211603c09",
+            max_count=51,
+        )
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 20" in result.output
 

--- a/tests/cmd/test_install.py
+++ b/tests/cmd/test_install.py
@@ -10,13 +10,13 @@ from ggshield.cmd.main import cli
 from tests.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
-SAMPLE_PRE_COMMIT = """#!/bin/bash
+SAMPLE_PRE_COMMIT = """#!/usr/bin/env bash
 
 
 ggshield secret scan pre-commit "$@"
 """
 
-SAMPLE_PRE_PUSH = """#!/bin/bash
+SAMPLE_PRE_PUSH = """#!/usr/bin/env bash
 
 
 ggshield secret scan pre-push "$@"

--- a/tests/cmd/test_install.py
+++ b/tests/cmd/test_install.py
@@ -13,13 +13,13 @@ from tests.conftest import assert_invoke_exited_with, assert_invoke_ok
 SAMPLE_PRE_COMMIT = """#!/bin/bash
 
 
-ggshield secret scan pre-commit
+ggshield secret scan pre-commit "$@"
 """
 
 SAMPLE_PRE_PUSH = """#!/bin/bash
 
 
-ggshield secret scan pre-push
+ggshield secret scan pre-push "$@"
 """
 
 


### PR DESCRIPTION
## Description

This PR fixes #303: when ggshield is used a pre-push hook and the user pushes a new branch, ggshield does not know the branch start commit and scans up to 50 commits.

## What has been done

Some preliminary work has been done first:

- Adding a way to create *real* repositories in test code, so that tests are not out of touch with reality.
- Fixing some tests which were out of touch with reality.

Then the command was fixed, by taking inspiration from how pre-commit solves this problem, and extending our fix for scanning parent-less commits (#313) to apply there too.

Finally, the generated hook had to be fixed, because the `ggshield secret scan pre-push` now uses the command-line arguments, which were not forwarded by the hook we generated.

## Issue

Fixes #303.
