### PR TITLE
Fix hook failing in VisualStudio

### DIFF
--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -101,8 +101,8 @@ def create_hook(
     local_hook_str = ""
     if local_hook_support:
         local_hook_str = f"""
-if [[ -f .git/hooks/{hook_type} ]]; then
-    if ! .git/hooks/{hook_type} $@; then
+if [ -f .git/hooks/{hook_type} ]; then
+    if ! .git/hooks/{hook_type} "$@"; then
         echo 'Local {hook_type} hook failed, please see output above'
         exit 1
     fi
@@ -113,7 +113,7 @@ fi
 
     with open(hook_path, mode) as f:
         if mode == "w":
-            f.write("#!/usr/bin/env bash\n")
+            f.write("#!/bin/sh\n")
 
         f.write(f'\n{local_hook_str}\nggshield secret scan {hook_type} "$@"\n')
         os.chmod(hook_path, 0o700)

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -11,13 +11,13 @@ from ggshield.core.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
-SAMPLE_PRE_COMMIT = """#!/usr/bin/env bash
+SAMPLE_PRE_COMMIT = """#!/bin/sh
 
 
 ggshield secret scan pre-commit "$@"
 """
 
-SAMPLE_PRE_PUSH = """#!/usr/bin/env bash
+SAMPLE_PRE_PUSH = """#!/bin/sh
 
 
 ggshield secret scan pre-push "$@"
@@ -244,7 +244,7 @@ class TestInstallGlobal:
 
         hook = open(f"{path}/{hook_type}", "r")
         hook_str = hook.read()
-        assert f"if [[ -f .git/hooks/{hook_type} ]]; then" in hook_str
+        assert f"if [ -f .git/hooks/{hook_type} ]; then" in hook_str
         assert f"ggshield secret scan {hook_type}" in hook_str
 
         assert (

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -12,14 +12,10 @@ from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
 SAMPLE_PRE_COMMIT = """#!/bin/sh
-
-
 ggshield secret scan pre-commit "$@"
 """
 
 SAMPLE_PRE_PUSH = """#!/bin/sh
-
-
 ggshield secret scan pre-push "$@"
 """
 


### PR DESCRIPTION
## Description

This PR fixes Visual Studio failing to run our git hook by using `/bin/sh` as a shebang, meaning only Posix shell (no more `if [[ something ]]`)

While working on this I noticed some output messages were mixing Windows and Unix path separators, producing things like that:

```
$ ggshield.exe install -m global -t pre-commit -f
pre-commit successfully added in C:\Users\User/.git/hooks/pre-commit
```

I took the opportunity to migrate the code in `install.py` to use `Path`, fixing that issue while doing so.

Best reviewed commit-by-commit.

## Issue

Fixes #467 