### PR TITLE
Make `auth login` handle server-side removed tokens

### DIFF
--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -4,7 +4,7 @@ from pygitguardian import GGClient
 from requests import Session
 
 from .config import Config
-from .constants import DEFAULT_DASHBOARD_URL
+from .constants import DEFAULT_INSTANCE_URL
 from .errors import APIKeyCheckError, UnexpectedError, UnknownInstanceError
 
 
@@ -16,7 +16,7 @@ def create_client_from_config(config: Config) -> GGClient:
         api_key = config.api_key
         api_url = config.api_url
     except UnknownInstanceError as e:
-        if e.instance == DEFAULT_DASHBOARD_URL:
+        if e.instance == DEFAULT_INSTANCE_URL:
             # This can happen when the user first tries the app and has not gone through
             # the authentication procedure yet. In this case, replace the error message
             # complaining about an unknown instance with a more user-friendly one.

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -7,7 +7,7 @@ import click
 from ggshield.core.config.auth_config import AuthConfig
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import get_attr_mapping, remove_url_trailing_slash
-from ggshield.core.constants import DEFAULT_DASHBOARD_URL
+from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.utils import api_to_dashboard_url, clean_url, dashboard_to_api_url
 
 
@@ -103,7 +103,7 @@ class Config:
         if self.user_config.instance:
             return self.user_config.instance
 
-        return DEFAULT_DASHBOARD_URL
+        return DEFAULT_INSTANCE_URL
 
     def set_cmdline_instance_name(self, name: str) -> None:
         """

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -14,6 +14,6 @@ CACHE_FILENAME = "./.cache_ggshield"
 GLOBAL_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", ".gitguardian.yaml"]
 LOCAL_CONFIG_PATHS = ["./.gitguardian", "./.gitguardian.yml", "./.gitguardian.yaml"]
 DEFAULT_LOCAL_CONFIG_PATH = "./.gitguardian.yaml"
-DEFAULT_DASHBOARD_URL = "https://dashboard.gitguardian.com"
+DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 AUTH_CONFIG_FILENAME = "auth_config.yaml"
 ON_PREMISE_API_URL_PATH_PREFIX = "/exposed"

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -440,7 +440,20 @@ class TestAuthLoginWeb:
     ):
         """
         Prepare object and function mocks to emulate HTTP requests
