### PR TITLE
Allow --verbose, --debug and --allow-self-signed everywhere

### DIFF
--- a/ggshield/cmd/auth/__init__.py
+++ b/ggshield/cmd/auth/__init__.py
@@ -1,9 +1,14 @@
+from typing import Any
+
 import click
+
+from ggshield.cmd.common_options import add_common_options
 
 from .login import login_cmd
 from .logout import logout_cmd
 
 
 @click.group(commands={"login": login_cmd, "logout": logout_cmd})
-def auth_group() -> None:
+@add_common_options()
+def auth_group(**kwargs: Any) -> None:
     """Commands to manage authentication."""

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -1,9 +1,10 @@
 import re
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import click
 
 from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.oauth import OAuthClient
@@ -81,6 +82,7 @@ def validate_login_path(
     default=None,
     help="Number of days before the token expires. 0 means the token never expires.",
 )
+@add_common_options()
 @click.pass_context
 def login_cmd(
     ctx: click.Context,
@@ -89,6 +91,7 @@ def login_cmd(
     token_name: Optional[str],
     lifetime: Optional[int],
     sso_url: Optional[str],
+    **kwargs: Any,
 ) -> int:
     """
     Authenticate with a GitGuardian workspace.

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 import click
 from requests.exceptions import ConnectionError
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.utils import dashboard_to_api_url
@@ -22,8 +25,11 @@ from .utils import CONNECTION_ERROR_MESSAGE
     help="Whether the token should be revoked on logout before being removed from the configuration.",
 )
 @click.option("--all", "all_", is_flag=True, help="Iterate over every saved tokens.")
+@add_common_options()
 @click.pass_context
-def logout_cmd(ctx: click.Context, instance: str, revoke: bool, all_: bool) -> int:
+def logout_cmd(
+    ctx: click.Context, instance: str, revoke: bool, all_: bool, **kwargs: Any
+) -> int:
     """
     Remove authentication for a GitGuardian instance.
     A successful logout results in the deletion of personal access token stored in the configuration.

--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -64,10 +64,28 @@ _debug_option = click.option(
 )
 
 
+def allow_self_signed_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[bool]
+) -> Optional[bool]:
+    if value is not None:
+        _get_config(ctx).allow_self_signed = value
+    return value
+
+
+_allow_self_signed_option = click.option(
+    "--allow-self-signed",
+    is_flag=True,
+    default=None,
+    help="Ignore ssl verification.",
+    callback=allow_self_signed_callback,
+)
+
+
 def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         _verbose_option(cmd)
         _debug_option(cmd)
+        _allow_self_signed_option(cmd)
         return cmd
 
     return decorator

--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -1,0 +1,50 @@
+"""
+This module defines options which should be available on all commands, such as the
+-v, --verbose option.
+
+To use it:
+- Add the `@add_common_options()` decorator after all the `click.option()` calls of the
+  command function.
+- Add a `**kwargs: Any` argument to the command function.
+
+The `kwargs` argument is required because due to the way click works,
+`add_common_options()` adds an argument for each option it defines.
+"""
+from typing import Any, Callable, Optional, cast
+
+import click
+
+from ggshield.core.config.user_config import UserConfig
+
+
+AnyFunction = Callable[..., Any]
+
+
+def _get_config(ctx: click.Context) -> UserConfig:
+    return cast(UserConfig, ctx.obj["config"].user_config)
+
+
+def _verbose_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[bool]
+) -> Optional[bool]:
+    if value is not None:
+        _get_config(ctx).verbose = value
+    return value
+
+
+_verbose_option = click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=None,
+    help="Verbose display mode.",
+    callback=_verbose_callback,
+)
+
+
+def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
+    def decorator(cmd: AnyFunction) -> AnyFunction:
+        _verbose_option(cmd)
+        return cmd
+
+    return decorator

--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Optional, cast
 
 import click
 
+from ggshield.cmd.debug_logs import setup_debug_logs
 from ggshield.core.config.user_config import UserConfig
 
 
