### PR TITLE
Fix pre-commit scanning commits with many files multiple times

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,4 @@
+# We set `pass_filenames` to `false` because ggshield gets filenames from commit IDs.
 - id: ggshield
   name: ggshield (pre-commit)
   entry: ggshield
@@ -5,21 +6,27 @@
   stages: [commit]
   args: ['secret', 'scan', 'pre-commit']
   language: python
+  pass_filenames: false
+
 - id: docker-ggshield
   name: ggshield (pre-commit,docker)
   language: docker_image
   entry: -e GITGUARDIAN_API_KEY gitguardian/ggshield:latest ggshield secret scan pre-commit
   description: Runs ggshield to detect hardcoded secrets, security vulnerabilities and policy breaks in docker images.
+  pass_filenames: false
+
 - id: ggshield-push
   name: ggshield (pre-push)
   entry: ggshield
   description: Runs ggshield to detect hardcoded secrets, security vulnerabilities and policy breaks.
   args: ['secret', 'scan', 'pre-push']
   stages: [push]
-  pass_filenames: false
   language: python
+  pass_filenames: false
+
 - id: docker-ggshield-push
   name: ggshield (pre-push,docker)
   language: docker_image
   entry: -e GITGUARDIAN_API_KEY gitguardian/ggshield:latest ggshield secret scan pre-push
   description: Runs ggshield to detect hardcoded secrets, security vulnerabilities and policy breaks in docker images.
+  pass_filenames: false

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -24,9 +24,7 @@ from ggshield.core.text_utils import display_warning
 from ggshield.core.utils import load_dot_env
 
 
-LOG_FORMAT = (
-    "%(asctime)s %(levelname)s %(thread)d %(name)s:%(funcName)s:%(lineno)d %(message)s"
-)
+LOG_FORMAT = "%(asctime)s %(levelname)s %(process)x:%(thread)x %(name)s:%(funcName)s:%(lineno)d %(message)s"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

By default, the pre-commit framework calls hooks with files to scan as arguments. If the file list is too long, it splits it and run scans in parallel.

This is not adapted for ggshield because `ggshield secret scan pre-commit` (and `pre-push`) gets the content to scan from the commit ID, the arguments are ignored. When pre-commit calls ggshield twice, ggshield scans the whole commit twice.

## What has been done

- Tell pre-commit to not call ggshield with filenames, we avoid this issue: ggshield is only called once. The loss of parallelism is not an problem since ggshield handles parallelism itself.
- In debug mode, log the PID in addition to the thread ID. This should make debugging multi-process issues easier in the future.

## Testing

I created a repository with 100 new files, one of them containing 2 secrets.

I setup ggshield as a pre-commit using the pre-commit framework with this `.pre-commit-config.yaml` file:

```yaml
default_stages: [commit]
repos:
  - repo: https://github.com/gitguardian/ggshield
    rev: v1.13.6
    hooks:
      - id: ggshield
        language_version: python3
        stages: [commit]
```

And this `.gitguardian.yml` file to enable ggshield debug mode:

```yaml
version: 2
debug: true
```

When I tried to commit:

```
$ git commit 2>&1 | grep args=
2022-11-08 14:10:41,494 DEBUG 140689641629504 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_42.py', 'config_32.py', 'config_81.py', 'config_77.py', 'config_20.py', 'config_70.py', 'config_55.py', 'config_76.py', 'config_79.py', 'config_89.py', 'config_67.py', 'config_75.py', 'config_93.py']
2022-11-08 14:10:41,475 DEBUG 139631412500288 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_33.py', 'config_19.py', 'config_18.py', 'config_60.py', 'config_49.py', 'config_25.py', 'config_47.py', 'config_41.py', 'config_9.py', 'config_15.py', 'config_27.py', 'config_74.py', 'config_10.py']
2022-11-08 14:10:41,495 DEBUG 140554620446528 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_36.py', 'config_72.py', 'config_68.py', 'config_24.py', 'config_91.py', 'config_6.py', 'config_51.py', 'config_85.py', 'config_69.py', 'config_23.py', 'config_65.py', 'config_50.py', 'config_84.py']
2022-11-08 14:10:41,509 DEBUG 140579810461504 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_98.py', 'config_97.py', 'config.py', 'config_59.py', 'config_94.py', 'config_80.py', 'config_40.py', 'config_4.py', 'config_26.py', 'config_38.py', 'config_95.py', 'config_21.py', 'config_61.py']
2022-11-08 14:10:41,445 DEBUG 140046867126080 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_90.py', 'config_58.py', 'config_28.py', 'config_29.py', 'config_100.py', 'config_88.py', 'config_2.py', 'config_71.py', '.pre-commit-config.yaml', 'config_56.py', 'config_83.py', 'config_64.py', 'config_3.py']
2022-11-08 14:10:41,481 DEBUG 140221633902400 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_66.py', 'config_31.py', 'config_13.py', 'config_1.py', 'config_39.py', 'config_12.py', 'config_99.py', 'config_11.py', 'config_48.py', 'config_35.py', 'config_92.py', 'config_52.py', 'config_44.py']
2022-11-08 14:10:41,549 DEBUG 140448858605376 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_87.py', 'config_5.py', 'config_14.py', 'config_46.py', 'config_53.py', 'config_37.py', 'config_86.py', 'config_96.py', 'config_57.py', 'config_16.py', 'config_17.py', 'config_54.py', 'config_8.py']
2022-11-08 14:10:41,560 DEBUG 140176600307520 ggshield.cmd.main:cli:148 args=['/home/agateau/.cache/pre-commit/repo9lwy4jxs/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit', 'config_22.py', 'config_7.py', 'config_34.py', 'config_63.py', 'config_82.py', 'config_45.py', 'config_43.py', 'config_30.py', 'config_78.py', 'config_62.py', 'config_73.py']
```

We can see 7 calls to ggshield here.

If we change the `rev:` entry in `.pre-commit-config.yaml` to use this branch (`rev: agateau/pre-commit-scan-only-once`) and run the same command:

```
$ git commit 2>&1 | grep args=
2022-11-08 14:11:37,522 DEBUG 100e48:7fcdb2b47740 ggshield.cmd.main:cli:146 args=['/home/agateau/.cache/pre-commit/repo6pvh6z80/py_env-python3/bin/ggshield', 'secret', 'scan', 'pre-commit']
```

We see only 1 ggshield call, without arguments.