-        and server interactions
+        and server interactions. The available mocks are:
+        - self._wait_for_callback_mock
+        - self._webbrowser_open_mock
+        - self._mock_server_class
+        - self._client_post_mock
+        - self._client_get_mock
+        - self._check_instance_has_enabled_flow_mock
+
+        It also defines the following fields:
+        self._token_name
+        self._lifetime
+        self._instance_url
+        self._sso_url
+        self._generated_token_name
         """
         token = "mysupertoken"
         config = Config()
@@ -460,8 +473,8 @@ class TestAuthLoginWeb:
         )
 
         # generate the expected oauth state
-        self._state = self._get_oauth_state() if is_state_valid else "invalid_state"
-        url_params = {"state": self._state}
+        oauth_state = self._get_oauth_state() if is_state_valid else "invalid_state"
+        url_params = {"state": oauth_state}
         if authorization_code:
             url_params["code"] = authorization_code
 

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
 from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, my_vcr
-from tests.unit.request_mock import MockRequestsResponse
+from tests.unit.request_mock import create_json_response
 
 
 @my_vcr.use_cassette("test_iac_scan_no_argument")
@@ -100,7 +100,7 @@ def test_iac_scan_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
+        return_value=create_json_response({"detail": "Not found (404)"}, 404),
     )
     result = cli_fs_runner.invoke(
         cli,
@@ -120,7 +120,7 @@ def test_iac_scan_json_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
+        return_value=create_json_response({"detail": "Not found (404)"}, 404),
     )
     cli_fs_runner.mix_stderr = False
     result = cli_fs_runner.invoke(
@@ -148,7 +148,7 @@ def test_iac_scan_unknown_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
+        return_value=create_json_response({"detail": "Not found (404)"}, 404),
     )
     result = cli_fs_runner.invoke(
         cli,

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -7,7 +7,8 @@ from pytest_mock import MockerFixture
 
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
-from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, MockRequestsResponse, my_vcr
+from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, my_vcr
+from tests.unit.request_mock import MockRequestsResponse
 
 
 @my_vcr.use_cassette("test_iac_scan_no_argument")

--- a/tests/unit/cmd/iac/test_scan.py
+++ b/tests/unit/cmd/iac/test_scan.py
@@ -99,7 +99,7 @@ def test_iac_scan_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse(404, {"detail": "Not found (404)"}),
+        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
     )
     result = cli_fs_runner.invoke(
         cli,
@@ -119,7 +119,7 @@ def test_iac_scan_json_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse(404, {"detail": "Not found (404)"}),
+        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
     )
     cli_fs_runner.mix_stderr = False
     result = cli_fs_runner.invoke(
@@ -147,7 +147,7 @@ def test_iac_scan_unknown_error_response(
 ) -> None:
     mocker.patch(
         "ggshield.core.client.GGClient.request",
-        return_value=MockRequestsResponse(404, {"detail": "Not found (404)"}),
+        return_value=MockRequestsResponse({"detail": "Not found (404)"}, 404),
     )
     result = cli_fs_runner.invoke(
         cli,

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -7,7 +7,7 @@ from ggshield.cmd.main import cli
 from ggshield.core.config import Config
 from ggshield.core.errors import ExitCode
 
-from .utils import prepare_config
+from .utils import add_instance_config
 
 
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
@@ -56,14 +56,13 @@ class TestAuthConfigList:
         # May 4th
         some_date = datetime(2022, 5, 4, 17, 0, 0, 0, tzinfo=timezone.utc)
 
-        prepare_config(expiry_date=some_date)
-        prepare_config(
+        add_instance_config(expiry_date=some_date)
+        add_instance_config(
             instance_url="https://some-gg-instance.com",
-            token="first_token",
             token_name="first token",
             expiry_date=some_date,
         )
-        prepare_config(
+        add_instance_config(
             instance_url="https://some-gg-instance.com",
             with_account=False,
             expiry_date=some_date,
@@ -92,7 +91,7 @@ class TestAuthConfigSet:
         """
         unchanged_value = 42
 
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=unchanged_value)
+        add_instance_config(default_token_lifetime=unchanged_value)
         exit_code, output = self.run_cmd(cli_fs_runner, value)
 
         config = Config()
@@ -118,8 +117,8 @@ class TestAuthConfigSet:
 
         unrelated_instance = "https://some-unreleted-gg-instance.com"
 
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=value)
-        prepare_config(unrelated_instance, default_token_lifetime=unchanged_value)
+        add_instance_config(default_token_lifetime=value)
+        add_instance_config(unrelated_instance, default_token_lifetime=unchanged_value)
 
         exit_code, output = self.run_cmd(
             cli_fs_runner, value, instance_url=DEFAULT_INSTANCE_URL
@@ -231,8 +230,8 @@ class TestAuthConfigUnset:
 
         unrelated_instance = "https://some-unreleted-gg-instance.com"
 
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=unset_value)
-        prepare_config(unrelated_instance, default_token_lifetime=unchanged_value)
+        add_instance_config(default_token_lifetime=unset_value)
+        add_instance_config(unrelated_instance, default_token_lifetime=unchanged_value)
 
         exit_code, output = self.run_cmd(
             cli_fs_runner, instance_url=DEFAULT_INSTANCE_URL
@@ -262,7 +261,7 @@ class TestAuthConfigUnset:
         AND other configs must not be affected
         """
         unchanged_value = 42
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=unchanged_value)
+        add_instance_config(default_token_lifetime=unchanged_value)
         exit_code, output = self.run_cmd(cli_fs_runner)
 
         config = Config()
@@ -283,8 +282,8 @@ class TestAuthConfigUnset:
         (per instance and default)
         """
         second_instance = "https://some-gg-instance.com"
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=30)
-        prepare_config(second_instance, default_token_lifetime=20)
+        add_instance_config(default_token_lifetime=30)
+        add_instance_config(second_instance, default_token_lifetime=20)
 
         exit_code, output = self.run_cmd(cli_fs_runner, all_=True)
 
