### PR TITLE
feat(auth): Only execute scans when a valid API key exists.

### DIFF
--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -48,9 +48,6 @@ def archive_cmd(
         )
 
         with create_progress_bar(doc_type="files") as progress:
-            task_scan = progress.add_task(
-                "[green]Scanning Archive...", total=len(files.files)
-            )
 
             scan_context = ScanContext(
                 scan_mode=ScanMode.ARCHIVE,
@@ -64,6 +61,9 @@ def archive_cmd(
                 ignored_matches=config.secret.ignored_matches,
                 ignored_detectors=config.secret.ignored_detectors,
                 ignore_known_secrets=config.ignore_known_secrets,
+            )
+            task_scan = progress.add_task(
+                "[green]Scanning Archive...", total=len(files.files)
             )
             results = scanner.scan(
                 files.files,

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -62,9 +62,6 @@ def docset_cmd(
     output_handler = create_output_handler(ctx)
     try:
         with create_progress_bar(doc_type="files") as progress:
-            task_scan = progress.add_task(
-                "[green]Scanning content...", total=len(files)
-            )
 
             scan_context = ScanContext(
                 scan_mode=ScanMode.DOCSET,
@@ -78,7 +75,9 @@ def docset_cmd(
                 ignored_detectors=config.secret.ignored_detectors,
                 ignore_known_secrets=config.ignore_known_secrets,
             )
-
+            task_scan = progress.add_task(
+                "[green]Scanning content...", total=len(files)
+            )
             scans = create_scans_from_docset_files(
                 scanner=scanner,
                 input_files=files,

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -46,9 +46,6 @@ def path_cmd(
         )
 
         with create_progress_bar(doc_type="files") as progress:
-            task_scan = progress.add_task(
-                "[green]Scanning Path...", total=len(files.files)
-            )
 
             scan_context = ScanContext(
                 scan_mode=ScanMode.PATH,
@@ -62,6 +59,9 @@ def path_cmd(
                 scan_context=scan_context,
                 ignored_detectors=config.secret.ignored_detectors,
                 ignore_known_secrets=config.ignore_known_secrets,
+            )
+            task_scan = progress.add_task(
+                "[green]Scanning Path...", total=len(files.files)
             )
             results = scanner.scan(
                 files.files,

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -109,9 +109,6 @@ def pypi_cmd(
         )
 
         with create_progress_bar(doc_type="files") as progress:
-            task_scan = progress.add_task(
-                "[green]Scanning PyPI Package...", total=len(files.files)
-            )
 
             scan_context = ScanContext(
                 scan_mode=ScanMode.PYPI,
@@ -125,6 +122,9 @@ def pypi_cmd(
                 scan_context=scan_context,
                 ignored_detectors=config.secret.ignored_detectors,
                 ignore_known_secrets=config.ignore_known_secrets,
+            )
+            task_scan = progress.add_task(
+                "[green]Scanning PyPI Package...", total=len(files.files)
             )
             results = scanner.scan(
                 files.files,

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -1,3 +1,5 @@
+import os
+
 from appdirs import user_cache_dir, user_config_dir
 
 
@@ -6,7 +8,11 @@ APPAUTHOR = "GitGuardian"
 
 
 def get_config_dir() -> str:
-    return user_config_dir(appname=APPNAME, appauthor=APPAUTHOR)
+    try:
+        # See tests/conftest.py for details
+        return os.environ["TEST_CONFIG_DIR"]
+    except KeyError:
+        return user_config_dir(appname=APPNAME, appauthor=APPAUTHOR)
 
 
 def get_cache_dir() -> str:

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -88,6 +88,15 @@ class MissingTokenError(AuthError):
         super().__init__(instance, f"No token is saved for this instance: '{instance}'")
 
 
+class APIKeyCheckError(AuthError):
+    """
+    Raised when checking the API key fails
+    """
+
+    def __init__(self, instance: str, message: str):
+        super().__init__(instance, message)
+
+
 def format_validation_error(exc: ValidationError) -> str:
     """
     Take a Marshmallow ValidationError and turn it into a more user-friendly message
@@ -121,7 +130,7 @@ def handle_exception(exc: Exception, verbose: bool) -> int:
     )
     click.echo()
 
-    display_error(f"ERROR: {exc}.")
+    display_error(f"ERROR: {exc}")
     if isinstance(exc, UnicodeEncodeError) and platform.system() == "Windows":
         display_error(
             "\n"

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -258,9 +258,6 @@ def docker_scan_archive(
     files = get_files_from_docker_archive(archive)
 
     with create_progress_bar(doc_type="files") as progress:
-        task_scan = progress.add_task(
-            "[green]Scanning Docker Image...", total=len(files.files)
-        )
 
         scanner = SecretScanner(
             client=client,
@@ -269,6 +266,9 @@ def docker_scan_archive(
             ignored_matches=matches_ignore,
             ignored_detectors=ignored_detectors,
             ignore_known_secrets=ignore_known_secrets,
+        )
+        task_scan = progress.add_task(
+            "[green]Scanning Docker Image...", total=len(files.files)
         )
         results = scanner.scan(
             files.files,

--- a/ggshield/scan/repo.py
+++ b/ggshield/scan/repo.py
@@ -11,6 +11,7 @@ from pygitguardian import GGClient
 from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 
 from ggshield.core.cache import Cache
+from ggshield.core.client import check_client_api_key
 from ggshield.core.config import Config
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import ExitCode, handle_exception
@@ -84,6 +85,7 @@ def scan_commits_content(
             ignored_matches=matches_ignore,
             ignored_detectors=ignored_detectors,
             ignore_known_secrets=ignore_known_secrets,
+            check_api_key=False,  # Key has been checked in `scan_commit_range()`
         )
         results = scanner.scan(
             commit_files,
@@ -157,6 +159,7 @@ def scan_commit_range(
     :param commit_list: List of commits sha to scan
     :param verbose: Display successful scan's message
     """
+    check_client_api_key(client)
 
     with create_progress_bar(doc_type="commits") as progress:
 

--- a/ggshield/scan/scanner.py
+++ b/ggshield/scan/scanner.py
@@ -12,6 +12,7 @@ from pygitguardian.iac_models import IaCScanResult
 from pygitguardian.models import Detail, ScanResult
 
 from ggshield.core.cache import Cache
+from ggshield.core.client import check_client_api_key
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import (
     leak_dictionary_by_ignore_sha,
@@ -171,7 +172,11 @@ class SecretScanner:
         ignored_matches: Optional[Iterable[IgnoredMatch]] = None,
         ignored_detectors: Optional[Set[str]] = None,
         ignore_known_secrets: Optional[bool] = None,
+        check_api_key: Optional[bool] = True,
     ):
+        if check_api_key:
+            check_client_api_key(client)
+
         self.client = client
         self.cache = cache
         self.ignored_matches = ignored_matches or []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,12 @@ skipwindows = pytest.mark.skipif(
     platform.system() == "Windows" and not os.environ.get("DISABLE_SKIPWINDOWS"),
     reason="Skipped on Windows for now, define DISABLE_SKIPWINDOWS environment variable to unskip",
 )
+
+
+@pytest.fixture(autouse=True)
+def do_not_use_real_config_dir(monkeypatch, tmp_path):
+    """
+    This fixture ensures we do not use the real configuration directory, where
+    `ggshield auth` stores credentials.
+    """
+    monkeypatch.setenv("TEST_CONFIG_DIR", str(tmp_path))

--- a/tests/functional/secret/test_scan_invalid_api_key.py
+++ b/tests/functional/secret/test_scan_invalid_api_key.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from tests.functional.utils import run_ggshield_scan
+
+
+CURRENT_DIR = Path(__file__).parent
+
+
+def test_scan_no_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
+    run_ggshield_scan("path", __file__, cwd=CURRENT_DIR, expected_code=3)
+
+
+def test_scan_invalid_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("GITGUARDIAN_API_KEY", "not_a_valid_key")
+    run_ggshield_scan("path", __file__, cwd=CURRENT_DIR, expected_code=3)

--- a/tests/unit/cassettes/multiple_secrets.yaml
+++ b/tests/unit/cassettes/multiple_secrets.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:20 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '30'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body:
         '[{"filename": "test.txt", "document": "@@ -0,0 +1,2 @@\n+FacebookAppKeys
         :\n+String docker run --name geonetwork -d             -p 8080:8080 -e MYSQL_HOST=google.com             -e
@@ -16,12 +68,20 @@ interactions:
           - '276'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - d1e10b5b-3731-472a-9bb0-7f63ed062f82
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -33,42 +93,37 @@ interactions:
           detection"],"policy_breaks":[{"type":"MySQL Credentials","policy":"Secrets
           detection","matches":[{"type":"host","match":"google.com","index_start":114,"index_end":123,"line_start":3,"line_end":3},{"type":"port","match":"5434","index_start":151,"index_end":154,"line_start":3,"line_end":3},{"type":"username","match":"root","index_start":174,"index_end":177,"line_start":3,"line_end":3},{"type":"password","match":"m42ploz2wd","index_start":209,"index_end":218,"line_start":3,"line_end":3}],"validity":"failed_to_check"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '598'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:37 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:23 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=MhfGb3sicM+VsVX1yS7SD0JdyhUOh3XRInG0rv9eqCzLX78XlGM/050VugazmclwVWw7haMJ7kTGzZ2nfOdil4dDScrVTeCYNwVhtr8/H69d+AtLgm6e9Ydb9MVx;
-            Expires=Mon, 25 Jul 2022 17:11:34 GMT; Path=/
-          - AWSALBCORS=MhfGb3sicM+VsVX1yS7SD0JdyhUOh3XRInG0rv9eqCzLX78XlGM/050VugazmclwVWw7haMJ7kTGzZ2nfOdil4dDScrVTeCYNwVhtr8/H69d+AtLgm6e9Ydb9MVx;
-            Expires=Mon, 25 Jul 2022 17:11:34 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '3054'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/no_newline_before_secret.yaml
+++ b/tests/unit/cassettes/no_newline_before_secret.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:14 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body:
         '[{"filename": "artifactory", "document": "@@ -1,3 +1,3 @@\n some line\n
         some other line\n-deleted line\n\\ No newline at end of file\n+sg_key = \"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\"\n\\
@@ -15,15 +67,20 @@ interactions:
           - '252'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=HoK6UUgRNNTYGXWc8cF8+eeX3Vtd1LvGXEKoSPAoB19uUne9HQWmehyX8/mxQGMmvSm/NXYHSL1HgKHvBNNZeRdidxL6twX69h1zxvVnZEqctUi4qCZm8LMU5Kgf;
-            AWSALBCORS=HoK6UUgRNNTYGXWc8cF8+eeX3Vtd1LvGXEKoSPAoB19uUne9HQWmehyX8/mxQGMmvSm/NXYHSL1HgKHvBNNZeRdidxL6twX69h1zxvVnZEqctUi4qCZm8LMU5Kgf
+        GGShield-Command-Id:
+          - f30ccae3-61dc-4cc2-b253-0f9e222d63b7
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -34,42 +91,37 @@ interactions:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":97,"index_end":165,"line_start":6,"line_end":6}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '355'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Tue, 19 Jul 2022 16:17:01 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:14 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=0Mw68mtQbooV9R8TDM2VPrOTOOoI0oRe0SDgnIJlq9S9fPnCoISq6V5NLkj2V+nKG5xWANlF9clyPMVhWz5aTFnhTkPSrbsIpQD7nc2hGrYRosymZ2mBSnMReG9G;
-            Expires=Tue, 26 Jul 2022 16:17:01 GMT; Path=/
-          - AWSALBCORS=0Mw68mtQbooV9R8TDM2VPrOTOOoI0oRe0SDgnIJlq9S9fPnCoISq6V5NLkj2V+nKG5xWANlF9clyPMVhWz5aTFnhTkPSrbsIpQD7nc2hGrYRosymZ2mBSnMReG9G;
-            Expires=Tue, 26 Jul 2022 16:17:01 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '47'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/no_secret.yaml
+++ b/tests/unit/cassettes/no_secret.yaml
@@ -1,8 +1,60 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "test.txt", "document": "@@ -0,0 +1 @@\n+this is a patch
-        without secret\n"}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:26 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "test", "document": "@@ -0,0 +1 @@\n+this is a patch without
+        secret\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -11,18 +63,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '90'
+          - '86'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=4C/hDMPg1Ti/BIbHBPcKrmz0GBKT5otZWFGZPv3gjyF9ZVW+Fnc843orsns3UC2XZ33bLXjpPLty27ZIfUiLHAZpuPu6QGxa1j+EDw5L43TkSfUWxNN5Ku2v5ku/;
-            AWSALBCORS=4C/hDMPg1Ti/BIbHBPcKrmz0GBKT5otZWFGZPv3gjyF9ZVW+Fnc843orsns3UC2XZ33bLXjpPLty27ZIfUiLHAZpuPu6QGxa1j+EDw5L43TkSfUWxNN5Ku2v5ku/
+        GGShield-Command-Id:
+          - 75b7a4b6-d283-4c63-adf3-8223d2f54626
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -33,42 +90,37 @@ interactions:
           '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '108'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:40 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:26 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=tPncdmpGTiDOImREBRVlgN5EQYNr7DouwSnkK8Idcx00NuVOPNzgpFBTDOgg+UQrL0JOlDsWFzaNn3viwzmGn0W7bSMVntsqIHO7iBKz2+X4g93WclTEIjaa3RN9;
-            Expires=Mon, 25 Jul 2022 17:11:40 GMT; Path=/
-          - AWSALBCORS=tPncdmpGTiDOImREBRVlgN5EQYNr7DouwSnkK8Idcx00NuVOPNzgpFBTDOgg+UQrL0JOlDsWFzaNn3viwzmGn0W7bSMVntsqIHO7iBKz2+X4g93WclTEIjaa3RN9;
-            Expires=Mon, 25 Jul 2022 17:11:40 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '38'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/one_line_and_multiline_patch.yaml
+++ b/tests/unit/cassettes/one_line_and_multiline_patch.yaml
@@ -1,7 +1,59 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "test.txt", "document": "@@ -0,0 +1,29 @@\n+FacebookAppKeys:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:25 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "test", "document": "@@ -0,0 +1,29 @@\n+FacebookAppKeys:
         294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----\n+MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l\n+bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I\n+NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW\n+TQIhANrCE7O+wlCKe0WJqQ3lYlHG91XWyGVgfExJwBDsAD9LAiEAmDY5OSsH0n2A\n+22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT\n+bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb\n+RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4\n+-----END
         RSA PRIVATE KEY----- token: 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\n"}]'
       headers:
@@ -12,18 +64,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '716'
+          - '712'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=Jw2i8Dj+GE9sJDBLVTBVwb8VKoPfipIU4wXrhhEwZaeN7XOReVCBwX3Su0wbv3euCGY92hOvM6q02WCzwwMZQW+bVerzKOH995iQ+OCCJjvO0kmtdBUG1G4oJRNo;
-            AWSALBCORS=Jw2i8Dj+GE9sJDBLVTBVwb8VKoPfipIU4wXrhhEwZaeN7XOReVCBwX3Su0wbv3euCGY92hOvM6q02WCzwwMZQW+bVerzKOH995iQ+OCCJjvO0kmtdBUG1G4oJRNo
+        GGShield-Command-Id:
+          - 4ee49210-d7de-4858-9102-25926744c546
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -32,51 +89,45 @@ interactions:
       body:
         string:
           '[{"policy_break_count":2,"policies":["File extensions","Filenames","Secrets
-          detection"],"policy_breaks":[{"type":"RSA Private Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"-----BEGIN
+          detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":594,"index_end":662,"line_start":10,"line_end":10}],"validity":"no_checker"},{"type":"RSA
+          Private Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"-----BEGIN
           RSA PRIVATE KEY-----\n+MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l\n+bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I\n+NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW\n+TQIhANrCE7O+wlCKe0WJqQ3lYlHG91XWyGVgfExJwBDsAD9LAiEAmDY5OSsH0n2A\n+22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT\n+bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb\n+RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4\n+-----END
-          RSA PRIVATE KEY-----","index_start":86,"index_end":585,"line_start":2,"line_end":10}],"validity":"no_checker"},{"type":"SendGrid
-          Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":594,"index_end":662,"line_start":10,"line_end":10}],"validity":"no_checker"}]}]'
+          RSA PRIVATE KEY-----","index_start":86,"index_end":585,"line_start":2,"line_end":10}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Type:
-          - application/json
-        Date:
-          - Tue, 19 Jul 2022 08:57:32 GMT
-        Referrer-Policy:
-          - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=TE/M1Pvp0xXk0jxVg1F2sjhF743e1pDLE0I3wD0t06tonn3rIhgP47VqPMT6vtAzJzQ80Ctimj0VTtipADeP4DgTyCb+mfI8LACRh3jG88dJEf3t6Cz4nICvV7E8;
-            Expires=Tue, 26 Jul 2022 08:57:32 GMT; Path=/
-          - AWSALBCORS=TE/M1Pvp0xXk0jxVg1F2sjhF743e1pDLE0I3wD0t06tonn3rIhgP47VqPMT6vtAzJzQ80Ctimj0VTtipADeP4DgTyCb+mfI8LACRh3jG88dJEf3t6Cz4nICvV7E8;
-            Expires=Tue, 26 Jul 2022 08:57:32 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains
-        Transfer-Encoding:
-          - chunked
-        Vary:
-          - Accept-Encoding
-          - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
-          - nosniff
-          - nosniff
-        X-Frame-Options:
-          - DENY
-          - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
-          - 1; mode=block
         content-length:
           - '1049'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:26 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '223'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
       status:
         code: 200
         message: OK

--- a/tests/unit/cassettes/quota.yaml
+++ b/tests/unit/cassettes/quota.yaml
@@ -9,49 +9,46 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
       method: GET
       uri: https://api.gitguardian.com/v1/quotas
     response:
       body:
-        string: '{"content":{"count":152,"limit":1000,"remaining":848,"since":"2022-06-15"}}'
+        string: '{"content":{"count":70097,"limit":1000000,"remaining":929903,"since":"2023-02-05"}}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - GET, HEAD, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '75'
-        Content-Type:
+        content-length:
+          - '83'
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 15:45:19 GMT
-        Referrer-Policy:
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 07 Mar 2023 16:45:26 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=qnY7JoqgyZdZ1Hk5LFVO0kaQSh1iT81NG4q/NDgv3nPrNEZYtf4qNlKyMAsVWApab8rVtPSKsB79obMv8lsX1uMFdmVcPcxEf6hmSgHGUOr43kPCIwIeGB8OHsF+;
-            Expires=Fri, 22 Jul 2022 15:45:19 GMT; Path=/
-          - AWSALBCORS=qnY7JoqgyZdZ1Hk5LFVO0kaQSh1iT81NG4q/NDgv3nPrNEZYtf4qNlKyMAsVWApab8rVtPSKsB79obMv8lsX1uMFdmVcPcxEf6hmSgHGUOr43kPCIwIeGB8OHsF+;
-            Expires=Fri, 22 Jul 2022 15:45:19 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.25.0
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '19'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.85.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/simple_secret.yaml
+++ b/tests/unit/cassettes/simple_secret.yaml
@@ -1,7 +1,59 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "test.txt", "document": "@@ -0,0 +2 @@\n+# gg token\n+apikey
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:23 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '33'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "test", "document": "@@ -0,0 +2 @@\n+# gg token\n+apikey
         = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
       headers:
         Accept:
@@ -11,18 +63,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '356'
+          - '352'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=MhfGb3sicM+VsVX1yS7SD0JdyhUOh3XRInG0rv9eqCzLX78XlGM/050VugazmclwVWw7haMJ7kTGzZ2nfOdil4dDScrVTeCYNwVhtr8/H69d+AtLgm6e9Ydb9MVx;
-            AWSALBCORS=MhfGb3sicM+VsVX1yS7SD0JdyhUOh3XRInG0rv9eqCzLX78XlGM/050VugazmclwVWw7haMJ7kTGzZ2nfOdil4dDScrVTeCYNwVhtr8/H69d+AtLgm6e9Ydb9MVx
+        GGShield-Command-Id:
+          - 4404db4b-295a-4ca4-8e0c-7b373eb22cc1
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -34,42 +91,37 @@ interactions:
           detection"],"policy_breaks":[{"type":"GitGuardian Development Secret","policy":"Secrets
           detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":37,"index_end":305,"line_start":3,"line_end":3}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '573'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:38 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:24 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=D2GBsBzlbpudKyQBlAwwr47XAUf1R8Ll4Hcuk0DYNZaX841FggSunG72mJhAMQDqng1YHKaHRm32v0oOPZ7uA/BUWQRAlm2KvIRI+63ci4c30NMzvMdG9U0UfOzb;
-            Expires=Mon, 25 Jul 2022 17:11:38 GMT; Path=/
-          - AWSALBCORS=D2GBsBzlbpudKyQBlAwwr47XAUf1R8Ll4Hcuk0DYNZaX841FggSunG72mJhAMQDqng1YHKaHRm32v0oOPZ7uA/BUWQRAlm2KvIRI+63ci4c30NMzvMdG9U0UfOzb;
-            Expires=Mon, 25 Jul 2022 17:11:38 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '53'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/single_add.yaml
+++ b/tests/unit/cassettes/single_add.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:10 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body: '[{"filename": "test", "document": "@@ -0,0 +1 @@\n+sg_key = \"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\";\n"}]'
       headers:
         Accept:
@@ -12,15 +64,20 @@ interactions:
           - '139'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=tPncdmpGTiDOImREBRVlgN5EQYNr7DouwSnkK8Idcx00NuVOPNzgpFBTDOgg+UQrL0JOlDsWFzaNn3viwzmGn0W7bSMVntsqIHO7iBKz2+X4g93WclTEIjaa3RN9;
-            AWSALBCORS=tPncdmpGTiDOImREBRVlgN5EQYNr7DouwSnkK8Idcx00NuVOPNzgpFBTDOgg+UQrL0JOlDsWFzaNn3viwzmGn0W7bSMVntsqIHO7iBKz2+X4g93WclTEIjaa3RN9
+        GGShield-Command-Id:
+          - c023925e-e193-4f03-809c-470f9210b1f8
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -31,42 +88,37 @@ interactions:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":25,"index_end":93,"line_start":2,"line_end":2}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '354'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:41 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:10 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=FVF4oSk9rBgqBsBubFOo8ZxLnjVgcS26LcnxW47lMDafbmJzmbnVK+qjZPhWqlX6D9zOmP3fq/NSj7YQMyD3dGxf6x+i/mQ/bRVU8OXkKfG9y1h2l0G1qPoa6OBU;
-            Expires=Mon, 25 Jul 2022 17:11:41 GMT; Path=/
-          - AWSALBCORS=FVF4oSk9rBgqBsBubFOo8ZxLnjVgcS26LcnxW47lMDafbmJzmbnVK+qjZPhWqlX6D9zOmP3fq/NSj7YQMyD3dGxf6x+i/mQ/bRVU8OXkKfG9y1h2l0G1qPoa6OBU;
-            Expires=Mon, 25 Jul 2022 17:11:41 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '104'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/single_delete.yaml
+++ b/tests/unit/cassettes/single_delete.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:12 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body:
         '[{"filename": "test", "document": "@@ -1,2 +1 @@\n something\n-sg_key =
         \"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\";\n"}]'
@@ -14,15 +66,20 @@ interactions:
           - '151'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=FVF4oSk9rBgqBsBubFOo8ZxLnjVgcS26LcnxW47lMDafbmJzmbnVK+qjZPhWqlX6D9zOmP3fq/NSj7YQMyD3dGxf6x+i/mQ/bRVU8OXkKfG9y1h2l0G1qPoa6OBU;
-            AWSALBCORS=FVF4oSk9rBgqBsBubFOo8ZxLnjVgcS26LcnxW47lMDafbmJzmbnVK+qjZPhWqlX6D9zOmP3fq/NSj7YQMyD3dGxf6x+i/mQ/bRVU8OXkKfG9y1h2l0G1qPoa6OBU
+        GGShield-Command-Id:
+          - 8859d9ce-1201-4b30-b802-70c07cc53421
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -33,42 +90,37 @@ interactions:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":36,"index_end":104,"line_start":3,"line_end":3}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '355'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:42 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:12 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD;
-            Expires=Mon, 25 Jul 2022 17:11:42 GMT; Path=/
-          - AWSALBCORS=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD;
-            Expires=Mon, 25 Jul 2022 17:11:42 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '65'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/single_file.yaml
+++ b/tests/unit/cassettes/single_file.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:13 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body: '[{"filename": "test_file", "document": "+sg_key = \"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\";\n"}]'
       headers:
         Accept:
@@ -12,15 +64,20 @@ interactions:
           - '129'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD;
-            AWSALBCORS=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD
+        GGShield-Command-Id:
+          - d2c7ef97-5dae-4d06-bb6b-3d3b64bf88ac
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -31,42 +88,37 @@ interactions:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":11,"index_end":79,"line_start":1,"line_end":1}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '354'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Tue, 19 Jul 2022 16:17:00 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:13 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=HoK6UUgRNNTYGXWc8cF8+eeX3Vtd1LvGXEKoSPAoB19uUne9HQWmehyX8/mxQGMmvSm/NXYHSL1HgKHvBNNZeRdidxL6twX69h1zxvVnZEqctUi4qCZm8LMU5Kgf;
-            Expires=Tue, 26 Jul 2022 16:17:00 GMT; Path=/
-          - AWSALBCORS=HoK6UUgRNNTYGXWc8cF8+eeX3Vtd1LvGXEKoSPAoB19uUne9HQWmehyX8/mxQGMmvSm/NXYHSL1HgKHvBNNZeRdidxL6twX69h1zxvVnZEqctUi4qCZm8LMU5Kgf;
-            Expires=Tue, 26 Jul 2022 16:17:00 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '66'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/single_move.yaml
+++ b/tests/unit/cassettes/single_move.yaml
@@ -1,5 +1,57 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
+      body:
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:11 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
       body:
         '[{"filename": "test", "document": "@@ -1 +1,2 @@\n+something\n sg_key =
         \"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\";\n"}]'
@@ -14,15 +66,20 @@ interactions:
           - '151'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD;
-            AWSALBCORS=ShxhYhI0vSsVVDSdipRBlS7sq1fLx0Qba17EbWRa68fvI0aJ0CLTItri/nY/fsRlvgmIgX0RPVHiaj8umkrc27b0Qub8E75G+vdRp++/MyiqtfVyYrR+krG0FbtD
+        GGShield-Command-Id:
+          - a5679b78-96d8-4ae1-af75-f9d47709e4f4
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -33,42 +90,37 @@ interactions:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":36,"index_end":104,"line_start":3,"line_end":3}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '355'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 17:11:42 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:11 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=goVJMSSG9Wl1yeNPjQnCCiIx6fOd6t161uKl8REmLXDJaFTjO3Ckj5WghK1nyjtFfQo3QaTQen3oJQVOC/FPz8ISOyI2vuOtPtZXXKpqGN1nNx57CfVgBo/i70bC;
-            Expires=Mon, 25 Jul 2022 17:11:42 GMT; Path=/
-          - AWSALBCORS=goVJMSSG9Wl1yeNPjQnCCiIx6fOd6t161uKl8REmLXDJaFTjO3Ckj5WghK1nyjtFfQo3QaTQen3oJQVOC/FPz8ISOyI2vuOtPtZXXKpqGN1nNx57CfVgBo/i70bC;
-            Expires=Mon, 25 Jul 2022 17:11:42 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '81'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_directory_verbose.yaml
+++ b/tests/unit/cassettes/test_directory_verbose.yaml
@@ -1,10 +1,62 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp04k0goz_/dir/subdir/file3",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp04k0goz_/file1",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp04k0goz_/dir/subdir/file4",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp04k0goz_/dir/file2",
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:58 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmpakdvu16p/dir/file2", "document": "This is a file
+        with no secrets."}, {"filename": "/tmp/tmpakdvu16p/dir/subdir/file3", "document":
+        "This is a file with no secrets."}, {"filename": "/tmp/tmpakdvu16p/dir/subdir/file4",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmpakdvu16p/file1",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -14,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '582'
+          - '374'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - db99fe8b-193b-4142-848e-ab22c39258ec
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -30,47 +90,43 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '429'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:19 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:58 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=V91ekLxHmkrst+VZcuotwg5YMlN+cVHfByswOhKOEG/mOTTGRipn11Rd1i33s8Kzd6pbhajK3nL5toxOwISePQIU+eg+xOubtZpcc1SeUOKLhdMXqocSS7Hk01cK;
-            Expires=Fri, 22 Jul 2022 16:33:19 GMT; Path=/
-          - AWSALBCORS=V91ekLxHmkrst+VZcuotwg5YMlN+cVHfByswOhKOEG/mOTTGRipn11Rd1i33s8Kzd6pbhajK3nL5toxOwISePQIU+eg+xOubtZpcc1SeUOKLhdMXqocSS7Hk01cK;
-            Expires=Fri, 22 Jul 2022 16:33:19 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '48'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_directory_verbose_yes.yaml
+++ b/tests/unit/cassettes/test_directory_verbose_yes.yaml
@@ -1,10 +1,62 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpzt74g5ht/dir/file2",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpzt74g5ht/dir/subdir/file4",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpzt74g5ht/dir/subdir/file3",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpzt74g5ht/file1",
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:59 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmpynkveevh/file1", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/subdir/file4", "document":
+        "This is a file with no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/file2",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/subdir/file3",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -14,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '582'
+          - '374'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - 96f89e8f-74e2-4d00-8d2e-4c9960b3384e
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -30,47 +90,43 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '429'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:20 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:59 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=TRn4Xr5fR/8tbLfwzM3+ae+BFuUJKSASCboEULzbaEBtBW2kgykZg7aE1lNDDht8m37NWF2LLiFZT89vJtJL4D1tZWS/TjfVJexKyyTEm49j7onFjrshxTohaeBd;
-            Expires=Fri, 22 Jul 2022 16:33:20 GMT; Path=/
-          - AWSALBCORS=TRn4Xr5fR/8tbLfwzM3+ae+BFuUJKSASCboEULzbaEBtBW2kgykZg7aE1lNDDht8m37NWF2LLiFZT89vJtJL4D1tZWS/TjfVJexKyyTEm49j7onFjrshxTohaeBd;
-            Expires=Fri, 22 Jul 2022 16:33:20 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '47'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_directory_yes.yaml
+++ b/tests/unit/cassettes/test_directory_yes.yaml
@@ -1,10 +1,62 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpxd2g5n0t/dir/subdir/file3",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpxd2g5n0t/file1",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpxd2g5n0t/dir/file2",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpxd2g5n0t/dir/subdir/file4",
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:57 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '13'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmp10iyogkx/dir/subdir/file3", "document": "This is
+        a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/dir/file2", "document":
+        "This is a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/file1", "document":
+        "This is a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/dir/subdir/file4",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -14,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '582'
+          - '374'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - df47ca9f-494d-4cdd-9e96-c2acb8d89fec
         GGShield-Command-Path:
           - cli scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -30,47 +90,43 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '429'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:18 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:57 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=8NkiFygKzGK+uNBDkzTRPzv6ayMVsQ4Dp+z/N438VEWZO+1RcJ/4W/QnrgsnQKaeU6El9J6TXJleDFlb9J1pW8m6VfDgjY+xS98bZ3ovODmAjrSFCeMdObEX+6CF;
-            Expires=Fri, 22 Jul 2022 16:33:18 GMT; Path=/
-          - AWSALBCORS=8NkiFygKzGK+uNBDkzTRPzv6ayMVsQ4Dp+z/N438VEWZO+1RcJ/4W/QnrgsnQKaeU6El9J6TXJleDFlb9J1pW8m6VfDgjY+xS98bZ3ovODmAjrSFCeMdObEX+6CF;
-            Expires=Fri, 22 Jul 2022 16:33:18 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '47'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_files_verbose.yaml
+++ b/tests/unit/cassettes/test_files_verbose.yaml
@@ -1,9 +1,61 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpm0tkhdvv/file2",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpm0tkhdvv/file1",
-        "document": "This is a file with no secrets."}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:55 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmph3z167km/file2", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmph3z167km/file1", "document": "This is a
+        file with no secrets."}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +64,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '278'
+          - '174'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - 082cc817-ad9b-4666-a022-8462629d156f
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -28,45 +88,41 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '215'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:17 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:55 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=EpYVIKAoWOsEDH+o0wKQHl8YOVRxQbG/kNx/jrqnHtgDh4M+R37KlLz+ngRb4PFLQi37voTedtK69XDa94yWgObSadhhOFKlMSNOzluUjJjb38MQ3dLL2/HqzzWe;
-            Expires=Fri, 22 Jul 2022 16:33:17 GMT; Path=/
-          - AWSALBCORS=EpYVIKAoWOsEDH+o0wKQHl8YOVRxQbG/kNx/jrqnHtgDh4M+R37KlLz+ngRb4PFLQi37voTedtK69XDa94yWgObSadhhOFKlMSNOzluUjJjb38MQ3dLL2/HqzzWe;
-            Expires=Fri, 22 Jul 2022 16:33:17 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '44'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_files_verbose_yes.yaml
+++ b/tests/unit/cassettes/test_files_verbose_yes.yaml
@@ -1,9 +1,61 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp7m1yslsc/file1",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp7m1yslsc/file2",
-        "document": "This is a file with no secrets."}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:56 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '12'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmptw7s4r08/file2", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmptw7s4r08/file1", "document": "This is a
+        file with no secrets."}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +64,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '278'
+          - '174'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - ef111652-d429-4de4-ad15-78334c87995e
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -28,45 +88,41 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '215'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:18 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:56 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=SYvS1+a78uKiCd5FUL0TPlQ8GktAzwPNu72tH37kdVxYkKTcq8ka1/ZveHcKUt6VWx0mB6tL44wh0q0KYLi/udZhNIyqP7a/MBN0twrEG1DBxQCQzK83QBM3hGgn;
-            Expires=Fri, 22 Jul 2022 16:33:17 GMT; Path=/
-          - AWSALBCORS=SYvS1+a78uKiCd5FUL0TPlQ8GktAzwPNu72tH37kdVxYkKTcq8ka1/ZveHcKUt6VWx0mB6tL44wh0q0KYLi/udZhNIyqP7a/MBN0twrEG1DBxQCQzK83QBM3hGgn;
-            Expires=Fri, 22 Jul 2022 16:33:17 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '43'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_files_yes.yaml
+++ b/tests/unit/cassettes/test_files_yes.yaml
@@ -1,9 +1,61 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmprfadc53m/file1",
-        "document": "This is a file with no secrets."}, {"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmprfadc53m/file2",
-        "document": "This is a file with no secrets."}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:54 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmp6fbfbwg3/file1", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmp6fbfbwg3/file2", "document": "This is a
+        file with no secrets."}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +64,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '278'
+          - '174'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - 0d77354a-2c49-4887-8d77-635f78b29f59
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -28,45 +88,41 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]},{"policy_break_count":0,"policies":["Secrets
-          detection","File extensions","Filenames"],"policy_breaks":[]}]'
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]},{"policy_break_count":0,"policies":["File
+          extensions","Filenames","Secrets detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '215'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:16 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:54 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=bHksCef8GJX5jf+DDzRUDKuCvzS79AgK+Vl99NkdGGYWdHSjmvOoAa88nEJogjmAtQ8ebivrHyacrA8m+sd4eiqulN9I+PYzwtGIC+kJma4sK8xolBk2Y0PV2WCu;
-            Expires=Fri, 22 Jul 2022 16:33:16 GMT; Path=/
-          - AWSALBCORS=bHksCef8GJX5jf+DDzRUDKuCvzS79AgK+Vl99NkdGGYWdHSjmvOoAa88nEJogjmAtQ8ebivrHyacrA8m+sd4eiqulN9I+PYzwtGIC+kJma4sK8xolBk2Y0PV2WCu;
-            Expires=Fri, 22 Jul 2022 16:33:16 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '42'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_health_check.yaml
+++ b/tests/unit/cassettes/test_health_check.yaml
@@ -9,49 +9,44 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
       method: GET
       uri: https://api.gitguardian.com/v1/health
     response:
       body:
         string: '{"detail":"Valid API key."}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - GET, HEAD, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '27'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 15:45:19 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:43 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=x6mok2aHb/dr+09EDz0c2HC/Yg0HUKWq8JrU5j9jonFChlk++BIqGt0yWFGVJaVzjQiiA3KBI5Ct76uhEWBQ0zOb9ZuLufxKqo2y7/SjD0/MAjlVjomshdBJwmn5;
-            Expires=Fri, 22 Jul 2022 15:45:19 GMT; Path=/
-          - AWSALBCORS=x6mok2aHb/dr+09EDz0c2HC/Yg0HUKWq8JrU5j9jonFChlk++BIqGt0yWFGVJaVzjQiiA3KBI5Ct76uhEWBQ0zOb9ZuLufxKqo2y7/SjD0/MAjlVjomshdBJwmn5;
-            Expires=Fri, 22 Jul 2022 15:45:19 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_iac_scan_empty_directory.yaml
+++ b/tests/unit/cassettes/test_iac_scan_empty_directory.yaml
@@ -1,13 +1,10 @@
 interactions:
   - request:
       body: !!binary |
-        LS1lOWJlNDk2MDFmYjdiN2FjZThmNmU1YmYwODJlZTQyOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
-        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJNRURJVU0ifQ0KLS1lOWJlNDk2MDFmYjdiN2FjZThm
-        NmU1YmYwODJlZTQyOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJl
-        Y3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAeAKfYgL/7cEBDQAAAMKg909tDjeg
-        AAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tZTliZTQ5NjAxZmI3YjdhY2U4ZjZlNWJmMDgyZWU0Mjkt
-        LQ0K
+        LS1lZTJiYzcxOTQ5MTIyYmYxNDc4ZDY5Y2JlM2I0NGNmOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        sdzgYwL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tZWUyYmM3MTk0OTEy
+        MmJmMTQ3OGQ2OWNiZTNiNDRjZjktLQ0K
       headers:
         Accept:
           - '*/*'
@@ -16,50 +13,62 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '345'
+          - '195'
         Content-Type:
-          - multipart/form-data; boundary=e9be49601fb7b7ace8f6e5bf082ee429
+          - multipart/form-data; boundary=ee2bc71949122bf1478d69cbe3b44cf9
+        GGShield-Command-Id:
+          - c998ce48-fffb-4a13-8642-7c3bdb4cacb6
         GGShield-Command-Path:
           - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.11.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.4 (Darwin;py3.10.4) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+        mode:
+          - directory
       method: POST
       uri: https://api.gitguardian.com/v1/iac_scan
     response:
       body:
-        string: '{"id":"","type":"path_scan","iac_engine_version":"1.1.0","entities_with_incidents":[]}'
+        string: '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[]}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '86'
-        Content-Type:
+        content-length:
+          - '87'
+        content-type:
           - application/json
-        Date:
-          - Tue, 07 Jun 2022 07:47:06 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:46 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Strict-Transport-Security:
-          - max-age=15724800; includeSubDomains
-        Vary:
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
           - Cookie
-        X-App-Version:
-          - 3751cc90
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '186'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.68.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
@@ -1,20 +1,18 @@
 interactions:
   - request:
       body: !!binary |
-        LS0yMmNhZjM3MTdiOWY4MmU0NTM1ZDg1MGRhZjBiYjEyZA0KQ29udGVudC1EaXNwb3NpdGlvbjog
-        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0yMmNhZjM3MTdiOWY4MmU0NTM1ZDg1
-        MGRhZjBiYjEyZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
-        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAYE3VYgL/7ZfBbuIwEIZzzlNYfoBgGyeh
-        B6Q99thDb9XKMsGprDpxZDsFtOq7rwOFbmlpV6uWsmU+Dlh28BzIr28mG2WjH1dyeankXLnkUyAb
-        Dn0TMuZP62GfEkZZgpbJEeh9kC6WT84TNkFN0I2a0iKfUF5QzrMyJ5RPJmkCfHu0rEStjRJNb4Lu
-        4uK+N61ycqaNDlr5LNQfkf+CbzJeFsUm6+wp82NKn+efETLknxwz/52RRratOvRcfKyuv9//nzrl
-        be8qhbBceOFV1TsdVuLW2b7DCM/kXKilbOKbgdGvFCF1G3/h10uEKj13YmZsdefRFN1gkq0/I4J/
-        xvOH9CFN0VsFhOuHe19WCatOxRuxbtflcPp2rVgHovxPZCfh//FL/1Pw/1H8X77qf15cQKLOyv+t
-        /QTz/63/8738F3lZgv+/wP+tCgvr7oSszEE3P3YAW6aolsareNA5G2xlze4Ah6ob1F0724jOurA9
-        YGxwvP1jb7c7VI3lg7bt4yXSGLt43gFs76cso+OM8ozmODYBEOf/1P8w/5/U/M8vSk5h/j8r//s4
-        au1N/6sP6gDe8z8l+/1/SRn4/yv8L81MGO2Dii/Ba+7fKT7K9/L6+gqsCwAAAAAAAAAAAAAAcOL8
-        BiIV1CcAKAAADQotLTIyY2FmMzcxN2I5ZjgyZTQ1MzVkODUwZGFmMGJiMTJkLS0NCg==
+        LS1lNzQ4MTk3NWE2ZjdiMjQ4MmU0ODgzNWMwNDRmYzJhYg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        0tzgYwL/7ZjNbqMwEIA58xQWD0A85reHSnvssYfeVpVliImsGoxss0m16rvXtJtsNps2qpS26u58
+        HAwe8FwYvjHpIl18uxabKymW0kbvAn3mpZHSLP99Ps8DZcAisok+gMl5YUP66P+E1aT3qpeXUFZF
+        WdOLqk6BVlVd13GE/PMo0fJOackHw39MepBWNEorr6RLfXe++i/LpxqHqoD98bn8oYggzyoKRZkx
+        FlFGqxwiQj+y/oUWopFDJ3wvjt13Kv5Fia10ZrKtJIlYOz5Ivzb2jotWcztpmZCkEUsuN6If56uf
+        MSFyFZ5xZMsl6YR2MgRGa7xpjd4FEt+OSQh01vR8NNZvA4yFWW/25nazc9aQ3isz/FpEaG3W8zKt
+        WlreaNPebdcHlkKWQp5CkcQP+MF6Oyn6H/2P/kf/OzWswrDfA9yfqQM45X+g2YH/gVXo/8/wv9AN
+        18p5GV6CY+7fKT7I9+rm5hqti/5H/6P/ka/u/37SXo0HHcB5/gKc3v/Dgf8ZFDn6/xP872Q72dD5
+        8ZU10/jK7n8+3d+Ru9ARfE9o+nQsaHIb4g+hOYjJawle/Mfg70c59xihKZ3T/bn7/ztXyIOljCAI
+        giAIgiAIgiAIcpRHao+D4gAoAAANCi0tZTc0ODE5NzVhNmY3YjI0ODJlNDg4MzVjMDQ0ZmMyYWIt
+        LQ0K
       headers:
         Accept:
           - '*/*'
@@ -23,72 +21,76 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '790'
+          - '630'
         Content-Type:
-          - multipart/form-data; boundary=22caf3717b9f82e4535d850daf0bb12d
+          - multipart/form-data; boundary=e7481975a6f7b2482e48835c044fc2ab
+        GGShield-Command-Id:
+          - 19c59999-7621-4b1c-ae95-b8daa4e2dc34
         GGShield-Command-Path:
           - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+        mode:
+          - directory
       method: POST
       uri: https://api.gitguardian.com/v1/iac_scan
     response:
       body:
         string:
-          '{"id":"0","type":"path_scan","iac_engine_version":"1.5.0","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
-          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://gitguardian.com"}]},{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
+          '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
           egress traffic might lead to remote code execution","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
-          egress means that the asset can download data from the whole web.","documentation_url":"https://gitguardian.com"},{"policy":"Unrestricted
+          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0002"},{"policy":"Unrestricted
           ingress traffic leaves assets exposed to remote attacks","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
           security group has open ingress from all IPs, and on all ports. This means
           that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
           no port range is specified. This\nmeans that some applications running on
           assets of this security group may be reached by\nexternal traffic, while they
-          are not expected to do so.","documentation_url":"https://gitguardian.com"}]}]}'
+          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0003"}]},{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Type:
+        content-length:
+          - '1557'
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 12:09:05 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:19 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=2T61Y/S/wxe1YCBF1V8qIkPkTRe37YPerUbTLNmFsZqUvWtoQFGJYz+BnDOfB95F2VVNxIJy1QuY2/3KQxVJrOn0cBkGRNCg0n+jfOhxASQEEyqTml/rd5PucqdD;
-            Expires=Mon, 25 Jul 2022 12:09:05 GMT; Path=/
-          - AWSALBCORS=2T61Y/S/wxe1YCBF1V8qIkPkTRe37YPerUbTLNmFsZqUvWtoQFGJYz+BnDOfB95F2VVNxIJy1QuY2/3KQxVJrOn0cBkGRNCg0n+jfOhxASQEEyqTml/rd5PucqdD;
-            Expires=Mon, 25 Jul 2022 12:09:05 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Transfer-Encoding:
+        transfer-encoding:
           - chunked
-        Vary:
-          - Accept-Encoding
-          - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '366'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
-        content-length:
-          - '1440'
       status:
         code: 200
         message: OK

--- a/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
@@ -1,17 +1,15 @@
 interactions:
   - request:
       body: !!binary |
-        LS1iOTRhMGYyNTkyOWFhZjBjODY0MjRiMWY1YWE3ZDA3Mw0KQ29udGVudC1EaXNwb3NpdGlvbjog
-        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS1iOTRhMGYyNTkyOWFhZjBjODY0MjRi
-        MWY1YWE3ZDA3Mw0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
-        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAXk3VYgL/7dO7bsIwGAXgzH4Kyw8QbJO6
-        LEgdO3avKssEB1l1QuRLC6p49xoYUFXB1DLA+TLkV2L7DMmpJ/Xk6cVsnq1Z2lD9C3507s75tDnN
-        ++eCSyEruqmuIMdkQomv7pOc0T653s6FepiJRolG1mrGG6kaUsHNc6bVnfNW99knN5bhI/vBBrNw
-        3iVnY526v+i/ao4df1Tq2HV56vxUiJ/9l5zv+8+v2f/RG2+GwZ5bV5Z13e19fxJsXOfQWsrMZ9TR
-        tjm4tNWrsM4jo2xhltpuTF/+DEa/CKV2VXbEw0hp65ZBL/y6fY90Tl8Zrw/XhLO38n5HdoTQSwE6
-        5P25v1PSdrTlROaGQxwjl7NKDqoMAAAAAAAAAAAAAAAAAAAAd+obwA9IMQAoAAANCi0tYjk0YTBm
-        MjU5MjlhYWYwYzg2NDI0YjFmNWFhN2QwNzMtLQ0K
+        LS04MGJhNTkyNmQwNTBhZDcwYWY1ODhmZjNkN2M1ZTY0NA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        0NzgYwL/7dO7TsMwGAXgzH4Kyw+Q2knjhKESIyM7QpaTupVF0la+QCvUd8dNB5CAskAl2vNl8K84
+        9lly8kk+ub3X2zuj58Zlf4IffbdyXk7f58N7wQtRZHSbnUH0QbsUn12noqFDsIOZCVlXsuE3tcyF
+        LGUzbUgGF8/qTi1sb9QQ+2A3aXiO/co43dreBmt8Hha/0X8px46LuhIf12P9hcjEtKy5qGRZpP4X
+        hahS//k5+697rVuzWugw6K+++2n/nyLO+HV0naFMv3jlTRedDTu1dOu4YZS1eq7MVg/pz2D0lVBq
+        lumEH0dKOzt3qu3X3ZOnM/rAeD4+E84e0/6e7AmhpwKUi4d7P6eE3cakG5ldjXGMnM5KOagyAAAA
+        AAAAAAAAAAAAAAAAXKk3RwiykQAoAAANCi0tODBiYTU5MjZkMDUwYWQ3MGFmNTg4ZmYzZDdjNWU2
+        NDQtLQ0K
       headers:
         Accept:
           - '*/*'
@@ -20,70 +18,74 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '600'
+          - '462'
         Content-Type:
-          - multipart/form-data; boundary=b94a0f25929aaf0c86424b1f5aa7d073
+          - multipart/form-data; boundary=80ba5926d050ad70af588ff3d7c5e644
+        GGShield-Command-Id:
+          - 8c328f6e-01e2-431c-a925-7582b9c6c1a0
         GGShield-Command-Path:
           - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+        mode:
+          - directory
       method: POST
       uri: https://api.gitguardian.com/v1/iac_scan
     response:
       body:
         string:
-          '{"id":"0","type":"path_scan","iac_engine_version":"1.5.0","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
+          '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
           egress traffic might lead to remote code execution","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
-          egress means that the asset can download data from the whole web.","documentation_url":"https://gitguardian.com"},{"policy":"Unrestricted
+          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0002"},{"policy":"Unrestricted
           ingress traffic leaves assets exposed to remote attacks","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
           security group has open ingress from all IPs, and on all ports. This means
           that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
           no port range is specified. This\nmeans that some applications running on
           assets of this security group may be reached by\nexternal traffic, while they
-          are not expected to do so.","documentation_url":"https://gitguardian.com"}]}]}'
+          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0003"}]}]}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Type:
+        content-length:
+          - '1167'
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 12:09:03 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:17 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=+DrrNhuqI85Gl2cdAUAlqH/pc+UkOZ6kTEso3sWCuUQ77jaM4/6vQ/3abIZkKFaV9SI26JaoFnzJrX68caBWpZ7OJtwIFi6YuekB8x4FtE35Z3oAr1b6oApdznhy;
-            Expires=Mon, 25 Jul 2022 12:09:03 GMT; Path=/
-          - AWSALBCORS=+DrrNhuqI85Gl2cdAUAlqH/pc+UkOZ6kTEso3sWCuUQ77jaM4/6vQ/3abIZkKFaV9SI26JaoFnzJrX68caBWpZ7OJtwIFi6YuekB8x4FtE35Z3oAr1b6oApdznhy;
-            Expires=Mon, 25 Jul 2022 12:09:03 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Transfer-Encoding:
+        transfer-encoding:
           - chunked
-        Vary:
-          - Accept-Encoding
-          - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '331'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
-        content-length:
-          - '1089'
       status:
         code: 200
         message: OK

--- a/tests/unit/cassettes/test_iac_scan_no_vulnerabilities.yaml
+++ b/tests/unit/cassettes/test_iac_scan_no_vulnerabilities.yaml
@@ -1,17 +1,15 @@
 interactions:
   - request:
       body: !!binary |
-        LS04ZTE3MGUwNmVmYjZiMGRlNzYwZDQyMzUzNDAyZjJmYg0KQ29udGVudC1EaXNwb3NpdGlvbjog
-        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS04ZTE3MGUwNmVmYjZiMGRlNzYwZDQy
-        MzUzNDAyZjJmYg0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
-        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAX03VYgL/7dS9bsMgFAVgz34K5AcgBv+l
-        Q6SOHfsGiBBcoWBjYVxHqvruxUqTVJWytRmS8y2274XLgI7piq6eX+XhRcud9sm/yI+uPfO8KC/v
-        S53lnPGEHJIbmMYgfTw+eUx8TbpgOr1hdbVmZc3KgjZP8UaqMk3g7hmpRGusFr0T75PttZdbY00w
-        eqSh/bv81+Ux401dH7POL5kvWPUr/3XVNAnJb5n/wUor+15fWxeXte393X/q9egmrzTJ5DyKXofZ
-        +b2Qygo/WZ2RbCt3Qh9kNyxfHykh+i3uGcnJhrTSjjo2Bu+CU86eG1lQQxYbrXedGJwPpwbnsRrc
-        j9q5upwajw/G9d9DpLVuXsYos/Nia53an+YzTllBWUlZlaWf+GEBAAAAAAAAAAAAAAAAAADAI/oC
-        3amPhgAoAAANCi0tOGUxNzBlMDZlZmI2YjBkZTc2MGQ0MjM1MzQwMmYyZmItLQ0K
+        LS01NGM3ZTA4MWEwYTAyMmQ0NmRhZmFjNGQ3Y2Y5Zjg4NA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        0dzgYwL/7dRNboMwEAVg1jmFxQGIbf6SRaQuu+wNrIGYyorByJgmUtW7F5omzaJVN22kNu/bGN7g
+        mdWQLJPl3QMd7jVttY9+BT/66uQ8zT6e51xwKWTEDtEVjEMgP42PbpNcsTaYVm9EUebFiq/LMhGr
+        tEzX2SKCf89QrRpjteqcehptpz1Vxppg9JCE5uf2vyjedlyUubg8j+sv8khkaclFXqRyyiUvMx4x
+        fs39J0tU6a6h0NJn331X/6MWXg9u9LVmMe0H1emwd36nqLbKj1bHLK5oq/SB2n5+e14wph+nOwM7
+        2bCG7KCnQu9dcLWz50Ic6j6eCo13reqdD6eClFMa3EV2Tuep0/hgXPfehKx1+7lNbbZeVdbVu1N/
+        IRORJiJLRB4vXvDDAgAAAAAAAAAAAAAAAAAAgFv0Cr7ECy8AKAAADQotLTU0YzdlMDgxYTBhMDIy
+        ZDQ2ZGFmYWM0ZDdjZjlmODg0LS0NCg==
       headers:
         Accept:
           - '*/*'
@@ -20,57 +18,62 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '618'
+          - '478'
         Content-Type:
-          - multipart/form-data; boundary=8e170e06efb6b0de760d42353402f2fb
+          - multipart/form-data; boundary=54c7e081a0a022d46dafac4d7cf9f884
+        GGShield-Command-Id:
+          - 11f19f95-6fea-42be-b4b4-63b085be29b8
         GGShield-Command-Path:
           - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+        mode:
+          - directory
       method: POST
       uri: https://api.gitguardian.com/v1/iac_scan
     response:
       body:
-        string: '{"id":"0","type":"path_scan","iac_engine_version":"1.5.0","entities_with_incidents":[]}'
+        string: '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[]}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '87'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 12:09:04 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:18 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=E0P1LcKF9ZkOMI5ZQAFrAevdpgY5ZhXhN495IhsAUOEEqfOv9WYp5WoiqvV7zyHmHrBUyUzFrJkACeH1Ifg9okPjhL4ABEHXgdKHvv9q86AURXUfFE6qDb40LS1l;
-            Expires=Mon, 25 Jul 2022 12:09:04 GMT; Path=/
-          - AWSALBCORS=E0P1LcKF9ZkOMI5ZQAFrAevdpgY5ZhXhN495IhsAUOEEqfOv9WYp5WoiqvV7zyHmHrBUyUzFrJkACeH1Ifg9okPjhL4ABEHXgdKHvv9q86AURXUfFE6qDb40LS1l;
-            Expires=Mon, 25 Jul 2022 12:09:04 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '291'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
+++ b/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
@@ -1,16 +1,14 @@
 interactions:
   - request:
       body: !!binary |
-        LS0xZmMzNjFiMDYzOGE3ODM5MWJkNTM3ZGI1ZGQwYjJhOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
-        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
-        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0xZmMzNjFiMDYzOGE3ODM5MWJkNTM3
-        ZGI1ZGQwYjJhOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
-        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAXU3VYgL/7dS/asMwEAZwzX4KoQdwJMWx
-        kyHQMWOG7OacnItA/oMsty6l714XD4FCtjaF9PstJ8TBDdJ36SpdPR1pOjBdOIhfoRe3qtbr7Hr+
-        ujfaGivkJO5gHCKFebz4n+xWNtE1vDf5Zmuy3GQm3djdzhRFIuDhOTqXtfNcDq59nsvL6FsOVDnv
-        4lsa65/Kf54tGS/yfMm6vWbe6PW3/BfGFkLqe+a/9+SpbflW39xW14/3/kngoRvDmaWi16EkX5Xe
-        DZHnT6CkquhS8kRN71nJ90TKPnSxO3de7qU6nE5HlXxgTQAAAAAAAAAAAAAAAAAAAAD8pU+3XszC
-        ACgAAA0KLS0xZmMzNjFiMDYzOGE3ODM5MWJkNTM3ZGI1ZGQwYjJhOS0tDQo=
+        LS1mNzU2YjMzMzI0MjZmZWUzZDAyMmYxYTFlY2JhM2YyZA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        z9zgYwL/7dQxT4QwGAbgzvyKhh/AtUBbGC5xvPGG28kHV0yTAhcoijH+d7lz0EHjomfU91nepm3S
+        5XubbJLNzZ6WnaWjHdm3EC8+SiGy/HV93pcilSnjC7uCeQo0rs+z/ykteBdcZ7dSG6ULUZo8KZXS
+        siwiBn+eo6ZqnbfV5PrbNe5m39uRauddeEhC+1X91/rScWmUfJsXUmRM5pkRUulMGnZuv1GMi2v2
+        nzxRbfuWQkfv3fvs/JeKRjsN89hYHtP9VJGvK++mYNchiHlc07GyC3Unb2P+GHF+GocwNIPnWx7v
+        Dod9HD3hmwAAAAAAAAAAAAAAAAAAAAD4Sc+t46KUACgAAA0KLS1mNzU2YjMzMzI0MjZmZWUzZDAy
+        MmYxYTFlY2JhM2YyZC0tDQo=
       headers:
         Accept:
           - '*/*'
@@ -19,60 +17,65 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '557'
+          - '416'
         Content-Type:
-          - multipart/form-data; boundary=1fc361b0638a78391bd537db5dd0b2a9
+          - multipart/form-data; boundary=f756b3332426fee3d022f1a1ecba3f2d
+        GGShield-Command-Id:
+          - b5bf5d67-52a2-447e-b061-4f136dc4c4b7
         GGShield-Command-Path:
           - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+        mode:
+          - directory
       method: POST
       uri: https://api.gitguardian.com/v1/iac_scan
     response:
       body:
         string:
-          '{"id":"0","type":"path_scan","iac_engine_version":"1.5.0","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
+          '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://gitguardian.com"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '437'
-        Content-Type:
+        content-length:
+          - '476'
+        content-type:
           - application/json
-        Date:
-          - Mon, 18 Jul 2022 12:09:02 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:16 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=HaQOiZVRGkp4aEIs6WC5stjnFi4F7xVKJAKqhvB9qeYOyc/aevwpynLNGRdADm9OfA3j9hZ4gsM8k/8GaLyYcMDpHU+SlyQ9ODJ05LKEH9CZpmx7IgcKePYM6qGD;
-            Expires=Mon, 25 Jul 2022 12:09:02 GMT; Path=/
-          - AWSALBCORS=HaQOiZVRGkp4aEIs6WC5stjnFi4F7xVKJAKqhvB9qeYOyc/aevwpynLNGRdADm9OfA3j9hZ4gsM8k/8GaLyYcMDpHU+SlyQ9ODJ05LKEH9CZpmx7IgcKePYM6qGD;
-            Expires=Mon, 25 Jul 2022 12:09:02 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '357'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_file.yaml
+++ b/tests/unit/cassettes/test_scan_file.yaml
@@ -1,8 +1,60 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp8mk5zl_2/file",
-        "document": "This is a file with no secrets."}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:49 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmpo6icvcox/file", "document": "This is a file with
+        no secrets."}]'
       headers:
         Accept:
           - '*/*'
@@ -11,59 +63,64 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '138'
+          - '86'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - e707351a-b085-4b22-a9f3-ec1565208d8b
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
       uri: https://api.gitguardian.com/v1/multiscan
     response:
       body:
-        string: '[{"policy_break_count":0,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[]}]'
+        string:
+          '[{"policy_break_count":0,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '108'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:11 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:50 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=Zrz1YBr7nYDv1JX+6GLX63gr2Slp5l4bvf3zSKpV6kcueVWjo7KlndVJT4iappGy0BaNP7D4lveLRGsCbvv1RguRo9BF+L+/o5EsV5KPk6eMM9WZ9VowzSU9hTaq;
-            Expires=Fri, 22 Jul 2022 16:33:11 GMT; Path=/
-          - AWSALBCORS=Zrz1YBr7nYDv1JX+6GLX63gr2Slp5l4bvf3zSKpV6kcueVWjo7KlndVJT4iappGy0BaNP7D4lveLRGsCbvv1RguRo9BF+L+/o5EsV5KPk6eMM9WZ9VowzSU9hTaq;
-            Expires=Fri, 22 Jul 2022 16:33:11 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '37'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_file_secret-False.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-False.yaml
@@ -1,9 +1,63 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp9yr0_vfi/file_secret",
-        "document": "diff --git a/test.txt b/test.txt\nnew file mode 100644\nindex 0000000..b80e3df\n---
-        /dev/null\n+++ b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:53 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '9'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmpwiqo1tre/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
+        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
+        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
+        b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '535'
+          - '676'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - cda2e266-836b-4e4f-b395-f2635c0d38ca
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -28,45 +90,41 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":1,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[{"type":"GitGuardian
-          Development Secret","policy":"Secrets detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":139,"index_end":407,"line_start":8,"line_end":8}],"validity":"no_checker"}]}]'
+          '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[{"type":"GitGuardian Development Secret","policy":"Secrets
+          detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":311,"index_end":579,"line_start":14,"line_end":14}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '574'
-        Content-Type:
+        content-length:
+          - '576'
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:15 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:53 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=/7nR1OEGSqlqUq/zlBxVs1Uq+2d5jHDiN74+Nld5Wj2JaKGVW0lq3ZgbztgmbIKMpMsu73bU1mKUSzaRvHoPH0woLnDrMA0eSED5uJoDXB37CyHUu2PWQfsp9Lbl;
-            Expires=Fri, 22 Jul 2022 16:33:15 GMT; Path=/
-          - AWSALBCORS=/7nR1OEGSqlqUq/zlBxVs1Uq+2d5jHDiN74+Nld5Wj2JaKGVW0lq3ZgbztgmbIKMpMsu73bU1mKUSzaRvHoPH0woLnDrMA0eSED5uJoDXB37CyHUu2PWQfsp9Lbl;
-            Expires=Fri, 22 Jul 2022 16:33:15 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '49'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_file_secret-True.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-True.yaml
@@ -1,9 +1,63 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmp7d4a1n11/file_secret",
-        "document": "diff --git a/test.txt b/test.txt\nnew file mode 100644\nindex 0000000..b80e3df\n---
-        /dev/null\n+++ b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"ggtt-v-12345azert\";\n"}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:52 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmp76tsr31l/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
+        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
+        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
+        b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"ggtt-v-12345azert\";\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '283'
+          - '424'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - 7fe1d4a9-2ca2-4557-a38a-26de57ff0d67
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -28,45 +90,41 @@ interactions:
     response:
       body:
         string:
