### PR TITLE
Improve error message when a user has no API key set

### DIFF
--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -20,7 +20,18 @@ def create_client_from_config(config: Config) -> GGClient:
             # This can happen when the user first tries the app and has not gone through
             # the authentication procedure yet. In this case, replace the error message
             # complaining about an unknown instance with a more user-friendly one.
-            raise APIKeyCheckError(e.instance, "GitGuardian API key is needed.")
+            raise APIKeyCheckError(
+                e.instance,
+                """A GitGuardian API key is needed to use ggshield.
+To get one, authenticate to your dashboard by running:
+
+    ggshield auth login
+
+If you are using an on-prem version of GitGuardian, \
+use the --instance option to point to it.
+Read the following documentation for more information: \
+https://docs.gitguardian.com/ggshield-docs/reference/auth/login""",
+            )
         else:
             raise
 

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -152,7 +152,7 @@ def test_retrieve_client_blank_state(isolated_fs):
     """
     with pytest.raises(
         APIKeyCheckError,
-        match="GitGuardian API key is needed",
+        match="A GitGuardian API key is needed to use ggshield.",
     ):
         with patch.dict(os.environ, clear=True):
             create_client_from_config(Config())


### PR DESCRIPTION
When a user has no API key set, we add instructions about how to authenticate to GitGuardian's dashboard and get one as part of the error message.  

We also reference our documentation and mention how to deal with the login if the user have an on-prem install.