@@ -42,9 +43,31 @@ _verbose_option = click.option(
 )
 
 
+def debug_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[bool]
+) -> Optional[bool]:
+    # The --debug option is marked as "is_eager" so that we can setup logs as soon as
+    # possible. If we don't then log commands for the creation of the Config instance
+    # are ignored
+    if value is not None:
+        setup_debug_logs(value is True)
+    return value
+
+
+_debug_option = click.option(
+    "--debug",
+    is_flag=True,
+    default=None,
+    is_eager=True,
+    help="Show debug information.",
+    callback=debug_callback,
+)
+
+
 def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         _verbose_option(cmd)
+        _debug_option(cmd)
         return cmd
 
     return decorator

--- a/ggshield/cmd/config/__init__.py
+++ b/ggshield/cmd/config/__init__.py
@@ -1,4 +1,8 @@
+from typing import Any
+
 import click
+
+from ggshield.cmd.common_options import add_common_options
 
 from .config_get import config_get_command
 from .config_list import config_list_cmd
@@ -16,5 +20,6 @@ from .config_unset import config_unset_command
         "migrate": config_migrate_cmd,
     }
 )
-def config_group() -> None:
+@add_common_options()
+def config_group(**kwargs: Any) -> None:
     """Commands to manage configuration."""

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.config.constants import FIELD_OPTIONS
 from ggshield.core.config import Config
 from ggshield.core.config.errors import UnknownInstanceError
@@ -17,9 +18,10 @@ from ggshield.core.config.errors import UnknownInstanceError
     metavar="URL",
     help="Get per instance configuration.",
 )
+@add_common_options()
 @click.pass_context
 def config_get_command(
-    ctx: click.Context, field_name: str, instance_url: Optional[str]
+    ctx: click.Context, field_name: str, instance_url: Optional[str], **kwargs: Any
 ) -> int:
     """
     Print the value of the given configuration key.

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
 from .constants import DATETIME_FORMAT
@@ -7,7 +10,8 @@ from .constants import DATETIME_FORMAT
 
 @click.command()
 @click.pass_context
-def config_list_cmd(ctx: click.Context) -> int:
+@add_common_options()
+def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Print the list of configuration keys and values.
     """

--- a/ggshield/cmd/config/config_migrate.py
+++ b/ggshield/cmd/config/config_migrate.py
@@ -1,11 +1,15 @@
 import os
+from typing import Any
 
 import click
+
+from ggshield.cmd.common_options import add_common_options
 
 
 @click.command()
 @click.pass_context
-def config_migrate_cmd(ctx: click.Context) -> None:
+@add_common_options()
+def config_migrate_cmd(ctx: click.Context, **kwargs: Any) -> None:
     """
     Migrate configuration file to the latest version
     """

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
 from .constants import FIELD_OPTIONS
@@ -17,9 +18,14 @@ from .constants import FIELD_OPTIONS
     metavar="URL",
     help="Set per instance configuration.",
 )
+@add_common_options()
 @click.pass_context
 def config_set_command(
-    ctx: click.Context, field_name: str, value: str, instance: Optional[str]
+    ctx: click.Context,
+    field_name: str,
+    value: str,
+    instance: Optional[str],
+    **kwargs: Any,
 ) -> int:
     """
     Update the value of the given configuration key.

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
 from .constants import FIELD_OPTIONS
@@ -18,9 +19,14 @@ from .constants import FIELD_OPTIONS
     help="Set per instance configuration.",
 )
 @click.option("--all", "all_", is_flag=True, help="Iterate over every instances.")
+@add_common_options()
 @click.pass_context
 def config_unset_command(
-    ctx: click.Context, field_name: str, instance_url: Optional[str], all_: bool
+    ctx: click.Context,
+    field_name: str,
+    instance_url: Optional[str],
+    all_: bool,
+    **kwargs: Any,
 ) -> int:
     """
     Remove the value of the given configuration key.

