### PR TITLE
Allow using --exit-zero, --exclude and --ignore-known-secrets anywhere on the command line

### DIFF
--- a/ggshield/cmd/scan/__init__.py
+++ b/ggshield/cmd/scan/__init__.py
@@ -2,8 +2,8 @@ from typing import Any, List, Optional
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.secret.scan import (
+    add_secret_scan_common_options,
     archive_cmd,
     ci_cmd,
     docker_archive_cmd,
@@ -45,21 +45,6 @@ from ggshield.core.utils import json_output_option_decorator
     help="Show secrets in plaintext instead of hiding them.",
 )
 @click.option(
-    "--exit-zero",
-    is_flag=True,
-    default=None,
-    envvar="GITGUARDIAN_EXIT_ZERO",
-    help="Always return a 0 (non-error) status code, even if incidents are found."
-    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
-)
-@click.option(
-    "--all-policies",
-    is_flag=True,
-    default=None,
-    help="Present fails of all policies (Filenames, FileExtensions, Secret Detection)."
-    "By default, only Secret Detection is shown.",
-)
-@click.option(
     "--output",
     "-o",
     type=click.Path(exists=False, resolve_path=True),
@@ -73,30 +58,28 @@ from ggshield.core.utils import json_output_option_decorator
     help="Exclude results from a detector.",
     multiple=True,
 )
+# Deprecated options
 @click.option(
-    "--exclude",
+    "--all-policies",
+    is_flag=True,
     default=None,
-    type=click.Path(),
-    help="Do not scan the specified path.",
-    multiple=True,
+    hidden=True,
 )
 @click.option(
     "--ignore-default-excludes",
     default=False,
     is_flag=True,
-    help="Ignore excluded patterns by default. [default: False]",
+    hidden=True,
 )
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def deprecated_scan_group(
     ctx: click.Context,
     show_secrets: bool,
-    exit_zero: bool,
-    all_policies: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
+    all_policies: Optional[bool] = None,
     ignore_default_excludes: bool = False,
     **kwargs: Any,
 ) -> int:
@@ -109,9 +92,7 @@ def deprecated_scan_group(
     return scan_group_impl(
         ctx,
         show_secrets,
-        exit_zero,
         json_output,
         output,
         banlist_detector,
-        exclude,
     )

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -3,7 +3,6 @@ from typing import Any, List, Optional, Type
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.secret.scan.archive import archive_cmd
 from ggshield.cmd.secret.scan.ci import ci_cmd
 from ggshield.cmd.secret.scan.docker import docker_name_cmd
@@ -16,11 +15,13 @@ from ggshield.cmd.secret.scan.prereceive import prereceive_cmd
 from ggshield.cmd.secret.scan.pypi import pypi_cmd
 from ggshield.cmd.secret.scan.range import range_cmd
 from ggshield.cmd.secret.scan.repo import repo_cmd
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
-from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.text_utils import display_error
-from ggshield.core.utils import IGNORED_DEFAULT_WILDCARDS, json_output_option_decorator
+from ggshield.core.utils import json_output_option_decorator
 from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
 
 
@@ -48,20 +49,6 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     help="Show secrets in plaintext instead of hiding them.",
 )
 @click.option(
-    "--exit-zero",
-    is_flag=True,
-    default=None,
-    envvar="GITGUARDIAN_EXIT_ZERO",
-    help="Always return a 0 (non-error) status code, even if incidents are found."
-    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
-)
-@click.option(
-    "--all-policies",
-    is_flag=True,
-    default=None,
-    hidden=True,
-)
-@click.option(
     "--output",
     "-o",
     type=click.Path(exists=False, resolve_path=True),
@@ -75,12 +62,12 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     help="Exclude results from a detector.",
     multiple=True,
 )
+# Deprecated options
 @click.option(
-    "--exclude",
+    "--all-policies",
+    is_flag=True,
     default=None,
-    type=click.Path(),
-    help="Do not scan the specified path.",
-    multiple=True,
+    hidden=True,
 )
 @click.option(
     "--ignore-default-excludes",
@@ -88,75 +75,47 @@ from ggshield.output import JSONOutputHandler, OutputHandler, TextOutputHandler
     is_flag=True,
     hidden=True,
 )
