### PR TITLE
Add a repository with secrets to the performance bench

### DIFF
--- a/scripts/perfbench/run_cmd.py
+++ b/scripts/perfbench/run_cmd.py
@@ -23,7 +23,7 @@ DEFAULT_GGSHIELD_VERSIONS = ["prod", "current"]
 
 BENCHMARK_COMMANDS = [
     ("secret", "scan", "--exit-zero", "path", "-ry", "."),
-    ("secret", "scan", "--exit-zero", "commit-range", "HEAD~50.."),
+    ("secret", "scan", "--exit-zero", "commit-range", "HEAD~9.."),
     ("iac", "scan", "--exit-zero", "."),
 ]
 

--- a/scripts/perfbench/setup_cmd.py
+++ b/scripts/perfbench/setup_cmd.py
@@ -10,6 +10,7 @@ BENCHMARK_REPOSITORIES = [
     ("https://github.com/python-pillow/Pillow", "9.3.0"),
     ("https://github.com/docker/compose", "v2.12.2"),
     ("https://github.com/sqlite/sqlite", "version-3.39.4"),
+    ("https://github.com/ZGuardian/leaky-repo", "1.1.2"),
 ]
 
 


### PR DESCRIPTION
To provide a more interesting benchmark, add a weird repositories with lots of secrets to our list.

Reduce the number of commits scanned, because the added repository does not have enough commits.