### PR TITLE
Improve error management to better catch some git errors

### DIFF
--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -82,6 +82,17 @@ def git(
             cwd=cwd,
         )
         return result.stdout.decode("utf-8", errors="ignore").rstrip()
+    except subprocess.CalledProcessError as e:
+        if "detected dubious ownership in repository" in e.stderr.decode(
+            "utf-8", errors="ignore"
+        ):
+            raise UnexpectedError(
+                "Git command failed because of a dubious ownership in repository.\n"
+                "If you still want to run ggshield, make sure you mark "
+                "the current repository as safe for git with:\n"
+                "   git config --global --add safe.repository <YOUR_REPO>"
+            )
+        raise e
     except subprocess.TimeoutExpired:
         raise click.Abort('Command "{}" timed out'.format(" ".join(command)))
 


### PR DESCRIPTION
### Summary  

Git recently patched a CVE that causes some commands to fail if a repository is not owned by the command executor. In this PR we raise a more explicit error in such cases.

### Validation  

Steps to validate :  
- Run a Docker image with the correct requirements to install ggshield
- Mount a volume containing : gghsield repo checked out on this branch, another git repository
- Open a shell in the container
- Install ggshield
- Run a `ggshield secret scan repo <PATH_TO_OTHER_REPO>`

You should get the following error message :
```
(ggshield) app@4ee33c28fd3e:/data/ggshield$ ggshield secret scan repo ../MY_REPO/

ERROR: Git command failed because of a dubious ownership in repository.
If you still want to run ggshield, make sure you mark the current repository as safe for git.
`git config --global --add safe.repository=<YOUR_REPO>`.

Re-run the command with --verbose to get a stack trace.
```

On the other hand, if you create a git repository inside the Docker image and scan it with a `ggshield secret scan repo`, no error message is displayed since the origin of the git repo is not "dubious" anymore.