### PR TITLE
Handle GitHub Rate Limits During Update Checks

### DIFF
--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -63,6 +63,11 @@ def check_for_updates() -> Optional[str]:
     try:
         resp = requests.get(
             "https://api.github.com/repos/GitGuardian/GGShield/releases/latest",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": f"GGShield {__version__}",
+                "X-Github-Api-Version": "2022-11-28",
+            },
             timeout=CHECK_TIMEOUT,
         )
     except Exception as e:

--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -75,6 +75,25 @@ def check_for_updates() -> Optional[str]:
         return None
 
     if resp.status_code != 200:
+        # Handle GitHub rate limit responses gracefully
+        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting
+        if int(resp.headers.get("X-RateLimit-Remaining", -1)) == 0:
+            logger.debug("GitHub rate limit exceeded - rescheduling update check")
+
+            # Reset the next update check based on when the GH API quota resets
+            check_at = int(resp.headers.get("X-RateLimit-Reset", -1.0)) - 24 * 60 * 60
+            if check_at < 0:
+                # Somehow we've hit the rate limit and the reset header is missing
+                # This can only happen if GH changes their responses
+                logger.error("Failed rescheduling update check")
+
+            try:
+                save_yaml_dict({"check_at": check_at}, CACHE_FILE)
+            except Exception as e:
+                logger.error("Could not save time of version check to cache: %s", e)
+
+            return None
+
         logger.error("Failed to check: %s", resp.text)
         return None
 

--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -81,7 +81,7 @@ def check_for_updates() -> Optional[str]:
             logger.debug("GitHub rate limit exceeded - rescheduling update check")
 
             # Reset the next update check based on when the GH API quota resets
-            check_at = int(resp.headers.get("X-RateLimit-Reset", -1.0)) - 24 * 60 * 60
+            check_at = int(resp.headers.get("X-RateLimit-Reset", -1)) - 24 * 60 * 60
             if check_at < 0:
                 # Somehow we've hit the rate limit and the reset header is missing
                 # This can only happen if GH changes their responses

--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -86,6 +86,7 @@ def check_for_updates() -> Optional[str]:
                 # Somehow we've hit the rate limit and the reset header is missing
                 # This can only happen if GH changes their responses
                 logger.error("Failed rescheduling update check")
+                return None
 
             try:
                 save_yaml_dict({"check_at": check_at}, CACHE_FILE)


### PR DESCRIPTION
GGShield checks for updates by connecting to GitHub anonymously.  The anonymous API quota is relatively small.  For organizations where hundreds of users all connect via a common egress IP, this can result in significant error messages (collectively across users) / confusion during GGShield operations.  For example:

```
% git commit -m 'My Awesome Commit' awesome.py
Failed to check: {"message":"API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

This PR address this issue by checking for quota exceeded condition and rescheduling the update check for after the quota has been reset.

Additionally, it adds headers to the update check request that are recommended by GitHub:

User Agent: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required
GH API Version: https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28
Media type (accept): https://docs.github.com/en/rest/overview/media-types?apiVersion=2022-11-28
