### PR TITLE
FIX: GGshield should not install its tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,13 @@ jobs:
         run: |
           echo "GGTEST_DOCKER_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022" >> $GITHUB_ENV
 
+      - name: Ensure a clean package installation
+        run: |
+          pip install wheel check-wheel-contents
+          python setup.py clean --all bdist_wheel
+          # The created wheel (.whl) file will be found and analyzed within the `dist/` folder
+          check-wheel-contents dist/
+
       - name: Run unit tests
         run: |
           coverage run --source ggshield -m pytest --disable-pytest-warnings --disable-socket tests/unit

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version() -> str:
 setup(
     name="ggshield",
     version=get_version(),
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     description="Detect secrets from all sources using GitGuardian's brains",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Related issue
https://github.com/GitGuardian/ggshield/issues/383

### About this MR
This MR introduces two small changes:
- Now; ggshield does not install its tests folders and subfolders
- We have a new CI step that ensures such behavior (installing non-desired chunks of ggshield) does not occur again.
