### PR TITLE
Make the `ggshield scan` deprecation message more alarming

### DIFF
--- a/ggshield/cmd/scan/__init__.py
+++ b/ggshield/cmd/scan/__init__.py
@@ -17,7 +17,7 @@ from ggshield.cmd.secret.scan import (
     repo_cmd,
     scan_group_impl,
 )
-from ggshield.core.text_utils import display_warning
+from ggshield.core.text_utils import display_error
 
 
 @click.group(
@@ -60,7 +60,9 @@ def deprecated_scan_group(
     """
     Deprecated: use `ggshield secret scan (...)` instead.
     """
-    display_warning(
-        "Warning: Using `ggshield scan (...)` is deprecated. Use `ggshield secret scan (...)` instead.",
+    # We use `display_error` to print this warning message in red color
+    display_error(
+        "Warning: The `ggshield scan (...)` commands are deprecated and will be removed in version 1.15.0. "
+        "Use `ggshield secret scan (...)` instead."
     )
     return scan_group_impl(ctx)


### PR DESCRIPTION
# Introduction
Currently, we show a warning message when the deprecated command `ggshield scan` is used. The message we show is in yellow.
We would like to print it in red and inform the user that this command will be completely removed starting from version 1.15.0

# Method
We introduced a new boolean argument to the `display_warning` function called `critical`, which is set to False by default. If `¢ritical` is True, we show the message in red, and yellow otherwise.
### Why not create a new style?
We use the `error` style to display the message in red. We did not create another style `critical_warning` because we'll be duplicating the same style properties (red color) as the `error` style.

