### PR TITLE
fix(output): #448 Re-introduce the "all clear" message when applicable

### DIFF
--- a/ggshield/output/text/message.py
+++ b/ggshield/output/text/message.py
@@ -238,6 +238,20 @@ def policy_break_header(
 """
 
 
+def no_leak_message() -> str:
+    """
+    Build a message if no secret is found.
+    """
+    return format_text("\nNo secrets have been found\n", STYLE["no_secret"])
+
+
+def no_new_leak_message() -> str:
+    """
+    Build a message if no new secret is found.
+    """
+    return format_text("\nNo new secrets have been found\n", STYLE["no_secret"])
+
+
 def iac_vulnerability_header(issue_n: int, vulnerability: IaCVulnerability) -> str:
     """
     Build a header for the iac policy break.

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -46,6 +46,7 @@ class TestPathScan:
             result = cli_fs_runner.invoke(cli, ["secret", "scan", "path", "file"])
         assert result.exit_code == ExitCode.SUCCESS, result.output
         assert not result.exception
+        assert "No secrets have been found" in result.output
 
     @pytest.mark.parametrize("use_deprecated_syntax", [False, True])
     def test_scan_file_secret(self, cli_fs_runner, use_deprecated_syntax):
@@ -173,6 +174,7 @@ class TestPathScan:
         assert not result.exception
         assert "file1\n" in result.output
         assert "file2\n" in result.output
+        assert "No secrets have been found" in result.output
 
     def test_files_verbose_abort(self, cli_fs_runner):
         self.create_files()
@@ -192,6 +194,7 @@ class TestPathScan:
         assert not result.exception
         assert "file1\n" in result.output
         assert "file2\n" in result.output
+        assert "No secrets have been found" in result.output
 
 
 class TestScanDirectory:
@@ -243,6 +246,7 @@ class TestScanDirectory:
         assert "file1\n" in result.output
         assert self.path_line("dir/file2") in result.output
         assert self.path_line("dir/subdir/file3") in result.output
+        assert "No secrets have been found" in result.output
 
     def test_directory_verbose_abort(self, cli_fs_runner):
         self.create_files()
@@ -288,6 +292,7 @@ class TestScanDirectory:
         assert "file1\n" in result.output
         assert self.path_line("dir/file2") in result.output
         assert self.path_line("dir/subdir/file3") in result.output
+        assert "No secrets have been found" in result.output
 
     def test_scan_path_should_detect_non_git_files(self, cli_fs_runner):
         """
@@ -354,3 +359,5 @@ class TestScanDirectory:
                 assert (
                     f": {nb_secret} incident{'s' if plural else ''} "
                 ) in result.output
+            else:
+                assert "No secrets have been found" in result.output


### PR DESCRIPTION
## Context
This previous [commit](https://github.com/GitGuardian/ggshield/commit/5eda13805490f899491b9b0cf7ff7fbb6be05945) removed the "No secrets have been found" message.  

## The issue
1. We re-introduce this message with a variation when ignore-known-secrets is used. 
2. We adapt the tests
3. We refactor the existing test `test_ignore_known_secrets`. Most of the logic is in the `assert_...` functions, it should be easier to read : refer to our internal documentation for the different cases.  

closes #448 