### PR TITLE
Fix warnings when running unit-tests

### DIFF
--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -111,9 +111,9 @@ class JSONScanCollectionSchema(BaseSchema):
 
 
 class IaCJSONFileResultSchema(IaCFileResultSchema):  # type: ignore
-    total_incidents = fields.Integer(default=0)
+    total_incidents = fields.Integer(dump_default=0)
 
 
 class IaCJSONScanResultSchema(IaCScanResultSchema):  # type: ignore
     entities_with_incidents = fields.List(fields.Nested(IaCJSONFileResultSchema))
-    total_incidents = fields.Integer(default=0)
+    total_incidents = fields.Integer(dump_default=0)


### PR DESCRIPTION
## The problem

Running the test suite produces these warnings at the end:

```
../../.local/share/virtualenvs/ggshield-c3rFhSjf/lib/python3.8/site-packages/marshmallow/fields.py:173
../../.local/share/virtualenvs/ggshield-c3rFhSjf/lib/python3.8/site-packages/marshmallow/fields.py:173
  /home/agateau/.local/share/virtualenvs/ggshield-c3rFhSjf/lib/python3.8/site-packages/marshmallow/fields.py:173: RemovedInMarshmallow4Warning: The 'default' argument to fields is deprecated. Use 'dump_default' instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## The fix

Marshmallow deprecated `default` in favor of `dump_default` in [Marshmallow 3.13.0][changelog].

We depend on Marshmallow 3.15, so we can use `dump_default`.

[changelog]: https://marshmallow.readthedocs.io/en/latest/changelog.html#id8
