### PR TITLE
Add a benchmark script

### DIFF
--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -1,0 +1,43 @@
+name: Performance benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+    run_options:
+      description: 'Additional options to pass to `run`'
+
+jobs:
+  benchmark:
+    name: Run performance benchmark
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: 1
+      # How many time to repeat each run
+      REPEATS: 3
+      # If a run takes more than $MAX_DELTA seconds compared to reference, fail the job
+      MAX_DELTA: 3
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pipenv
+          pipenv install --system
+
+      - name: Setup benchmark
+        run: |
+          scripts/perfbench/perfbench setup
+
+      - name: Run benchmark
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+        run: |
+          scripts/perfbench/perfbench run --repeats $REPEATS ${{ github.event.inputs.run_options }}
+
+      - name: Generate report
+        run: |
+          scripts/perfbench/perfbench report --max-delta $MAX_DELTA >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,6 @@ repos:
         files: '^README\.md$'
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.17.0
+    rev: 0.19.0
     hooks:
       - id: check-github-workflows

--- a/scripts/perfbench/.gitignore
+++ b/scripts/perfbench/.gitignore
@@ -1,0 +1,1 @@
+.perfbench

--- a/scripts/perfbench/perfbench
+++ b/scripts/perfbench/perfbench
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+This script benchmarks ggshield by measuring the time spent to run different
+ggshield commands against several repositories, using several ggshield versions
+"""
+import logging
+
+import click
+from report_cmd import report_cmd
+from run_cmd import run_cmd
+from setup_cmd import setup_cmd
+
+
+LOG_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+@click.group(
+    context_settings=CONTEXT_SETTINGS,
+    commands={
+        "setup": setup_cmd,
+        "run": run_cmd,
+        "report": report_cmd,
+    },
+)
+@click.pass_context
+def main(context: click.Context) -> None:
+    """Run performance benchmarks on various versions of ggshield"""
+    logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT, datefmt="%H:%M:%S")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perfbench/perfbench_utils.py
+++ b/scripts/perfbench/perfbench_utils.py
@@ -1,0 +1,49 @@
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import click
+
+
+DEFAULT_WORK_DIR = (Path(__file__).parent / ".perfbench").absolute()
+
+
+@dataclass
+class RawReportEntry:
+    """Represent the fields stored in the benchmark.jsonl file"""
+
+    version: str
+    repository: str
+    command: str
+    duration: float
+
+
+def check_run(args: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=True, **kwargs)
+
+
+work_dir_option = click.option(
+    "-w",
+    "--work-dir",
+    help="Where to store benchmark script work files.",
+    default=DEFAULT_WORK_DIR,
+    type=click.Path(),
+)
+
+
+def get_raw_report_path(work_dir: Path) -> Path:
+    return work_dir / "benchmark.jsonl"
+
+
+def find_latest_prod_version() -> str:
+    """Assumes we are in a ggshield checkout: returns the version for the latest tag"""
+    # List latest v* tag first
+    out = check_run(
+        ["git", "tag", "--list", "v*", "--sort=-v:refname"],
+        capture_output=True,
+        text=True,
+    )
+    lines: Sequence[str] = out.stdout.splitlines()
+    assert lines
+    return lines[0][1:]

--- a/scripts/perfbench/report_cmd.py
+++ b/scripts/perfbench/report_cmd.py
@@ -1,0 +1,190 @@
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import median, stdev
+from typing import Dict, Iterable, List, Optional, TextIO, Tuple
+
+import click
+from perfbench_utils import (
+    RawReportEntry,
+    find_latest_prod_version,
+    get_raw_report_path,
+    work_dir_option,
+)
+
+
+# Do not report changes if the delta is less than this duration
+DEFAULT_MIN_DELTA_SECS = 1
+
+# Report a failure if delta is more than this duration
+DEFAULT_MAX_DELTA_SECS = 3
+
+
+@dataclass
+class ReportRow:
+    command: str
+    repository: str
+    # Mapping of version => [durations]
+    durations_for_versions: Dict[str, List[float]] = field(default_factory=dict)
+
+
+def key_for_version(version: str) -> Tuple[int, ...]:
+    if version == "current":
+        # Make sure "current" is always last
+        return 999999, 0, 0
+    if version == "prod":
+        version = find_latest_prod_version()
+    return tuple(int(x) for x in version.split("."))
+
+
+def print_markdown_table(
+    out: TextIO, rows: List[List[str]], headers: List[str], alignments: str
+) -> None:
+    """
+    Prints a Markdown table.
+
+    `alignments` is a string of one character per column. The character must be L or R,
+    defining left or right alignment.
+    """
+    assert len(headers) == len(alignments)
+
+    widths = [0] * len(headers)
+    for row in [headers, *rows]:
+        for idx, cell in enumerate(row):
+            width = len(cell)
+            widths[idx] = max(widths[idx], width)
+
+    def print_row(row: Iterable[str]) -> None:
+        for cell, alignment, width in zip(row, alignments, widths):
+            if alignment == "R":
+                cell = cell.rjust(width)
+            else:
+                cell = cell.ljust(width)
+            out.write(f"| {cell} ")
+        out.write("|\n")
+
+    # print rows
+    print_row(headers)
+    separator_row = [
+        "-" * (w - 1) + (":" if a == "R" else "-") for a, w in zip(alignments, widths)
+    ]
+    print_row(separator_row)
+
+    for row in rows:
+        print_row(row)
+
+
+def create_duration_cells(
+    sorted_versions: List[str],
+    durations_for_versions: Dict[str, List[float]],
+    min_delta: float,
+    max_delta: float,
+) -> Tuple[List[str], bool]:
+    """Returns a list of cells, and a bool indicating whether we noticed a delta
+    higher than MAX_DELTA_SECS"""
+    cells: List[str] = []
+    reference: Optional[float] = None
+    fail = False
+    for version in sorted_versions:
+        durations_for_version = durations_for_versions[version]
+        duration = median(durations_for_version)
+        cell = f"{duration:.2f}s"
+
+        if len(durations_for_version) > 1:
+            deviation = stdev(durations_for_version)
+            cell += f" ±{deviation:.2f}"
+        cells.append(cell)
+
+        if reference is None:
+            reference = duration
+        else:
+            delta = duration - reference
+            if abs(delta) > min_delta:
+                if delta > max_delta:
+                    symbol = "▲" * 3
+                    fail = True
+                elif delta > 0:
+                    symbol = "▲"
+                else:
+                    symbol = "▼"
+            else:
+                symbol = "≈"
+
+            cells.append(f"{delta:+.2f} {symbol}")
+    return cells, fail
+
+
+@click.command()
+@click.option(
+    "--min-delta",
+    type=float,
+    help="If the duration difference with the reference run is less than this number of seconds,"
+    " do not report a change.",
+    default=DEFAULT_MIN_DELTA_SECS,
+)
+@click.option(
+    "--max-delta",
+    type=float,
+    help="If the duration difference with the reference run is *more* than this number of seconds,"
+    " exit with error.",
+    default=DEFAULT_MAX_DELTA_SECS,
+)
+@work_dir_option
+def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
+    """
+    Generate a report from a benchmark run
+    """
+    report_path = get_raw_report_path(work_dir)
+    if not report_path.exists():
+        logging.error(
+            "Raw report not found (%s does not exist). Use the `run` command first",
+            report_path,
+        )
+
+    # Load raw report file, group report rows by command and repository
+    version_set = set()
+    row_dict: Dict[Tuple[str, str], ReportRow] = {}
+    with report_path.open() as fp:
+        for line in fp:
+            dct = json.loads(line)
+            entry = RawReportEntry(**dct)
+
+            version_set.add(entry.version)
+
+            row = row_dict.setdefault(
+                (entry.command, entry.repository),
+                ReportRow(entry.command, entry.repository),
+            )
+            durations = row.durations_for_versions.setdefault(entry.version, [])
+            durations.append(entry.duration)
+
+    sorted_versions = sorted(version_set, key=key_for_version)
+
+    # Create table rows
+    table_rows = []
+    has_failed = False
+    for row in sorted(row_dict.values(), key=lambda x: (x.command, x.repository)):
+        duration_cells, fail = create_duration_cells(
+            sorted_versions,
+            row.durations_for_versions,
+            min_delta,
+            max_delta,
+        )
+        has_failed |= fail
+        table_rows.append([row.command, row.repository, *duration_cells])
+
+    # Create headers (no delta column for reference)
+    version_headers = [sorted_versions[0]]
+    for version in sorted_versions[1:]:
+        version_headers.extend([version, "delta"])
+
+    print_markdown_table(
+        sys.stdout,
+        table_rows,
+        headers=["command", "repository", *version_headers],
+        alignments="LL" + "R" * len(version_headers),
+    )
+
+    sys.exit(1 if has_failed else 0)

--- a/scripts/perfbench/run_cmd.py
+++ b/scripts/perfbench/run_cmd.py
@@ -1,0 +1,196 @@
+import json
+import logging
+import subprocess
+import sys
+import time
+import typing
+from dataclasses import asdict
+from pathlib import Path
+from shutil import which
+from typing import Any, Dict, List, Tuple
+
+import click
+from perfbench_utils import (
+    RawReportEntry,
+    check_run,
+    find_latest_prod_version,
+    get_raw_report_path,
+    work_dir_option,
+)
+
+
+DEFAULT_GGSHIELD_VERSIONS = ["prod", "current"]
+
+BENCHMARK_COMMANDS = [
+    ("secret", "scan", "--exit-zero", "path", "-ry", "."),
+    ("secret", "scan", "--exit-zero", "commit-range", "HEAD~50.."),
+    ("iac", "scan", "--exit-zero", "."),
+]
+
+
+class JSONLWriter:
+    def __init__(self, fp: typing.TextIO) -> None:
+        self.fp = fp
+
+    def add_entry(self, entry: Dict[str, Any]) -> None:
+        json.dump(entry, self.fp, sort_keys=True)
+        self.fp.write("\n")
+        self.fp.flush()
+
+
+def setup_ggshield(work_dir: Path, version: str) -> Path:
+    """
+    Install a version of ggshield in the work dir, return the path to the ggshield
+    command
+    """
+    if version == "current":
+        current_path = which("ggshield")
+        if current_path is None:
+            logging.error("Can't find ggshield in $PATH")
+            sys.exit(1)
+        return Path(current_path)
+
+    if version == "prod":
+        version = find_latest_prod_version()
+        logging.info("Latest prod version is %s", version)
+
+    ggshield_base_dir = work_dir / "ggshields" / version
+    if ggshield_base_dir.exists():
+        logging.info("ggshield %s is already installed", version)
+    else:
+        ggshield_base_dir.mkdir(parents=True)
+        logging.info("Installing ggshield %s in %s", version, ggshield_base_dir)
+        out = subprocess.run(
+            ["pipenv", "run", "pip", "install", f"ggshield=={version}"],
+            cwd=str(ggshield_base_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if out.returncode > 0:
+            logging.error("Failed to install ggshield %s", version)
+            # Use print() here, otherwise the output is unreadable because logging ignores \n characters
+            print(out.stdout, file=sys.stderr)
+            sys.exit(128)
+
+    proc = check_run(
+        ["pipenv", "run", "which", "ggshield"],
+        cwd=str(ggshield_base_dir),
+        capture_output=True,
+        text=True,
+    )
+    path = Path(proc.stdout.strip())
+    assert path.exists(), path
+    return path
+
+
+def run_one_command(
+    writer: JSONLWriter,
+    version: str,
+    ggshield_path: Path,
+    repo_dir: Path,
+    command: Tuple[str, ...],
+) -> None:
+    command_str = " ".join(command)
+    logging.info(
+        "Benchmarking version='%s', repository='%s', command='%s'",
+        version,
+        repo_dir.name,
+        command_str,
+    )
+    cmd = [str(ggshield_path)] + list(command)
+    start = time.time()
+    out = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=str(repo_dir),
+    )
+    duration = time.time() - start
+    logging.info("Command took %f seconds", duration)
+    if out.returncode > 0:
+        logging.error("Command failed with exit code %d", out.returncode)
+        # Use print() here, otherwise the output is unreadable because logging ignores \n characters
+        print(out.stdout, file=sys.stderr)
+        sys.exit(1)
+
+    writer.add_entry(
+        asdict(
+            RawReportEntry(
+                version=version,
+                repository=repo_dir.name,
+                command=command_str,
+                duration=duration,
+            )
+        )
+    )
+
+
+@click.command(
+    epilog='VERSION can be "prod" for the latest released version and "current" for'
+    " the version from the current branch.",
+)
+@work_dir_option
+@click.option(
+    "-V",
+    "--version",
+    "versions",
+    multiple=True,
+    default=DEFAULT_GGSHIELD_VERSIONS,
+    metavar="VERSION",
+    help="Versions of ggshield to benchmark. Use prod and current if not set.",
+)
+@click.option(
+    "-r",
+    "--repository",
+    "repositories",
+    multiple=True,
+    default=[],
+    help="Repositories to bench against. Must be a directory name from the work directory.",
+)
+@click.option(
+    "--repeats",
+    default=1,
+    help="Number of times to repeat each command (no repeat by default).",
+)
+def run_cmd(
+    work_dir: Path, versions: List[str], repositories: List[str], repeats: int
+) -> None:
+    """Run the benchmark"""
+    ggshield_paths = [(v, setup_ggshield(work_dir, v)) for v in versions]
+
+    # Prepare repository list
+    base_repo_dir = work_dir / "repositories"
+    if not base_repo_dir.exists():
+        logging.error("No repositories directory in %s, run `setup` first", work_dir)
+        sys.exit(1)
+
+    if repositories:
+        repository_paths = [base_repo_dir / r for r in repositories]
+        for path in repository_paths:
+            if not path.exists():
+                logging.error("No such repository '%s'", path)
+                sys.exit(1)
+    else:
+        repository_paths = [r for r in base_repo_dir.glob("*") if (r / ".git").exists()]
+
+    # Run the benchmark
+    report_path = get_raw_report_path(work_dir)
+
+    with report_path.open("a") as fp:
+        writer = JSONLWriter(fp)
+
+        for repository_path in repository_paths:
+            for command in BENCHMARK_COMMANDS:
+                # Loop on `repeats` and then on `version` to ensure runs for the different
+                # versions are interleaved. This should avoid getting different results
+                # between versions if the performance of the API changes during the
+                # benchmark.
+                for _ in range(repeats):
+                    for version, ggshield_path in ggshield_paths:
+                        run_one_command(
+                            writer, version, ggshield_path, repository_path, command
+                        )
+
+    logging.info("Raw report has been generated in %s", report_path)

--- a/scripts/perfbench/setup_cmd.py
+++ b/scripts/perfbench/setup_cmd.py
@@ -1,0 +1,34 @@
+import logging
+from pathlib import Path
+
+import click
+from perfbench_utils import check_run, work_dir_option
+
+
+BENCHMARK_REPOSITORIES = [
+    ("https://github.com/vuejs/vue", "v2.7.14"),
+    ("https://github.com/python-pillow/Pillow", "9.3.0"),
+    ("https://github.com/docker/compose", "v2.12.2"),
+    ("https://github.com/sqlite/sqlite", "version-3.39.4"),
+]
+
+
+def git_clone(base_repo_dir: Path, url: str, revision: str) -> None:
+    logging.info("Cloning %s (%s)", url, revision)
+    cmd = ["git", "clone", url, "--branch", revision]
+    check_run(cmd, cwd=str(base_repo_dir))
+
+
+@click.command()
+@work_dir_option
+def setup_cmd(work_dir: Path) -> None:
+    """Clone all the required repositories to run the benchmarks"""
+    base_repo_dir = work_dir / "repositories"
+    base_repo_dir.mkdir(parents=True, exist_ok=True)
+    for url, revision in BENCHMARK_REPOSITORIES:
+        _, name = url.rsplit("/", 1)
+        if (base_repo_dir / name).exists():
+            logging.info("%s has already been cloned", url)
+        else:
+            git_clone(base_repo_dir, url, revision)
+    logging.info("All set, you can now use the `run` command")


### PR DESCRIPTION
## Description

This PR adds a `scripts/perfbench/perfbench` script.

Results show up in the summary of the "Performance benchmark" check.

TODO:

- [x] Decide test repositories
- [x] Decide test commands
- [x] Decide if the benchmark must run on each PR or on main only:
  looks fast enough to run on each PR for now
- [x] Make benchmark report a warning/error if results are worse