### PR TITLE
Refactor file reading

### DIFF
--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -3,8 +3,12 @@ name: Performance benchmark
 on:
   pull_request:
   workflow_dispatch:
-    run_options:
-      description: 'Additional options to pass to `run`'
+    inputs:
+      run_options:
+        description: 'Additional options to pass to `run`'
+      python_version:
+        description: 'Python version to use (use https://github.com/actions/setup-python#supported-version-syntax)'
+        default: '3.10'
 
 jobs:
   benchmark:
@@ -23,8 +27,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python_version || '3.10' }}
+
       - name: Install dependencies
         run: |
+          python --version
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipenv
           pipenv install --system
@@ -37,7 +47,7 @@ jobs:
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
         run: |
-          scripts/perfbench/perfbench run --repeats $REPEATS ${{ github.event.inputs.run_options }}
+          scripts/perfbench/perfbench run --repeats $REPEATS ${{ inputs.run_options }}
 
       - name: Generate report
         run: |

--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -128,7 +128,7 @@ def update_context(
 
 
 def iac_scan(ctx: click.Context, directory: Path) -> Optional[IaCScanResult]:
-    files = get_iac_files_from_paths(
+    paths = get_iac_files_from_paths(
         path=directory,
         exclusion_regexes=ctx.obj["exclusion_regexes"],
         verbose=ctx.obj["config"].verbose,
@@ -145,7 +145,7 @@ def iac_scan(ctx: click.Context, directory: Path) -> Optional[IaCScanResult]:
 
     scan = client.iac_directory_scan(
         directory,
-        files.filenames,
+        paths,
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -11,17 +11,26 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import create_progress_bar, display_info
-from ggshield.scan import File, ScanCollection, ScanContext, ScanMode, SecretScanner
+from ggshield.scan import (
+    ScanCollection,
+    ScanContext,
+    ScanMode,
+    Scannable,
+    SecretScanner,
+    StringScannable,
+)
 
 
-def generate_files_from_docsets(file: TextIO, verbose: bool = False) -> Iterator[File]:
+def generate_files_from_docsets(
+    file: TextIO, verbose: bool = False
+) -> Iterator[Scannable]:
     for line in file:
         obj = json.loads(line)
         documents = obj["documents"]
         for document in documents:
             if verbose:
                 display_info(f"  * {document['id']}")
-            yield File(document["content"], document["id"])
+            yield StringScannable(document["id"], document["content"])
 
 
 def create_scans_from_docset_files(

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -9,7 +9,7 @@ from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 from ggshield.core.binary_extensions import BINARY_EXTENSIONS
 from ggshield.core.filter import is_filepath_excluded
 from ggshield.core.git_shell import git_ls, is_git_dir
-from ggshield.scan import File, Files
+from ggshield.scan import File, Files, Scannable
 
 
 DOCUMENT_SIZE_THRESHOLD_MBYTES = DOCUMENT_SIZE_THRESHOLD_BYTES // (1024 * 1024)
@@ -94,7 +94,9 @@ def is_path_binary(path: str) -> bool:
     return ext[1:] in BINARY_EXTENSIONS
 
 
-def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterator[File]:
+def generate_files_from_paths(
+    paths: Iterable[str], verbose: bool
+) -> Iterator[Scannable]:
     """Loop on filepaths and return an iterator on scannable files."""
     for path in paths:
         if os.path.isdir(path) or not os.path.exists(path):
@@ -104,23 +106,6 @@ def generate_files_from_paths(paths: Iterable[str], verbose: bool) -> Iterator[F
             if verbose:
                 click.echo(
                     f"ignoring binary file: {path}",
-                    err=True,
-                )
-            continue
-
-        file_size = os.path.getsize(path)
-        if file_size > DOCUMENT_SIZE_THRESHOLD_BYTES:
-            if verbose:
-                click.echo(
-                    f"ignoring file over {DOCUMENT_SIZE_THRESHOLD_MBYTES} MB: {path}",
-                    err=True,
-                )
-            continue
-
-        if file_size == 0:
-            if verbose:
-                click.echo(
-                    f"ignoring empty file: {path}",
                     err=True,
                 )
             continue

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -110,4 +110,4 @@ def generate_files_from_paths(
                 )
             continue
 
-        yield File.from_path(path)
+        yield File(path)

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -44,13 +44,11 @@ def get_iac_files_from_paths(
         ignore_git=ignore_git,
     ).apply_filter(is_file_iac_file)
 
-    return [str(Path(x).relative_to(path)) for x in files.paths]
+    return [str(x.relative_to(path)) for x in files.paths]
 
 
 def is_file_iac_file(scannable: Scannable) -> bool:
-    path = Path(scannable.filename)
-    extensions = path.suffixes
-    if any(ext in IAC_EXTENSIONS for ext in extensions):
+    if any(ext in IAC_EXTENSIONS for ext in scannable.path.suffixes):
         return True
-    name = path.name.lower()
+    name = scannable.path.name.lower()
     return any(keyword in name for keyword in IAC_FILENAME_KEYWORDS)

--- a/ggshield/output/text/iac_text_output_handler.py
+++ b/ggshield/output/text/iac_text_output_handler.py
@@ -55,7 +55,7 @@ class IaCTextOutputHandler(OutputHandler):
         result_buf.write(file_info(file_result.filename, len(file_result.incidents)))
 
         try:
-            file = File.from_path(str(file_path))
+            file = File(str(file_path))
             lines: List[Line] = get_lines_from_content(
                 file.content, Filemode.FILE, False
             )

--- a/ggshield/output/text/iac_text_output_handler.py
+++ b/ggshield/output/text/iac_text_output_handler.py
@@ -55,9 +55,9 @@ class IaCTextOutputHandler(OutputHandler):
         result_buf.write(file_info(file_result.filename, len(file_result.incidents)))
 
         try:
-            file = File.from_bytes(file_path.read_bytes(), str(file_path))
+            file = File.from_path(str(file_path))
             lines: List[Line] = get_lines_from_content(
-                file.document, Filemode.FILE, False
+                file.content, Filemode.FILE, False
             )
         except Exception:
             lines = []

--- a/ggshield/scan/__init__.py
+++ b/ggshield/scan/__init__.py
@@ -1,6 +1,6 @@
 from .scan_context import ScanContext
 from .scan_mode import ScanMode
-from .scannable import Commit, File, Files
+from .scannable import Commit, File, Files, Scannable, StringScannable
 from .scanner import Result, Results, ScanCollection, SecretScanner
 
 
@@ -14,4 +14,6 @@ __all__ = [
     "ScanCollection",
     "ScanContext",
     "ScanMode",
+    "Scannable",
+    "StringScannable",
 ]

--- a/ggshield/scan/__init__.py
+++ b/ggshield/scan/__init__.py
@@ -1,11 +1,12 @@
 from .scan_context import ScanContext
 from .scan_mode import ScanMode
-from .scannable import Commit, File, Files, Scannable, StringScannable
+from .scannable import Commit, DecodeError, File, Files, Scannable, StringScannable
 from .scanner import Result, Results, ScanCollection, SecretScanner
 
 
 __all__ = [
     "Commit",
+    "DecodeError",
     "File",
     "Files",
     "Result",

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -18,6 +18,7 @@ from ggshield.core.file_utils import is_path_binary
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.core.types import IgnoredMatch
 from ggshield.scan import (
+    DecodeError,
     Files,
     ScanCollection,
     ScanContext,
@@ -192,10 +193,13 @@ def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Sca
         # layer_filename is "<some_uuid>/layer.tar". We only keep "<some_uuid>"
         layer_name = os.path.dirname(layer_filename)
 
-        yield StringScannable(
-            url=f"{layer_name}:/{file_info.name}",
-            content=file_content,
-        )
+        try:
+            yield StringScannable.from_bytes(
+                url=f"{layer_name}:/{file_info.name}",
+                content=file_content,
+            )
+        except DecodeError:
+            pass
 
 
 def docker_pull_image(image_name: str, timeout: int) -> None:

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -17,7 +17,14 @@ from ggshield.core.errors import UnexpectedError
 from ggshield.core.file_utils import is_path_binary
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.core.types import IgnoredMatch
-from ggshield.scan import File, Files, ScanCollection, ScanContext, SecretScanner
+from ggshield.scan import (
+    Files,
+    ScanCollection,
+    ScanContext,
+    Scannable,
+    SecretScanner,
+    StringScannable,
+)
 
 
 FILEPATH_BANLIST = [
@@ -64,7 +71,7 @@ def get_files_from_docker_archive(archive_path: Path) -> Files:
         return Files(list(chain((config_file_to_scan,), layer_files_to_scan)))
 
 
-def _get_config(archive: tarfile.TarFile) -> Tuple[Dict, Dict, File]:
+def _get_config(archive: tarfile.TarFile) -> Tuple[Dict, Dict, Scannable]:
     """
     Extracts Docker image archive manifest and configuration.
     Returns a tuple with:
@@ -93,7 +100,7 @@ def _get_config(archive: tarfile.TarFile) -> Tuple[Dict, Dict, File]:
     return (
         manifest,
         json.loads(config_file_content),
-        File(config_file_content, filename="Dockerfile or build-args"),
+        StringScannable("Dockerfile or build-args", config_file_content),
     )
 
 
@@ -130,7 +137,7 @@ def _should_scan_layer(layer_info: Dict) -> bool:
 
 def _get_layers_files(
     archive: tarfile.TarFile, layers_info: Iterable[Dict]
-) -> Iterable[File]:
+) -> Iterable[Scannable]:
     """
     Extracts File objects to be scanned for given layers.
     """
@@ -151,7 +158,7 @@ def _validate_filepath(
     return True
 
 
-def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[File]:
+def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Scannable]:
     """
     Extracts File objects to be scanned for given layer.
     """
@@ -185,10 +192,9 @@ def _get_layer_files(archive: tarfile.TarFile, layer_info: Dict) -> Iterable[Fil
         # layer_filename is "<some_uuid>/layer.tar". We only keep "<some_uuid>"
         layer_name = os.path.dirname(layer_filename)
 
-        # Do not use os.path.join() for the filename argument: we always want Unix path
-        # separators here
-        yield File.from_bytes(
-            raw_document=file_content, filename=f"{layer_name}:/{file_info.name}"
+        yield StringScannable(
+            url=f"{layer_name}:/{file_info.name}",
+            content=file_content,
         )
 
 

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -206,12 +206,6 @@ class Files:
         """Convenience property to list paths in the same order as files"""
         return [x.path for x in self.files]
 
-    @property
-    def filenames(self) -> List[str]:
-        """Convenience property to list filenames in the same order as files"""
-        # TODO: deprecate
-        return [x.filename for x in self.files]
-
     def __repr__(self) -> str:
         return f"<Files files={self.files}>"
 

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -128,11 +128,9 @@ class Scannable(ABC):
 class File(Scannable):
     """Implementation of Scannable for files from the disk."""
 
-    def __init__(
-        self, document: Optional[str], filename: str, filemode: Filemode = Filemode.FILE
-    ):
-        super().__init__(filename, filemode)
-        self._content = document
+    def __init__(self, filename: str):
+        super().__init__(filename)
+        self._content: Optional[str] = None
 
     def is_longer_than(self, size: int) -> bool:
         doc_size = len(self._content) if self._content else os.path.getsize(self.path)
@@ -150,11 +148,6 @@ class File(Scannable):
             return
         with open(self.path, "rb") as f:
             self._content = File._decode_bytes(f.read(), self.filename)
-
-    @staticmethod
-    def from_path(filename: str) -> "File":
-        """Creates a File instance for a file. Content is *not* read immediately."""
-        return File(None, filename)
 
     @staticmethod
     def _decode_bytes(raw_document: bytes, filename: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,12 @@ import pytest
 GG_VALID_TOKEN = "ggtt-v-12345azert"  # ggignore
 
 
+def is_windows():
+    return platform.system() == "Windows"
+
+
 skipwindows = pytest.mark.skipif(
-    platform.system() == "Windows" and not os.environ.get("DISABLE_SKIPWINDOWS"),
+    is_windows() and not os.environ.get("DISABLE_SKIPWINDOWS"),
     reason="Skipped on Windows for now, define DISABLE_SKIPWINDOWS environment variable to unskip",
 )
 

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -7,9 +7,8 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
-from ggshield.scan import ScanCollection
+from ggshield.scan import Files, ScanCollection, StringScannable
 from ggshield.scan.docker import _validate_filepath
-from ggshield.scan.scannable import File, Files
 from tests.unit.conftest import (
     DATA_PATH,
     UNCHECKED_SECRET_PATCH,
@@ -115,7 +114,7 @@ class TestDockerCMD:
         assert image_path.exists()
 
         get_files_mock.return_value = Files(
-            files=[File(document=UNCHECKED_SECRET_PATCH, filename="file_secret")]
+            files=[StringScannable(content=UNCHECKED_SECRET_PATCH, url="file_secret")]
         )
         with my_vcr.use_cassette("test_scan_file_secret"):
             json_arg = ["--json"] if json_output else []

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -6,9 +6,8 @@ from click.testing import CliRunner
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
 from ggshield.core.utils import EMPTY_SHA, Filemode
-from ggshield.scan import Result, Results, ScanCollection
+from ggshield.scan import Result, Results, ScanCollection, StringScannable
 from ggshield.scan.repo import cd
-from ggshield.scan.scannable import File
 from tests.repository import Repository
 from tests.unit.conftest import (
     _SIMPLE_SECRET_PATCH,
@@ -172,8 +171,10 @@ class TestPreReceive:
                     results=Results(
                         results=[
                             Result(
-                                file=File(
-                                    _SIMPLE_SECRET_PATCH, "server.conf", Filemode.MODIFY
+                                file=StringScannable(
+                                    content=_SIMPLE_SECRET_PATCH,
+                                    url="server.conf",
+                                    filemode=Filemode.MODIFY,
                                 ),
                                 scan=_SIMPLE_SECRET_PATCH_SCAN_RESULT,
                             )

--- a/tests/unit/core/test_file_utils.py
+++ b/tests/unit/core/test_file_utils.py
@@ -5,7 +5,7 @@ from random import randrange
 import pytest
 
 from ggshield.core.file_utils import generate_files_from_paths
-from ggshield.scan import File
+from ggshield.scan import DecodeError, File
 from tests.conftest import is_windows
 
 
@@ -71,15 +71,30 @@ def test_file_does_not_decode_binary(tmp_path):
     """
     GIVEN a 2000 random bytes file
     WHEN File tries to decode it
-    THEN it fails
-    AND set its `content` attribute to ""
+    THEN it raises a DecodeError
     """
     path = tmp_path / "test.conf"
     data = (randrange(256) for _ in range(2000))
     path.write_bytes(bytes(data))
 
     file = File(str(path))
-    assert file.content == ""
+    with pytest.raises(DecodeError):
+        _dummy = file.content  # noqa (mute "_dummy" is never used)
+
+
+def test_file_is_longer_does_not_decode_binary(tmp_path):
+    """
+    GIVEN a 2000 random bytes file
+    WHEN is_longer_than() is called on it
+    THEN it raises a DecodeError
+    """
+    path = tmp_path / "test.conf"
+    data = (randrange(256) for _ in range(2000))
+    path.write_bytes(bytes(data))
+
+    file = File(str(path))
+    with pytest.raises(DecodeError):
+        file.is_longer_than(1000)
 
 
 @pytest.mark.parametrize("size", [1, 100])

--- a/tests/unit/core/test_file_utils.py
+++ b/tests/unit/core/test_file_utils.py
@@ -62,7 +62,7 @@ def test_file_decode_content(tmp_path, encoding: str, bom: bytes):
     content = "Ascii 123, accents: éèà, hiragana: ぁ, emoji: 🛡️"
     raw_content = bom + content.encode(encoding)
     path.write_bytes(raw_content)
-    file = File.from_path(str(path))
+    file = File(str(path))
     assert file.content == content
 
 
@@ -77,7 +77,7 @@ def test_file_does_not_decode_binary(tmp_path):
     data = (randrange(256) for _ in range(2000))
     path.write_bytes(bytes(data))
 
-    file = File.from_path(str(path))
+    file = File(str(path))
     assert file.content == ""
 
 
@@ -92,6 +92,6 @@ def test_file_is_longer_than_does_not_read_file(tmp_path, size):
     path = tmp_path / "test.conf"
     path.write_text("x" * size)
 
-    file = File.from_path(str(path))
+    file = File(str(path))
     assert file.is_longer_than(50) == (size > 50)
     assert file._content is None

--- a/tests/unit/core/test_file_utils.py
+++ b/tests/unit/core/test_file_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from ggshield.core.file_utils import generate_files_from_paths
 from ggshield.scan import File
+from tests.conftest import is_windows
 
 
 @pytest.mark.parametrize(
@@ -145,5 +146,22 @@ def test_file_repr():
     WHEN repr() is called
     THEN it returns the correct output
     """
-    file = File("/some/path")
-    assert repr(file) == "<File url=file:///some/path filemode=Filemode.FILE>"
+    if is_windows():
+        str_path = r"c:\Windows"
+        expected_url = "file://c:/Windows"
+    else:
+        str_path = "/usr"
+        expected_url = "file:///usr"
+    file = File(str_path)
+    assert repr(file) == f"<File url={expected_url} filemode=Filemode.FILE>"
+
+
+def test_file_path():
+    """
+    GIVEN an OS-specific path
+    WHEN creating a File on it
+    THEN file.path returns the correct path
+    """
+    str_path = r"c:\Windows" if is_windows() else "/usr"
+    file = File(str_path)
+    assert file.path == Path(str_path)

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -20,7 +20,14 @@ from ggshield.core.utils import (
     get_lines_from_content,
     load_dot_env,
 )
-from ggshield.scan import Commit, File, Files, ScanContext, ScanMode, SecretScanner
+from ggshield.scan import (
+    Commit,
+    Files,
+    ScanContext,
+    ScanMode,
+    SecretScanner,
+    StringScannable,
+)
 from ggshield.scan.repo import cd
 from ggshield.scan.scan_context import parse_os_release
 from tests.unit.conftest import (
@@ -85,7 +92,7 @@ def test_make_indices_patch(
         o = Commit()
         o._patch = content
     else:
-        o = Files([File(content, "test_file")])
+        o = Files([StringScannable(content=content, url="test_file")])
     with my_vcr.use_cassette(name):
         scanner = SecretScanner(
             client=client,

--- a/tests/unit/iac/test_filter.py
+++ b/tests/unit/iac/test_filter.py
@@ -33,9 +33,9 @@ def test_get_iac_files_from_paths(tmp_path):
         Path(path).write_text("something")
 
     files = get_iac_files_from_paths(tmp_path, set(), True)
-    assert len(files.files) == 10
-    assert "file1.json" not in files.filenames
-    assert "file2.json" in files.filenames
+    assert len(files) == 10
+    assert "file1.json" not in files
+    assert "file2.json" in files
 
 
 def test_get_iac_files_from_paths_excluded(tmp_path):
@@ -49,9 +49,9 @@ def test_get_iac_files_from_paths_excluded(tmp_path):
         Path(path).write_text("something")
 
     files = get_iac_files_from_paths(tmp_path, {re.compile(r"file2")}, True)
-    assert len(files.files) == 9
-    assert "file2.json" not in files.filenames
-    assert "file3.yaml" in files.filenames
+    assert len(files) == 9
+    assert "file2.json" not in files
+    assert "file3.yaml" in files
 
 
 @pytest.mark.parametrize("ignore_git", (False, True))
@@ -76,9 +76,9 @@ def test_get_iac_files_from_paths_ignore_git(tmp_path, ignore_git):
 
     files = get_iac_files_from_paths(tmp_path, set(), True, ignore_git)
     if ignore_git:
-        assert len(files.files) == 10
-        assert "file2.json" in files.filenames
+        assert len(files) == 10
+        assert "file2.json" in files
     else:
-        assert len(files.files) == 9
-        assert "file2.json" not in files.filenames
-        assert "file3.yaml" in files.filenames
+        assert len(files) == 9
+        assert "file2.json" not in files
+        assert "file3.yaml" in files

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -17,8 +17,8 @@ from ggshield.scan import (
     ScanContext,
     ScanMode,
     SecretScanner,
+    StringScannable,
 )
-from ggshield.scan.scannable import File
 from tests.unit.conftest import (
     _MULTIPLE_SECRETS_PATCH,
     _NO_SECRET_PATCH,
@@ -164,9 +164,9 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
     output_handler = JSONOutputHandler(show_secrets=True, verbose=verbose)
 
     result: Result = Result(
-        File(
-            document=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
-            filename="leak.txt",
+        StringScannable(
+            content=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
+            url="leak.txt",
             filemode=Filemode.NEW,
         ),
         scan=deepcopy(TWO_POLICY_BREAKS),  # 2 policy breaks

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -6,7 +6,7 @@ import pytest
 
 from ggshield.core.utils import Filemode
 from ggshield.output import TextOutputHandler
-from ggshield.scan import File, Result, Results, ScanCollection
+from ggshield.scan import File, Result, Results, ScanCollection, StringScannable
 from tests.unit.conftest import (
     _MULTI_SECRET_ONE_LINE_PATCH,
     _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
@@ -208,7 +208,7 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
     output_handler = TextOutputHandler(show_secrets=True, verbose=verbose)
 
     result: Result = Result(
-        File(document=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT, filename="leak.txt"),
+        StringScannable(content=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT, url="leak.txt"),
         scan=deepcopy(TWO_POLICY_BREAKS),  # 2 policy breaks
     )
 

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -6,7 +6,7 @@ import pytest
 
 from ggshield.core.utils import Filemode
 from ggshield.output import TextOutputHandler
-from ggshield.scan import File, Result, Results, ScanCollection, StringScannable
+from ggshield.scan import Result, Results, ScanCollection, StringScannable
 from tests.unit.conftest import (
     _MULTI_SECRET_ONE_LINE_PATCH,
     _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
@@ -37,9 +37,9 @@ from tests.unit.conftest import (
     [
         pytest.param(
             Result(
-                File(
-                    document=_SIMPLE_SECRET_PATCH,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_SIMPLE_SECRET_PATCH,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_SIMPLE_SECRET_PATCH_SCAN_RESULT,
@@ -48,9 +48,9 @@ from tests.unit.conftest import (
         ),
         pytest.param(
             Result(
-                File(
-                    document=_MULTI_SECRET_ONE_LINE_PATCH,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_MULTI_SECRET_ONE_LINE_PATCH,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT,
@@ -59,9 +59,9 @@ from tests.unit.conftest import (
         ),
         pytest.param(
             Result(
-                File(
-                    document=_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT,
@@ -70,9 +70,9 @@ from tests.unit.conftest import (
         ),
         pytest.param(
             Result(
-                File(
-                    document=_MULTI_SECRET_TWO_LINES_PATCH,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_MULTI_SECRET_TWO_LINES_PATCH,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT,
@@ -81,9 +81,9 @@ from tests.unit.conftest import (
         ),
         pytest.param(
             Result(
-                File(
-                    document=_SIMPLE_SECRET_MULTILINE_PATCH,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_SIMPLE_SECRET_MULTILINE_PATCH,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT,
@@ -92,9 +92,9 @@ from tests.unit.conftest import (
         ),
         pytest.param(
             Result(
-                File(
-                    document=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
-                    filename="leak.txt",
+                StringScannable(
+                    content=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
+                    url="leak.txt",
                     filemode=Filemode.NEW,
                 ),
                 scan=_ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT,
@@ -277,9 +277,9 @@ def test_ignore_known_secrets_exit_code(ignore_known_secrets, secrets_types):
     output_handler = TextOutputHandler(show_secrets=True, verbose=False)
 
     result: Result = Result(
-        File(
-            document=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
-            filename="leak.txt",
+        StringScannable(
+            content=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
+            url="leak.txt",
         ),
         scan=deepcopy(TWO_POLICY_BREAKS),  # 2 policy breaks
     )

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -87,7 +87,7 @@ class TestDockerScan:
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
     def test_get_files_from_docker_archive(self, image_path: Path):
-        files = get_files_from_docker_archive(image_path)
+        scannables = get_files_from_docker_archive(image_path)
 
         expected_files = {
             "Dockerfile or build-args": None,
@@ -96,12 +96,14 @@ class TestDockerScan:
             "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f:/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
         }
 
-        assert set(files.filenames) == {str(file_path) for file_path in expected_files}
+        assert set(scannables.filenames) == {
+            str(file_path) for file_path in expected_files
+        }
 
-        file_dict = {x.filename: x for x in files.files}
+        scannable_dict = {x.filename: x for x in scannables.files}
         for file_path, expected_content in expected_files.items():
-            file = file_dict[str(file_path)]
-            assert expected_content is None or file.document == expected_content
+            scannable = scannable_dict[str(file_path)]
+            assert expected_content is None or scannable.content == expected_content
 
 
 DOCKER_TIMEOUT = 12

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -96,11 +96,9 @@ class TestDockerScan:
             "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f:/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
         }
 
-        assert set(scannables.filenames) == {
-            str(file_path) for file_path in expected_files
-        }
+        assert set(x.url for x in scannables.files) == {str(x) for x in expected_files}
 
-        scannable_dict = {x.filename: x for x in scannables.files}
+        scannable_dict = {x.url: x for x in scannables.files}
         for file_path, expected_content in expected_files.items():
             scannable = scannable_dict[str(file_path)]
             assert expected_content is None or scannable.content == expected_content

--- a/tests/unit/scan/test_scan_repo.py
+++ b/tests/unit/scan/test_scan_repo.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ggshield.scan import Commit, File, Result, Results
+from ggshield.scan import Commit, Result, Results, StringScannable
 from ggshield.scan.repo import get_commits_by_batch, scan_commits_content
 from ggshield.scan.scannable import CommitInformation
 from tests.unit.conftest import TWO_POLICY_BREAKS
@@ -56,9 +56,9 @@ def test_get_commits_content_by_batch(
         commit = Commit(sha=f"some_sha_{commit_nb}")
         commit.get_files = MagicMock(
             return_value=[
-                File(
-                    document=f"some content {file_nb}",
-                    filename=f"some_filename_{file_nb}.py",
+                StringScannable(
+                    content=f"some content {file_nb}",
+                    url=f"some_filename_{file_nb}.py",
                 )
                 for file_nb in range(size)
             ]
@@ -79,11 +79,11 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
     """
     commit_info = CommitInformation("unknown", "", "")
     commit_1 = Commit(sha="some_sha_1")
-    commit_1._files = [File(document="document", filename="filename")]
+    commit_1._files = [StringScannable(content="document", url="filename")]
     commit_1._info = commit_info
 
     commit_2 = Commit(sha="some_sha_2")
-    commit_2._files = [File(document="document", filename="filename")]
+    commit_2._files = [StringScannable(content="document", url="filename")]
     commit_2._info = commit_info
 
     secret_scanner_mock.return_value.scan.return_value = Results(
@@ -127,15 +127,15 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
     commit_info = CommitInformation("unknown", "", "")
     commit_1 = Commit(sha="some_sha_1")
 
-    file1_1 = File(document="document1", filename="filename1")
-    file1_2 = File(document="document2", filename="filename2")
-    file1_3 = File(document="document3", filename="filename3")
+    file1_1 = StringScannable(content="document1", url="filename1")
+    file1_2 = StringScannable(content="document2", url="filename2")
+    file1_3 = StringScannable(content="document3", url="filename3")
 
     commit_1._files = [file1_1, file1_2, file1_3]
     commit_1._info = commit_info
 
-    file2_1 = File(document="document2", filename="filename2")
-    file2_2 = File(document="document3", filename="filename3")
+    file2_1 = StringScannable(content="document2", url="filename2")
+    file2_2 = StringScannable(content="document3", url="filename3")
 
     commit_2 = Commit(sha="some_sha_2")
     commit_2._files = [file2_1, file2_2]

--- a/tests/unit/scan/test_scannable.py
+++ b/tests/unit/scan/test_scannable.py
@@ -117,9 +117,9 @@ def test_patch_separation():
     assert c.info.date == "Fri Oct 18 13:20:00 2012 +0100"
 
     assert len(files) == len(EXPECTED_PATCH_CONTENT)
-    for file_, (name, document) in zip(files, EXPECTED_PATCH_CONTENT):
+    for file_, (name, content) in zip(files, EXPECTED_PATCH_CONTENT):
         assert file_.filename == name
-        assert file_.document == document
+        assert file_.content == content
 
 
 def test_patch_separation_ignore():

--- a/tests/unit/scan/test_scannable.py
+++ b/tests/unit/scan/test_scannable.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List, Tuple
 
 import click
@@ -319,3 +320,13 @@ def test_get_files(
 
     names_and_modes = [(x.filename, x.filemode) for x in files]
     assert names_and_modes == expected_names_and_modes
+
+
+def test_string_scannable_path():
+    """
+    GIVEN a StringScannable instance
+    WHEN path() is called
+    THEN it returns the right value
+    """
+    scannable = StringScannable(url="custom:/some/path", content="")
+    assert scannable.path == Path("/some/path")

--- a/tests/unit/scan/test_scannable.py
+++ b/tests/unit/scan/test_scannable.py
@@ -7,7 +7,7 @@ from pygitguardian.models import Detail
 
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.utils import Filemode
-from ggshield.scan import Commit, File, Files
+from ggshield.scan import Commit, Files, StringScannable
 from ggshield.scan.scannable import _parse_patch_header_line
 from ggshield.scan.scanner import handle_scan_chunk_error
 from tests.unit.conftest import DATA_PATH
@@ -151,8 +151,8 @@ CHECK_ENVIRONMENT=true
 
 
 def test_apply_filter():
-    file1 = File("", "file1")
-    file2 = File("", "file2")
+    file1 = StringScannable(content="", url="file1")
+    file2 = StringScannable(content="", url="file2")
     files = Files([file1, file2])
 
     filtered_files = files.apply_filter(lambda file: file.filename == "file1")
@@ -173,7 +173,7 @@ def test_handle_scan_error_api_key():
         pytest.param(
             Detail("Too many documents to scan"),
             400,
-            [File("", "/example") for _ in range(21)],
+            [StringScannable(content="", url="/example") for _ in range(21)],
             id="too many documents",
         ),
         pytest.param(
@@ -182,13 +182,12 @@ def test_handle_scan_error_api_key():
             ),
             400,
             [
-                File(
-                    "still valid",
-                    "/home/user/too/long/file/name",
+                StringScannable(
+                    content="still valid", url="/home/user/too/long/file/name"
                 ),
-                File("", "valid"),
-                File("", "valid"),
-                File("", "valid"),
+                StringScannable(content="", url="valid"),
+                StringScannable(content="", url="valid"),
+                StringScannable(content="", url="valid"),
             ],
             id="single file exception",
         ),


### PR DESCRIPTION
## Description

This PR paves the way to supporting server-side config and reading from various sources. It does so by refactoring the File class and introducing an abstract base class for scannable content, called Scannable.

Scannable has the following API:

- `url` property: Act as a unique identifier for the Scannable. May use custom protocols if required
- `path` property: "path" part of the API, returned as a `pathlib.Path`. Useful for local files
- `is_longer_than(self, size: int) -> bool`: returns true if the length of the *decoded* content is greater than `size`. Used by SecretScanner to decide if afile should be scanned or not
- `content` property: Returns the *decoded* content

File now inherits from Scannable and implements its API.

This PR also introduces StringScannable, which inherits from Scannable too. It is used for scannable content already loaded in memory. Individual patches of a commit are now represented using StringScannable.

## Performance

Interestingly, the performance bench results are very different between my machine and the CI.

CI results:

| command                                       | repository |         prod |      current |   delta |
| --------------------------------------------- | ---------- | -----------: | -----------: | ------: |
| iac scan --exit-zero .                        | Pillow     |  1.58s ±0.10 |  1.54s ±0.04 | -0.04 ≈ |
| iac scan --exit-zero .                        | compose    |  1.45s ±0.02 |  1.42s ±0.13 | -0.03 ≈ |
| iac scan --exit-zero .                        | leaky-repo |  0.97s ±0.04 |  1.01s ±0.07 | +0.04 ≈ |
| iac scan --exit-zero .                        | sqlite     |  0.73s ±0.01 |  0.74s ±0.01 | +0.01 ≈ |
| iac scan --exit-zero .                        | vue        |  1.10s ±0.01 |  1.08s ±0.03 | -0.02 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | Pillow     |  1.90s ±0.11 |  1.94s ±0.03 | +0.04 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | compose    |  1.91s ±0.03 |  1.97s ±0.02 | +0.06 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | leaky-repo |  1.77s ±0.06 |  1.84s ±0.04 | +0.07 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | sqlite     |  0.90s ±0.01 |  0.91s ±0.00 | +0.01 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | vue        |  0.79s ±0.00 |  0.82s ±0.03 | +0.02 ≈ |
| secret scan --exit-zero path -ry .            | Pillow     | 11.70s ±0.27 | 13.85s ±0.22 | +2.14 ▲ |
| secret scan --exit-zero path -ry .            | compose    |  3.50s ±0.01 |  3.52s ±0.17 | +0.01 ≈ |
| secret scan --exit-zero path -ry .            | leaky-repo |  2.29s ±1.02 |  1.94s ±0.14 | -0.35 ≈ |
| secret scan --exit-zero path -ry .            | sqlite     | 26.08s ±0.23 | 27.66s ±0.30 | +1.58 ▲ |
| secret scan --exit-zero path -ry .            | vue        |  5.77s ±0.07 |  5.84s ±0.04 | +0.07 ≈ |

My machine:

| command                                       | repository |         prod |     current |    delta |
| --------------------------------------------- | ---------- | -----------: | ----------: | -------: |
| iac scan --exit-zero .                        | Pillow     |        4.30s |       4.05s |  -0.26 ≈ |
| iac scan --exit-zero .                        | compose    |        2.28s |       2.34s |  +0.06 ≈ |
| iac scan --exit-zero .                        | leaky-repo |        1.74s |       1.76s |  +0.02 ≈ |
| iac scan --exit-zero .                        | sqlite     |        1.28s |       1.45s |  +0.17 ≈ |
| iac scan --exit-zero .                        | vue        |        3.37s |       2.19s |  -1.18 ▼ |
| secret scan --exit-zero commit-range HEAD~9.. | Pillow     |        4.53s |       5.05s |  +0.52 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | compose    |        5.71s |       5.36s |  -0.35 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | leaky-repo |        3.60s |       3.67s |  +0.07 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | sqlite     |        2.60s |       2.38s |  -0.22 ≈ |
| secret scan --exit-zero commit-range HEAD~9.. | vue        |        2.13s |       1.95s |  -0.18 ≈ |
| secret scan --exit-zero path -ry .            | Pillow     | 13.12s ±1.12 | 9.92s ±0.88 |  -3.20 ▼ |
| secret scan --exit-zero path -ry .            | compose    |        5.25s |       4.06s |  -1.19 ▼ |
| secret scan --exit-zero path -ry .            | leaky-repo |        3.92s |       4.10s |  +0.18 ≈ |
| secret scan --exit-zero path -ry .            | sqlite     |       30.08s |      15.57s | -14.52 ▼ |
| secret scan --exit-zero path -ry .            | vue        |        6.84s |       5.02s |  -1.82 ▼ |

I haven't found a rational explanation for this difference. I am going to dig a bit more.