### PR TITLE
Fix fails on pull-requests from forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: Application Main Branch
 
+# About steps requiring the GITGUARDIAN_API_KEY:
+#
+# For security reasons, secrets are not available when a workflow is triggered by a pull request from a fork. This
+# causes all steps requiring the GITGUARDIAN_API_KEY to fail. To avoid this, we skip those steps when we are triggered
+# by a pull request from a fork.
+
 on:
   pull_request:
   push:
@@ -113,6 +119,8 @@ jobs:
           fail_ci_if_error: false
 
       - name: Run functional tests
+        # See note about steps requiring the GITGUARDIAN_API at the top of this file
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         shell: bash
         run: |
           make functest GITGUARDIAN_API_KEY=${{ secrets.GITGUARDIAN_API_KEY }} GITGUARDIAN_API_URL=${{ secrets.GITGUARDIAN_API_URL }}
@@ -158,6 +166,8 @@ jobs:
 
   test_github_secret_scan_action:
     name: Test GitHub action for `secret scan`
+    # See note about steps requiring the GITGUARDIAN_API at the top of this file
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -177,6 +187,8 @@ jobs:
 
   test_github_iac_scan_action:
     name: Test GitHub action for `iac scan`
+    # See note about steps requiring the GITGUARDIAN_API at the top of this file
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   benchmark:
     name: Run performance benchmark
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     env:
       PYTHONUNBUFFERED: 1


### PR DESCRIPTION
Do not run steps which require the GITGUARDIAN_API_KEY variable. These steps always fail because the variable is not available for pull-requests coming from forks.

Fixes #374

## Testing

This PR merges a branch from the GitGuardian/ggshield repository, so all steps should run.

PR #484 merges the same branch, but from my fork of the repository, and this time not all steps run. 
Update: looks like GitHub is confused and now shows the same results as for this PR. You can look at this [previous run](https://github.com/GitGuardian/ggshield/actions/runs/4243739433) to see skipped jobs (the GitHub action test jobs) and steps (the functional tests inside the build jobs). There is also this [run of the performance benchmark](https://github.com/GitGuardian/ggshield/actions/runs/4243739426) which is skipped too.