--- a/ggshield/cmd/debug_logs.py
+++ b/ggshield/cmd/debug_logs.py
@@ -1,0 +1,29 @@
+import logging
+import sys
+
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(process)x:%(thread)x %(name)s:%(funcName)s:%(lineno)d %(message)s"
+
+
+def setup_debug_logs(debug: bool) -> None:
+    """Configure Python logger. Disable messages up to logging.ERROR level by default.
+
+    The reason we disable error messages is that we call logging.error() in addition to
+    showing user-friendly error messages, but we don't want the error logs to show up
+    with the user-friendly error messages, unless --debug has been set.
+    """
+    level = logging.DEBUG if debug else logging.CRITICAL
+
+    if sys.version_info[:2] < (3, 8):
+        # Simulate logging.basicConfig() `force` argument, introduced in Python 3.8
+        root = logging.getLogger()
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+            handler.close()
+        logging.basicConfig(filename=None, level=level, format=LOG_FORMAT)
+    else:
+        logging.basicConfig(filename=None, level=level, format=LOG_FORMAT, force=True)
+
+    if debug:
+        # Silence charset_normalizer, its debug output does not bring much
+        logging.getLogger("charset_normalizer").setLevel(logging.WARNING)

--- a/ggshield/cmd/iac/__init__.py
+++ b/ggshield/cmd/iac/__init__.py
@@ -1,8 +1,12 @@
+from typing import Any
+
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.iac.scan import scan_cmd
 
 
 @click.group(commands={"scan": scan_cmd})
-def iac_group() -> None:
+@add_common_options()
+def iac_group(**kwargs: Any) -> None:
     """Commands to work with infrastructure as code."""

--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Sequence, Type
 import click
 from pygitguardian.models import Detail
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_TAR_CONTENT_SIZE
@@ -72,22 +73,23 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[s
     "directory",
     type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),
 )
+@add_common_options()
 @click.pass_context
 def scan_cmd(
     ctx: click.Context,
     exit_zero: bool,
     minimum_severity: str,
-    verbose: bool,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
     json: bool,
     directory: Path,
+    **kwargs: Any,
 ) -> int:
     """
     Scan a directory for IaC vulnerabilities.
     """
     update_context(
-        ctx, exit_zero, minimum_severity, verbose, ignore_policies, ignore_paths, json
+        ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths, json
     )
     result = iac_scan(ctx, directory)
     scan = ScanCollection(id=str(directory), type="path_scan", iac_result=result)