-          '[{"policy_break_count":1,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[{"type":"GitGuardian
-          Test Token Checked","policy":"Secrets detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":139,"index_end":155,"line_start":8,"line_end":8}],"validity":"valid"}]}]'
+          '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[{"type":"GitGuardian Test Token Checked","policy":"Secrets
+          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":311,"index_end":327,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '317'
-        Content-Type:
+        content-length:
+          - '319'
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:14 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:52 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=J+d0AcmaoZDvC+te1TbB5QRg75kt9N/QvUQAzNtIEwnMpO3bkc0xzf/c8KOip78/clJGRVxy3n9NJ5N75lxZmnSFUPtel108J+yNVLgM04f4HTeTJWdOpmMVLCFV;
-            Expires=Fri, 22 Jul 2022 16:33:14 GMT; Path=/
-          - AWSALBCORS=J+d0AcmaoZDvC+te1TbB5QRg75kt9N/QvUQAzNtIEwnMpO3bkc0xzf/c8KOip78/clJGRVxy3n9NJ5N75lxZmnSFUPtel108J+yNVLgM04f4HTeTJWdOpmMVLCFV;
-            Expires=Fri, 22 Jul 2022 16:33:14 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '51'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_file_secret.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret.yaml
@@ -1,9 +1,63 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpocfhbvp1/file_secret",
-        "document": "diff --git a/test.txt b/test.txt\nnew file mode 100644\nindex 0000000..b80e3df\n---
-        /dev/null\n+++ b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:48 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '10'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
+        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
+        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
+        b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -12,61 +66,65 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '535'
+          - '659'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - e634899f-2982-4791-a3f6-3998013f25a5
         GGShield-Command-Path:
