### PR TITLE
fix: allow iac scan command to run with no argument

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -67,6 +67,7 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[s
 @click.argument(
     "directory",
     type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),
+    required=False,
 )
 @add_common_options()
 @click.pass_context
@@ -77,12 +78,14 @@ def scan_cmd(
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
     json: bool,
-    directory: Path,
+    directory: Optional[Path],
     **kwargs: Any,
 ) -> int:
     """
     Scan a directory for IaC vulnerabilities.
     """
+    if directory is None:
+        directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
     result = iac_scan(ctx, directory)
     scan = ScanCollection(id=str(directory), type="path_scan", iac_result=result)

--- a/tests/unit/cassettes/test_iac_scan_no_argument.yaml
+++ b/tests/unit/cassettes/test_iac_scan_no_argument.yaml
@@ -1,0 +1,76 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS0xYWZiMmVkNzFkMWVlMmM2ZGM1MmMzM2FjYjgyMGM3Zg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
+        cen4YwL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tMWFmYjJlZDcxZDFl
+        ZTJjNmRjNTJjMzNhY2I4MjBjN2YtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '195'
+        Content-Type:
+          - multipart/form-data; boundary=1afb2ed71d1ee2c6dc52c33acb820c7f
+        GGShield-Command-Id:
+          - 0c0fcd4d-5e4c-43b4-b2ff-ebbce62370dc
+        GGShield-Command-Path:
+          - cli iac scan
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.8.10
+        GGShield-Version:
+          - 1.14.4
+        User-Agent:
+          - pygitguardian/1.5.0 (Linux;py3.8.10) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_scan
+    response:
+      body:
+        string: '{"id":"0","type":"path_scan","iac_engine_version":"1.7.0","entities_with_incidents":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '87'
+        content-type:
+          - application/json
+        date:
+          - Fri, 24 Feb 2023 16:44:34 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.24.1
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '173'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.85.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -10,6 +10,23 @@ from ggshield.core.errors import ExitCode
 from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, MockRequestsResponse, my_vcr
 
 
+@my_vcr.use_cassette("test_iac_scan_no_argument")
+def test_scan_no_arg(cli_fs_runner: CliRunner) -> None:
+    """
+    GIVEN -
+    WHEN running the iac scan command with no argument
+    THEN the return code is 0
+    """
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "iac",
+            "scan",
+        ],
+    )
+    assert result.exit_code == ExitCode.SUCCESS
+
+
 @my_vcr.use_cassette("test_iac_scan_empty_directory")
 def test_scan_valid_args(cli_fs_runner: CliRunner) -> None:
     """
@@ -74,7 +91,7 @@ def test_iac_scan_file_error_response(cli_fs_runner: CliRunner) -> None:
         ],
     )
     assert result.exit_code == ExitCode.USAGE_ERROR
-    assert "Error: Invalid value for 'DIRECTORY'" in result.stdout
+    assert "Error: Invalid value for '[DIRECTORY]'" in result.stdout
 
 
 def test_iac_scan_error_response(


### PR DESCRIPTION
Allow `ggshield iac scan` to run with no provided argument (taking current directory as default)