### PR TITLE
chore: improve error handling in check_client_api_key()

### DIFF
--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -2,6 +2,7 @@ from typing import Type
 from unittest.mock import Mock
 
 import pytest
+import requests.exceptions
 from pygitguardian.models import HealthCheckResponse
 
 from ggshield.core.client import check_client_api_key
@@ -12,6 +13,7 @@ from ggshield.core.errors import APIKeyCheckError, UnexpectedError
     ("response", "error_class"),
     (
         (HealthCheckResponse("Guru Meditation", 500), UnexpectedError),
+        (HealthCheckResponse("Nobody here", 404), UnexpectedError),
         (HealthCheckResponse("Unauthorized", 401), APIKeyCheckError),
     ),
 )
@@ -26,4 +28,16 @@ def test_check_client_api_key_error(
     client_mock = Mock()
     client_mock.health_check.return_value = response
     with pytest.raises(error_class):
+        check_client_api_key(client_mock)
+
+
+def test_check_client_api_key_network_error():
+    """
+    GIVEN a client with a wrong instance URL
+    WHEN check_client_api_key() is called
+    THEN it raises an UnexpectedError
+    """
+    client_mock = Mock()
+    client_mock.health_check = Mock(side_effect=requests.exceptions.ConnectionError)
+    with pytest.raises(UnexpectedError):
         check_client_api_key(client_mock)


### PR DESCRIPTION
When we fail to connect, do not let the error propagate: the backtrace is ugly to read in verbose mode.

When the key is invalid, do not show `response.detail`. It contains "Invalid API key", so we end up printing:

    ERROR: Invalid API key. Details: Invalid API key.

When we receive a 404, tell the user to check the server URL.
