### PR TITLE
Rework error messages when we can't load the configuration

### DIFF
--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -171,9 +171,9 @@ class UserConfig(FilteredConfig):
                 )
         except ValidationError as exc:
             message = format_validation_error(exc)
-            raise ParseError(f"Error in {config_path}:\n{message}") from exc
-        except ValueError as ve:
-            raise ParseError(f"Error in {config_path}:\n{str(ve)}") from ve
+            raise ParseError(message) from exc
+        except ValueError as exc:
+            raise ParseError(str(exc)) from exc
 
         update_from_other_instance(self, obj)
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -30,16 +30,15 @@ def load_yaml_dict(path: str) -> Optional[Dict[str, Any]]:
     with open(path, "r") as f:
         try:
             data = yaml.safe_load(f) or {}
-            if not isinstance(data, dict):
-                raise ValueError(
-                    f"The configuration in '{path}' is invalid. Configuration must be a dict."
-                )
         except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
-            message = f"Parsing error while reading {path}:\n{str(e)}"
+            message = f"{path} is not a valid YAML file:\n{str(e)}"
             raise ValueError(message)
-        else:
-            replace_in_keys(data, old_char="-", new_char="_")
-            return data
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} should be a dictionary.")
+
+    replace_in_keys(data, old_char="-", new_char="_")
+    return data
 
 
 def save_yaml_dict(data: Dict[str, Any], path: str) -> None:

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -69,7 +69,7 @@ class TestAuthConfig:
         """
         write_text(get_auth_config_filepath(), "Not a:\nyaml file.\n")
         expected_output = (
-            f"Parsing error while reading {re.escape(get_auth_config_filepath())}:"
+            f"{re.escape(get_auth_config_filepath())} is not a valid YAML file:"
         )
 
         with pytest.raises(

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -16,7 +16,7 @@ from tests.unit.conftest import write_text, write_yaml
 class TestUserConfig:
     def test_parsing_error(cli_fs_runner, local_config_path):
         write_text(local_config_path, "Not a:\nyaml file.\n")
-        expected_output = f"Parsing error while reading {local_config_path}:"
+        expected_output = f"{local_config_path} is not a valid YAML file:"
         with pytest.raises(ParseError, match=expected_output):
             Config()
 


### PR DESCRIPTION
## Description

This PR slightly reworks error messages when we can't load the configuration. It removes some  `Error: Error in (...)` sequences and some duplication of the filename. The "Invalid YAML" error message is still a bit filled with jargon, but it's good enough for now I think.

It also reduces indentation in `load_yaml_dict()` to make code a bit easier to read.

### Before

Invalid YAML:

```
$ ggshield api-status
Error: Error in ./.gitguardian.yaml:
Parsing error while reading ./.gitguardian.yaml:
while parsing a flow node
expected the node content, but found '<stream end>'
  in "./.gitguardian.yaml", line 2, column 1
```

YAML string:

```
$ ggshield api-status
Error: Error in ./.gitguardian.yaml:
The configuration in './.gitguardian.yaml' is invalid. Configuration must be a dict.
```

### After

Invalid YAML:

```
$ ggshield api-status
Error: ./.gitguardian.yaml is not a valid YAML file:
while parsing a flow node
expected the node content, but found '<stream end>'
  in "./.gitguardian.yaml", line 2, column 1
```

YAML string:

```
$ ggshield api-status
Error: ./.gitguardian.yaml should be a dictionary.
```