-          - cli secret scan path
+          - cli secret scan docker-archive
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
-          - path
+          - docker
       method: POST
       uri: https://api.gitguardian.com/v1/multiscan
     response:
       body:
         string:
-          '[{"policy_break_count":1,"policies":["Secrets detection","File extensions","Filenames"],"policy_breaks":[{"type":"GitGuardian
-          Development Secret","policy":"Secrets detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":139,"index_end":407,"line_start":8,"line_end":8}],"validity":"no_checker"}]}]'
+          '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[{"type":"GitGuardian Development Secret","policy":"Secrets
+          detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":311,"index_end":579,"line_start":14,"line_end":14}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '574'
-        Content-Type:
+        content-length:
+          - '576'
+        content-type:
           - application/json
-        Date:
-          - Fri, 15 Jul 2022 16:33:12 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:49 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=nJCn04JwU3UsHZRUgMWDp1l5VDm0UknK5Cturj8QpZeKXPSABtG3zkuVFiOfFB/844LAw3dE9BdDep7qxVORuf5ncrM4ABv7j7oPdWQadr6WIBqVF8WXjLy8w7e5;
-            Expires=Fri, 22 Jul 2022 16:33:12 GMT; Path=/
-          - AWSALBCORS=nJCn04JwU3UsHZRUgMWDp1l5VDm0UknK5Cturj8QpZeKXPSABtG3zkuVFiOfFB/844LAw3dE9BdDep7qxVORuf5ncrM4ABv7j7oPdWQadr6WIBqVF8WXjLy8w7e5;
-            Expires=Fri, 22 Jul 2022 16:33:12 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.0
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '74'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_file_secret_with_validity.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret_with_validity.yaml
@@ -1,7 +1,59 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "test.txt", "document": "@@ -0,0 +2 @@\n+# gg token\n+apikey
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:24 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '11'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "test", "document": "@@ -0,0 +2 @@\n+# gg token\n+apikey
         = \"ggtt-v-12345azert\";\n"}]'
       headers:
         Accept:
