### PR TITLE
Fix crash if git is not available

### DIFF
--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -8,7 +8,7 @@ from click import UsageError
 
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.errors import UnexpectedError
-from ggshield.core.git_shell import check_git_dir, check_git_installed, git
+from ggshield.core.git_shell import check_git_dir, git
 
 
 @click.command(context_settings={"ignore_unknown_options": True})
@@ -43,7 +43,6 @@ def install_cmd(
 
 def install_global(hook_type: str, force: bool, append: bool) -> int:
     """Global pre-commit/pre-push hook installation."""
-    check_git_installed()
     hook_dir_path = get_global_hook_dir_path()
 
     if not hook_dir_path:

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -12,7 +12,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
-from ggshield.core.git_shell import GIT_PATH, shell
+from ggshield.core.git_shell import git
 from ggshield.core.utils import REGEX_GIT_URL
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.repo import scan_repo_path
@@ -56,7 +56,7 @@ def repo_cmd(
 
     if REGEX_GIT_URL.match(repository):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            shell([GIT_PATH, "clone", repository, tmpdirname])
+            git(["clone", repository, tmpdirname])
             return scan_repo_path(
                 client=client,
                 cache=cache,

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -44,9 +44,11 @@ GIT_PATH = get_git_path(os.getcwd())
 @lru_cache(None)
 def is_git_dir(wd: str) -> bool:
     check_git_installed()
-    cmd = [GIT_PATH, "-C", wd, "status"]
-    result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return result.returncode == 0
+    try:
+        git(["rev-parse", "--show-toplevel"], cwd=wd)
+    except subprocess.CalledProcessError:
+        return False
+    return True
 
 
 def check_git_dir(wd: Optional[str] = None) -> None:

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -8,8 +8,6 @@ from typing import List, Optional
 import click
 from click import UsageError
 
-from ggshield.core.errors import UnexpectedError
-
 
 COMMAND_TIMEOUT = 45
 
@@ -43,7 +41,6 @@ GIT_PATH = get_git_path(os.getcwd())
 
 @lru_cache(None)
 def is_git_dir(wd: str) -> bool:
-    check_git_installed()
     try:
         git(["rev-parse", "--show-toplevel"], cwd=wd)
     except subprocess.CalledProcessError:
@@ -61,16 +58,6 @@ def check_git_dir(wd: Optional[str] = None) -> None:
 
 def get_git_root(wd: Optional[str] = None) -> str:
     return git(["rev-parse", "--show-toplevel"], cwd=wd)
-
-
-@lru_cache(None)
-def check_git_installed() -> None:
-    """Check if git is installed."""
-    with subprocess.Popen(
-        [GIT_PATH, "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-    ) as process:
-        if process.wait():
-            raise UnexpectedError("Git is not installed.")
 
 
 def git(

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from functools import lru_cache
 from shutil import which
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import click
 from click import UsageError
@@ -100,10 +100,6 @@ def shell(
         raise click.Abort('Command "{}" timed out'.format(" ".join(command)))
 
 
-def shell_split(command: List[str], **kwargs: Any) -> List[str]:
-    return shell(command, **kwargs).split("\n")
-
-
 def git(command: List[str], timeout: int = COMMAND_TIMEOUT, check: bool = True) -> str:
     """Calls git with the given arguments, returns stdout as a string"""
     return shell([GIT_PATH] + command, timeout=timeout, check=check)
@@ -116,7 +112,7 @@ def git_ls(wd: Optional[str] = None) -> List[str]:
 
     cmd.extend(("ls-files", "--recurse-submodules"))
 
-    return shell_split(cmd, timeout=600)
+    return shell(cmd, timeout=600).split("\n")
 
 
 def is_valid_git_commit_ref(ref: str) -> bool:
@@ -151,7 +147,7 @@ def get_list_commit_SHA(
     cmd.append("--")
 
     try:
-        commit_list = shell_split(cmd, check=True)
+        commit_list = shell(cmd, check=True).split("\n")
     except subprocess.CalledProcessError as e:
         if b"bad revision" in e.stderr and "~1.." in commit_range:
             # We got asked to list commits for A~1...B. If A~1 does not exist, but A

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -8,7 +8,7 @@ import charset_normalizer
 from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.filter import is_filepath_excluded
-from ggshield.core.git_shell import GIT_PATH, shell
+from ggshield.core.git_shell import git
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.utils import REGEX_HEADER_INFO, Filemode
 
@@ -286,9 +286,9 @@ class Commit(Files):
                 "-m",  # split multi-parent (aka merge) commits into several one-parent commits
             ]
             if self.sha:
-                self._patch = shell([GIT_PATH, "show", self.sha] + common_args)
+                self._patch = git(["show", self.sha] + common_args)
             else:
-                self._patch = shell([GIT_PATH, "diff", "--cached"] + common_args)
+                self._patch = git(["diff", "--cached"] + common_args)
 
         return self._patch
 

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
 from ggshield.core.utils import EMPTY_SHA, Filemode
-from ggshield.scan import Result, Results, ScanCollection
+from ggshield.scan import Commit, Result, Results, ScanCollection
 from ggshield.scan.repo import cd
 from tests.repository import Repository
 from tests.unit.conftest import (
@@ -156,10 +156,12 @@ class TestPreReceive:
         )
 
     @patch("ggshield.cmd.secret.scan.prereceive.get_list_commit_SHA")
+    @patch("ggshield.scan.repo.get_commits_by_batch")
     @patch("ggshield.scan.repo.scan_commits_content")
     def test_stdin_supports_gitlab_web_ui(
         self,
         scan_commits_content_mock: Mock,
+        get_commits_by_batch_mock: Mock,
         get_list_mock: Mock,
         cli_fs_runner: CliRunner,
     ):
@@ -173,6 +175,7 @@ class TestPreReceive:
         old_sha = "56781234"
         new_sha = "1234abcd"
         get_list_mock.return_value = [new_sha]
+        get_commits_by_batch_mock.return_value = [[Commit(sha=new_sha)]]
         scan_commits_content_mock.return_value = ScanCollection(
             id="some_id",
             type="commit-ranges",

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -4,17 +4,16 @@ import pytest
 from click import UsageError
 
 from ggshield.core.git_shell import (
-    GIT_PATH,
     check_git_dir,
+    git,
     is_git_dir,
     is_valid_git_commit_ref,
-    shell,
 )
 from ggshield.scan.repo import cd
 
 
 def test_git_shell():
-    assert "usage: git" in shell([GIT_PATH, "help"])
+    assert "usage: git" in git(["help"])
 
 
 def test_is_git_dir(tmp_path):

--- a/tests/unit/scan/test_scan_repo.py
+++ b/tests/unit/scan/test_scan_repo.py
@@ -7,6 +7,7 @@ import pytest
 from ggshield.core.utils import Filemode
 from ggshield.scan import Commit, File, Result, Results
 from ggshield.scan.repo import get_commits_by_batch, scan_commits_content
+from ggshield.scan.scannable import CommitInformation
 from tests.unit.conftest import TWO_POLICY_BREAKS
 
 
@@ -77,11 +78,14 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
     WHEN scan_commits_content returns 2 policy break for each commit
     THEN the total number of policy breaks is 4
     """
+    commit_info = CommitInformation("unknown", "", "")
     commit_1 = Commit(sha="some_sha_1")
     commit_1._files = [File(document="document", filename="filename")]
+    commit_1._info = commit_info
 
     commit_2 = Commit(sha="some_sha_2")
     commit_2._files = [File(document="document", filename="filename")]
+    commit_2._info = commit_info
 
     secret_scanner_mock.return_value.scan.return_value = Results(
         results=[


### PR DESCRIPTION
## Description

This PR fixes the crash which happens when running on a machine where git is not installed.

Before:

```
$ ggshield --help
Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/src-NVTF7jWz/bin/ggshield", line 5, in <module>
    from ggshield.cmd.main import main
  File "/src/ggshield/cmd/main.py", line 10, in <module>
    from ggshield.cmd.auth import auth_group
  File "/src/ggshield/cmd/auth/__init__.py", line 5, in <module>
    from ggshield.cmd.common_options import add_common_options
  File "/src/ggshield/cmd/common_options.py", line 18, in <module>
    from ggshield.core.config.user_config import UserConfig
  File "/src/ggshield/core/config/__init__.py", line 1, in <module>
    from .auth_config import AccountConfig, InstanceConfig
  File "/src/ggshield/core/config/auth_config.py", line 20, in <module>
    from ggshield.core.utils import datetime_from_isoformat
  File "/src/ggshield/core/utils.py", line 16, in <module>
    from .git_shell import get_git_root, is_git_dir
  File "/src/ggshield/core/git_shell.py", line 41, in <module>
    GIT_PATH = get_git_path(os.getcwd())
  File "/src/ggshield/core/git_shell.py", line 24, in get_git_path
    raise Exception("unable to find git executable in PATH/PATHEXT")
Exception: unable to find git executable in PATH/PATHEXT
```

After:

```
$ ggshield --help
Usage: ggshield [OPTIONS] COMMAND [ARGS]...

Options:
  -c, --config-path FILE          Set a custom config file. Ignores local and
                                  global config files.
  --check-for-updates / --no-check-for-updates
                                  Check for ggshield updates.
  --allow-self-signed             Ignore ssl verification.
  --debug                         Show debug information.
  -v, --verbose                   Verbose display mode.
  --version                       Show the version and exit.
  -h, --help                      Show this message and exit.

Commands:
  api-status  Show API status.
  auth        Commands to manage authentication.
  config      Commands to manage configuration.
  iac         Commands to work with infrastructure as code.
  install     Install a pre-commit or pre-push git hook (local or global).
  quota       Show quotas overview.
  secret      Commands to work with secrets.
```

Scanning files work:

```
$ ggshield secret scan path setup.py
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1 files scanned out of 1 0:00:00
```

When trying to run a command which requires git:

```
$ ggshield secret scan commit-range HEAD~2..
unable to find git executable in PATH/PATHEXT

$ apt install git
[...]

$ ggshield secret scan commit-range HEAD~2..
Scanning Commits... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2 commits scanned out of 2 0:00:00
```

## Issue

Fixes #329.