### PR TITLE
Refactor file reading, Docker part

### DIFF
--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -4,15 +4,11 @@ from pathlib import Path
 from typing import Iterable, Iterator, List, Set, Union
 
 import click
-from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.binary_extensions import BINARY_EXTENSIONS
 from ggshield.core.filter import is_filepath_excluded
 from ggshield.core.git_shell import git_ls, is_git_dir
 from ggshield.scan import File, Files, Scannable
-
-
-DOCUMENT_SIZE_THRESHOLD_MBYTES = DOCUMENT_SIZE_THRESHOLD_BYTES // (1024 * 1024)
 
 
 def get_files_from_paths(

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -4,7 +4,7 @@ import re
 import urllib.parse
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Callable, Iterable, List, NamedTuple, Optional, Set, Tuple
+from typing import BinaryIO, Callable, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 import charset_normalizer
 from charset_normalizer import CharsetMatch
@@ -170,6 +170,41 @@ class Scannable(ABC):
             raw_document = raw_document[len(codecs.BOM_UTF8) :]
         return raw_document.decode(charset_match.encoding, errors="replace")
 
+    @staticmethod
+    def _is_file_longer_than(fp: BinaryIO, size: int) -> Tuple[bool, Optional[str]]:
+        """Helper function to implement is_longer_than() for file-based Scannable classes.
+
+        Returns a tuple of:
+        - True if file is longer than `size`, False otherwise
+        - The decoded content as a string, if it has been fully read, None otherwise
+
+        Raises DecodeError if the file cannot be decoded.
+        """
+        byte_content = b""
+        str_content = ""
+
+        charset_matches = charset_normalizer.from_fp(fp)
+        charset_match = charset_matches.best()
+        if charset_match is None:
+            raise DecodeError
+        fp.seek(0)
+        while True:
+            # Try to read more than the requested size:
+            # - If the file is smaller, that changes nothing
+            # - if the file is bigger, we potentially avoid a second read
+            byte_chunk = fp.read(size * 2)
+            if byte_chunk:
+                byte_content += byte_chunk
+                # Note: we decode `byte_content` and not `byte_chunk`: we can't
+                # decode just the chunk because we have no way to know if it starts
+                # and ends at complete code-point boundaries
+                str_content = Scannable._decode_bytes(byte_content, charset_match)
+                if len(str_content) > size:
+                    return True, None
+            else:
+                # We read the whole file, keep it
+                return False, str_content
+
 
 class File(Scannable):
     """Implementation of Scannable for files from the disk."""
@@ -196,52 +231,21 @@ class File(Scannable):
             # We already have the content, easy
             return len(self._content) > size
 
-        byte_size = self.path.stat().st_size
-        if byte_size < size:
+        if self.path.stat().st_size < size:
             # Shortcut: if the byte size is smaller than `size`, we can be sure the
             # decoded size will be smaller
             return False
 
-        # We need to decode at least the beginning of the file to determine if it's
-        # small enough
-        byte_content = b""
-        str_content = ""
         with self.path.open("rb") as fp:
-            charset_matches = charset_normalizer.from_fp(fp)
-            charset_match = charset_matches.best()
-            if charset_match is None:
-                raise DecodeError
-            fp.seek(0)
-            while True:
-                # Try to read more than the requested size:
-                # - If the file is smaller, that changes nothing
-                # - if the file is bigger, we potentially avoid a second read
-                byte_chunk = fp.read(size * 2)
-                if byte_chunk:
-                    byte_content += byte_chunk
-                    # Note: we decode `byte_content` and not `byte_chunk`: we can't
-                    # decode just the chunk because we have no way to know if it starts
-                    # and ends at complete code-point boundaries
-                    str_content = Scannable._decode_bytes(byte_content, charset_match)
-                    if len(str_content) > size:
-                        return True
-                else:
-                    # We read the whole file, keep it
-                    self._content = str_content
-                    return False
+            result, self._content = Scannable._is_file_longer_than(fp, size)
+        return result
 
     @property
     def content(self) -> str:
-        self._prepare()
-        assert self._content is not None
+        if self._content is None:
+            with self.path.open("rb") as f:
+                self._content = Scannable._decode_bytes(f.read())
         return self._content
-
-    def _prepare(self) -> None:
-        """Ensures file content has been read and decoded"""
-        if self._content is not None:
-            return
-        with self.path.open("rb") as f:
-            self._content = Scannable._decode_bytes(f.read())
 
 
 class StringScannable(Scannable):
@@ -252,12 +256,6 @@ class StringScannable(Scannable):
         self._url = url
         self._path: Optional[Path] = None
         self._content = content
-
-    @staticmethod
-    def from_bytes(
-        url: str, content: bytes, filemode: Filemode = Filemode.FILE
-    ) -> "StringScannable":
-        return StringScannable(url, Scannable._decode_bytes(content), filemode)
 
     @property
     def url(self) -> str:

--- a/ggshield/scan/scanner.py
+++ b/ggshield/scan/scanner.py
@@ -259,7 +259,7 @@ class SecretScanner:
                     continue
                 content = scannable.content
             except DecodeError:
-                click.echo(f"Can't decode {scannable.path}, skipping")
+                click.echo(f"Can't decode {scannable.path}, skipping", err=True)
                 skipped_chunks_count += 1
                 continue
 

--- a/scripts/perfbench/perfbench_utils.py
+++ b/scripts/perfbench/perfbench_utils.py
@@ -14,7 +14,7 @@ class RawReportEntry:
     """Represent the fields stored in the benchmark.jsonl file"""
 
     version: str
-    repository: str
+    dataset: str
     command: str
     duration: float
 

--- a/scripts/perfbench/report_cmd.py
+++ b/scripts/perfbench/report_cmd.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_DELTA_SECS = 3
 @dataclass
 class ReportRow:
     command: str
-    repository: str
+    dataset: str
     # Mapping of version => [durations]
     durations_for_versions: Dict[str, List[float]] = field(default_factory=dict)
 
@@ -143,7 +143,7 @@ def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
             report_path,
         )
 