@@ -11,18 +63,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '104'
+          - '100'
         Content-Type:
           - application/json
-        Cookie:
-          - AWSALB=GYUV0/k/nyKtrZIvq22zhP1QXULrH0r+6Yi+8DQKatD4GQ1FELUtQwFtgkJqClF356jPef5bcpFV4KYFfZEaAL5JT6yRrTxJRqg1JGg/C99L0sCl5FByT1n5I0rs;
-            AWSALBCORS=GYUV0/k/nyKtrZIvq22zhP1QXULrH0r+6Yi+8DQKatD4GQ1FELUtQwFtgkJqClF356jPef5bcpFV4KYFfZEaAL5JT6yRrTxJRqg1JGg/C99L0sCl5FByT1n5I0rs
+        GGShield-Command-Id:
+          - 1df80264-012e-4f8b-9da3-ab87d8bce5cc
         GGShield-Command-Path:
           - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0)
+          - pygitguardian/1.5.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -34,42 +91,37 @@ interactions:
           detection"],"policy_breaks":[{"type":"GitGuardian Test Token Checked","policy":"Secrets
           detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":37,"index_end":53,"line_start":3,"line_end":3}],"validity":"valid"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
+        content-length:
           - '315'
-        Content-Type:
+        content-type:
           - application/json
