### PR TITLE
fix(codecs): #399 Encode the content of the documents in UTF-8

### DIFF
--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -217,7 +217,8 @@ class File:
 
     @staticmethod
     def _decode_bytes(raw_document: bytes, filename: str) -> str:
-        """Low level function to decode bytes, tries hard to find the correct encoding.
+        """Low level function to decode bytes, tries hard to find the correct encoding
+        and converts to UTF-8, as expected by pygitguardian.models.DocumentSchema.
         For now it returns an empty string if the document could not be decoded"""
         result = charset_normalizer.from_bytes(raw_document).best()
         if result is None:
@@ -230,7 +231,11 @@ class File:
         # ourselves
         if result.encoding == "utf_8" and raw_document.startswith(codecs.BOM_UTF8):
             raw_document = raw_document[len(codecs.BOM_UTF8) :]
-        return raw_document.decode(result.encoding, errors="replace")
+        return (
+            raw_document.decode(result.encoding, errors="replace")
+            .encode("utf-8", errors="replace")
+            .decode("utf-8", errors="replace")
+        )
 
     def __repr__(self) -> str:
         return f"<File filename={self.filename} filemode={self.filemode}>"


### PR DESCRIPTION
Tries to fix #399 

We decoding a file, we keep the encoding of the file but `py-gitguardian` expects `UTF-8` and encode without using an error handlers:

`py-gitguardian/models.py:L55-65`
```python
    def validate_document(self, document: str) -> None:
        """
        validate that document is smaller than scan limit
        """
        encoded = document.encode("utf-8")
        if len(encoded) > DOCUMENT_SIZE_THRESHOLD_BYTES:
            raise ValidationError(
                "file exceeds the maximum allowed size of {}B".format(
                    DOCUMENT_SIZE_THRESHOLD_BYTES
                )
            )
```

This PR makes `File._decode_bytes` re-encode the content of documents in UTF-8. The function is tested and `test_file_decode_content` shows its behavior stays the same on *normal* files.