-@click.option(
-    "--ignore-known-secrets",
-    is_flag=True,
-    default=None,
-    help="Ignore",
-)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def scan_group(
     ctx: click.Context,
     show_secrets: bool,
-    exit_zero: bool,
-    all_policies: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
+    all_policies: Optional[bool] = None,
     ignore_default_excludes: bool = False,
-    ignore_known_secrets: bool = False,
     **kwargs: Any,
 ) -> int:
     """Commands to scan various contents."""
     return scan_group_impl(
         ctx,
         show_secrets,
-        exit_zero,
         json_output,
         output,
         banlist_detector,
-        exclude,
-        ignore_known_secrets,
     )
 
 
 def scan_group_impl(
     ctx: click.Context,
     show_secrets: bool,
-    exit_zero: bool,
     json_output: bool,
     output: Optional[str],
     banlist_detector: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
-    ignore_known_secrets: bool = False,
 ) -> int:
     """Implementation for scan_group(). Must be a separate function so that its code can
     be reused from the deprecated `cmd.scan` package."""
     ctx.obj["client"] = create_client_from_config(ctx.obj["config"])
     return_code = 0
 
-    ignored_paths = ctx.obj["config"].secret.ignored_paths
-    if exclude is not None:
-        ignored_paths.update(exclude)
-
-    ignored_paths.update(IGNORED_DEFAULT_WILDCARDS)
-
-    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(ignored_paths)
     config: Config = ctx.obj["config"]
 
     if show_secrets is not None:
         config.secret.show_secrets = show_secrets
 
-    if exit_zero is not None:
-        config.exit_zero = exit_zero
-
     if banlist_detector:
         config.secret.ignored_detectors.update(banlist_detector)