-        Date:
-          - Tue, 19 Jul 2022 08:57:31 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:25 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=Jw2i8Dj+GE9sJDBLVTBVwb8VKoPfipIU4wXrhhEwZaeN7XOReVCBwX3Su0wbv3euCGY92hOvM6q02WCzwwMZQW+bVerzKOH995iQ+OCCJjvO0kmtdBUG1G4oJRNo;
-            Expires=Tue, 26 Jul 2022 08:57:31 GMT; Path=/
-          - AWSALBCORS=Jw2i8Dj+GE9sJDBLVTBVwb8VKoPfipIU4wXrhhEwZaeN7XOReVCBwX3Su0wbv3euCGY92hOvM6q02WCzwwMZQW+bVerzKOH995iQ+OCCJjvO0kmtdBUG1G4oJRNo;
-            Expires=Tue, 26 Jul 2022 08:57:31 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '79'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cassettes/test_scan_path_file_one_line_and_multiline_patch.yaml
+++ b/tests/unit/cassettes/test_scan_path_file_one_line_and_multiline_patch.yaml
@@ -1,10 +1,64 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpvmrk0dvh/file_secret",
-        "document": "diff --git a/test.txt b/test.txt\nnew file mode 100644\nindex 0000000..b80e3df\n---
-        /dev/null\n+++ b/test\n@@ -0,0 +1,29 @@\n+FacebookAppKeys: 294790898041573 /
-        ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----\n+MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l\n+bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I\n+NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW\n+TQIhANrCE7O+wlCKe0WJqQ3lYlHG91XWyGVgfExJwBDsAD9LAiEAmDY5OSsH0n2A\n+22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT\n+bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb\n+RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4\n+-----END
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:56:00 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '12'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmp5jpbcpdc/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
+        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
+        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
+        b/test\n@@ -0,0 +1,29 @@\n+FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371
+        -----BEGIN RSA PRIVATE KEY-----\n+MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l\n+bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I\n+NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW\n+TQIhANrCE7O+wlCKe0WJqQ3lYlHG91XWyGVgfExJwBDsAD9LAiEAmDY5OSsH0n2A\n+22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT\n+bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb\n+RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4\n+-----END
         RSA PRIVATE KEY----- token: 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\n"}]'
       headers:
         Accept:
