### PR TITLE
Fix homebrew update

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -164,9 +164,28 @@ jobs:
           path: ./homebrew-ggshield
 
       - name: Install dependencies
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install ggshield homebrew-pypi-poet
+
+          pip install homebrew-pypi-poet
+
+          # Install the newly released version of ggshield. Retry in case of
+          # failure because it can take some time before the version we just
+          # published on pypi.org is available for download.
+          version=${GITHUB_REF/refs\/tags\/v/}
+          max_tries=5
+          for try in $(seq 1 $max_tries) ; do
+              echo "Downloading ggshield==$version, attempt $try/$max_tries"
+              if pip install ggshield==$version ; then
+                  exit 0
+              else
+                  sleep 10
+              fi
+          done
+
+      - name: Update Homebrew formulas
+        run: |
           poet -f ggshield \
               | sed 's/Shiny new formula/Detect secrets in source code, scan your repos and docker images for leaks/g' \
               | sed '7a\  license "MIT"' \


### PR DESCRIPTION
Fix Homebrew formulas not being correctly update on release.

This can happen if the new package is not yet available from pypi.org when we update the formula. In this case `pip install ggshield` installs the previous version.
    
Fix this by explicitly requesting the new version and trying 5 times to install.

## Tests

Tested on a fork of the repo:
- Failure to install the latest version (simulated by using a version number which is not available on pypi.org): https://github.com/agateau-gg/ggshield/actions/runs/3233886780/jobs/5296316238
- Successfully installing the new version (simulated by using the version number of the current release): https://github.com/agateau-gg/ggshield/actions/runs/3233900129/jobs/5296345794 (Job fails because the fork does not have the credentials to publish, as expected)