### PR TITLE
feat(test_path): #168 unskip failing tests on Windows

### DIFF
--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -3,6 +3,7 @@ import math
 import operator
 import re
 from collections import OrderedDict
+from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Set
 
 from click import UsageError
@@ -172,7 +173,7 @@ def init_exclusion_regexes(paths_ignore: Iterable[str]) -> Set[re.Pattern]:
 
 
 def is_filepath_excluded(filepath: str, exclusion_regexes: Set[re.Pattern]) -> bool:
-    return any(r.search(filepath) for r in exclusion_regexes)
+    return any(r.search(str(PurePosixPath(Path(filepath)))) for r in exclusion_regexes)
 
 
 def censor_match(match: Match) -> str:


### PR DESCRIPTION
The --exclude option was not working as expected on Windows because of failing regexes when excluding filepaths.  
We use `pathlib.PurePosixPath` to convert Windows path to posix path and apply regex on them.  

We also add an extra test to test the exclusion of a whole directory from the scan.