### PR TITLE
Remove SSH server keys from our Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,14 @@ ENV PATH /app/.venv/bin:$PATH
 
 WORKDIR /app
 
-# Install your required build dependencies here
-RUN set -e ; \
-    apt-get update ; \
-    apt-get dist-upgrade -y --no-install-recommends ; \
-    apt-get install -y --no-install-recommends git openssh-client ; \
-    apt-get autoremove -y ; \
-    apt-get clean ; \
-    pip3 install pipenv --upgrade ; \
-    rm -rf /var/lib/apt/lists/*
+RUN \
+    apt-get update \
+    && apt-get dist-upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends git openssh-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install pipenv --upgrade
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 RUN set -e ; \
     apt-get update ; \
     apt-get dist-upgrade -y --no-install-recommends ; \
-    apt-get install -y --no-install-recommends git ssh ; \
+    apt-get install -y --no-install-recommends git openssh-client ; \
     apt-get autoremove -y ; \
     apt-get clean ; \
     pip3 install pipenv --upgrade ; \


### PR DESCRIPTION
## The problem

Our Docker image contains SSH server keys. These keys are generated when openssh server is installed. These keys are in /etc/ssh:

```
$ docker run --rm gitguardian/ggshield:latest ls /etc/ssh/
moduli
ssh_config
ssh_config.d
ssh_host_ecdsa_key
ssh_host_ecdsa_key.pub
ssh_host_ed25519_key
ssh_host_ed25519_key.pub
ssh_host_rsa_key
ssh_host_rsa_key.pub
sshd_config
sshd_config.d
```

`ggshield` Docker image does not need an SSH server though, it only needs an SSH *client*, to be able to clone git repositories over SSH.

## What has been done

This PR changes the Dockerfile to only install the SSH client, so now we have:

```
$ docker run --rm gitguardian/ggshield:tst ls /etc/ssh/ 
ssh_config
ssh_config.d
```

While I was at it, I simplified the package installation part of the Dockerfile a bit, in a separate commit.