### PR TITLE
Make our Docker image usable even if the source is not mounted in /data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !README.md
 !LICENSE
 !setup*
+!docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,10 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Get enough commits to run `ggshield secret scan commit-range` on ourselves
+          fetch-depth: 10
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN set -ex; \
     mkdir /data; chmod 777 /data
 
 USER app
-RUN git config --global --add safe.directory /data
 
 WORKDIR /data
 VOLUME [ "/data" ]
 
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["ggshield"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mark the current directory as safe. If we don't do this, git commands fail
+# because the source in $PWD is owned by a different user than our `app` user.
+git config --global --add safe.directory "$PWD"
+
+exec "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,14 @@
+import os
+import platform
+
+import pytest
+
+
 # This is a test token, it is always reported as a valid secret
 GG_VALID_TOKEN = "ggtt-v-12345azert"  # ggignore
+
+
+skipwindows = pytest.mark.skipif(
+    platform.system() == "Windows" and not os.environ.get("DISABLE_SKIPWINDOWS"),
+    reason="Skipped on Windows for now, define DISABLE_SKIPWINDOWS environment variable to unskip",
+)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,6 +6,9 @@ import pytest
 
 FUNCTESTS_DATA_PATH = Path(__file__).parent / "data"
 
+# Path to the root of ggshield repository
+REPO_PATH = Path(__file__).parent.parent.parent
+
 HAS_DOCKER = shutil.which("docker") is not None
 
 # Use this as a decorator for tests which call the `docker` binary

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,4 +1,12 @@
+import shutil
 from pathlib import Path
+
+import pytest
 
 
 FUNCTESTS_DATA_PATH = Path(__file__).parent / "data"
+
+HAS_DOCKER = shutil.which("docker") is not None
+
+# Use this as a decorator for tests which call the `docker` binary
+requires_docker = pytest.mark.skipif(not HAS_DOCKER, reason="This test requires Docker")

--- a/tests/functional/secret/test_scan_docker.py
+++ b/tests/functional/secret/test_scan_docker.py
@@ -7,7 +7,7 @@ from string import Template
 import pytest
 
 from tests.conftest import GG_VALID_TOKEN
-from tests.functional.conftest import FUNCTESTS_DATA_PATH
+from tests.functional.conftest import FUNCTESTS_DATA_PATH, requires_docker
 from tests.functional.utils import (
     assert_is_valid_json,
     recreate_censored_content,
@@ -15,12 +15,10 @@ from tests.functional.utils import (
 )
 
 
-HAS_DOCKER = shutil.which("docker") is not None
-
 TEST_DOCKER_IMAGE = os.getenv("GGTEST_DOCKER_IMAGE", "ubuntu:20.04")
 
 
-pytestmark = pytest.mark.skipif(not HAS_DOCKER, reason="These tests require Docker")
+pytestmark = requires_docker()
 
 
 def build_image(tmp_path: Path, name: str) -> None:

--- a/tests/functional/test_docker_image.py
+++ b/tests/functional/test_docker_image.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+
+import pytest
+
+from tests.conftest import skipwindows
+from tests.functional.conftest import REPO_PATH, requires_docker
+
+
+pytestmark = [requires_docker, skipwindows]
+
+
+@pytest.fixture(scope="module")
+def docker_image():
+    """Build our Docker image"""
+    image_name = "ggshield_func_test"
+    build_cmd = ["docker", "build", "-t", image_name, str(REPO_PATH)]
+    subprocess.run(build_cmd, check=True)
+    return image_name
+
+
+@pytest.mark.parametrize(
+    ("mount_dir", "set_work_dir"),
+    (
+        ("/data", False),
+        ("/src", True),
+    ),
+)
+def test_docker_image_can_use_git(docker_image, mount_dir, set_work_dir) -> None:
+    """
+    GIVEN gitguardian/ggshield Docker image
+    AND a git working tree mounted in `mount_dir`
+    WHEN running a `ggshield secret scan` command which uses git on `mount_dir`
+    THEN the scan succeeds without no `dubious directory` errors
+    """
+    src_dir = os.getcwd()
+    extra_args = ["-w", mount_dir] if set_work_dir else []
+
+    run_cmd = [
+        "docker",
+        "run",
+        "-e",
+        "GITGUARDIAN_API_KEY",
+        "-v",
+        f"{src_dir}:{mount_dir}",
+        *extra_args,
+        docker_image,
+        "ggshield",
+        "secret",
+        "scan",
+        "commit-range",
+        "HEAD~2..",
+    ]
+    subprocess.run(run_cmd, check=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,12 +19,6 @@ from tests.conftest import GG_VALID_TOKEN
 os.environ.setdefault("PYTHONBREAKPOINT", "ipdb.set_trace")
 
 
-skipwindows = pytest.mark.skipif(
-    platform.system() == "Windows" and not os.environ.get("DISABLE_SKIPWINDOWS"),
-    reason="Skipped on Windows for now, define DISABLE_SKIPWINDOWS environment variable to unskip",
-)
-
-
 def is_macos():
     return platform.system() == "Darwin"
 


### PR DESCRIPTION
## Description

This PR changes gitguardian/ggshield image behavior so that $PWD is marked as a safe git directory at run time, instead of always marking /data. This ensures the Docker image can be used to run scan commands that use git, even if the source to scan is not mounted in /data.

Also adds a test for this.