### PR TITLE
Centralize directory access in a dirs.py module

### DIFF
--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -3,17 +3,17 @@ import os.path
 import time
 from typing import Optional, Tuple
 
-import appdirs
 import requests
 
 from ggshield import __version__
+from ggshield.core.dirs import get_cache_dir
 
 from .config.utils import load_yaml, save_yaml
 
 
 logger = logging.getLogger(__name__)
 CACHE_FILE = os.path.join(
-    appdirs.user_cache_dir(appname="ggshield", appauthor="GitGuardian"),
+    get_cache_dir(),
     "update_check.yaml",
 )
 

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -12,11 +12,11 @@ from ggshield.core.config.errors import (
 )
 from ggshield.core.config.utils import (
     ensure_path_exists,
-    get_auth_config_dir,
     get_auth_config_filepath,
     load_yaml,
     save_yaml,
 )
+from ggshield.core.dirs import get_config_dir
 from ggshield.core.utils import datetime_from_isoformat
 
 
@@ -125,7 +125,7 @@ class AuthConfig:
 
     def save(self) -> None:
         config_path = get_auth_config_filepath()
-        ensure_path_exists(get_auth_config_dir())
+        ensure_path_exists(get_config_dir())
         data = AuthConfigSchema().dump(self)
         data = prepare_auth_config_dict_for_save(data)
         save_yaml(data, config_path)

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import click
 import yaml
-from appdirs import user_config_dir
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME
+from ggshield.core.dirs import get_config_dir
 from ggshield.core.text_utils import display_error
 
 
@@ -54,12 +54,8 @@ def save_yaml(data: Dict[str, Any], path: str) -> None:
             ) from e
 
 
-def get_auth_config_dir() -> str:
-    return user_config_dir(appname="ggshield", appauthor="GitGuardian")
-
-
 def get_auth_config_filepath() -> str:
-    return os.path.join(get_auth_config_dir(), AUTH_CONFIG_FILENAME)
+    return os.path.join(get_config_dir(), AUTH_CONFIG_FILENAME)
 
 
 def get_global_path(filename: str) -> str:

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -1,0 +1,13 @@
+from appdirs import user_cache_dir, user_config_dir
+
+
+APPNAME = "ggshield"
+APPAUTHOR = "GitGuardian"
+
+
+def get_config_dir() -> str:
+    return user_config_dir(appname=APPNAME, appauthor=APPAUTHOR)
+
+
+def get_cache_dir() -> str:
+    return user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR)

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -50,7 +50,7 @@ DT_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 @pytest.fixture(autouse=True)
 def tmp_config(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "ggshield.core.config.utils.get_auth_config_dir", lambda: str(tmp_path)
+        "ggshield.core.config.utils.get_config_dir", lambda: str(tmp_path)
     )
 
 

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -16,7 +16,7 @@ DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 @pytest.fixture(autouse=True)
 def tmp_config(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "ggshield.core.config.utils.get_auth_config_dir", lambda: str(tmp_path)
+        "ggshield.core.config.utils.get_config_dir", lambda: str(tmp_path)
     )
 
 

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -40,7 +40,7 @@ expiry: not set
 @pytest.fixture(autouse=True)
 def tmp_config(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "ggshield.core.config.utils.get_auth_config_dir", lambda: str(tmp_path)
+        "ggshield.core.config.utils.get_config_dir", lambda: str(tmp_path)
     )
 
 


### PR DESCRIPTION
### :red_circle:  Target issue 
https://github.com/GitGuardian/ggshield/issues/376

### :notebook: Description
This PR refactors ggshield's code.  We introduce a new module `core/dirs.py` that gets imported by two different files:
- `ggshield/core/check_updates.py`
- `ggshield/core/config/utils.py`

which helps us avoid interacting directly with `appdirs` package: narrowing the room for error.

