### PR TITLE
chore(workflows): update gh-action-pypi-publish action branch

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -51,7 +51,7 @@ jobs:
           name: packages
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
`gh-action-pypi-publish` action has sunset its master branch. We switch to branch `release/v1`.  

See this [part of the action's readme](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-).