### PR TITLE
feat(ErrorCodes): Enhance ErrorCodes; make them more expressive.

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -7,6 +7,7 @@ from ggshield.cmd.auth.utils import check_instance_has_enabled_flow
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.oauth import OAuthClient
 from ggshield.core.utils import clean_url
 
@@ -45,7 +46,7 @@ def validate_login_path(
         config_parsed_url.scheme != sso_parsed_url.scheme
         or config_parsed_url.netloc != sso_parsed_url.netloc
     ):
-        raise click.ClickException("instance and SSO URL params do not match")
+        raise UnexpectedError("instance and SSO URL params do not match")
     return instance, sso_login_path
 
 
@@ -131,18 +132,18 @@ def login_cmd(
             token = click.prompt("Enter your GitGuardian API token", hide_input=True)
 
         if not token:
-            raise click.ClickException("No API token was provided.")
+            raise UnexpectedError("No API token was provided.")
 
         # enforce using the token (and not use config default)
         client = create_client(api_key=token, api_url=config.api_url)
         response = client.get(endpoint="token")
         if not response.ok:
-            raise click.ClickException("Authentication failed with token.")
+            raise UnexpectedError("Authentication failed with token.")
 
         api_token_data = response.json()
         scopes = api_token_data["scope"]
         if "scan" not in scopes:
-            raise click.ClickException("This token does not have the scan scope.")
+            raise UnexpectedError("This token does not have the scan scope.")
 
         instance_config.init_account(token, api_token_data)
         config.auth_config.save()

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
+from ggshield.core.errors import AuthError, UnexpectedError
 from ggshield.core.utils import dashboard_to_api_url
 
 from .utils import CONNECTION_ERROR_MESSAGE
@@ -66,7 +67,7 @@ def logout(config: Config, instance_url: str, revoke: bool) -> None:
 def check_account_config_exists(config: Config, instance_url: str) -> None:
     instance = config.auth_config.get_instance(instance_url)
     if instance.account is None:
-        raise click.ClickException(
+        raise UnexpectedError(
             f"No token found for instance {instance_url}\n"
             "First try to login by running:\n"
             "  ggshield auth login"
@@ -88,13 +89,14 @@ def revoke_token(config: Config, instance_url: str) -> None:
     try:
         response = client.post(endpoint="token/revoke")
     except ConnectionError:
-        raise click.ClickException(CONNECTION_ERROR_MESSAGE)
+        raise UnexpectedError(CONNECTION_ERROR_MESSAGE)
 
     if response.status_code != 204:
-        raise click.ClickException(
+        raise AuthError(
+            instance_url,
             "Could not perform the logout command because your token is already revoked or invalid.\n"
             "Please try with the following command:\n"
-            "  ggshield auth logout --no-revoke"
+            "  ggshield auth logout --no-revoke",
         )
 
 

--- a/ggshield/cmd/auth/utils.py
+++ b/ggshield/cmd/auth/utils.py
@@ -1,8 +1,8 @@
-import click
 from requests import ConnectionError
 
 from ggshield.core.client import create_session
 from ggshield.core.config import Config
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.utils import urljoin
 
 
@@ -30,18 +30,18 @@ def check_instance_has_enabled_flow(config: Config) -> None:
     try:
         response = session.get(urljoin(config.api_url, "/v1/metadata"), timeout=30)
     except ConnectionError:
-        raise click.ClickException(CONNECTION_ERROR_MESSAGE)
+        raise UnexpectedError(CONNECTION_ERROR_MESSAGE)
 
     if response.status_code == 404:
-        raise click.ClickException(VERSION_TOO_LOW_MESSAGE)
+        raise UnexpectedError(VERSION_TOO_LOW_MESSAGE)
     if not response.ok:
-        raise click.ClickException("Cannot check GitGuardian version.")
+        raise UnexpectedError("Cannot check GitGuardian version.")
     data = response.json()
     if data["version"].startswith("2022.04"):
-        raise click.ClickException(VERSION_TOO_LOW_MESSAGE)
+        raise UnexpectedError(VERSION_TOO_LOW_MESSAGE)
 
     flow_enabled = data["preferences"].get(
         "public_api__ggshield_auth_flow_enabled", True
     )
     if not flow_enabled:
-        raise click.ClickException(DISABLED_FLOW_MESSAGE)
+        raise UnexpectedError(DISABLED_FLOW_MESSAGE)

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -5,7 +5,7 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.config.constants import FIELD_OPTIONS
 from ggshield.core.config import Config
-from ggshield.core.config.errors import UnknownInstanceError
+from ggshield.core.errors import UnknownInstanceError
 
 
 @click.command()

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 import click
+from click import UsageError
 
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
@@ -37,7 +38,7 @@ def config_set_command(
         try:
             value = int(value)  # type: ignore
         except ValueError:
-            raise click.ClickException("default_token_lifetime must be an int")
+            raise UsageError("default_token_lifetime must be an int")
 
     if instance is None:
         setattr(config.auth_config, field_name, value)

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -4,8 +4,10 @@ import sys
 from typing import Any, Optional
 
 import click
+from click import UsageError
 
 from ggshield.cmd.common_options import add_common_options
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.git_shell import GIT_PATH, check_git_dir, check_git_installed
 
 
@@ -97,10 +99,10 @@ def create_hook(
     hook_path = f"{hook_dir_path}/{hook_type}"
 
     if os.path.isdir(hook_path):
-        raise click.ClickException(f"{hook_path} is a directory.")
+        raise UsageError(f"{hook_path} is a directory.")
 
     if os.path.isfile(hook_path) and not (force or append):
-        raise click.ClickException(
+        raise UnexpectedError(
             f"{hook_path} already exists."
             " Use --force to override or --append to add to current script"
         )

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -22,6 +22,7 @@ from ggshield.cmd.status import status_cmd
 from ggshield.core import check_updates
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
+from ggshield.core.config.errors import ExitCode
 from ggshield.core.text_utils import display_warning
 from ggshield.core.utils import load_dot_env
 
@@ -39,9 +40,9 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> None:
     when exit_zero is enabled
     """
     show_config_deprecation_message(ctx)
-    if ctx.obj["config"].exit_zero:
+    if exit_code == ExitCode.SCAN_FOUND_PROBLEMS and ctx.obj["config"].exit_zero:
         logger.debug("scan exit_code forced to 0")
-        sys.exit(0)
+        sys.exit(ExitCode.SUCCESS)
 
     logger.debug("scan exit_code=%d", exit_code)
     sys.exit(exit_code)

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -22,7 +22,7 @@ from ggshield.cmd.status import status_cmd
 from ggshield.core import check_updates
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from ggshield.core.text_utils import display_warning
 from ggshield.core.utils import load_dot_env
 

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -7,6 +7,7 @@ from pygitguardian.models import Detail, Quota, QuotaResponse
 
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.utils import json_output_option_decorator
 from ggshield.output.text.message import format_quota_color
 
@@ -21,10 +22,10 @@ def quota_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
     response: Union[Detail, QuotaResponse] = client.quota_overview()
 
     if not isinstance(response, (Detail, QuotaResponse)):
-        raise click.ClickException("Unexpected quota response")
+        raise UnexpectedError("Unexpected quota response")
 
     if isinstance(response, Detail):
-        raise click.ClickException(response.detail)
+        raise UnexpectedError(response.detail)
 
     quota: Quota = response.content
 

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -11,6 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.config import Config
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
 from ggshield.scan import Files, ScanCollection, ScanContext, ScanMode, SecretScanner
@@ -34,7 +35,7 @@ def archive_cmd(
         try:
             shutil.unpack_archive(path, extract_dir=Path(temp_dir))
         except Exception as exn:
-            raise click.ClickException(f'Failed to unpack "{path}" archive: {exn}')
+            raise UnexpectedError(f'Failed to unpack "{path}" archive: {exn}')
 
         config: Config = ctx.obj["config"]
         files: Files = get_files_from_paths(

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -9,8 +9,9 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.cache import ReadOnlyCache
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
-from ggshield.core.utils import EMPTY_SHA, handle_exception
+from ggshield.core.utils import EMPTY_SHA
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.repo import scan_commit_range
 

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -3,13 +3,14 @@ from enum import Enum
 from typing import Any, List
 
 import click
+from click import UsageError
 
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
 from ggshield.core.cache import ReadOnlyCache
-from ggshield.core.errors import handle_exception
+from ggshield.core.errors import UnexpectedError, handle_exception
 from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA
 from ggshield.scan import ScanContext, ScanMode
@@ -46,7 +47,7 @@ def jenkins_range(verbose: bool) -> List[str]:  # pragma: no cover
     if commit_list:
         return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "\tRepository URL: <Fill if public>\n"
         f"\tGIT_COMMIT: {head_commit}"
@@ -73,7 +74,7 @@ def travis_range(verbose: bool) -> List[str]:  # pragma: no cover
     if commit_list:
         return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "\tRepository URL: <Fill if public>\n"
         f"\tTRAVIS_COMMIT_RANGE: {commit_range}"
@@ -90,7 +91,7 @@ def bitbucket_pipelines_range(verbose: bool) -> List[str]:  # pragma: no cover
     if commit_list:
         return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
         f"  CI_COMMIT_SHA: {commit_sha}"
@@ -124,7 +125,7 @@ def circle_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
     if commit_list:
         return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "\tRepository URL: <Fill if public>\n"
         f"\tCIRCLE_RANGE: {compare_range}\n"
@@ -161,7 +162,7 @@ def gitlab_ci_range(verbose: bool) -> List[str]:  # pragma: no cover
     if commit_list:
         return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
         f"  CI_MERGE_REQUEST_TARGET_BRANCH_NAME: {merge_request_target_branch}\n"
@@ -212,7 +213,7 @@ def github_actions_range(verbose: bool) -> List[str]:  # pragma: no cover
         if commit_list:
             return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
         f"github_push_before_sha: {push_before_sha}\n"
@@ -234,7 +235,7 @@ def drone_range(verbose: bool) -> List[str]:  # pragma: no cover
         if commit_list:
             return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
         f"  DRONE_COMMIT_BEFORE: {before_sha}"
@@ -252,7 +253,7 @@ def azure_range(verbose: bool) -> List[str]:  # pragma: no cover
         if commit_list:
             return commit_list
 
-    raise click.ClickException(
+    raise UnexpectedError(
         "Unable to get commit range. Please submit an issue with the following info:\n"
         "  Repository URL: <Fill if public>\n"
         f"  BUILD_SOURCEVERSION: {head_commit}"
@@ -272,7 +273,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
         if not (
             os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")
         ):
-            raise click.ClickException(
+            raise UsageError(
                 "`secret scan ci` should only be used in a CI environment."
             )
 
@@ -301,7 +302,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
             commit_list = azure_range(config.verbose)
             ci_mode = SupportedCI.AZURE
         else:
-            raise click.ClickException(
+            raise UnexpectedError(
                 f"Current CI is not detected or supported."
                 f" Supported CIs: {', '.join([ci.value for ci in SupportedCI])}."
             )

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -8,7 +8,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.utils import handle_exception
+from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.docker import docker_save_to_tmp, docker_scan_archive
 

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -7,7 +7,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.utils import handle_exception
+from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.docker import docker_scan_archive
 

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -9,8 +9,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.constants import MAX_WORKERS
+from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import create_progress_bar, display_info
-from ggshield.core.utils import handle_exception
 from ggshield.scan import File, ScanCollection, ScanContext, ScanMode, SecretScanner
 
 

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -8,9 +8,9 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.constants import MAX_WORKERS
+from ggshield.core.errors import handle_exception
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
-from ggshield.core.utils import handle_exception
 from ggshield.scan import ScanCollection, ScanContext, ScanMode, SecretScanner
 
 

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -5,8 +5,8 @@ import click
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import check_git_dir
-from ggshield.core.utils import handle_exception
 from ggshield.output import TextOutputHandler
 from ggshield.output.text.message import remediation_message
 from ggshield.scan import Commit, ScanCollection, ScanContext, ScanMode, SecretScanner

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -9,6 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import (
     check_git_dir,
     get_list_commit_SHA,
@@ -16,7 +17,7 @@ from ggshield.core.git_shell import (
     is_valid_git_commit_ref,
 )
 from ggshield.core.text_utils import display_warning
-from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, handle_exception
+from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE
 from ggshield.output.text.message import remediation_message
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.repo import scan_commit_range

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -12,7 +12,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.cache import ReadOnlyCache
-from ggshield.core.errors import handle_exception
+from ggshield.core.errors import UnexpectedError, handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA, git
 from ggshield.core.text_utils import display_error
 from ggshield.core.utils import EMPTY_SHA, PRERECEIVE_TIMEOUT
@@ -103,7 +103,7 @@ def parse_stdin() -> Tuple[str, str]:
     """
     prereceive_input = sys.stdin.read().strip()
     if not prereceive_input:
-        raise click.ClickException(f"Invalid input arguments: '{prereceive_input}'")
+        raise UnexpectedError(f"Invalid input arguments: '{prereceive_input}'")
 
     # TODO There can be more than one line here, for example when pushing multiple
     # branches. We should support this.

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -12,9 +12,10 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.cache import ReadOnlyCache
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA, git
 from ggshield.core.text_utils import display_error
-from ggshield.core.utils import EMPTY_SHA, PRERECEIVE_TIMEOUT, handle_exception
+from ggshield.core.utils import EMPTY_SHA, PRERECEIVE_TIMEOUT
 from ggshield.output import GitLabWebUIOutputHandler
 from ggshield.output.text.message import remediation_message
 from ggshield.scan import ScanContext, ScanMode

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -15,6 +15,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.file_utils import get_files_from_paths
 from ggshield.core.text_utils import create_progress_bar
 from ggshield.scan import Files, ScanCollection, ScanContext, ScanMode, SecretScanner
@@ -45,10 +46,10 @@ def save_package_to_tmp(temp_dir: str, package_name: str) -> None:
         click.echo("OK", err=True)
 
     except subprocess.CalledProcessError:
-        raise click.ClickException(f'Failed to download "{package_name}"')
+        raise UnexpectedError(f'Failed to download "{package_name}"')
 
     except subprocess.TimeoutExpired:
-        raise click.ClickException('Command "{}" timed out'.format(" ".join(command)))
+        raise UnexpectedError('Command "{}" timed out'.format(" ".join(command)))
 
 
 def get_files_from_package(
@@ -68,7 +69,7 @@ def get_files_from_package(
             str(archive), extract_dir=archive_dir_path, **unpack_kwargs
         )
     except Exception as exn:
-        raise click.ClickException(f'Failed to unpack package "{package_name}": {exn}.')
+        raise UnexpectedError(f'Failed to unpack package "{package_name}": {exn}.')
 
     exclusion_regexes.add(re.compile(re.escape(archive.name)))
 

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -6,8 +6,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA
-from ggshield.core.utils import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.repo import scan_commit_range
 

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import click
+from click import UsageError
 
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
@@ -31,7 +32,7 @@ def range_cmd(
     try:
         commit_list = get_list_commit_SHA(commit_range)
         if not commit_list:
-            raise click.ClickException("invalid commit range")
+            raise UsageError("invalid commit range")
         if config.verbose:
             click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import Any
 
 import click
+from click import UsageError
 from pygitguardian import GGClient
 
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
@@ -66,8 +67,8 @@ def repo_cmd(
             )
 
     if any(host in repository for host in ("gitlab.com", "github.com")):
-        raise click.ClickException(
+        raise UsageError(
             f"{repository} doesn't seem to be a valid git URL.\n"
             f"Did you mean {repository}.git?"
         )
-    raise click.ClickException(f"{repository} is neither a valid path nor a git URL")
+    raise UsageError(f"{repository} is neither a valid path nor a git URL")

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -7,6 +7,7 @@ from pygitguardian.models import HealthCheckResponse
 
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.utils import json_output_option_decorator
 from ggshield.output.text.message import format_healthcheck_status
@@ -21,7 +22,7 @@ def status_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
     response: HealthCheckResponse = client.health_check()
 
     if not isinstance(response, HealthCheckResponse):
-        raise click.ClickException("Unexpected health check response")
+        raise UnexpectedError("Unexpected health check response")
 
     click.echo(
         response.to_json()

--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -2,10 +2,10 @@ import json
 import os
 from typing import Any, Dict, List
 
-import click
 from pygitguardian.models import PolicyBreak
 
 from ggshield.core.constants import CACHE_FILENAME
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import get_ignore_sha
 from ggshield.core.text_utils import display_warning
 from ggshield.core.types import IgnoredMatch, IgnoredMatchSchema
@@ -37,7 +37,7 @@ class Cache:
                 try:
                     _cache = json.load(f)
                 except Exception as e:
-                    raise click.ClickException(
+                    raise UnexpectedError(
                         "Parsing error while"
                         f"reading {self.cache_filename}:\n{str(e)}"
                     )
@@ -75,7 +75,7 @@ class Cache:
             try:
                 json.dump(self.to_dict(), f)
             except Exception as e:
-                raise click.ClickException(
+                raise UnexpectedError(
                     f"Error while saving cache in {self.cache_filename}:\n{str(e)}"
                 )
 

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -1,8 +1,8 @@
 from typing import Dict, Optional, Union, cast
 
-import click
 import requests
 import urllib3
+from click import UsageError
 from pygitguardian import GGClient
 from pygitguardian.client import is_ok
 from pygitguardian.models import Detail
@@ -12,7 +12,7 @@ from ..iac.models import IaCScanResult, IaCScanResultSchema
 from ..iac.models.iac_scan_parameters import IaCScanParameters, IaCScanParametersSchema
 from .config import Config
 from .constants import DEFAULT_DASHBOARD_URL
-from .errors import UnknownInstanceError
+from .errors import UnexpectedError, UnknownInstanceError
 
 
 def load_detail(resp: Response) -> Detail:
@@ -47,7 +47,7 @@ def create_client_from_config(config: Config) -> GGClient:
             # This can happen when the user first tries the app and has not gone through
             # the authentication procedure yet. In this case, replace the error message
             # complaining about an unknown instance with a more user-friendly one.
-            raise click.ClickException("GitGuardian API key is needed.")
+            raise UsageError("GitGuardian API key is needed.")
         else:
             raise
 
@@ -72,7 +72,7 @@ def create_client(
         )
     except ValueError as e:
         # Can be raised by pygitguardian
-        raise click.ClickException(f"Failed to create API client. {e}")
+        raise UnexpectedError(f"Failed to create API client. {e}")
 
 
 def create_session(allow_self_signed: bool = False) -> Session:

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -11,8 +11,8 @@ from requests import Response, Session
 from ..iac.models import IaCScanResult, IaCScanResultSchema
 from ..iac.models.iac_scan_parameters import IaCScanParameters, IaCScanParametersSchema
 from .config import Config
-from .config.errors import UnknownInstanceError
 from .constants import DEFAULT_DASHBOARD_URL
+from .errors import UnknownInstanceError
 
 
 def load_detail(resp: Response) -> Detail:

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -5,11 +5,6 @@ from typing import Any, Dict, List, Optional, cast
 
 import marshmallow_dataclass
 
-from ggshield.core.config.errors import (
-    AuthExpiredError,
-    MissingTokenError,
-    UnknownInstanceError,
-)
 from ggshield.core.config.utils import (
     ensure_path_exists,
     get_auth_config_filepath,
@@ -17,6 +12,11 @@ from ggshield.core.config.utils import (
     save_yaml_dict,
 )
 from ggshield.core.dirs import get_config_dir
+from ggshield.core.errors import (
+    AuthExpiredError,
+    MissingTokenError,
+    UnknownInstanceError,
+)
 from ggshield.core.utils import datetime_from_isoformat
 
 

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -3,7 +3,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-import click
 import marshmallow_dataclass
 from marshmallow import ValidationError
 
@@ -19,7 +18,7 @@ from ggshield.core.constants import (
     GLOBAL_CONFIG_FILENAMES,
     LOCAL_CONFIG_PATHS,
 )
-from ggshield.core.errors import ParseError, format_validation_error
+from ggshield.core.errors import ParseError, UnexpectedError, format_validation_error
 from ggshield.core.types import FilteredConfig, IgnoredMatch, IgnoredMatchSchema
 from ggshield.core.utils import api_to_dashboard_url
 from ggshield.iac.policy_id import POLICY_ID_PATTERN, validate_policy_id
@@ -167,7 +166,7 @@ class UserConfig(FilteredConfig):
                 )
                 obj = UserV1Config.load_v1(data)
             else:
-                raise click.ClickException(
+                raise UnexpectedError(
                     f"Don't know how to load config version {config_version}"
                 )
         except ValidationError as exc:

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -7,7 +7,6 @@ import click
 import marshmallow_dataclass
 from marshmallow import ValidationError
 
-from ggshield.core.config.errors import ParseError, format_validation_error
 from ggshield.core.config.utils import (
     get_global_path,
     load_yaml_dict,
@@ -20,6 +19,7 @@ from ggshield.core.constants import (
     GLOBAL_CONFIG_FILENAMES,
     LOCAL_CONFIG_PATHS,
 )
+from ggshield.core.errors import ParseError, format_validation_error
 from ggshield.core.types import FilteredConfig, IgnoredMatch, IgnoredMatchSchema
 from ggshield.core.utils import api_to_dashboard_url
 from ggshield.iac.policy_id import POLICY_ID_PATTERN, validate_policy_id

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -3,11 +3,11 @@ from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-import click
 import yaml
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME
 from ggshield.core.dirs import get_config_dir
+from ggshield.core.errors import UnexpectedError
 
 
 def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> None:
@@ -50,7 +50,7 @@ def save_yaml_dict(data: Dict[str, Any], path: str) -> None:
             stream = yaml.dump(data, indent=2, default_flow_style=False)
             f.write(stream)
         except Exception as e:
-            raise click.ClickException(
+            raise UnexpectedError(
                 f"Error while saving config in {path}:\n{str(e)}"
             ) from e
 

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -37,6 +37,11 @@ class _ExitError(click.ClickException):
         self.exit_code = exit_code
 
 
+class UnexpectedError(_ExitError):
+    def __init__(self, message: str) -> None:
+        super().__init__(ExitCode.UNEXPECTED_ERROR, message)
+
+
 class ParseError(_ExitError):
     """
     Failed to load file

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -1,8 +1,11 @@
+import traceback
 from enum import IntEnum
 from typing import Any, Dict
 
 import click
 from marshmallow import ValidationError
+
+from ggshield.core.text_utils import display_error
 
 
 class ExitCode(IntEnum):
@@ -108,3 +111,21 @@ def format_validation_error(exc: ValidationError) -> str:
     format_items(message_dct, 0)
 
     return "\n".join(lines)
+
+
+def handle_exception(exc: Exception, verbose: bool) -> int:
+    """
+    Take an exception, print information about it and return the exit code to use
+    """
+    if isinstance(exc, click.exceptions.Abort):
+        return ExitCode.SUCCESS
+    exit_code = (
+        exc.exit_code if isinstance(exc, _ExitError) else ExitCode.UNEXPECTED_ERROR
+    )
+
+    if not isinstance(exc, click.ClickException) and verbose:
+        traceback.print_exc()
+
+    display_error(str(exc))
+
+    return exit_code

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -5,7 +5,7 @@ import re
 from collections import OrderedDict
 from typing import Dict, Iterable, List, Optional, Set
 
-import click
+from click import UsageError
 from pygitguardian.models import Match, PolicyBreak, ScanResult
 
 from ggshield.core.types import IgnoredMatch
@@ -166,7 +166,7 @@ def init_exclusion_regexes(paths_ignore: Iterable[str]) -> Set[re.Pattern]:
     res = set()
     for path in paths_ignore:
         if not is_pattern_valid(path):
-            raise click.ClickException(f"{path} is not a valid exclude pattern.")
+            raise UsageError(f"{path} is not a valid exclude pattern.")
         res.add(re.compile(translate_user_pattern(path)))
     return res
 

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -6,6 +6,9 @@ from shutil import which
 from typing import Any, List, Optional
 
 import click
+from click import UsageError
+
+from ggshield.core.errors import UnexpectedError
 
 
 COMMAND_TIMEOUT = 45
@@ -51,7 +54,7 @@ def check_git_dir(wd: Optional[str] = None) -> None:
     if wd is None:
         wd = os.getcwd()
     if not is_git_dir(wd):
-        raise click.ClickException("Not a git directory.")
+        raise UsageError("Not a git directory.")
 
 
 def get_git_root(wd: Optional[str] = None) -> str:
@@ -70,7 +73,7 @@ def check_git_installed() -> None:
         [GIT_PATH, "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     ) as process:
         if process.wait():
-            raise click.ClickException("Git is not installed.")
+            raise UnexpectedError("Git is not installed.")
 
 
 def shell(

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -15,6 +15,7 @@ from ggshield.core.utils import urljoin
 
 from .client import create_client, create_session
 from .config import Config, InstanceConfig
+from .errors import UnexpectedError
 
 
 CLIENT_ID = "ggshield_oauth"
@@ -171,7 +172,7 @@ class OAuthClient:
             except OSError:
                 continue
         else:
-            raise click.ClickException("Could not find unoccupied port.")
+            raise UnexpectedError("Could not find unoccupied port.")
 
     def _wait_for_callback(self) -> None:
         """
@@ -187,11 +188,11 @@ class OAuthClient:
                 # the `process_callback` function
                 self.server.handle_request()  # type: ignore
         except KeyboardInterrupt:
-            raise click.ClickException("Aborting")
+            raise click.Abort()
 
         if self._handler_wrapper.error_message is not None:
             # if no error message is attached, the process is considered successful
-            raise click.ClickException(self._handler_wrapper.error_message)
+            raise UnexpectedError(self._handler_wrapper.error_message)
 
     def _get_code(self, uri: str) -> str:
         """

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -7,6 +7,7 @@ from typing import Iterable, List, NamedTuple, Optional
 from urllib.parse import ParseResult, urlparse
 
 import click
+from click import UsageError
 from dotenv import load_dotenv
 from pygitguardian.models import Match
 
@@ -278,12 +279,12 @@ def dashboard_to_api_url(dashboard_url: str, warn: bool = False) -> str:
     """
     parsed_url = clean_url(dashboard_url, warn=warn)
     if parsed_url.scheme != "https" and not parsed_url.netloc.startswith("localhost"):
-        raise click.ClickException(
+        raise UsageError(
             f"Invalid scheme for dashboard URL '{dashboard_url}', expected HTTPS"
         )
     if any(parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
         if parsed_url.path:
-            raise click.ClickException(
+            raise UsageError(
                 f"Invalid dashboard URL '{dashboard_url}', got an unexpected path '{parsed_url.path}'"
             )
         parsed_url = parsed_url._replace(
@@ -303,12 +304,10 @@ def api_to_dashboard_url(api_url: str, warn: bool = False) -> str:
     """
     parsed_url = clean_url(api_url, warn=warn)
     if parsed_url.scheme != "https" and not parsed_url.netloc.startswith("localhost"):
-        raise click.ClickException(
-            f"Invalid scheme for API URL '{api_url}', expected HTTPS"
-        )
+        raise UsageError(f"Invalid scheme for API URL '{api_url}', expected HTTPS")
     if parsed_url.netloc.endswith(".gitguardian.com"):  # SaaS
         if parsed_url.path:
-            raise click.ClickException(
+            raise UsageError(
                 f"Invalid API URL '{api_url}', got an unexpected path '{parsed_url.path}'"
             )
         parsed_url = parsed_url._replace(

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import traceback
 from datetime import datetime
 from enum import Enum
 from typing import Iterable, List, NamedTuple, Optional
@@ -11,7 +10,6 @@ import click
 from dotenv import load_dotenv
 from pygitguardian.models import Match
 
-from ggshield.core.config.errors import ExitCode, _ExitError
 from ggshield.core.constants import ON_PREMISE_API_URL_PATH_PREFIX
 
 from .git_shell import get_git_root, is_git_dir
@@ -218,22 +216,6 @@ json_output_option_decorator = click.option(
     show_default=True,
     help="JSON output results",
 )
-
-
-def handle_exception(e: Exception, verbose: bool) -> int:
-    """
-    Handle exception from a scan command.
-    """
-    if isinstance(e, click.exceptions.Abort):
-        return ExitCode.SUCCESS
-    exit_code = e.exit_code if isinstance(e, _ExitError) else ExitCode.UNEXPECTED_ERROR
-
-    if not isinstance(e, click.ClickException) and verbose:
-        traceback.print_exc()
-
-    display_error(str(e))
-
-    return exit_code
 
 
 def _find_dot_env() -> Optional[str]:

--- a/ggshield/output/output_handler.py
+++ b/ggshield/output/output_handler.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import click
 
+from ggshield.core.errors import ExitCode
 from ggshield.scan import ScanCollection
 
 
@@ -21,7 +22,7 @@ class OutputHandler(ABC):
         self.verbose = verbose
         self.output = output
 
-    def process_scan(self, scan: ScanCollection) -> int:
+    def process_scan(self, scan: ScanCollection) -> ExitCode:
         """Process a scan collection, write the report to :attr:`self.output`
 
         :param scan: The scan collection to process
@@ -48,9 +49,9 @@ class OutputHandler(ABC):
         raise NotImplementedError()
 
     @staticmethod
-    def _get_exit_code(scan: ScanCollection) -> int:
+    def _get_exit_code(scan: ScanCollection) -> ExitCode:
         if scan.has_iac_result:
-            return 1
+            return ExitCode.SCAN_FOUND_PROBLEMS
         if scan.has_new_secrets:
-            return 1
-        return 0
+            return ExitCode.SCAN_FOUND_PROBLEMS
+        return ExitCode.SUCCESS

--- a/ggshield/output/text/text_output_handler.py
+++ b/ggshield/output/text/text_output_handler.py
@@ -2,9 +2,9 @@ from copy import deepcopy
 from io import StringIO
 from typing import ClassVar, List
 
-import click
 from pygitguardian.models import Match
 
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import censor_content, leak_dictionary_by_ignore_sha
 from ggshield.core.text_utils import Line, pluralize
 from ggshield.core.utils import Filemode, find_match_indices, get_lines_from_content
@@ -105,7 +105,7 @@ class TextOutputHandler(OutputHandler):
         offset = get_offset(padding, is_patch)
 
         if len(lines) == 0:
-            raise click.ClickException("Parsing of scan result failed.")
+            raise UnexpectedError("Parsing of scan result failed.")
 
         number_of_displayed_secrets = 0
         for ignore_sha, policy_breaks in sha_dict.items():

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -8,11 +8,12 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
-import click
+from click import UsageError
 from pygitguardian import GGClient
 from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.cache import Cache
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.file_utils import is_path_binary
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.core.types import IgnoredMatch
@@ -207,9 +208,9 @@ def docker_pull_image(image_name: str, timeout: int) -> None:
             timeout=timeout,
         )
     except subprocess.CalledProcessError:
-        raise click.ClickException(f'Image "{image_name}" not found')
+        raise UsageError(f'Image "{image_name}" not found')
     except subprocess.TimeoutExpired:
-        raise click.ClickException('Command "{}" timed out'.format(" ".join(command)))
+        raise UnexpectedError('Command "{}" timed out'.format(" ".join(command)))
 
 
 def docker_save_to_tmp(image_name: str, destination_path: Path, timeout: int) -> None:
@@ -237,11 +238,11 @@ def docker_save_to_tmp(image_name: str, destination_path: Path, timeout: int) ->
 
             docker_save_to_tmp(image_name, destination_path, timeout)
         else:
-            raise click.ClickException(
+            raise UnexpectedError(
                 f"Unable to save docker archive:\nError: {err_string}"
             )
     except subprocess.TimeoutExpired:
-        raise click.ClickException('Command "{}" timed out'.format(" ".join(command)))
+        raise UnexpectedError('Command "{}" timed out'.format(" ".join(command)))
 
 
 def docker_scan_archive(

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -13,10 +13,10 @@ from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import create_progress_bar, display_error
 from ggshield.core.types import IgnoredMatch
-from ggshield.core.utils import handle_exception
 from ggshield.output import OutputHandler
 from ggshield.scan import Commit, Results, ScanCollection, ScanContext, SecretScanner
 

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -6,14 +6,14 @@ from contextlib import contextmanager
 from functools import partial
 from typing import Callable, Iterable, Iterator, List, Optional, Set
 
-import click
+from click import UsageError
 from pygitguardian import GGClient
 from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
-from ggshield.core.errors import handle_exception
+from ggshield.core.errors import ExitCode, handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA, is_git_dir
 from ggshield.core.text_utils import create_progress_bar, display_error
 from ggshield.core.types import IgnoredMatch
@@ -45,7 +45,7 @@ def scan_repo_path(
 ) -> int:  # pragma: no cover
     try:
         if not is_git_dir(repo_path):
-            raise click.ClickException(f"{repo_path} is not a git repository")
+            raise UsageError(f"{repo_path} is not a git repository")
 
         with cd(repo_path):
             return scan_commit_range(
@@ -152,7 +152,7 @@ def scan_commit_range(
     scan_context: ScanContext,
     ignored_detectors: Optional[Set[str]] = None,
     ignore_known_secrets: bool = False,
-) -> int:  # pragma: no cover
+) -> ExitCode:
     """
     Scan every commit in a range.
 

--- a/ggshield/scan/scanner.py
+++ b/ggshield/scan/scanner.py
@@ -11,6 +11,7 @@ from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 from pygitguardian.models import Detail, ScanResult
 
 from ggshield.core.cache import Cache
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import (
     leak_dictionary_by_ignore_sha,
     remove_ignored_from_result,
@@ -308,7 +309,7 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[File]) -> None:
     if detail.status_code == 401:
         raise click.UsageError(detail.detail)
     if detail.status_code is None:
-        raise click.ClickException(f"Error scanning: {detail.detail}")
+        raise UnexpectedError(f"Error scanning: {detail.detail}")
 
     details = None
 

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -14,7 +14,7 @@ from ggshield.cmd.auth.utils import (
 )
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from ggshield.core.oauth import (
     OAuthClient,
     OAuthError,

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -14,6 +14,7 @@ from ggshield.cmd.auth.utils import (
 )
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
+from ggshield.core.config.errors import ExitCode
 from ggshield.core.oauth import (
     OAuthClient,
     OAuthError,
@@ -236,7 +237,7 @@ class TestAuthLoginWeb:
         prepare_config(instance_url=instance_url)
 
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_not_called()
 
         self._assert_last_print(
@@ -263,7 +264,7 @@ class TestAuthLoginWeb:
         prepare_config(instance_url=instance_url, expiry_date=dt)
 
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_not_called()
 
         self._assert_last_print(
@@ -280,7 +281,7 @@ class TestAuthLoginWeb:
 
         self.prepare_mocks(monkeypatch, used_port_count=1000)
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 1
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
 
         self._webbrowser_open_mock.assert_not_called()
         self._client_post_mock.assert_not_called()
@@ -311,7 +312,7 @@ class TestAuthLoginWeb:
             is_state_valid=is_state_valid,
         )
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 1
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
 
         self._webbrowser_open_mock.assert_called_once()
         self._assert_open_url()
@@ -333,7 +334,7 @@ class TestAuthLoginWeb:
         """
         self.prepare_mocks(monkeypatch, is_exchange_ok=False)
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 1
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
 
         self._webbrowser_open_mock.assert_called_once()
         self._assert_open_url()
@@ -351,7 +352,7 @@ class TestAuthLoginWeb:
         """
         self.prepare_mocks(monkeypatch, is_token_valid=False)
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 1
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
 
         self._webbrowser_open_mock.assert_called_once()
         self._assert_open_url()
@@ -394,7 +395,7 @@ class TestAuthLoginWeb:
             prepare_config(instance_url="http://some-gg-instance.com")
 
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
 
         self._webbrowser_open_mock.assert_called_once()
         self._assert_open_url(expected_port=29170 + used_port_count)
@@ -821,7 +822,7 @@ class TestAuthLoginWeb:
         self._check_instance_has_enabled_flow_mock.side_effect = setter
 
         exit_code, output = self.run_cmd(cli_fs_runner)
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_called()
         self._assert_open_url(host=expected_web_host)
         self._check_instance_has_enabled_flow_mock.assert_called_once()

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -172,7 +172,7 @@ class TestAuthLogout:
         instance: Optional[str] = None,
         revoke: bool = True,
         all_tokens: bool = False,
-    ) -> None:
+    ) -> Tuple[int, str]:
         cmd = ["auth", "logout"]
         if instance is not None:
             cmd.append("--instance=" + instance)

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -6,7 +6,7 @@ from requests.exceptions import ConnectionError
 
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 
 from ..utils import prepare_config
 

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -32,7 +32,7 @@ class TestAuthLogout:
         prepare_config(with_account=False)
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url)
 
-        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
+        assert exit_code == ExitCode.UNEXPECTED_ERROR, output
         assert output == (
             f"Error: No token found for instance {instance_url}\n"
             "First try to login by running:\n"
@@ -109,7 +109,7 @@ class TestAuthLogout:
         config = Config()
         assert config.auth_config.get_instance(DEFAULT_INSTANCE_URL).account is not None
 
-        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
+        assert exit_code == ExitCode.UNEXPECTED_ERROR, output
         assert output == (
             "Error: Could not connect to GitGuardian.\n"
             "Please check your internet connection and if the specified URL is correct.\n"
@@ -133,7 +133,7 @@ class TestAuthLogout:
         config = Config()
         assert config.auth_config.get_instance(DEFAULT_INSTANCE_URL).account is not None
 
-        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
+        assert exit_code == ExitCode.AUTHENTICATION_ERROR, output
         assert output == (
             "Error: Could not perform the logout command "
             "because your token is already revoked or invalid.\n"

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError
 
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
+from ggshield.core.config.errors import ExitCode
 
 from ..utils import prepare_config
 
@@ -31,7 +32,7 @@ class TestAuthLogout:
         prepare_config(with_account=False)
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url)
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
         assert output == (
             f"Error: No token found for instance {instance_url}\n"
             "First try to login by running:\n"
@@ -71,7 +72,7 @@ class TestAuthLogout:
             config.auth_config.get_instance(unrelated_url).account is not None
         ), "the unrelated instance should not be affected."
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         instance_url = instance_url or "https://dashboard.gitguardian.com"
 
         expected_output = f"Successfully logged out for instance {instance_url}\n\n"
@@ -108,7 +109,7 @@ class TestAuthLogout:
         config = Config()
         assert config.auth_config.get_instance(DEFAULT_INSTANCE_URL).account is not None
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
         assert output == (
             "Error: Could not connect to GitGuardian.\n"
             "Please check your internet connection and if the specified URL is correct.\n"
@@ -132,7 +133,7 @@ class TestAuthLogout:
         config = Config()
         assert config.auth_config.get_instance(DEFAULT_INSTANCE_URL).account is not None
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
         assert output == (
             "Error: Could not perform the logout command "
             "because your token is already revoked or invalid.\n"
@@ -163,7 +164,7 @@ class TestAuthLogout:
         for instance in Config().auth_config.instances:
             assert instance.account is None, output
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
 
     @staticmethod
     def run_cmd(

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
 from ggshield.cmd.main import cli
+from ggshield.core.config.errors import ExitCode
 from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, MockRequestsResponse, my_vcr
 
 
@@ -32,7 +33,7 @@ def test_scan_valid_args(cli_fs_runner: CliRunner) -> None:
             ".",
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == ExitCode.SUCCESS
 
 
 def test_invalid_policy_id(cli_fs_runner: CliRunner) -> None:
@@ -53,7 +54,7 @@ def test_invalid_policy_id(cli_fs_runner: CliRunner) -> None:
             ".",
         ],
     )
-    assert result.exit_code == 1
+    assert result.exit_code == ExitCode.SCAN_FOUND_PROBLEMS
     assert (
         "The policies ['GG_IAC_002'] do not match the pattern 'GG_IAC_[0-9]{4}'"
         in str(result.exception)
@@ -72,7 +73,7 @@ def test_iac_scan_file_error_response(cli_fs_runner: CliRunner) -> None:
             "tmp/iac_file_single_vulnerability.tf",
         ],
     )
-    assert result.exit_code == 2
+    assert result.exit_code == ExitCode.USAGE_ERROR
     assert "Error: Invalid value for 'DIRECTORY'" in result.stdout
 
 

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
 from ggshield.cmd.main import cli
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, MockRequestsResponse, my_vcr
 
 

--- a/tests/unit/cmd/scan/test_ci.py
+++ b/tests/unit/cmd/scan/test_ci.py
@@ -7,7 +7,7 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.cmd.secret.scan.ci import EMPTY_SHA
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 

--- a/tests/unit/cmd/scan/test_ci.py
+++ b/tests/unit/cmd/scan/test_ci.py
@@ -7,6 +7,7 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.cmd.secret.scan.ci import EMPTY_SHA
+from ggshield.core.config.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
@@ -152,7 +153,7 @@ def test_ci_cmd_does_not_work_outside_ci(_, cli_fs_runner: click.testing.CliRunn
     result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
 
     # THEN it fails
-    assert_invoke_exited_with(result, 1)
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
 
     # And the error message explains why
     assert "only be used in a CI environment" in result.stdout
@@ -169,7 +170,7 @@ def test_ci_cmd_does_not_work_if_ci_env_is_odd(
     result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
 
     # THEN it fails
-    assert_invoke_exited_with(result, 1)
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
 
     # And the error message explains why
     assert "Current CI is not detected" in result.stdout

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -97,7 +97,7 @@ class TestDockerCMD:
             ["-v", "secret", "scan", "docker", "ggshield-non-existant"],
         )
         assert_invoke_exited_with(result, 1)
-        assert 'Error: Image "ggshield-non-existant" not found\n' in result.output
+        assert 'Image "ggshield-non-existant" not found\n' in result.output
 
     @patch("ggshield.scan.docker.get_files_from_docker_archive")
     @pytest.mark.parametrize(

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -6,6 +6,7 @@ import click
 import pytest
 
 from ggshield.cmd.main import cli
+from ggshield.core.config.errors import ExitCode
 from ggshield.scan import ScanCollection
 from ggshield.scan.docker import _validate_filepath
 from ggshield.scan.scannable import File, Files
@@ -96,7 +97,7 @@ class TestDockerCMD:
             cli,
             ["-v", "secret", "scan", "docker", "ggshield-non-existant"],
         )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert 'Image "ggshield-non-existant" not found\n' in result.output
 
     @patch("ggshield.scan.docker.get_files_from_docker_archive")

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -6,7 +6,7 @@ import click
 import pytest
 
 from ggshield.cmd.main import cli
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from ggshield.scan import ScanCollection
 from ggshield.scan.docker import _validate_filepath
 from ggshield.scan.scannable import File, Files

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -87,7 +87,7 @@ class TestDockerCMD:
     def test_docker_scan_failed_to_save(
         self, scan_mock: Mock, save_mock: Mock, cli_fs_runner: click.testing.CliRunner
     ):
-        save_mock.side_effect = click.exceptions.ClickException(
+        save_mock.side_effect = click.UsageError(
             'Image "ggshield-non-existant" not found'
         )
         scan_mock.return_value = ScanCollection(
@@ -131,7 +131,7 @@ class TestDockerCMD:
                     str(image_path),
                 ],
             )
-            assert_invoke_exited_with(result, 1)
+            assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
             get_files_mock.assert_called_once()
 
             if json_output:

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
+from ggshield.core.config.errors import ExitCode
 from tests.unit.conftest import (
     _ONE_LINE_AND_MULTILINE_PATCH,
     UNCHECKED_SECRET_PATCH,
@@ -43,7 +44,7 @@ class TestPathScan:
             result = cli_fs_runner.invoke(cli, ["-v", "secret", "scan", "path", "file"])
         else:
             result = cli_fs_runner.invoke(cli, ["secret", "scan", "path", "file"])
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == ExitCode.SUCCESS, result.output
         assert not result.exception
 
     @pytest.mark.parametrize("use_deprecated_syntax", [False, True])
@@ -282,7 +283,7 @@ class TestScanDirectory:
         result = cli_fs_runner.invoke(
             cli, ["secret", "scan", "path", "./", "-r", "-vy"]
         )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == ExitCode.SUCCESS, result.output
         assert not result.exception
         assert "file1\n" in result.output
         assert self.path_line("dir/file2") in result.output
@@ -308,7 +309,7 @@ class TestScanDirectory:
         result = cli_fs_runner.invoke(
             cli, ["secret", "scan", "-v", "path", "--recursive", "."]
         )
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == ExitCode.SUCCESS, result.output
         assert all(
             string in result.output
             for string in ["Do you want to continue", "not_committed"]
@@ -347,7 +348,7 @@ class TestScanDirectory:
                     "--exit-zero",
                 ],
             )
-            assert result.exit_code == 0, result.output
+            assert result.exit_code == ExitCode.SUCCESS, result.output
             if nb_secret:
                 plural = nb_secret > 1
                 assert (

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -65,7 +65,7 @@ class TestPathScan:
 
         with my_vcr.use_cassette("test_scan_file_secret"):
             result = cli_fs_runner.invoke(cli, cmd)
-            assert_invoke_exited_with(result, 1)
+            assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
             assert result.exception
             assert (
                 """>> Secret detected: GitGuardian Development Secret
@@ -86,7 +86,7 @@ class TestPathScan:
             result = cli_fs_runner.invoke(
                 cli, ["-v", "secret", "scan", "path", "file_secret"]
             )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
         assert result.exception
         assert (
             """>> Secret detected: GitGuardian Test Token Checked
@@ -109,7 +109,7 @@ class TestPathScan:
             result = cli_fs_runner.invoke(
                 cli, ["-v", "secret", "scan", "--json", "path", "file_secret"]
             )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
         assert result.exception
 
         if validity:

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import (
     _ONE_LINE_AND_MULTILINE_PATCH,
     UNCHECKED_SECRET_PATCH,

--- a/tests/unit/cmd/scan/test_prepush.py
+++ b/tests/unit/cmd/scan/test_prepush.py
@@ -5,6 +5,7 @@ import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
+from ggshield.core.errors import ExitCode
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE, IGNORED_DEFAULT_WILDCARDS
 from ggshield.scan import ScanContext, ScanMode
@@ -410,7 +411,7 @@ class TestPrepush:
         remote_sha = local_repo.get_top_sha()
         shas = [local_repo.create_commit() for _ in range(20)]
 
-        scan_commit_range_mock.return_value = 1
+        scan_commit_range_mock.return_value = ExitCode.SCAN_FOUND_PROBLEMS
 
         with cd(str(local_repo.path)):
             result = cli_fs_runner.invoke(
@@ -425,7 +426,7 @@ class TestPrepush:
                 ],
                 input=f"refs/heads/main {shas[-1]} refs/heads/main {remote_sha}",
             )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 20" in result.output
 

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Set
 from unittest.mock import Mock, patch
 
-import click
 import pytest
 
 from ggshield.cmd.secret.scan.pypi import (
@@ -13,6 +12,7 @@ from ggshield.cmd.secret.scan.pypi import (
     get_files_from_package,
     save_package_to_tmp,
 )
+from ggshield.core.errors import UnexpectedError
 
 
 class TestPipDownload:
@@ -43,7 +43,7 @@ class TestPipDownload:
             "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=None)
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                UnexpectedError,
                 match=f'Failed to download "{self.package_name}"',
             ):
                 save_package_to_tmp(
@@ -58,7 +58,7 @@ class TestPipDownload:
             ),
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                UnexpectedError,
                 match=(
                     f'Command "pip download {self.package_name} '
                     f'--dest {self.tmp_dir} --no-deps" timed out'

--- a/tests/unit/cmd/scan/test_repo.py
+++ b/tests/unit/cmd/scan/test_repo.py
@@ -1,4 +1,5 @@
 from ggshield.cmd.main import cli
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with
 
 
@@ -12,7 +13,7 @@ class TestScanRepo:
         result = cli_fs_runner.invoke(
             cli, ["scan", "repo", "https://github.com/gitguardian/ggshield"]
         )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
         assert (
             "Error: https://github.com/gitguardian/ggshield doesn't seem to "
             "be a valid git URL.\nDid you mean "
@@ -28,7 +29,7 @@ class TestScanRepo:
         result = cli_fs_runner.invoke(
             cli, ["scan", "repo", "trial.gitguardian.com/gitguardian/ggshield"]
         )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
         assert (
             "Error: trial.gitguardian.com/gitguardian/ggshield is"
             " neither a valid path nor a git URL" in result.output

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
+from ggshield.core.config.errors import ExitCode
 
 from .utils import prepare_config
 
@@ -70,7 +71,7 @@ class TestAuthConfigList:
 
         exit_code, output = self.run_cmd(cli_fs_runner)
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == EXPECTED_OUTPUT
 
     @staticmethod
@@ -101,7 +102,7 @@ class TestAuthConfigSet:
             == unchanged_value
         ), "The instance config should remain unchanged"
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == ""
 
     @pytest.mark.parametrize("value", [0, 365])
@@ -137,7 +138,7 @@ class TestAuthConfigSet:
             config.auth_config.default_token_lifetime == default_value
         ), "The default auth config should remain unchanged"
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == ""
 
     def test_set_invalid_field_name(self, cli_fs_runner):
@@ -151,7 +152,7 @@ class TestAuthConfigSet:
 
         exit_code, output = self.run_cmd(cli_fs_runner, 0, param="invalid_field_name")
 
-        assert exit_code == 2, output
+        assert exit_code == ExitCode.USAGE_ERROR, output
         expected_output = (
             "Usage: cli config set [OPTIONS] {default_token_lifetime} VALUE\n"
             "Try 'cli config set -h' for help.\n\n"
@@ -176,7 +177,7 @@ class TestAuthConfigSet:
 
         exit_code, output = self.run_cmd(cli_fs_runner, "wrong_value")
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
         assert output == "Error: default_token_lifetime must be an int\n"
 
         config = Config()
@@ -197,7 +198,7 @@ class TestAuthConfigSet:
 
         exit_code, output = self.run_cmd(cli_fs_runner, 0, instance_url=instance_url)
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.AUTHENTICATION_ERROR, output
         assert output == f"Error: Unknown instance: '{instance_url}'\n"
 
         config = Config()
@@ -250,7 +251,7 @@ class TestAuthConfigUnset:
             config.auth_config.default_token_lifetime == default_value
         ), "The default auth config should remain unchanged"
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == ""
 
     def test_unset_lifetime_default_config_value(self, cli_fs_runner):
@@ -271,7 +272,7 @@ class TestAuthConfigUnset:
             == unchanged_value
         ), "Unrelated instance config should remain unchanged"
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == ""
 
     def test_unset_lifetime_all(self, cli_fs_runner):
@@ -298,7 +299,7 @@ class TestAuthConfigUnset:
         ), output
         assert config.auth_config.default_token_lifetime is None, output
 
-        assert exit_code == 0, output
+        assert exit_code == ExitCode.SUCCESS, output
         assert output == ""
 
     def test_unset_lifetime_invalid_instance(self, cli_fs_runner):
@@ -314,7 +315,7 @@ class TestAuthConfigUnset:
 
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url=instance_url)
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.AUTHENTICATION_ERROR, output
         assert output == f"Error: Unknown instance: '{instance_url}'\n"
 
         config = Config()
@@ -370,7 +371,7 @@ class TestAuthConfigGet:
         exit_code, output = self.run_cmd(cli_fs_runner)
 
         assert output == f"default_token_lifetime: {expected_value}\n"
-        assert exit_code == 0
+        assert exit_code == ExitCode.SUCCESS
 
     @pytest.mark.parametrize(
         ["default_value", "instance_value", "expected_value"],
@@ -406,7 +407,7 @@ class TestAuthConfigGet:
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url=instance_url)
 
         assert output == f"default_token_lifetime: {expected_value}\n"
-        assert exit_code == 0
+        assert exit_code == ExitCode.SUCCESS
 
     def test_unset_lifetime_invalid_instance(self, cli_fs_runner):
         """
@@ -417,7 +418,7 @@ class TestAuthConfigGet:
         instance_url = "https://some-invalid-gg-instance.com"
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url=instance_url)
 
-        assert exit_code == 1, output
+        assert exit_code == ExitCode.AUTHENTICATION_ERROR, output
         assert output == f"Error: Unknown instance: '{instance_url}'\n"
 
     def test_set_invalid_field_name(self, cli_fs_runner):
@@ -427,7 +428,7 @@ class TestAuthConfigGet:
         THEN the command should exit with an error
         """
         exit_code, output = self.run_cmd(cli_fs_runner, param="invalid_field_name")
-        assert exit_code == 2, output
+        assert exit_code == ExitCode.USAGE_ERROR, output
         expected_output = (
             "Usage: cli config get [OPTIONS] {default_token_lifetime}\n"
             "Try 'cli config get -h' for help.\n\n"

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -177,8 +177,8 @@ class TestAuthConfigSet:
 
         exit_code, output = self.run_cmd(cli_fs_runner, "wrong_value")
 
-        assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS, output
-        assert output == "Error: default_token_lifetime must be an int\n"
+        assert exit_code == ExitCode.USAGE_ERROR, output
+        assert "Error: default_token_lifetime must be an int" in output
 
         config = Config()
         assert (

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -5,7 +5,7 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.core.config import Config
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 
 from .utils import prepare_config
 

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from ggshield.cmd.main import cli
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
@@ -39,7 +40,7 @@ class TestInstallLocal:
 
         result = cli_fs_runner.invoke(cli, ["install", "-m", "local"])
         os.system("rm -R .git/hooks/pre-commit")
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
         assert result.exception
         assert "Error: .git/hooks/pre-commit is a directory" in result.output
 
@@ -50,7 +51,7 @@ class TestInstallLocal:
         assert os.path.isfile(".git/hooks/pre-commit")
 
         result = cli_fs_runner.invoke(cli, ["install", "-m", "local"])
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert result.exception
         assert "Error: .git/hooks/pre-commit already exists." in result.output
 
@@ -115,7 +116,7 @@ class TestInstallLocal:
             "already exists. Use --force to override or --append to add to current script\n"
             in result.output
         )
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
 
     @pytest.mark.parametrize("hook_type", ["pre-push", "pre-commit"])
     @patch("ggshield.cmd.install.check_git_dir")
@@ -208,7 +209,7 @@ class TestInstallGlobal:
 
         result = cli_fs_runner.invoke(cli, ["install", "-m", "global"])
         os.system("rm -R global/hooks/pre-commit")
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
         assert result.exception
 
     def test_global_not_exist(self, cli_fs_runner, mockHookDirPath):
@@ -258,7 +259,7 @@ class TestInstallGlobal:
         assert os.path.isfile("global/hooks/pre-commit")
 
         result = cli_fs_runner.invoke(cli, ["install", "-m", "global"])
-        assert_invoke_exited_with(result, 1)
+        assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert result.exception
         assert "Error: global/hooks/pre-commit already exists." in result.output
 

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -8,9 +8,9 @@ from typing import Optional
 import pytest
 
 from ggshield.core.config import AccountConfig, Config, InstanceConfig
-from ggshield.core.config.errors import UnknownInstanceError
 from ggshield.core.config.utils import get_auth_config_filepath, load_yaml_dict
 from ggshield.core.constants import DEFAULT_LOCAL_CONFIG_PATH
+from ggshield.core.errors import UnknownInstanceError
 from ggshield.core.utils import dashboard_to_api_url
 from tests.unit.conftest import write_yaml
 from tests.unit.core.config.conftest import TEST_AUTH_CONFIG

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -1,5 +1,4 @@
 import pytest
-from click import ClickException
 
 from ggshield.core.config import Config
 from ggshield.core.config.user_config import (
@@ -7,7 +6,7 @@ from ggshield.core.config.user_config import (
     IaCConfig,
     UserConfig,
 )
-from ggshield.core.errors import ParseError
+from ggshield.core.errors import ParseError, UnexpectedError
 from ggshield.core.types import IgnoredMatch
 from tests.unit.conftest import write_text, write_yaml
 
@@ -91,7 +90,7 @@ class TestUserConfig:
         """
         write_yaml(local_config_path, {"version": CURRENT_CONFIG_VERSION + 1})
 
-        with pytest.raises(ClickException):
+        with pytest.raises(UnexpectedError):
             UserConfig.load(local_config_path)
 
     def test_save_load_roundtrip(self):

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -2,12 +2,12 @@ import pytest
 from click import ClickException
 
 from ggshield.core.config import Config
-from ggshield.core.config.errors import ParseError
 from ggshield.core.config.user_config import (
     CURRENT_CONFIG_VERSION,
     IaCConfig,
     UserConfig,
 )
+from ggshield.core.errors import ParseError
 from ggshield.core.types import IgnoredMatch
 from tests.unit.conftest import write_text, write_yaml
 

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from click import ClickException
+from click import UsageError
 
 from ggshield.core.git_shell import (
     GIT_PATH,
@@ -41,5 +41,5 @@ def test_check_git_dir(tmp_path):
     check_git_dir()
 
     with cd(str(tmp_path)):
-        with pytest.raises(ClickException):
+        with pytest.raises(UsageError):
             check_git_dir()

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -9,6 +9,7 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
+from ggshield.core.config.errors import UnknownInstanceError
 from ggshield.core.utils import (
     MatchIndices,
     api_to_dashboard_url,
@@ -162,7 +163,7 @@ def test_retrieve_client_unknown_custom_dashboard_url(isolated_fs):
     THEN the exception message mentions the instance name
     """
     with pytest.raises(
-        click.ClickException,
+        UnknownInstanceError,
         match="Unknown instance: 'https://example.com'",
     ):
         with patch.dict(os.environ, clear=True):

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -9,7 +9,7 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
-from ggshield.core.config.errors import UnknownInstanceError
+from ggshield.core.errors import UnknownInstanceError
 from ggshield.core.utils import (
     MatchIndices,
     api_to_dashboard_url,

--- a/tests/unit/output/test_iac_text_output.py
+++ b/tests/unit/output/test_iac_text_output.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from click.testing import CliRunner, Result
 
 from ggshield.cmd.main import cli
+from ggshield.core.errors import ExitCode
 from tests.unit.conftest import (
     _IAC_MULTIPLE_VULNERABILITIES,
     _IAC_NO_VULNERABILITIES,
@@ -126,7 +127,7 @@ def assert_file_single_vulnerability_displayed(result: Result):
         "GG_IAC_0001",
     }
     assert '2 | resource "aws_alb_listener" "bad_example" {' in result.stdout
-    assert_invoke_exited_with(result, 1)
+    assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
 
 
 def assert_file_multiple_vulnerabilities_displayed(result: Result):
@@ -137,4 +138,4 @@ def assert_file_multiple_vulnerabilities_displayed(result: Result):
     }
     assert '2 | resource "aws_security_group" "bad_example" {' in result.stdout
     assert '8 |  resource "aws_security_group_rule" "bad_example" {' in result.stdout
-    assert_invoke_exited_with(result, 1)
+    assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import click
 import pytest
 
+from ggshield.core.errors import UnexpectedError
 from ggshield.scan.docker import (
     InvalidDockerArchiveException,
     _get_config,
@@ -123,7 +124,7 @@ class TestDockerPull:
             "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=[])
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                click.UsageError,
                 match='Image "ggshield-non-existant" not found',
             ):
                 docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
@@ -134,7 +135,7 @@ class TestDockerPull:
             side_effect=subprocess.TimeoutExpired(cmd=[], timeout=DOCKER_TIMEOUT),
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                UnexpectedError,
                 match='docker pull ggshield-non-existant" timed out',
             ):
                 docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
@@ -169,7 +170,7 @@ class TestDockerSave:
             ),
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                click.UsageError,
                 match='Image "ggshield-non-existant" not found',
             ):
                 docker_save_to_tmp(
@@ -213,7 +214,7 @@ class TestDockerSave:
             ),
         ):
             with pytest.raises(
-                click.exceptions.ClickException,
+                UnexpectedError,
                 match="Unable to save docker archive:",
             ):
                 docker_save_to_tmp(
@@ -227,7 +228,7 @@ class TestDockerSave:
         ):
             expected_msg = f'Command "docker save ggshield-non-existant -o {str(self.TMP_ARCHIVE)}" timed out'  # noqa: E501
             with pytest.raises(
-                click.exceptions.ClickException,
+                UnexpectedError,
                 match=re.escape(expected_msg),
             ):
                 docker_save_to_tmp(

--- a/tests/unit/scan/test_scanner.py
+++ b/tests/unit/scan/test_scanner.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from ggshield.core.config.errors import ExitCode
+from ggshield.core.errors import ExitCode
 from ggshield.core.utils import Filemode
 from ggshield.scan import Commit, ScanContext, ScanMode, SecretScanner
 from tests.unit.conftest import (

--- a/tests/unit/scan/test_scanner.py
+++ b/tests/unit/scan/test_scanner.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import pytest
 
+from ggshield.core.config.errors import ExitCode
 from ggshield.core.utils import Filemode
 from ggshield.scan import Commit, ScanContext, ScanMode, SecretScanner
 from tests.unit.conftest import (
@@ -28,13 +29,15 @@ _EXPECT_NO_SECRET = {
         (
             "multiple_secrets",
             _MULTIPLE_SECRETS_PATCH,
-            ExpectedScan(exit_code=1, matches=4, first_match="", want=None),
+            ExpectedScan(
+                ExitCode.SCAN_FOUND_PROBLEMS, matches=4, first_match="", want=None
+            ),
         ),
         (
             "simple_secret",
             UNCHECKED_SECRET_PATCH,
             ExpectedScan(
-                exit_code=1,
+                ExitCode.SCAN_FOUND_PROBLEMS,
                 matches=1,
                 first_match=GG_TEST_TOKEN,
                 want=None,
@@ -43,7 +46,9 @@ _EXPECT_NO_SECRET = {
         (
             "one_line_and_multiline_patch",
             _ONE_LINE_AND_MULTILINE_PATCH,
-            ExpectedScan(exit_code=1, matches=1, first_match=None, want=None),
+            ExpectedScan(
+                ExitCode.SCAN_FOUND_PROBLEMS, matches=1, first_match=None, want=None
+            ),
         ),
         (
             "no_secret",


### PR DESCRIPTION
##  :book: Introduction
This PR aims at introducing a _refactored_ version of dealing with error codes and handling them. 

## :building_construction:  Main changes
- Introduce a new Enumerator (of type [IntEnum](https://docs.python.org/3/library/enum.html#enum.IntEnum) to define error codes
```python
class ErrorCodes(IntEnum):
    """
    Define constant error codes based on their type
    """

    SCAN_FAILED = 1
    UNEXPECTED_ERROR = 128
```

- Inject the new codes 

## :hourglass:   Future work
Maybe we should consider ending support for the feature(?) of returning 1 if secrets are found after a scan has been conducted (as described in this issue: https://github.com/GitGuardian/ggshield/issues/404). 
If this PR gets merged, confusion in the codebase will arise. On one hand, we will define **exit_code = 1** as a **SCAN_FAILED**, on the other hand, we refer to a successful scan, which yielded secrets, with an **exist_code = 1**. :thinking: 