@@ -100,7 +102,6 @@ def update_context(
     ctx: click.Context,
     exit_zero: bool,
     minimum_severity: str,
-    verbose: bool,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
     json: bool,
@@ -117,9 +118,6 @@ def update_context(
 
     if ignore_policies is not None:
         config.user_config.iac.ignored_policies.update(ignore_policies)
-
-    if verbose is not None:
-        config.user_config.verbose = verbose
 
     if exit_zero is not None:
         config.user_config.exit_zero = exit_zero

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -1,10 +1,11 @@
 import os
 import subprocess
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.git_shell import GIT_PATH, check_git_dir, check_git_installed
 
 
@@ -25,7 +26,10 @@ from ggshield.core.git_shell import GIT_PATH, check_git_dir, check_git_installed
 )
 @click.option("--force", "-f", is_flag=True, help="Force override")
 @click.option("--append", "-a", is_flag=True, help="Append to existing script")
-def install_cmd(mode: str, hook_type: str, force: bool, append: bool) -> int:
+@add_common_options()
+def install_cmd(
+    mode: str, hook_type: str, force: bool, append: bool, **kwargs: Any
+) -> int:
     """Install a pre-commit or pre-push git hook (local or global)."""
     return_code = (
         install_global(hook_type=hook_type, force=force, append=append)

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -82,12 +82,6 @@ def config_path_callback(
     callback=config_path_callback,
 )
 @click.option(
-    "--allow-self-signed",
-    is_flag=True,
-    default=None,
-    help="Ignore ssl verification.",
-)
-@click.option(
     "--check-for-updates/--no-check-for-updates",
     is_flag=True,
     default=True,
@@ -98,7 +92,6 @@ def config_path_callback(
 @click.pass_context
 def cli(
     ctx: click.Context,
-    allow_self_signed: bool,
     debug: Optional[bool],
     check_for_updates: bool,
     **kwargs: Any,
@@ -115,9 +108,6 @@ def cli(
         # if --debug is not set but `debug` is set in the configuration file, then
         # we must setup logs now.
         setup_debug_logs(True)
-
-    if allow_self_signed is not None:
-        config.allow_self_signed = allow_self_signed
 
     logger.debug("args=%s", sys.argv)
     logger.debug("py-gitguardian=%s", pygitguardian.__version__)

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
-from typing import Union
+from typing import Any, Union
 
 import click
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, Quota, QuotaResponse
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
 from ggshield.core.utils import json_output_option_decorator
 from ggshield.output.text.message import format_quota_color
@@ -12,8 +13,9 @@ from ggshield.output.text.message import format_quota_color
 
 @click.command()
 @json_output_option_decorator
+@add_common_options()
 @click.pass_context
-def quota_cmd(ctx: click.Context, json_output: bool) -> int:
+def quota_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
     """Show quotas overview."""
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()

--- a/ggshield/cmd/scan/__init__.py
+++ b/ggshield/cmd/scan/__init__.py
@@ -1,7 +1,8 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.secret.scan import (
     archive_cmd,
     ci_cmd,
@@ -59,9 +60,6 @@ from ggshield.core.utils import json_output_option_decorator
     "By default, only Secret Detection is shown.",
 )
 @click.option(
-    "--verbose", "-v", is_flag=True, default=None, help="Verbose display mode."
-)
-@click.option(
     "--output",
     "-o",
     type=click.Path(exists=False, resolve_path=True),
@@ -88,18 +86,19 @@ from ggshield.core.utils import json_output_option_decorator
     is_flag=True,
     help="Ignore excluded patterns by default. [default: False]",
 )
+@add_common_options()
 @click.pass_context
 def deprecated_scan_group(
     ctx: click.Context,
     show_secrets: bool,
     exit_zero: bool,
     all_policies: bool,
-    verbose: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
     ignore_default_excludes: bool = False,
+    **kwargs: Any,
 ) -> int:
     """
     Deprecated: use `ggshield secret scan (...)` instead.
@@ -111,7 +110,6 @@ def deprecated_scan_group(
         ctx,
         show_secrets,
         exit_zero,
-        verbose,
         json_output,
         output,
         banlist_detector,

--- a/ggshield/cmd/secret/__init__.py
+++ b/ggshield/cmd/secret/__init__.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.secret.ignore import ignore_cmd
 from ggshield.cmd.secret.scan import scan_group
 
 
 @click.group(commands={"scan": scan_group, "ignore": ignore_cmd})
-def secret_group() -> None:
+@add_common_options()
+def secret_group(**kwargs: Any) -> None:
     """Commands to work with secrets."""

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 
@@ -10,8 +13,13 @@ from ggshield.core.config import Config
     is_flag=True,
     help="Ignore secrets found in the last ggshield secret scan run",
 )
+@add_common_options()
 @click.pass_context
-def ignore_cmd(ctx: click.Context, last_found: bool) -> None:
+def ignore_cmd(
+    ctx: click.Context,
+    last_found: bool,
+    **kwargs: Any,
+) -> None:
     """
     Ignore some secrets.
     """

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -1,8 +1,9 @@
 import os
-from typing import List, Optional, Type
+from typing import Any, List, Optional, Type
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.secret.scan.archive import archive_cmd
 from ggshield.cmd.secret.scan.ci import ci_cmd
 from ggshield.cmd.secret.scan.docker import docker_name_cmd
@@ -61,9 +62,6 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     hidden=True,
 )
 @click.option(
-    "--verbose", "-v", is_flag=True, default=None, help="Verbose display mode."
-)
-@click.option(
     "--output",
     "-o",
     type=click.Path(exists=False, resolve_path=True),
@@ -96,26 +94,26 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     default=None,
     help="Ignore",
 )
+@add_common_options()
 @click.pass_context
 def scan_group(
     ctx: click.Context,
     show_secrets: bool,
     exit_zero: bool,
     all_policies: bool,
-    verbose: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
     ignore_default_excludes: bool = False,
     ignore_known_secrets: bool = False,
+    **kwargs: Any,
 ) -> int:
     """Commands to scan various contents."""
     return scan_group_impl(
         ctx,
         show_secrets,
         exit_zero,
-        verbose,
         json_output,
         output,
         banlist_detector,
@@ -128,7 +126,6 @@ def scan_group_impl(
     ctx: click.Context,
     show_secrets: bool,
     exit_zero: bool,
-    verbose: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
@@ -151,9 +148,6 @@ def scan_group_impl(
 
     if show_secrets is not None:
         config.secret.show_secrets = show_secrets
-
-    if verbose is not None:
-        config.verbose = verbose
 
     if exit_zero is not None:
         config.exit_zero = exit_zero

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -2,9 +2,11 @@ import shutil
 import tempfile
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
@@ -16,8 +18,13 @@ from ggshield.scan import Files, ScanCollection, ScanContext, ScanMode, SecretSc
 @click.argument(
     "path", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
 )
+@add_common_options()
 @click.pass_context
-def archive_cmd(ctx: click.Context, path: str) -> int:  # pragma: no cover
+def archive_cmd(
+    ctx: click.Context,
+    path: str,
+    **kwargs: Any,
+) -> int:  # pragma: no cover
     """
     scan archive <PATH>.
     """

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -1,9 +1,10 @@
 import os
 from enum import Enum
-from typing import List
+from typing import Any, List
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA, handle_exception
@@ -255,8 +256,9 @@ def azure_range(verbose: bool) -> List[str]:  # pragma: no cover
 
 
 @click.command()
+@add_common_options()
 @click.pass_context
-def ci_cmd(ctx: click.Context) -> int:
+def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     scan in a CI environment.
     """

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -1,8 +1,10 @@
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanContext, ScanMode
@@ -23,8 +25,11 @@ DOCKER_COMMAND_TIMEOUT = 360
     show_default=True,
 )
 @click.argument("name", nargs=1, type=click.STRING, required=True)
+@add_common_options()
 @click.pass_context
-def docker_name_cmd(ctx: click.Context, name: str, docker_timeout: int) -> int:
+def docker_name_cmd(
+    ctx: click.Context, name: str, docker_timeout: int, **kwargs: Any
+) -> int:
     """
     scan a docker image <NAME>.
 

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from typing import Any
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanContext, ScanMode
@@ -12,10 +14,12 @@ from ggshield.scan.docker import docker_scan_archive
 @click.argument(
     "archive", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
 )
+@add_common_options()
 @click.pass_context
 def docker_archive_cmd(
     ctx: click.Context,
     archive: Path,
+    **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
     scan a docker archive <ARCHIVE> without attempting to save or pull the image.

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -1,9 +1,10 @@
 import json
 from functools import partial
-from typing import Callable, Iterable, Iterator, List, TextIO
+from typing import Any, Callable, Iterable, Iterator, List, TextIO
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.core.utils import handle_exception
@@ -45,8 +46,13 @@ def create_scans_from_docset_files(
 
 @click.command()
 @click.argument("files", nargs=-1, type=click.File(), required=True)
+@add_common_options()
 @click.pass_context
-def docset_cmd(ctx: click.Context, files: List[TextIO]) -> int:  # pragma: no cover
+def docset_cmd(
+    ctx: click.Context,
+    files: List[TextIO],
+    **kwargs: Any,
+) -> int:  # pragma: no cover
     """
     scan docset JSONL files.
     """

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -1,8 +1,9 @@
 from functools import partial
-from typing import List
+from typing import Any, List
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
@@ -17,9 +18,14 @@ from ggshield.scan import ScanCollection, ScanContext, ScanMode, SecretScanner
 )
 @click.option("--recursive", "-r", is_flag=True, help="Scan directory recursively")
 @click.option("--yes", "-y", is_flag=True, help="Confirm recursive scan")
+@add_common_options()
 @click.pass_context
 def path_cmd(
-    ctx: click.Context, paths: List[str], recursive: bool, yes: bool
+    ctx: click.Context,
+    paths: List[str],
+    recursive: bool,
+    yes: bool,
+    **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
     scan files and directories.

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Any, List
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.git_shell import check_git_dir
 from ggshield.core.utils import handle_exception
 from ggshield.output import TextOutputHandler
@@ -24,9 +25,10 @@ BYPASS_MESSAGE = """  - if you use the pre-commit framework:
 
 @click.command()
 @click.argument("precommit_args", nargs=-1, type=click.UNPROCESSED)
+@add_common_options()
 @click.pass_context
 def precommit_cmd(
-    ctx: click.Context, precommit_args: List[str]
+    ctx: click.Context, precommit_args: List[str], **kwargs: Any
 ) -> int:  # pragma: no cover
     """
     scan as a pre-commit git hook.

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import sys
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.git_shell import (
     check_git_dir,
     get_list_commit_SHA,
@@ -45,8 +46,9 @@ BYPASS_MESSAGE = """  - if you use the pre-commit framework:
 
 @click.command()
 @click.argument("prepush_args", nargs=-1, type=click.UNPROCESSED)
+@add_common_options()
 @click.pass_context
-def prepush_cmd(ctx: click.Context, prepush_args: List[str]) -> int:
+def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> int:
     """
     scan as a pre-push git hook.
     """

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -3,10 +3,11 @@ import os
 import sys
 import threading
 from types import TracebackType
-from typing import List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_shell import get_list_commit_SHA, git
 from ggshield.core.text_utils import display_error
@@ -126,8 +127,11 @@ def parse_stdin() -> Tuple[str, str]:
     help="Deprecated",
     hidden=True,
 )
+@add_common_options()
 @click.pass_context
-def prereceive_cmd(ctx: click.Context, web: bool, prereceive_args: List[str]) -> int:
+def prereceive_cmd(
+    ctx: click.Context, web: bool, prereceive_args: List[str], **kwargs: Any
+) -> int:
     """
     scan as a pre-receive git hook.
     """

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -5,10 +5,11 @@ import sys
 import tempfile
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Set
 
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.file_utils import get_files_from_paths
@@ -81,8 +82,13 @@ def get_files_from_package(
 
 @click.command()
 @click.argument("package_name", nargs=1, type=click.STRING, required=True)
+@add_common_options()
 @click.pass_context
-def pypi_cmd(ctx: click.Context, package_name: str) -> int:  # pragma: no cover
+def pypi_cmd(
+    ctx: click.Context,
+    package_name: str,
+    **kwargs: Any,
+) -> int:  # pragma: no cover
     """
     scan a pypi package <NAME>.
     """

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import click
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.git_shell import get_list_commit_SHA
 from ggshield.core.utils import handle_exception
 from ggshield.scan import ScanContext, ScanMode
@@ -8,8 +11,13 @@ from ggshield.scan.repo import scan_commit_range
 
 @click.command()
 @click.argument("commit_range", nargs=1, type=click.STRING)
+@add_common_options()
 @click.pass_context
-def range_cmd(ctx: click.Context, commit_range: str) -> int:  # pragma: no cover
+def range_cmd(
+    ctx: click.Context,
+    commit_range: str,
+    **kwargs: Any,
+) -> int:  # pragma: no cover
     """
     scan a defined COMMIT_RANGE in git.
 

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -1,9 +1,11 @@
 import os
 import tempfile
+from typing import Any
 
 import click
 from pygitguardian import GGClient
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.git_shell import GIT_PATH, shell
@@ -14,8 +16,11 @@ from ggshield.scan.repo import scan_repo_path
 
 @click.command()
 @click.argument("repository", nargs=1, type=click.STRING, required=True)
+@add_common_options()
 @click.pass_context
-def repo_cmd(ctx: click.Context, repository: str) -> int:  # pragma: no cover
+def repo_cmd(
+    ctx: click.Context, repository: str, **kwargs: Any
+) -> int:  # pragma: no cover
     """
     scan a REPOSITORY's commits at a given URL or path.
 

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
+from typing import Any
 
 import click
 from pygitguardian import GGClient
 from pygitguardian.models import HealthCheckResponse
 
+from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.utils import json_output_option_decorator
@@ -11,8 +13,9 @@ from ggshield.output.text.message import format_healthcheck_status
 
 
 @click.command()
+@add_common_options()
 @click.pass_context
-def status_cmd(ctx: click.Context, json_output: bool) -> int:
+def status_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
     """Show API status."""
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: HealthCheckResponse = client.health_check()

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -235,7 +235,7 @@ class TestScanDirectory:
     def test_directory_verbose(self, cli_fs_runner):
         self.create_files()
         result = cli_fs_runner.invoke(
-            cli, ["-v", "secret", "scan", "path", "./", "-r"], input="y\n"
+            cli, ["secret", "scan", "path", "./", "-r", "-v"], input="y\n"
         )
         assert_invoke_ok(result)
         assert not result.exception
@@ -246,7 +246,7 @@ class TestScanDirectory:
     def test_directory_verbose_abort(self, cli_fs_runner):
         self.create_files()
         result = cli_fs_runner.invoke(
-            cli, ["-v", "secret", "scan", "path", "./", "-r"], input="n\n"
+            cli, ["secret", "-v", "scan", "path", "./", "-r"], input="n\n"
         )
         assert_invoke_ok(result)
         assert not result.exception
@@ -257,9 +257,9 @@ class TestScanDirectory:
         result = cli_fs_runner.invoke(
             cli,
             [
-                "-v",
                 "secret",
                 "scan",
+                "-v",
                 "--exclude",
                 "file1",
                 "--exclude",
@@ -280,7 +280,7 @@ class TestScanDirectory:
     def test_directory_verbose_yes(self, cli_fs_runner):
         self.create_files()
         result = cli_fs_runner.invoke(
-            cli, ["-v", "secret", "scan", "path", "./", "-r", "-y"]
+            cli, ["secret", "scan", "path", "./", "-r", "-vy"]
         )
         assert result.exit_code == 0, result.output
         assert not result.exception

--- a/tests/unit/cmd/test_debug_option.py
+++ b/tests/unit/cmd/test_debug_option.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from ggshield.cmd.main import cli
+from tests.unit.conftest import assert_invoke_ok
+
+
+def test_debug_option(cli_fs_runner):
+    """
+    GIVEN a directory with a configuration file
+    WHEN ggshield is called with --debug
+    THEN the log output contains the path to the configuration file
+    """
+    config_path = Path(".gitguardian.yaml")
+    config_path.write_text("version: 2")
+
+    cli_fs_runner.mix_stderr = False
+    # Use a command which does not hit the network
+    result = cli_fs_runner.invoke(cli, ["--debug", "config", "list"])
+    assert_invoke_ok(result)
+    assert ".gitguardian.yaml" in result.stderr


### PR DESCRIPTION
## Description

Click does not allow defining options across groups, this means `ggshield -v secret scan path foo.py` works but not `ggshield secret scan path foo.py -v`.

## What has been done

This PR introduces a new module in `cmd`: `common_options`. This module provides an `add_common_options()` decorator to define Click options we want to make available anywhere on the command-line. Supported options are:

- `-v`, `--verbose`
- `--debug`
- `--allow-self-signed`

With these changes, all these commands now work and do the same thing:

```
ggshield -v secret scan path foo.py
ggshield secret -v scan path foo.py
ggshield secret scan -v path foo.py
ggshield secret scan path -v foo.py
ggshield secret scan path foo.py -v
```

## In the next ~episode~ PR

I have another branch stacked on top of this one to do something similar for `secret scan` options like `--json`, `--exit-zero`, `--show-secrets`...

## Issue

Part of #197
