### PR TITLE
fix: Fail when the server cannot be accessed

### DIFF
--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -544,6 +544,10 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[File]) -> None:
     logger.error("status_code=%d detail=%s", detail.status_code, detail.detail)
     if detail.status_code == 401:
         raise click.UsageError(detail.detail)
+    if detail.status_code is None:
+        raise click.ClickException(
+            f"Error scanning, network error occurred: {detail.detail}"
+        )
 
     details = None
 


### PR DESCRIPTION
If you run `ggshield` without an internet connection, it will print errors but not fail. Within a CI if the server is not accessible, the CI will not fail.

This PR raises an exception when the status code is missing, meaning the server did not respond.