### PR TITLE
Fix fails on pull-requests from forks (PR from a fork)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,10 @@ jobs:
           fail_ci_if_error: false
 
       - name: Run functional tests
+        # For security reasons, secrets are not available when running tests for a pull request from a fork. This causes
+        # all functional tests to fail because GITGUARDIAN_API_KEY is not defined. To avoid this, skip this step if we
+        # were triggered by a pull request from a fork.
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         shell: bash
         run: |
           make functest GITGUARDIAN_API_KEY=${{ secrets.GITGUARDIAN_API_KEY }} GITGUARDIAN_API_URL=${{ secrets.GITGUARDIAN_API_URL }}
@@ -158,6 +162,7 @@ jobs:
 
   test_github_secret_scan_action:
     name: Test GitHub action for `secret scan`
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -177,6 +182,7 @@ jobs:
 
   test_github_iac_scan_action:
     name: Test GitHub action for `iac scan`
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   benchmark:
     name: Run performance benchmark
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     env:
       PYTHONUNBUFFERED: 1


### PR DESCRIPTION
These tests fail because they need the GITGUARDIAN_API_KEY variable, but it's not available for pull-requests coming from forks.

Fixes #374