### PR TITLE
Fix issue 357 trailing slash in instance creates a new instance

### DIFF
--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -5,7 +5,7 @@ import click
 
 from ggshield.core.config.auth_config import AuthConfig
 from ggshield.core.config.user_config import UserConfig
-from ggshield.core.config.utils import get_attr_mapping
+from ggshield.core.config.utils import get_attr_mapping, remove_url_trailing_slash
 from ggshield.core.constants import DEFAULT_DASHBOARD_URL
 from ggshield.core.utils import api_to_dashboard_url, clean_url, dashboard_to_api_url
 
@@ -77,7 +77,8 @@ class Config:
             return self._cmdline_instance_name
 
         try:
-            return os.environ["GITGUARDIAN_INSTANCE"]
+            url = os.environ["GITGUARDIAN_INSTANCE"]
+            return remove_url_trailing_slash(url)
         except KeyError:
             pass
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -126,3 +126,10 @@ def remove_common_dict_items(dct: Dict, reference_dct: Dict) -> Dict:
         result_dct[key] = value
 
     return result_dct
+
+
+def remove_url_trailing_slash(url: str) -> str:
+    if url[-1] == "/":
+        return url[:-1]
+    else:
+        return url

--- a/tests/core/config/test_utils.py
+++ b/tests/core/config/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from ggshield.core.config.utils import (
     remove_common_dict_items,
+    remove_url_trailing_slash,
     replace_in_keys,
     update_from_other_instance,
 )
@@ -106,3 +107,8 @@ def test_remove_common_dict_items(
 ):
     result = remove_common_dict_items(src, reference)
     assert result == expected
+
+
+def test_remove_url_trailing_slash():
+    result = remove_url_trailing_slash("https://dashboard.gitguardian.com/")
+    assert result == "https://dashboard.gitguardian.com"


### PR DESCRIPTION
The only place in the code where the GITGUARDIAN_INSTANCE env variable was loaded was 'ggshield\ggshield\core\config\config.py' so removing the trailing slash when reading the url would make the command 
`ggshield auth login --instance https://dashboard.gitguardian.com/` 
Equals to:
`ggshield auth login --instance https://dashboard.gitguardian.com` 
and returns: 
`ggshield is already authenticated without an expiry date`

if used after a first call to `ggshield auth login --instance https://dashboard.gitguardian.com`


I simply unit tested my utils function that removed the traling slash. I tried to write a test for the two consecutive calls but got stuck so far as the configuration for the existing tests seems to try to assert that no instances are stored before the cli command is run.


```python
def prepare_mocks(
        self,
        monkeypatch,
        token_name=None,
        lifetime=None,
        instance_url=None,
        authorization_code="some_authorization_code",
        used_port_count=0,
        is_state_valid=True,
        is_exchange_ok=True,
        is_token_valid=True,
        sso_url=None,
    ):
        """
        Prepare object and function mocks to emulate HTTP requests
        and server interactions
        """
        token = "mysupertoken"
        config = Config()
        assert len(config.auth_config.instances) == 0
```

I tried to define a prepare_mocks_for_second_call function that did just the same with the assertion that `len(config.auth_config.instances) == 1` but it was uncessfull as on the second call  I was expecting `self._webbrowser_open_mock.assert_not_called()` not to be triggered as you can see in this test:

```python
def test_existing_non_expired_token(
        self, month, day, str_date, instance_url, cli_fs_runner, monkeypatch
    ):
        dt = datetime.strptime(f"2100-{month}-{day}T00:00:00+0000", DT_FORMAT)

        self.prepare_mocks(monkeypatch, instance_url=instance_url)
        prepare_config(instance_url=instance_url, expiry_date=dt)

        exit_code, output = self.run_cmd(cli_fs_runner)
        assert exit_code == 0, output
        self._webbrowser_open_mock.assert_not_called()

        self._assert_last_print(
            output, f"ggshield is already authenticated until {str_date} 2100"
        )
```