-    # Load raw report file, group report rows by command and repository
+    # Load raw report file, group report rows by command and dataset
     version_set = set()
     row_dict: Dict[Tuple[str, str], ReportRow] = {}
     with report_path.open() as fp:
@@ -154,8 +154,8 @@ def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
             version_set.add(entry.version)
 
             row = row_dict.setdefault(
-                (entry.command, entry.repository),
-                ReportRow(entry.command, entry.repository),
+                (entry.command, entry.dataset),
+                ReportRow(entry.command, entry.dataset),
             )
             durations = row.durations_for_versions.setdefault(entry.version, [])
             durations.append(entry.duration)
@@ -165,7 +165,7 @@ def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
     # Create table rows
     table_rows = []
     has_failed = False
-    for row in sorted(row_dict.values(), key=lambda x: (x.command, x.repository)):
+    for row in sorted(row_dict.values(), key=lambda x: (x.command, x.dataset)):
         duration_cells, fail = create_duration_cells(
             sorted_versions,
             row.durations_for_versions,
@@ -173,7 +173,7 @@ def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
             max_delta,
         )
         has_failed |= fail
-        table_rows.append([row.command, row.repository, *duration_cells])
+        table_rows.append([row.command, row.dataset, *duration_cells])
 
     # Create headers (no delta column for reference)
     version_headers = [sorted_versions[0]]
@@ -183,7 +183,7 @@ def report_cmd(min_delta: float, max_delta: float, work_dir: Path) -> None:
     print_markdown_table(
         sys.stdout,
         table_rows,
-        headers=["command", "repository", *version_headers],
+        headers=["command", "dataset", *version_headers],
         alignments="LL" + "R" * len(version_headers),
     )
 


### PR DESCRIPTION
## Description

This PR is a follow-up for #503. It reworks the way we read the content of Docker images to avoid enforcing document size limits manually.

It also adds calls to `ggshield secret scan docker` to our performance benchmark.

After this change, `DOCUMENT_SIZE_THRESHOLD_BYTES` is only used by `SecretScanner`, except for tests. This puts us in a better position to make this value customizable for on-prem instances.

## Details

The work is done by introducing a `DockerContentScannable` class, which knows how to read content inside a Docker image archive (which is a tar archive containing other tar archives, one per layer)

It also introduces a `DockerFiles` class, which inherits from `Files`, and keeps a reference to the overall opened tar archive, so that it stays open.

Some of the code from `File` has been moved to helper static methods in `Scannable` so that `DockerContntScannable` can use them.