@@ -362,11 +361,11 @@ class TestAuthConfigGet:
         config.auth_config.default_token_lifetime = default_value
         config.save()
 
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=instance_value)
+        add_instance_config(default_token_lifetime=instance_value)
 
         # add some noise
         unrelated_instance_url = "https://some-unrelated-gg-instance.com"
-        prepare_config(unrelated_instance_url, default_token_lifetime=43)
+        add_instance_config(unrelated_instance_url, default_token_lifetime=43)
 
         exit_code, output = self.run_cmd(cli_fs_runner)
 
@@ -400,9 +399,9 @@ class TestAuthConfigGet:
         config.auth_config.default_token_lifetime = default_value
         config.save()
 
-        prepare_config(instance_url, default_token_lifetime=instance_value)
-        prepare_config(DEFAULT_INSTANCE_URL, default_token_lifetime=43)
-        prepare_config(unrelated_instance_url, default_token_lifetime=44)
+        add_instance_config(instance_url, default_token_lifetime=instance_value)
+        add_instance_config(default_token_lifetime=43)
+        add_instance_config(unrelated_instance_url, default_token_lifetime=44)
 
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url=instance_url)
 

--- a/tests/unit/cmd/utils.py
+++ b/tests/unit/cmd/utils.py
@@ -2,23 +2,19 @@ from datetime import datetime
 from typing import Optional
 
 from ggshield.core.config import AccountConfig, Config, InstanceConfig
