### PR TITLE
Do not fail when `auth login` is called with a lifetime argument

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -5,7 +5,7 @@ import click
 
 from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
 from ggshield.core.client import create_client
-from ggshield.core.config import AccountConfig, Config
+from ggshield.core.config import Config
 from ggshield.core.oauth import OAuthClient
 from ggshield.core.utils import clean_url
 
@@ -133,15 +133,7 @@ def login_cmd(
         if "scan" not in scopes:
             raise click.ClickException("This token does not have the scan scope.")
 
-        account_config = AccountConfig(
-            workspace_id=api_token_data.get("account_id"),
-            token=token,
-            expire_at=api_token_data.get("expire_at"),
-            token_name=api_token_data.get("name", ""),
-            type=api_token_data.get("type", ""),
-        )
-
-        instance_config.account = account_config
+        instance_config.init_account(token, api_token_data)
         config.auth_config.save()
         click.echo("Authentication was successful.")
         return 0

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import marshmallow_dataclass
 
@@ -17,6 +17,7 @@ from ggshield.core.config.utils import (
     load_yaml,
     save_yaml,
 )
+from ggshield.core.utils import datetime_from_isoformat
 
 
 @dataclass
@@ -43,6 +44,21 @@ class InstanceConfig:
             self.account is not None
             and self.account.expire_at is not None
             and self.account.expire_at <= datetime.now(timezone.utc)
+        )
+
+    def init_account(self, token: str, token_data: Dict[str, Any]) -> None:
+        """Initialize our account based on the token and the data received from the
+        `token` endpoint"""
+        expire_at_str = token_data.get("expire_at")
+        expire_at = (
+            None if expire_at_str is None else datetime_from_isoformat(expire_at_str)
+        )
+        self.account = AccountConfig(
+            workspace_id=cast(int, token_data["account_id"]),
+            token=token,
+            expire_at=expire_at,
+            token_name=token_data["name"],
+            type=token_data["type"],
         )
 
 

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -14,7 +14,7 @@ from oauthlib.oauth2 import OAuth2Error, WebApplicationClient
 from ggshield.core.utils import urljoin
 
 from .client import create_client, create_session
-from .config import AccountConfig, Config, InstanceConfig
+from .config import Config, InstanceConfig
 
 
 CLIENT_ID = "ggshield_oauth"
@@ -269,14 +269,7 @@ class OAuthClient:
         Save the new token in the configuration.
         """
         assert self._access_token is not None
-        account_config = AccountConfig(
-            workspace_id=api_token_data["account_id"],
-            token=self._access_token,
-            expire_at=api_token_data.get("expire_at"),
-            token_name=api_token_data.get("name", ""),
-            type=api_token_data.get("type", ""),
-        )
-        self.instance_config.account = account_config
+        self.instance_config.init_account(self._access_token, api_token_data)
         self.config.auth_config.save()
 
     @property

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -4,6 +4,7 @@ import re
 import traceback
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Iterable, List, NamedTuple, Optional, Union
 from urllib.parse import ParseResult, urlparse
@@ -389,3 +390,10 @@ class ScanContext:
 
     def __post_init__(self) -> None:
         self.command_id = str(uuid.uuid4())
+
+
+def datetime_from_isoformat(text: str) -> datetime:
+    """Work around for datetime.isoformat() not supporting ISO dates ending with Z"""
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text)

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -459,7 +459,9 @@ class TestAuthLoginWeb:
         if is_exchange_ok:
             token_response_payload = _TOKEN_RESPONSE_PAYLOAD.copy()
             if lifetime is not None:
-                token_response_payload["expire_at"] = self._get_expiry_date()
+                token_response_payload[
+                    "expire_at"
+                ] = self._get_expiry_date().isoformat()
 
         # mock api call to exchange the code against a valid access token
         self._client_post_mock = Mock(

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -1,12 +1,14 @@
 import os
 import sys
 from copy import deepcopy
+from datetime import datetime, timezone
 
 import pytest
 
 from ggshield.core.config import Config
 from ggshield.core.config.auth_config import (
     AuthConfigSchema,
+    InstanceConfig,
     prepare_auth_config_dict_for_save,
 )
 from ggshield.core.config.utils import get_auth_config_filepath, replace_in_keys
@@ -141,3 +143,18 @@ class TestAuthConfig:
         write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
         config = Config()
         assert config.instances[0].account.expire_at.tzinfo is not None
+
+    def test_init_instance_config_with_expiration_date(self):
+        token_data = {
+            "type": "personal_access_token",
+            "account_id": 8,
+            "name": "ggshield token 2022-10-13",
+            "scope": ["scan"],
+            "expire_at": "2022-10-17T11:55:06Z",
+        }
+        instance = InstanceConfig(account=None, url="u")
+        instance.init_account(token="tok", token_data=token_data)
+
+        assert instance.account.expire_at == datetime(
+            2022, 10, 17, 11, 55, 6, tzinfo=timezone.utc
+        )


### PR DESCRIPTION
- Factorize code creating the AccountConfig instance from auth/login.py and oauth.py in a new method: InstanceConfig.init_account()

- Fix parsing of the optional "expire_at" value we receive from the API: we receive it as a string, so it must be converted into a `datetime`