### PR TITLE
Add debug logging when using environment variables

### DIFF
--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Mapping, Optional
 
@@ -8,6 +9,9 @@ from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import get_attr_mapping, remove_url_trailing_slash
 from ggshield.core.constants import DEFAULT_DASHBOARD_URL
 from ggshield.core.utils import api_to_dashboard_url, clean_url, dashboard_to_api_url
+
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -82,12 +86,15 @@ class Config:
 
         try:
             url = os.environ["GITGUARDIAN_INSTANCE"]
-            return remove_url_trailing_slash(url)
+            logger.debug("Using instance URL from $GITGUARDIAN_INSTANCE")
         except KeyError:
             pass
+        else:
+            return remove_url_trailing_slash(url)
 
         try:
             name = os.environ["GITGUARDIAN_API_URL"]
+            logger.debug("Using API URL from $GITGUARDIAN_API_URL")
         except KeyError:
             pass
         else:
@@ -138,9 +145,11 @@ class Config:
         - the api key from the selected instance
         """
         try:
-            return os.environ["GITGUARDIAN_API_KEY"]
+            key = os.environ["GITGUARDIAN_API_KEY"]
+            logger.debug("Using API key from $GITGUARDIAN_API_KEY")
         except KeyError:
-            return self.auth_config.get_instance_token(self.instance_name)
+            key = self.auth_config.get_instance_token(self.instance_name)
+        return key
 
     def add_ignored_match(self, *args: Any, **kwargs: Any) -> None:
         return self.user_config.secret.add_ignored_match(*args, **kwargs)


### PR DESCRIPTION
## Description

If the user authenticated with `ggshield auth login` but has `$GITGUARDIAN_API_KEY` defined, then the environment variable overrides the key stored by `ggshield auth login`.

To make debugging that easier, add `logger.debug()` calls when ggshield successfully reads environment variables.

## Testing

Tested manually with `ggshield --debug api-status` and `ggshield secret scan path ...`.

```
$ ggshield api-status --debug                            
2023-03-17 09:39:07,788 DEBUG ac3a:7f891735e1c0 ggshield.cmd.debug_logs:setup_debug_logs:35 args=['/home/agateau/.local/share/virtualenvs/ggshield-c3rFhSjf/bin/ggshield', 'api-status', '--debug']
2023-03-17 09:39:07,788 DEBUG ac3a:7f891735e1c0 ggshield.cmd.debug_logs:setup_debug_logs:36 py-gitguardian=1.5.0
2023-03-17 09:39:07,788 DEBUG ac3a:7f891735e1c0 ggshield.core.config.config:api_key:149 Using API key from $GITGUARDIAN_API_KEY
2023-03-17 09:39:07,790 DEBUG ac3a:7f891735e1c0 urllib3.connectionpool:_new_conn:1003 Starting new HTTPS connection (1): api.gitguardian.com:443
2023-03-17 09:39:08,397 DEBUG ac3a:7f891735e1c0 urllib3.connectionpool:_make_request:456 https://api.gitguardian.com:443 "GET /v1/health HTTP/1.1" 200 27
API URL: https://api.gitguardian.com
Status: healthy
App version: v2.25.2
Secrets engine version: 2.85.0
```