### PR TITLE
pre-receive: do not scan commits overwritten by push --force

### DIFF
--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -172,15 +172,7 @@ def prereceive_cmd(
         f"{before}...{after}", max_count=config.max_commits_for_hook + 1
     )
 
-    if not commit_list:
-        click.echo(
-            "Unable to get commit range.\n"
-            f"  before: {before}\n"
-            f"  after: {after}\n"
-            "Skipping pre-receive hook\n",
-            err=True,
-        )
-        return 0
+    assert commit_list, "Commit list should not be empty at this point"
 
     if len(commit_list) > config.max_commits_for_hook:
         click.echo(

--- a/tests/functional/secret/test_scan_commit_range.py
+++ b/tests/functional/secret/test_scan_commit_range.py
@@ -10,7 +10,7 @@ def test_scan_commit_range(tmp_path: Path) -> None:
     test_file = repo.path / "test"
     for n in range(10):
         test_file.write_text(f"Hello {n}")
-        repo.git("add", test_file)
+        repo.add(test_file)
         repo.create_commit(message=f"Hello {n}")
 
     run_ggshield_scan("commit-range", "HEAD~4...", expected_code=0, cwd=repo.path)
@@ -25,7 +25,7 @@ def test_scan_commit_range_finds_old_leak(tmp_path: Path) -> None:
     secret_file = repo.path / "secret.conf"
     secret_content = f"password = {GG_VALID_TOKEN}"
     secret_file.write_text(secret_content)
-    repo.git("add", "secret.conf")
+    repo.add("secret.conf")
 
     # AND some clean commits on top of it
     for _ in range(3):

--- a/tests/functional/secret/test_scan_precommit.py
+++ b/tests/functional/secret/test_scan_precommit.py
@@ -22,7 +22,7 @@ def test_scan_precommit(tmp_path: Path) -> None:
 
     # WHEN I try to commit a secret
     # THEN the hook prevents the commit
-    repo.git("add", "secret.conf")
+    repo.add("secret.conf")
     with pytest.raises(CalledProcessError) as exc:
         repo.create_commit()
 

--- a/tests/functional/secret/test_scan_prepush.py
+++ b/tests/functional/secret/test_scan_prepush.py
@@ -22,13 +22,13 @@ def test_scan_prepush(tmp_path: Path) -> None:
     secret_file = local_repo.path / "secret.conf"
     secret_content = f"password = {GG_VALID_TOKEN}"
     secret_file.write_text(secret_content)
-    local_repo.git("add", "secret.conf")
+    local_repo.add("secret.conf")
     local_repo.create_commit()
 
     # WHEN I try to push
     # THEN the hook prevents the push
     with pytest.raises(CalledProcessError) as exc:
-        local_repo.git("push")
+        local_repo.push()
 
     # AND the error message contains the leaked secret
     stdout = exc.value.stdout.decode()
@@ -45,7 +45,7 @@ def test_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:
     # Add a commit to the remote repository, otherwise git complains the branch does not
     # contain anything
     local_repo.create_commit()
-    local_repo.git("push")
+    local_repo.push()
 
     # AND ggshield installed as a pre-push hook
     run_ggshield("install", "-m", "local", "-t", "pre-push", cwd=local_repo.path)
@@ -56,4 +56,4 @@ def test_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:
 
     # WHEN I try to push the branch
     # THEN the hook does not crash
-    local_repo.git("push", "-u", "origin", branch_name)
+    local_repo.push("-u", "origin", branch_name)

--- a/tests/functional/secret/test_scan_prereceive.py
+++ b/tests/functional/secret/test_scan_prereceive.py
@@ -30,13 +30,13 @@ def test_scan_prereceive(tmp_path: Path) -> None:
     secret_file = local_repo.path / "secret.conf"
     secret_content = f"password = {GG_VALID_TOKEN}"
     secret_file.write_text(secret_content)
-    local_repo.git("add", "secret.conf")
+    local_repo.add("secret.conf")
     local_repo.create_commit()
 
     # WHEN I try to push
     # THEN the hook prevents the push
     with pytest.raises(CalledProcessError) as exc:
-        local_repo.git("push")
+        local_repo.push()
 
     # AND the error message contains the leaked secret
     stderr = exc.value.stderr.decode()
@@ -53,7 +53,7 @@ def test_scan_prereceive_branch_without_new_commits(tmp_path: Path) -> None:
     # Add a commit to the remote repository, otherwise git complains the branch does not
     # contain anything
     local_repo.create_commit()
-    local_repo.git("push")
+    local_repo.push()
 
     # AND ggshield installed as a pre-receive hook
     hook_path = remote_repo.path / "hooks" / "pre-receive"
@@ -66,4 +66,4 @@ def test_scan_prereceive_branch_without_new_commits(tmp_path: Path) -> None:
 
     # WHEN I try to push the branch
     # THEN the hook does not crash
-    local_repo.git("push", "-u", "origin", branch_name)
+    local_repo.push("-u", "origin", branch_name)

--- a/tests/functional/secret/test_scan_repo.py
+++ b/tests/functional/secret/test_scan_repo.py
@@ -13,7 +13,7 @@ def test_scan_repo(tmp_path: Path) -> None:
     secret_file = repo.path / "secret.conf"
     leak_content = f"password = {GG_VALID_TOKEN}"
     secret_file.write_text(leak_content)
-    repo.git("add", "secret.conf")
+    repo.add("secret.conf")
 
     # AND some clean commits on top of it
     for _ in range(3):

--- a/tests/repository.py
+++ b/tests/repository.py
@@ -40,6 +40,12 @@ class Repository:
         git(["clone", str(url), str(path)])
         return cls(path, remote_url=str(url))
 
+    def add(self, *args: Union[str, Path]):
+        self.git("add", *args)
+
+    def push(self, *args: str) -> None:
+        self.git("push", *args)
+
     def create_commit(self, message: str = "Test commit") -> str:
         self._ensure_credentials_are_set()
         self.git("commit", "--allow-empty", "-m", message)


### PR DESCRIPTION
## Description

When a branch is force-pushed, the pre-receive hook currently rescans the overwritten commits. This waste time and can report issues on code which is going away since it is being overwritten.

The pre-receive hook currently scans the commit range it receives via stdin (see [pre-receive hook doc][doc]), unless the code is pushing a new branch (because in this case the range start ref is the all-zeroes sha).

This PR fixes the bug by ignoring the range start ref received via stdin and always determining the start of the pushed code using the code currently used for the "new branch" case.

[doc]: https://git-scm.com/docs/githooks#pre-receive

## What has been done

- Some improvements to our `Repository` helper class: it learned how to `add()` and `push()`.
- Rewrote the pre-receive tests to use real repositories instead of mocking all git calls. This was required by the fix breaking most pre-receive tests, because the tests were too reliant on which git commands were run.
- Removed some no-longer-useful tests.
- Actually implement the fix.

## Issue

Fixes #437
