### PR TITLE
Make core.config.utils.load_yaml check the type of the loaded data

### DIFF
--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -8,7 +8,7 @@ import requests
 from ggshield import __version__
 from ggshield.core.dirs import get_cache_dir
 
-from .config.utils import load_yaml, save_yaml
+from .config.utils import load_yaml_dict, save_yaml_dict
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,11 @@ def check_for_updates() -> Optional[str]:
     """
     check_at = -1.0
     # Load the last time we checked
-    cached_data = load_yaml(CACHE_FILE)
+    try:
+        cached_data = load_yaml_dict(CACHE_FILE)
+    except ValueError:
+        # Swallow the error
+        cached_data = None
     if cached_data is not None:
         try:
             check_at = cached_data["check_at"]
@@ -49,7 +53,7 @@ def check_for_updates() -> Optional[str]:
     # Save check time now so that it is saved even if the check fails. This ensures we
     # don't try for every command if the user does not have network access.
     try:
-        save_yaml({"check_at": time.time()}, CACHE_FILE)
+        save_yaml_dict({"check_at": time.time()}, CACHE_FILE)
     except Exception as e:
         logger.error("Could not save time of version check to cache: %s", e)
         # Do not continue if we can't save check time. If we continue we are going to

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -13,8 +13,8 @@ from ggshield.core.config.errors import (
 from ggshield.core.config.utils import (
     ensure_path_exists,
     get_auth_config_filepath,
-    load_yaml,
-    save_yaml,
+    load_yaml_dict,
+    save_yaml_dict,
 )
 from ggshield.core.dirs import get_config_dir
 from ggshield.core.utils import datetime_from_isoformat
@@ -117,7 +117,8 @@ class AuthConfig:
     def load(cls) -> "AuthConfig":
         """Load the auth config from the app config file"""
         config_path = get_auth_config_filepath()
-        data = load_yaml(config_path)
+
+        data = load_yaml_dict(config_path)
         if data:
             data = prepare_auth_config_dict_for_parse(data)
             return AuthConfigSchema().load(data)  # type: ignore
@@ -128,7 +129,7 @@ class AuthConfig:
         ensure_path_exists(get_config_dir())
         data = AuthConfigSchema().dump(self)
         data = prepare_auth_config_dict_for_save(data)
-        save_yaml(data, config_path)
+        save_yaml_dict(data, config_path)
 
     def get_instance(self, instance_name: str) -> InstanceConfig:
         for instance in self.instances:

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import re
 from copy import deepcopy
 from datetime import datetime, timezone
 
@@ -61,20 +61,22 @@ class TestAuthConfig:
         ):
             Config()
 
-    def test_invalid_format(self, capsys):
+    def test_invalid_format(self):
         """
         GIVEN an auth config file with invalid content
         WHEN loading AuthConfig
         THEN it raises
         """
         write_text(get_auth_config_filepath(), "Not a:\nyaml file.\n")
+        expected_output = (
+            f"Parsing error while reading {re.escape(get_auth_config_filepath())}:"
+        )
 
-        Config()
-        out, err = capsys.readouterr()
-        sys.stdout.write(out)
-        sys.stderr.write(err)
-
-        assert f"Parsing error while reading {get_auth_config_filepath()}:" in err
+        with pytest.raises(
+            ValueError,
+            match=expected_output,
+        ):
+            Config()
 
     def test_token_not_expiring(self):
         """

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -9,7 +9,7 @@ import pytest
 
 from ggshield.core.config import AccountConfig, Config, InstanceConfig
 from ggshield.core.config.errors import UnknownInstanceError
-from ggshield.core.config.utils import get_auth_config_filepath, load_yaml
+from ggshield.core.config.utils import get_auth_config_filepath, load_yaml_dict
 from ggshield.core.constants import DEFAULT_LOCAL_CONFIG_PATH
 from ggshield.core.utils import dashboard_to_api_url
 from tests.unit.conftest import write_yaml
@@ -310,5 +310,5 @@ class TestConfig:
 
         assert not Path(DEFAULT_LOCAL_CONFIG_PATH).exists()
 
-        dct = load_yaml(local_config_path)
+        dct = load_yaml_dict(local_config_path)
         assert dct["instance"] == "https://after.com"

--- a/tests/unit/core/test_cache.py
+++ b/tests/unit/core/test_cache.py
@@ -12,11 +12,11 @@ from ggshield.core.types import IgnoredMatch
 
 @pytest.mark.usefixtures("isolated_fs")
 class TestCache:
-    def test_defaults(self, cli_fs_runner):
+    def test_defaults(self):
         cache = Cache()
         assert cache.last_found_secrets == []
 
-    def test_load_cache_and_purge(self, cli_fs_runner):
+    def test_load_cache_and_purge(self):
         with open(".cache_ggshield", "w") as file:
             json.dump({"last_found_secrets": [{"name": "", "match": "XXX"}]}, file)
         cache = Cache()
@@ -25,7 +25,7 @@ class TestCache:
         cache.purge()
         assert cache.last_found_secrets == []
 
-    def test_load_invalid_cache(self, cli_fs_runner, capsys):
+    def test_load_invalid_cache(self, capsys):
         with open(".cache_ggshield", "w") as file:
             json.dump({"invalid_option": True}, file)
 
@@ -33,7 +33,7 @@ class TestCache:
         captured = capsys.readouterr()
         assert "Unrecognized key in cache" in captured.err
 
-    def test_save_cache(self, cli_fs_runner):
+    def test_save_cache(self):
         with open(".cache_ggshield", "w") as file:
             json.dump({}, file)
         cache = Cache()
@@ -75,7 +75,7 @@ class TestCache:
 
         assert os.path.isfile(".cache_ggshield") is with_entry
 
-    def test_max_commits_for_hook_setting(self, cli_fs_runner):
+    def test_max_commits_for_hook_setting(self):
         """
         GIVEN a yaml config with `max-commits-for-hook=75`
         WHEN the config gets parsed


### PR DESCRIPTION
## :notebook: Intro
This PR fixes the problem we have when the `.gitguardian.yml` file contains a string (or anything else that is not a valid dict), we get a non-explanatory error message.

Moreover, this PR also cleans and refactors some parts of the code by:
- Removing unused imports
- Removing unused variables
- Removing unused arguments

It also changes the tests to make them compliant with the new changes.

## :red_circle: Target issue
https://github.com/GitGuardian/ggshield/issues/377

## :computer: New output
If the `configuration` is an invalid dict, we get the following output:
`The configuration in '.gitguardian.yml' is invalid. Please verify it.`