@@ -14,15 +68,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '895'
+          - '1036'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - 6521902d-a744-4e5d-add7-be99251f6f78
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -31,51 +93,45 @@ interactions:
       body:
         string:
           '[{"policy_break_count":2,"policies":["File extensions","Filenames","Secrets
-          detection"],"policy_breaks":[{"type":"RSA Private Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"-----BEGIN
+          detection"],"policy_breaks":[{"type":"SendGrid Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":868,"index_end":936,"line_start":21,"line_end":21}],"validity":"no_checker"},{"type":"RSA
+          Private Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"-----BEGIN
           RSA PRIVATE KEY-----\n+MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l\n+bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I\n+NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW\n+TQIhANrCE7O+wlCKe0WJqQ3lYlHG91XWyGVgfExJwBDsAD9LAiEAmDY5OSsH0n2A\n+22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT\n+bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb\n+RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4\n+-----END
-          RSA PRIVATE KEY-----","index_start":188,"index_end":687,"line_start":7,"line_end":15}],"validity":"no_checker"},{"type":"SendGrid
-          Key","policy":"Secrets detection","matches":[{"type":"apikey","match":"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","index_start":696,"index_end":764,"line_start":15,"line_end":15}],"validity":"no_checker"}]}]'
+          RSA PRIVATE KEY-----","index_start":360,"index_end":859,"line_start":13,"line_end":21}],"validity":"no_checker"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Type:
+        content-length:
+          - '1051'
+        content-type:
           - application/json
