### PR TITLE
Do not crash if pushed branch contains no new commits

### DIFF
--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -116,9 +116,10 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:
         return handle_exception(error, config.verbose)
 
 
-def find_branch_start(commit: str, remote: str) -> str:
+def find_branch_start(commit: str, remote: str) -> Optional[str]:
     """
-    Returns the first local-only commit of the branch
+    Returns the first local-only commit of the branch.
+    Returns None if the branch does not contain any new commit.
     """
     # List all ancestors of `commit` which are not in `remote`
     # Based on _pre_push_ns() from pre-commit
@@ -136,7 +137,10 @@ def find_branch_start(commit: str, remote: str) -> str:
         ]
     )
     ancestors = output.splitlines()
-    return ancestors[0]
+
+    if ancestors:
+        return ancestors[0]
+    return None
 
 
 def collect_from_stdin(remote_name: str) -> Tuple[str, str]:
@@ -160,6 +164,8 @@ def collect_from_stdin(remote_name: str) -> Tuple[str, str]:
 
     # Pushing to a new branch
     start_commit = find_branch_start(local_commit, remote_name)
+    if start_commit is None:
+        return local_commit, local_commit
     return (local_commit, f"{start_commit}~1")
 
 

--- a/tests/functional/secret/test_scan_prepush.py
+++ b/tests/functional/secret/test_scan_prepush.py
@@ -33,3 +33,27 @@ def test_scan_prepush(tmp_path: Path) -> None:
     # AND the error message contains the leaked secret
     stdout = exc.value.stdout.decode()
     assert recreate_censored_content(secret_content, GG_VALID_TOKEN) in stdout
+
+
+def test_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    # Add a commit to the remote repository, otherwise git complains the branch does not
+    # contain anything
+    local_repo.create_commit()
+    local_repo.git("push")
+
+    # AND ggshield installed as a pre-push hook
+    run_ggshield("install", "-m", "local", "-t", "pre-push", cwd=local_repo.path)
+
+    # AND a branch without new commits
+    branch_name = "topic"
+    local_repo.create_branch(branch_name)
+
+    # WHEN I try to push the branch
+    # THEN the hook does not crash
+    local_repo.git("push", "-u", "origin", branch_name)

--- a/tests/functional/secret/test_scan_prereceive.py
+++ b/tests/functional/secret/test_scan_prereceive.py
@@ -10,7 +10,6 @@ from tests.repository import Repository
 
 HOOK_CONTENT = """#!/bin/sh
 set -e
-echo "Hello from hook"
 ggshield secret scan pre-receive
 """
 
@@ -42,3 +41,29 @@ def test_scan_prereceive(tmp_path: Path) -> None:
     # AND the error message contains the leaked secret
     stderr = exc.value.stderr.decode()
     assert recreate_censored_content(secret_content, GG_VALID_TOKEN) in stderr
+
+
+def test_scan_prereceive_branch_without_new_commits(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    # Add a commit to the remote repository, otherwise git complains the branch does not
+    # contain anything
+    local_repo.create_commit()
+    local_repo.git("push")
+
+    # AND ggshield installed as a pre-receive hook
+    hook_path = remote_repo.path / "hooks" / "pre-receive"
+    hook_path.write_text(HOOK_CONTENT)
+    hook_path.chmod(0o755)
+
+    # AND a branch without new commits
+    branch_name = "topic"
+    local_repo.create_branch(branch_name)
+
+    # WHEN I try to push the branch
+    # THEN the hook does not crash
+    local_repo.git("push", "-u", "origin", branch_name)


### PR DESCRIPTION
In this case the call to `git rev-list...` returns no commits, causing
ggshield to crash because `ancestors` is empty.