+from ggshield.core.constants import DEFAULT_INSTANCE_URL
 
 
-def prepare_config(
-    instance_url: Optional[str] = None,
-    token: Optional[str] = None,
-    token_name: Optional[str] = None,
+def add_instance_config(
+    instance_url: str = DEFAULT_INSTANCE_URL,
+    token_name: str = "some token name",
     expiry_date: Optional[datetime] = None,
     with_account: Optional[bool] = True,
     default_token_lifetime: Optional[int] = None,
 ):
     """
-    Helper to save a token in the configuration
+    Creates an InstanceConfig with the provided arguments and adds it to the config
     """
-    instance_url = instance_url or "https://dashboard.gitguardian.com"
-    token = token or "some token name"
-    token_name = token_name or "some token name"
-
     if with_account:
         account_config = AccountConfig(
             workspace_id=1,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import os
 import platform
 from os.path import dirname, join, realpath
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import pytest
 import vcr
@@ -646,10 +646,11 @@ def assert_invoke_ok(result: Result):
 
 
 class MockRequestsResponse:
-    def __init__(self, status_code, json_data):
+    def __init__(self, json_data: Dict[str, Any], status_code: int = 200):
         self.headers = {"content-type": "application/json"}
         self.status_code = status_code
         self.json_data = json_data
+        self.ok = status_code < 400
 
     def json(self):
         return self.json_data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import os
 import platform
 from os.path import dirname, join, realpath
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 import vcr
@@ -643,14 +643,3 @@ def assert_invoke_exited_with(result: Result, exit_code: int):
 
 def assert_invoke_ok(result: Result):
     assert_invoke_exited_with(result, 0)
-
-
-class MockRequestsResponse:
-    def __init__(self, json_data: Dict[str, Any], status_code: int = 200):
-        self.headers = {"content-type": "application/json"}
-        self.status_code = status_code
-        self.json_data = json_data
-        self.ok = status_code < 400
-
-    def json(self):
-        return self.json_data

--- a/tests/unit/request_mock.py
+++ b/tests/unit/request_mock.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
+
+class MockRequestsResponse:
+    def __init__(self, json_data: Dict[str, Any], status_code: int = 200):
+        self.headers = {"content-type": "application/json"}
+        self.status_code = status_code
+        self.json_data = json_data
+        self.ok = status_code < 400
+
+    def json(self):
+        return self.json_data
+
+
+DataChecker = Callable[[Any], None]
+
+
+@dataclass
+class ExpectedCall:
+    method: str
+    endpoint: str
+    response: MockRequestsResponse
+
+    # If defined, RequestMock will call this function with the value of the `data` field
+    # it receives. It can be used to check the payload is as expected.
+    data_checker: Optional[DataChecker] = None
+
+
+class RequestMock:
+    """
+    Mocks HTTP requests. Usage:
+
+    ```python
+    # Create the mock
+    mock = RequestMock()
+
+    # Install the mock
+    monkeypatch.setattr("ggshield.core.client.Session.request", mock)
+
+    # Add expected calls
+    mock.add_GET("/foo1", MockRequestsResponse({"a": 12}))
+    mock.add_POST("/login", MockRequestsResponse({"a": 12}))
+    mock.add_GET("/not_found", MockRequestsResponse({"msg": "no-such-page"}, 400))
+
+    # Execute the code expected to make the calls
+    # If a call does not match the expected calls, an assert will raise
+    my_code()
+
+    # Verify the tested code passed all the calls
+    mock.assert_all_calls_happened()
+    ```
+    """
+
+    def __init__(self):
+        self._calls: List[ExpectedCall] = []
+
+    def add_GET(
+        self,
+        endpoint: str,
+        response: MockRequestsResponse,
+        data_checker: Optional[DataChecker] = None,
+    ):
+        self.add_call(ExpectedCall("GET", endpoint, response, data_checker))
+
+    def add_POST(
+        self,
+        endpoint: str,
+        response: MockRequestsResponse,
+        data_checker: Optional[DataChecker] = None,
+    ):
+        self.add_call(ExpectedCall("POST", endpoint, response, data_checker))
+
+    def add_call(self, call: ExpectedCall) -> None:
+        """Low-level method to add a call, it's simpler to use add_GET or add_POST instead"""
+        self._calls.append(call)
+
+    def assert_all_calls_happened(self) -> None:
+        assert self._calls == []
+
+    def __call__(
+        self, method: str, url: str, data: Optional[Any] = None, **kwargs: Any
+    ) -> MockRequestsResponse:
+        """This method is called by the tested code. It pops the next expected call and
+        checks it matches with the received call."""
+        method = method.upper()
+
+        # Get the expected call
+        if not self._calls:
+            pytest.fail(f"Unexpected call: {method} {url}")
+        call = self._calls.pop(0)
+
+        # Check the current call match the expected one
+        assert url.endswith(call.endpoint)
+        assert method == call.method
+        if call.data_checker:
+            call.data_checker(data)
+
+        return call.response


### PR DESCRIPTION
## Description

If `ggshield auth login` is used to create a token, but the token is then removed server-side, GGShield is not aware of it:
- When calling `ggshield auth login` at this point GGShield prints a message saying it's ready, but trying to scan prints an error message complaining about an invalid API key.
- Calling `ggshield auth logout` fails because the token does not exist server-side, so it can't be revoked.

One must call `ggshield auth logout --no-revoke` then `ggshield auth login` again.

## What has been done

With this PR, if a token is stored in the config, `ggshield auth login` checks it's valid. If it is not, it forgets it and start the auth workflow.

The amount of changes necessary to implement this new behavior was small, but writing tests was not. I ended up heavily refactoring `tests/unit/cmd/auth/test_login.py` to be able to do so.

That PR might be painful to review 😞.

The changes done to the testing code can be summarized to:
- Move the constant parts of `TestAuthLoginWeb.prepare_mock()` to an autouse fixture.
- Replace its 3 boolean arguments with an enum (LoginResult).
- Rework HTTP testing:
    - first by making the test code use MockRequestsResponse,
    - then by introducing a RequestMock class to be able to declare the chain of HTTP calls

Once this was done, the last commit actually implements the new `auth login` behavior.

## Testing

Added unit-tests, tested manually.