-        Date:
-          - Tue, 19 Jul 2022 16:55:14 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:56:00 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=bDzcLqH7Hw2x3jfG8Ot7YHU0lX5JAm+bhPPlLxAGMZMt98DPz8MUErecTTtOl/D1/mLnehe5aGxwA5U3K6P9iKhXWPwgP+NdYBY68ZXskiOihOYDeg2lmoS9pcbm;
-            Expires=Tue, 26 Jul 2022 16:55:14 GMT; Path=/
-          - AWSALBCORS=bDzcLqH7Hw2x3jfG8Ot7YHU0lX5JAm+bhPPlLxAGMZMt98DPz8MUErecTTtOl/D1/mLnehe5aGxwA5U3K6P9iKhXWPwgP+NdYBY68ZXskiOihOYDeg2lmoS9pcbm;
-            Expires=Tue, 26 Jul 2022 16:55:14 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Transfer-Encoding:
+        transfer-encoding:
           - chunked
-        Vary:
-          - Accept-Encoding
-          - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '307'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
-        content-length:
-          - '1050'
       status:
         code: 200
         message: OK

--- a/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
+++ b/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
@@ -1,9 +1,63 @@
 interactions:
   - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/health
+    response:
       body:
-        '[{"filename": "/private/var/folders/8g/n692j_595cg2nq1gbbb6_c1h0000gp/T/tmpbj5yewc9/file_secret",
-        "document": "diff --git a/test.txt b/test.txt\nnew file mode 100644\nindex 0000000..b80e3df\n---
-        /dev/null\n+++ b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"ggtt-v-12345azert\";\n"}]'
+        string: '{"detail":"Valid API key."}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '27'
+        content-type:
+          - application/json
+        date:
+          - Mon, 06 Feb 2023 10:55:51 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '13'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "/tmp/tmpjbzs68_0/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
+        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
+        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
+        b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"ggtt-v-12345azert\";\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -12,15 +66,23 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '283'
+          - '424'
         Content-Type:
           - application/json
