### PR TITLE
chore: fix typos in messages

### DIFF
--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -5,6 +5,7 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
+from ggshield.core.text_utils import pluralize
 
 
 @click.command()
@@ -47,9 +48,10 @@ def ignore_cmd_impl(ctx: click.Context, last_found: bool) -> None:
         config = ctx.obj["config"]
         cache = ctx.obj["cache"]
         nb = ignore_last_found(config, cache)
+        path = config.config_path
+        secrets_word = pluralize("secret", nb)
         click.echo(
-            f"{nb} secrets have been added to your ignore list in"
-            " .gitguardian.yaml under matches-ignore section."
+            f"Added {nb} {secrets_word} to the `secret.ignored-matches` section of {path}."
         )
 
 

--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -38,8 +38,7 @@ class Cache:
                     _cache = json.load(f)
                 except Exception as e:
                     raise UnexpectedError(
-                        "Parsing error while"
-                        f"reading {self.cache_filename}:\n{str(e)}"
+                        f"Parsing error while reading {self.cache_filename}:\n{str(e)}"
                     )
         self.update_cache(**_cache)
         return True

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -63,6 +63,10 @@ class Config:
         self.auth_config.save()
 
     @property
+    def config_path(self) -> str:
+        return self._config_path
+
+    @property
     def instance_name(self) -> str:
         """
         The instance name (defaulting to URL) of the selected instance


### PR DESCRIPTION
This is a simple PR to fix typos which have been annoying me for a while :)

- Cache: fix error message ("Parsing error whilereading")
- `ignore_cmd_impl()`:
    - fix outdated field name
    - fix pluralization
    - fix hard-coded configuration path
    - simplify wording