### PR TITLE
feat: Introduce new headers (OS, Python) version

### DIFF
--- a/ggshield/scan/scan_context.py
+++ b/ggshield/scan/scan_context.py
@@ -1,10 +1,54 @@
+import logging
+import platform
+import sys
 import uuid
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
 
 from ggshield import __version__
 
 from .scan_mode import ScanMode
+
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(None)
+def get_os_info() -> Tuple[str, str]:
+    if sys.platform.lower() == "linux":
+        return parse_os_release(Path("/etc/os-release"))
+    else:
+        return platform.system().lower(), platform.version()
+
+
+def parse_os_release(os_release_path: Path) -> Tuple[str, str]:
+    """
+    Extract and return Linux's OS-name and OS-Version
+    If extraction fails, we return ('linux', 'unknown')
+    """
+    error_tuple = "linux", "unknown"
+
+    try:
+        with open(os_release_path) as f:
+            lines = f.readlines()
+
+        # Build a dictionary from the os-release file contents
+        data_dict = {}
+        for line in lines:
+            if "=" in line:
+                key, value = line.split("=")
+                key, value = key.strip(), value.strip()
+                data_dict[key] = value.strip('"')
+
+        if "ID" not in data_dict:
+            return error_tuple
+
+        return data_dict["ID"], data_dict.get("VERSION_ID", "unknown")
+    except Exception as exc:
+        logger.warning(f"Failed to read Linux OS name and version: {exc}")
+        return error_tuple
 
 
 @dataclass
@@ -15,6 +59,8 @@ class ScanContext:
 
     def __post_init__(self) -> None:
         self.command_id = str(uuid.uuid4())
+        self.os_name, self.os_version = get_os_info()
+        self.python_version = platform.python_version()
 
     def get_http_headers(self) -> Dict[str, str]:
         """
@@ -26,8 +72,10 @@ class ScanContext:
             "Version": __version__,
             "Command-Path": self.command_path,
             "Command-Id": self.command_id,
+            "OS-Name": self.os_name,
+            "OS-Version": self.os_version,
+            "Python-Version": self.python_version,
         }
-
         if self.extra_headers:
             headers = {**headers, **self.extra_headers}
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -615,6 +615,10 @@ def isolated_fs(fs):
     # add cassettes dir
     cassettes_dir = join(dirname(realpath(__file__)), "cassettes")
     fs.add_real_directory(cassettes_dir)
+    # Add a fake OS-release file. It describes a linux OS
+    mock_contents = """ID="ubuntu"\nVERSION_ID="22.04"\n"""
+    f = fs.create_file("/etc/os-release")
+    f.set_contents(mock_contents)
 
 
 def write_text(filename: str, content: str):

--- a/tests/unit/scan/test_scan.py
+++ b/tests/unit/scan/test_scan.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from unittest.mock import ANY, Mock, patch
 
 from click import Command, Context, Group
@@ -7,6 +8,7 @@ from ggshield import __version__
 from ggshield.core.cache import Cache
 from ggshield.scan import Commit, ScanContext, ScanMode, SecretScanner
 from ggshield.scan.repo import cd
+from ggshield.scan.scan_context import get_os_info
 from tests.unit.conftest import UNCHECKED_SECRET_PATCH
 
 
@@ -24,6 +26,7 @@ def test_request_headers(scan_mock: Mock, client):
     c._patch = UNCHECKED_SECRET_PATCH
 
     with Context(Command("bar"), info_name="bar") as ctx:
+        os_name, os_version = get_os_info()
         ctx.parent = Context(Group("foo"), info_name="foo")
         scanner = SecretScanner(
             client=client,
@@ -40,6 +43,9 @@ def test_request_headers(scan_mock: Mock, client):
             "GGShield-Version": __version__,
             "GGShield-Command-Path": "foo bar",
             "GGShield-Command-Id": ANY,
+            "GGShield-OS-Name": os_name,
+            "GGShield-OS-Version": os_version,
+            "GGShield-Python-Version": platform.python_version(),
             "mode": "path",
         },
         ignore_known_secrets=None,


### PR DESCRIPTION
### Introduction
This MR introduces 3 new HTTP headers to the requests we submit to GG's API.

### Details
The headers include:
- `OS-Name` header: A header that contains the OS on which ggshield is running
- `OS-Version`: The version of said OS
- `Python-Version`: The python version used to run ggshield

### Output
The previously mentioned changes result in the reception of the following extra logs:
```
ggshield_os_name=ubuntu 
ggshield_os_version=22.04 
ggshield_python_version=3.10.6
``` 

### Questions
I wonder whether these metadata are okay or if we should trim them. 
For instance, instead of submitting a full verbose Python version, we may probably just send the first part (e.g., `3.10.6 `).
> I would advise against trimming the OS version though because we'll probably fail to match the **version** only (e.g., `#59-Ubuntu`) given that every OS may yield a different output.

