### PR TITLE
Fix config error messages #480

### DIFF
--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -8,7 +8,7 @@ import requests
 from ggshield import __version__
 from ggshield.core.dirs import get_cache_dir
 
-from .config.utils import load_yaml_dict, save_yaml_dict
+from .config.utils import load_config_data, save_yaml_dict
 
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def check_for_updates() -> Optional[str]:
     check_at = -1.0
     # Load the last time we checked
     try:
-        cached_data = load_yaml_dict(CACHE_FILE)
+        cached_data = load_config_data(CACHE_FILE)
     except ValueError:
         # Swallow the error
         cached_data = None

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -8,7 +8,7 @@ import marshmallow_dataclass
 from ggshield.core.config.utils import (
     ensure_path_exists,
     get_auth_config_filepath,
-    load_yaml_dict,
+    load_config_data,
     save_yaml_dict,
 )
 from ggshield.core.dirs import get_config_dir
@@ -118,7 +118,7 @@ class AuthConfig:
         """Load the auth config from the app config file"""
         config_path = get_auth_config_filepath()
 
-        data = load_yaml_dict(config_path)
+        data = load_config_data(config_path)
         if data:
             data = prepare_auth_config_dict_for_parse(data)
             return AuthConfigSchema().load(data)  # type: ignore

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -8,7 +8,7 @@ from marshmallow import ValidationError
 
 from ggshield.core.config.utils import (
     get_global_path,
-    load_yaml_dict,
+    load_config_data,
     remove_common_dict_items,
     save_yaml_dict,
     update_from_other_instance,
@@ -19,7 +19,12 @@ from ggshield.core.constants import (
     LOCAL_CONFIG_PATHS,
 )
 from ggshield.core.errors import ParseError, UnexpectedError, format_validation_error
-from ggshield.core.types import FilteredConfig, IgnoredMatch, IgnoredMatchSchema
+from ggshield.core.types import (
+    FilteredConfig,
+    IgnoredMatch,
+    IgnoredMatchSchema,
+    ValidatedConfig,
+)
 from ggshield.core.utils import api_to_dashboard_url
 from ggshield.iac.policy_id import POLICY_ID_PATTERN, validate_policy_id
 
@@ -77,7 +82,7 @@ class IaCConfig(FilteredConfig):
 
 
 @marshmallow_dataclass.dataclass
-class UserConfig(FilteredConfig):
+class UserConfig(FilteredConfig, ValidatedConfig):
     """
     Holds all ggshield settings defined by the user in the .gitguardian.yaml files
     (local and global).
@@ -155,7 +160,9 @@ class UserConfig(FilteredConfig):
     def _update_from_file(self, config_path: str) -> None:
 
         try:
-            data = load_yaml_dict(config_path) or {"version": CURRENT_CONFIG_VERSION}
+            data = load_config_data(config_path, config=self) or {
+                "version": CURRENT_CONFIG_VERSION
+            }
             config_version = data.pop("version", 1)
             if config_version == 2:
                 obj = UserConfigSchema().load(data)

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -7,7 +7,9 @@ import yaml
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME
 from ggshield.core.dirs import get_config_dir
-from ggshield.core.errors import UnexpectedError
+from ggshield.core.errors import ParseError, UnexpectedError
+from ggshield.core.text_utils import display_warning
+from ggshield.core.types import ValidatedConfig
 
 
 def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> None:
@@ -36,8 +38,21 @@ def load_yaml_dict(path: str) -> Optional[Dict[str, Any]]:
 
     if not isinstance(data, dict):
         raise ValueError(f"{path} should be a dictionary.")
+    return data
 
-    replace_in_keys(data, old_char="-", new_char="_")
+
+def load_config_data(
+    path: str, config: Optional[ValidatedConfig] = None
+) -> Optional[Dict[str, Any]]:
+    """Optionally check if all keys in loaded file are known for specified config"""
+    data = load_yaml_dict(path)
+    if data:
+        try:
+            if config:
+                config.validate_fields(data)
+            replace_in_keys(data, old_char="-", new_char="_")
+        except ParseError as e:
+            display_warning(e.message)
     return data
 
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -7,8 +7,7 @@ import yaml
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME
 from ggshield.core.dirs import get_config_dir
-from ggshield.core.errors import ParseError, UnexpectedError
-from ggshield.core.text_utils import display_warning
+from ggshield.core.errors import UnexpectedError
 from ggshield.core.types import ValidatedConfig
 
 
@@ -47,12 +46,9 @@ def load_config_data(
     """Optionally check if all keys in loaded file are known for specified config"""
     data = load_yaml_dict(path)
     if data:
-        try:
-            if config:
-                config.validate_fields(data)
-            replace_in_keys(data, old_char="-", new_char="_")
-        except ParseError as e:
-            display_warning(e.message)
+        if config:
+            config.validate_fields(data)
+        replace_in_keys(data, old_char="-", new_char="_")
     return data
 
 

--- a/ggshield/core/types.py
+++ b/ggshield/core/types.py
@@ -4,7 +4,24 @@ from typing import Any, Dict, Optional
 import marshmallow_dataclass
 from marshmallow.decorators import pre_load
 
+from ggshield.core.errors import ParseError
 from ggshield.core.text_utils import display_warning
+
+
+@marshmallow_dataclass.dataclass
+class ValidatedConfig:
+    @classmethod
+    def validate_fields(cls, data: Dict[str, Any], **kwargs: Any) -> None:
+        """
+        Raise exception on unknown keys
+        """
+        field_names = {field_.name for field_ in fields(cls)}
+        hyphen_names = {name.replace("_", "-") for name in field_names}
+        valid_names = field_names.union(hyphen_names)
+        valid_names.add("version")
+        for key in data.keys():
+            if key not in valid_names:
+                raise ParseError("Unrecognized key in config: {}".format(key))
 
 
 @marshmallow_dataclass.dataclass

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -8,7 +8,7 @@ from typing import Optional
 import pytest
 
 from ggshield.core.config import AccountConfig, Config, InstanceConfig
-from ggshield.core.config.utils import get_auth_config_filepath, load_yaml_dict
+from ggshield.core.config.utils import get_auth_config_filepath, load_config_data
 from ggshield.core.constants import DEFAULT_LOCAL_CONFIG_PATH
 from ggshield.core.errors import UnknownInstanceError
 from ggshield.core.utils import dashboard_to_api_url
@@ -310,5 +310,5 @@ class TestConfig:
 
         assert not Path(DEFAULT_LOCAL_CONFIG_PATH).exists()
 
-        dct = load_yaml_dict(local_config_path)
+        dct = load_config_data(local_config_path)
         assert dct["instance"] == "https://after.com"

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -242,6 +242,7 @@ class TestUserConfig:
                         {"name": "", "match": "one", "match_invalid_key": "two"},
                     ],
                 },
+                "hyphen-key": "example",
             },
         )
         UserConfig.load(local_config_path)
@@ -250,3 +251,4 @@ class TestUserConfig:
         assert "Unrecognized key in config: iac_unknown" in captured.err
         assert "Unrecognized key in config: secret_invalid_key" in captured.err
         assert "Unrecognized key in config: match_invalid_key" in captured.err
+        assert "Unrecognized key in config: hyphen-key" in captured.err


### PR DESCRIPTION
I created `load_config_data()` function that makes optional checks on field names of dict loaded from yaml file
Key names are checked inside `validate_fields()` method of `ValidatedConfig`.

`ValidatedConfig` separates checking key names from filtering them in `FilteredConfig`