+        GGShield-Command-Id:
+          - cffba95a-a087-4f28-ac9e-3509a477fd4a
         GGShield-Command-Path:
           - cli secret scan path
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.6
         GGShield-Version:
-          - 1.12.0
+          - 1.14.2
         User-Agent:
-          - pygitguardian/1.3.5 (Darwin;py3.10.0) ggshield
+          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -30,44 +92,39 @@ interactions:
         string:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"GitGuardian Test Token Checked","policy":"Secrets
-          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":139,"index_end":155,"line_start":8,"line_end":8}],"validity":"valid"}]}]'
+          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":311,"index_end":327,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
       headers:
-        Access-Control-Expose-Headers:
+        access-control-expose-headers:
           - X-App-Version
-        Allow:
+        allow:
           - POST, OPTIONS
-        Connection:
-          - keep-alive
-        Content-Length:
-          - '317'
-        Content-Type:
+        content-length:
+          - '319'
+        content-type:
           - application/json
-        Date:
-          - Tue, 19 Jul 2022 16:55:07 GMT
-        Referrer-Policy:
+        date:
+          - Mon, 06 Feb 2023 10:55:51 GMT
+        referrer-policy:
           - strict-origin-when-cross-origin
-        Server:
-          - nginx
-        Set-Cookie:
-          - AWSALB=b/nJ3Lqek+zYQwBuD/Zp0gwdhjGWZK9s8G1PahbW951kMPTl1eAV+bqbbL6QH3mJ5FIGUnwWzvcCahysSC7Btl8qQaWGJbhDpAV0ZrnyYyRxf0Mqih2O5hZlbdvv;
-            Expires=Tue, 26 Jul 2022 16:55:07 GMT; Path=/
-          - AWSALBCORS=b/nJ3Lqek+zYQwBuD/Zp0gwdhjGWZK9s8G1PahbW951kMPTl1eAV+bqbbL6QH3mJ5FIGUnwWzvcCahysSC7Btl8qQaWGJbhDpAV0ZrnyYyRxf0Mqih2O5hZlbdvv;
-            Expires=Tue, 26 Jul 2022 16:55:07 GMT; Path=/; SameSite=None; Secure
-        Strict-Transport-Security:
+        server:
+          - istio-envoy
+        strict-transport-security:
           - max-age=31536000; includeSubDomains
-        Vary:
+        vary:
           - Cookie
-        X-App-Version:
-          - v2.9.1
-        X-Content-Type-Options:
+        x-app-version:
+          - v2.22.2
+        x-content-type-options:
           - nosniff
           - nosniff
-        X-Frame-Options:
+        x-envoy-upstream-service-time:
+          - '90'
+        x-frame-options:
           - DENY
           - SAMEORIGIN
-        X-Secrets-Engine-Version:
-          - 2.71.0
-        X-XSS-Protection:
+        x-secrets-engine-version:
+          - 2.83.0
+        x-xss-protection:
           - 1; mode=block
       status:
         code: 200

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -134,10 +134,12 @@ class TestPreReceive:
             in result.output
         )
 
+    @patch("ggshield.scan.repo.check_client_api_key")
     @patch("ggshield.scan.repo.scan_commits_content")
     def test_stdin_supports_gitlab_web_ui(
         self,
         scan_commits_content_mock: Mock,
+        check_client_api_key_mock: Mock,
         tmp_path,
         cli_fs_runner: CliRunner,
     ):
@@ -154,6 +156,8 @@ class TestPreReceive:
         secret_file.write_text(f"github_token = {_SIMPLE_SECRET_TOKEN}\n")
         repo.add(secret_file)
         secret_sha = repo.create_commit()
+
+        check_client_api_key_mock.return_value = None
 
         # This test cannot mock scan_commit_range(): if it did that we would not get
         # the GitLab-specific output because output_handler.process_scan() would not be

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -1,0 +1,29 @@
+from typing import Type
+from unittest.mock import Mock
+
+import pytest
+from pygitguardian.models import HealthCheckResponse
+
+from ggshield.core.client import check_client_api_key
+from ggshield.core.errors import APIKeyCheckError, UnexpectedError
+
+
+@pytest.mark.parametrize(
+    ("response", "error_class"),
+    (
+        (HealthCheckResponse("Guru Meditation", 500), UnexpectedError),
+        (HealthCheckResponse("Unauthorized", 401), APIKeyCheckError),
+    ),
+)
+def test_check_client_api_key_error(
+    response: HealthCheckResponse, error_class: Type[Exception]
+):
+    """
+    GIVEN a client returning an error when its healthcheck endpoint is called
+    WHEN check_client_api_key() is called
+    THEN it raises the appropriate exception
+    """
+    client_mock = Mock()
+    client_mock.health_check.return_value = response
+    with pytest.raises(error_class):
+        check_client_api_key(client_mock)

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -11,7 +11,7 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
-from ggshield.core.errors import UnexpectedError, UnknownInstanceError
+from ggshield.core.errors import APIKeyCheckError, UnexpectedError, UnknownInstanceError
 from ggshield.core.utils import (
     MatchIndices,
     api_to_dashboard_url,
@@ -151,7 +151,7 @@ def test_retrieve_client_blank_state(isolated_fs):
     THEN the exception message is user-friendly for new users
     """
     with pytest.raises(
-        click.UsageError,
+        APIKeyCheckError,
         match="GitGuardian API key is needed",
     ):
         with patch.dict(os.environ, clear=True):

--- a/tests/unit/scan/test_scan.py
+++ b/tests/unit/scan/test_scan.py
@@ -35,6 +35,7 @@ def test_request_headers(scan_mock: Mock, client):
                 scan_mode=ScanMode.PATH,
                 command_path=ctx.command_path,
             ),
+            check_api_key=False,
         )
         scanner.scan(c.files)
     scan_mock.assert_called_with(


### PR DESCRIPTION
### Related issue
https://github.com/GitGuardian/ggshield/issues/456

### Solution
We propose checking that a healthy connection with API can be established.
If we fail to do it successfully, then we conclude we cannot interact with the API for the time being. Thus, we abort.

### Implementation
We use the `health_check` function from the `GGClient` class to retrieve the health of the API connection we tried to establish. We do it in two different locations:
1. In the `SecretScanner` class in order to check for the validity of the key within the class constructor
    - This can be toggled off by setting the argument `check_api_health` to `False` (defaults to `True`)
2. Within the `scan_commit_range()` function because it creates different scanner instances: One per scanned commit.


#### Previous behavior (bad :no_entry: )
```bash
❯ ggshield secret scan path ./README.md
status_code=401 detail=Invalid API key.
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1 files scanned out of 1 0:00:00

ERROR: Invalid API key..
```

#### New behavior (better :heavy_check_mark: )
```bash
❯ ggshield secret scan path ./README.md


ERROR: Invalid API key..
```