### PR TITLE
Unbreak `secret scan pypi` functional tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -8,7 +8,7 @@ from tests.functional.utils import run_ggshield_scan
 @pytest.mark.parametrize(
     "package, expected_code",
     (
-        ("ggshield", 1),  # ggshield contains some test secrets
+        ("ggshield==1.14.2", 1),  # ggshield 1.14.2 contains some test secrets
         ("marshmallow", 0),
     ),
 )


### PR DESCRIPTION
The release of 1.14.3 broke the `secret scan pypi` test. Thanks to #383, the ggshield pypi package no longer contains its tests, so it no longer contains test secrets. Pin the tested version to fix that.

While doing this, isort pre-commit decided to fail, because of https://github.com/PyCQA/isort/issues/2077, so fix that too.