-
-    if ignore_known_secrets:
-        config.ignore_known_secrets = ignore_known_secrets
 
     max_commits = get_max_commits_for_hook()
     if max_commits:

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -6,7 +6,9 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.config import Config
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
@@ -18,7 +20,7 @@ from ggshield.scan import Files, ScanCollection, ScanContext, ScanMode, SecretSc
 @click.argument(
     "path", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
 )
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def archive_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -4,7 +4,9 @@ from typing import Any, List
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA, handle_exception
@@ -256,7 +258,7 @@ def azure_range(verbose: bool) -> List[str]:  # pragma: no cover
 
 
 @click.command()
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -4,7 +4,9 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanContext, ScanMode
@@ -25,7 +27,7 @@ DOCKER_COMMAND_TIMEOUT = 360
     show_default=True,
 )
 @click.argument("name", nargs=1, type=click.STRING, required=True)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def docker_name_cmd(
     ctx: click.Context, name: str, docker_timeout: int, **kwargs: Any

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -3,7 +3,9 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import ScanContext, ScanMode
@@ -14,7 +16,7 @@ from ggshield.scan.docker import docker_scan_archive
 @click.argument(
     "archive", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
 )
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def docker_archive_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -4,7 +4,9 @@ from typing import Any, Callable, Iterable, Iterator, List, TextIO
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.core.utils import handle_exception
@@ -46,7 +48,7 @@ def create_scans_from_docset_files(
 
 @click.command()
 @click.argument("files", nargs=-1, type=click.File(), required=True)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def docset_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -3,7 +3,9 @@ from typing import Any, List
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
@@ -18,7 +20,7 @@ from ggshield.scan import ScanCollection, ScanContext, ScanMode, SecretScanner
 )
 @click.option("--recursive", "-r", is_flag=True, help="Scan directory recursively")
 @click.option("--yes", "-y", is_flag=True, help="Confirm recursive scan")
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def path_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -2,7 +2,9 @@ from typing import Any, List
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.git_shell import check_git_dir
 from ggshield.core.utils import handle_exception
 from ggshield.output import TextOutputHandler
@@ -25,7 +27,7 @@ BYPASS_MESSAGE = """  - if you use the pre-commit framework:
 
 @click.command()
 @click.argument("precommit_args", nargs=-1, type=click.UNPROCESSED)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def precommit_cmd(
     ctx: click.Context, precommit_args: List[str], **kwargs: Any

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -5,7 +5,9 @@ from typing import Any, List, Optional, Tuple
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.git_shell import (
     check_git_dir,
     get_list_commit_SHA,
@@ -46,7 +48,7 @@ BYPASS_MESSAGE = """  - if you use the pre-commit framework:
 
 @click.command()
 @click.argument("prepush_args", nargs=-1, type=click.UNPROCESSED)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> int:
     """

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -7,7 +7,9 @@ from typing import Any, List, Optional, Tuple, Type
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_shell import get_list_commit_SHA, git
 from ggshield.core.text_utils import display_error
@@ -127,7 +129,7 @@ def parse_stdin() -> Tuple[str, str]:
     help="Deprecated",
     hidden=True,
 )
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def prereceive_cmd(
     ctx: click.Context, web: bool, prereceive_args: List[str], **kwargs: Any

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -9,7 +9,9 @@ from typing import Any, Dict, List, Set
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.file_utils import get_files_from_paths
@@ -82,7 +84,7 @@ def get_files_from_package(
 
 @click.command()
 @click.argument("package_name", nargs=1, type=click.STRING, required=True)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def pypi_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -2,7 +2,9 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.git_shell import get_list_commit_SHA
 from ggshield.core.utils import handle_exception
 from ggshield.scan import ScanContext, ScanMode
@@ -11,7 +13,7 @@ from ggshield.scan.repo import scan_commit_range
 
 @click.command()
 @click.argument("commit_range", nargs=1, type=click.STRING)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def range_cmd(
     ctx: click.Context,

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -5,7 +5,9 @@ from typing import Any
 import click
 from pygitguardian import GGClient
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+)
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.git_shell import GIT_PATH, shell
@@ -16,7 +18,7 @@ from ggshield.scan.repo import scan_repo_path
 
 @click.command()
 @click.argument("repository", nargs=1, type=click.STRING, required=True)
-@add_common_options()
+@add_secret_scan_common_options()
 @click.pass_context
 def repo_cmd(
     ctx: click.Context, repository: str, **kwargs: Any

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -1,0 +1,70 @@
+from typing import Callable, List, Optional
+
+import click
+
+from ggshield.cmd.common_options import (
+    AnyFunction,
+    add_common_options,
+    create_config_callback,
+    get_config_from_context,
+)
+from ggshield.core.config.user_config import SecretConfig
+from ggshield.core.filter import init_exclusion_regexes
+from ggshield.core.utils import IGNORED_DEFAULT_WILDCARDS
+
+
+def _get_secret_config(ctx: click.Context) -> SecretConfig:
+    return get_config_from_context(ctx).secret
+
+
+_exit_zero_option = click.option(
+    "--exit-zero",
+    is_flag=True,
+    default=None,
+    envvar="GITGUARDIAN_EXIT_ZERO",
+    help="Always return a 0 (non-error) status code, even if incidents are found."
+    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
+    callback=create_config_callback("exit_zero"),
+)
+
+
+def _exclude_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[List[str]]
+) -> Optional[List[str]]:
+    ignored_paths = _get_secret_config(ctx).ignored_paths
+    if value is not None:
+        ignored_paths.update(value)
+
+    ignored_paths.update(IGNORED_DEFAULT_WILDCARDS)
+    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(ignored_paths)
+    return value
+
+
+_exclude_option = click.option(
+    "--exclude",
+    default=None,
+    type=click.Path(),
+    help="Do not scan the specified path.",
+    multiple=True,
+    callback=_exclude_callback,
+)
+
+
+_ignore_known_secrets_option = click.option(
+    "--ignore-known-secrets",
+    is_flag=True,
+    default=None,
+    help="Ignore secrets already known by GitGuardian dashboard",
+    callback=create_config_callback("ignore_known_secrets"),
+)
+
+
+def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
+    def decorator(cmd: AnyFunction) -> AnyFunction:
+        add_common_options()(cmd)
+        _exit_zero_option(cmd)
+        _exclude_option(cmd)
+        _ignore_known_secrets_option(cmd)
+        return cmd
+
+    return decorator

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -130,10 +130,10 @@ class TestPathScan:
                 [
                     "secret",
                     "scan",
-                    "--exit-zero",
                     "-v",
                     *json_arg,
                     "path",
+                    "--exit-zero",
                     "file_secret",
                 ],
             )
@@ -262,11 +262,11 @@ class TestScanDirectory:
                 "-v",
                 "--exclude",
                 "file1",
-                "--exclude",
-                "dir/file2",
                 "path",
                 "./",
                 "-r",
+                "--exclude",
+                "dir/file2",
             ],
             input="n\n",
         )
@@ -340,11 +340,11 @@ class TestScanDirectory:
                 [
                     "secret",
                     "scan",
-                    "--exit-zero",
                     "-v",
                     *ignored_detectors,
                     "path",
                     "file_secret",
+                    "--exit-zero",
                 ],
             )
             assert result.exit_code == 0, result.output


### PR DESCRIPTION
This is the second episode of #197.

First commit introduces a helper function to create Click callbacks which set config values: `create_config_callback()`. It then uses this helper for the --verbose and --allow-self-signed options.

Second commit introduces a `add_secret_scan_common_options()` decorator to define all scan options, similarly to `add_common_options()`. This decorator calls `add_common_options()`, so the commit modifies all scan commands to use `add_secret_scan_common_options()` instead of `add_common_options()`.

`add_secret_scan_common_options()` only implements the --exit-zero, --exclude  and --ignore-known-secrets options for now. Other options are coming in the next episode.