### PR TITLE
Cache Docker successful scans

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,5 +29,5 @@ types-oauthlib = "*"
 typing-extensions = "*"
 
 vcrpy = "*"
-pyfakefs = "*"
+pyfakefs = ">=5.2.0"
 scriv = { version = "*", extras = ["toml"] }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "90a7e540682caf25fbb227bc76525a023c6c428d3828145d81e27a57d42c388f"
+            "sha256": "bed5466a24f81ac9ed6a1fc7e90c48824f093630eb1cd5d59694b78deb31f7ea"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -98,26 +98,27 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
-                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.0"
+            "version": "==23.1"
         },
         "pygitguardian": {
+            "git": "https://github.com/GitGuardian/py-gitguardian.git",
             "hashes": [
                 "sha256:6a796702a25b2b1352576f0f557639cdff15d4a187ea59c181b09fab4dcc5c16",
                 "sha256:a29ac0835f1f57ffa4502ce112c7362221e4346d4ea361fd90df5b14eb75474c"
             ],
-            "version": "==1.5.1"
+            "ref": "c6b941f8046de0188bc167d5a3d4ea7ebdd81e78"
         },
         "pygments": {
             "hashes": [
-                "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
-                "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"
+                "sha256:77a3299119af881904cd5ecd1ac6a66214b6e9bed1f2db16993b54adede64094",
+                "sha256:f7e36cffc4c517fbc252861b9a6e4644ca0e5abadf9a113c72d1358ad09b9500"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.14.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.15.0"
         },
         "python-dotenv": {
             "hashes": [
@@ -231,11 +232,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "backcall": {
             "hashes": [
@@ -314,60 +315,60 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:006ed5582e9cbc8115d2e22d6d2144a0725db542f654d9d4fda86793832f873d",
-                "sha256:046936ab032a2810dcaafd39cc4ef6dd295df1a7cbead08fe996d4765fca9fe4",
-                "sha256:0484d9dd1e6f481b24070c87561c8d7151bdd8b044c93ac99faafd01f695c78e",
-                "sha256:0ce383d5f56d0729d2dd40e53fe3afeb8f2237244b0975e1427bfb2cf0d32bab",
-                "sha256:186e0fc9cf497365036d51d4d2ab76113fb74f729bd25da0975daab2e107fd90",
-                "sha256:2199988e0bc8325d941b209f4fd1c6fa007024b1442c5576f1a32ca2e48941e6",
-                "sha256:299bc75cb2a41e6741b5e470b8c9fb78d931edbd0cd009c58e5c84de57c06731",
-                "sha256:3668291b50b69a0c1ef9f462c7df2c235da3c4073f49543b01e7eb1dee7dd540",
-                "sha256:36dd42da34fe94ed98c39887b86db9d06777b1c8f860520e21126a75507024f2",
-                "sha256:38004671848b5745bb05d4d621526fca30cee164db42a1f185615f39dc997292",
-                "sha256:387fb46cb8e53ba7304d80aadca5dca84a2fbf6fe3faf6951d8cf2d46485d1e5",
-                "sha256:3eb55b7b26389dd4f8ae911ba9bc8c027411163839dea4c8b8be54c4ee9ae10b",
-                "sha256:420f94a35e3e00a2b43ad5740f935358e24478354ce41c99407cddd283be00d2",
-                "sha256:4ac0f522c3b6109c4b764ffec71bf04ebc0523e926ca7cbe6c5ac88f84faced0",
-                "sha256:4c752d5264053a7cf2fe81c9e14f8a4fb261370a7bb344c2a011836a96fb3f57",
-                "sha256:4f01911c010122f49a3e9bdc730eccc66f9b72bd410a3a9d3cb8448bb50d65d3",
-                "sha256:4f68ee32d7c4164f1e2c8797535a6d0a3733355f5861e0f667e37df2d4b07140",
-                "sha256:4fa54fb483decc45f94011898727802309a109d89446a3c76387d016057d2c84",
-                "sha256:507e4720791977934bba016101579b8c500fb21c5fa3cd4cf256477331ddd988",
-                "sha256:53d0fd4c17175aded9c633e319360d41a1f3c6e352ba94edcb0fa5167e2bad67",
-                "sha256:55272f33da9a5d7cccd3774aeca7a01e500a614eaea2a77091e9be000ecd401d",
-                "sha256:5764e1f7471cb8f64b8cda0554f3d4c4085ae4b417bfeab236799863703e5de2",
-                "sha256:57b77b9099f172804e695a40ebaa374f79e4fb8b92f3e167f66facbf92e8e7f5",
-                "sha256:5afdad4cc4cc199fdf3e18088812edcf8f4c5a3c8e6cb69127513ad4cb7471a9",
-                "sha256:5cc0783844c84af2522e3a99b9b761a979a3ef10fb87fc4048d1ee174e18a7d8",
-                "sha256:5e1df45c23d4230e3d56d04414f9057eba501f78db60d4eeecfcb940501b08fd",
-                "sha256:6146910231ece63facfc5984234ad1b06a36cecc9fd0c028e59ac7c9b18c38c6",
-                "sha256:797aad79e7b6182cb49c08cc5d2f7aa7b2128133b0926060d0a8889ac43843be",
-                "sha256:7c20b731211261dc9739bbe080c579a1835b0c2d9b274e5fcd903c3a7821cf88",
-                "sha256:817295f06eacdc8623dc4df7d8b49cea65925030d4e1e2a7c7218380c0072c25",
-                "sha256:81f63e0fb74effd5be736cfe07d710307cc0a3ccb8f4741f7f053c057615a137",
-                "sha256:872d6ce1f5be73f05bea4df498c140b9e7ee5418bfa2cc8204e7f9b817caa968",
-                "sha256:8c99cb7c26a3039a8a4ee3ca1efdde471e61b4837108847fb7d5be7789ed8fd9",
-                "sha256:8dbe2647bf58d2c5a6c5bcc685f23b5f371909a5624e9f5cd51436d6a9f6c6ef",
-                "sha256:8efb48fa743d1c1a65ee8787b5b552681610f06c40a40b7ef94a5b517d885c54",
-                "sha256:92ebc1619650409da324d001b3a36f14f63644c7f0a588e331f3b0f67491f512",
-                "sha256:9d22e94e6dc86de981b1b684b342bec5e331401599ce652900ec59db52940005",
-                "sha256:ba279aae162b20444881fc3ed4e4f934c1cf8620f3dab3b531480cf602c76b7f",
-                "sha256:bc4803779f0e4b06a2361f666e76f5c2e3715e8e379889d02251ec911befd149",
-                "sha256:bfe7085783cda55e53510482fa7b5efc761fad1abe4d653b32710eb548ebdd2d",
-                "sha256:c448b5c9e3df5448a362208b8d4b9ed85305528313fca1b479f14f9fe0d873b8",
-                "sha256:c90e73bdecb7b0d1cea65a08cb41e9d672ac6d7995603d6465ed4914b98b9ad7",
-                "sha256:d2b96123a453a2d7f3995ddb9f28d01fd112319a7a4d5ca99796a7ff43f02af5",
-                "sha256:d52f0a114b6a58305b11a5cdecd42b2e7f1ec77eb20e2b33969d702feafdd016",
-                "sha256:d530191aa9c66ab4f190be8ac8cc7cfd8f4f3217da379606f3dd4e3d83feba69",
-                "sha256:d683d230b5774816e7d784d7ed8444f2a40e7a450e5720d58af593cb0b94a212",
-                "sha256:db45eec1dfccdadb179b0f9ca616872c6f700d23945ecc8f21bb105d74b1c5fc",
-                "sha256:db8c2c5ace167fd25ab5dd732714c51d4633f58bac21fb0ff63b0349f62755a8",
-                "sha256:e2926b8abedf750c2ecf5035c07515770944acf02e1c46ab08f6348d24c5f94d",
-                "sha256:e627dee428a176ffb13697a2c4318d3f60b2ccdde3acdc9b3f304206ec130ccd",
-                "sha256:efe1c0adad110bf0ad7fb59f833880e489a61e39d699d37249bdf42f80590169"
+                "sha256:06ddd9c0249a0546997fdda5a30fbcb40f23926df0a874a60a8a185bc3a87d93",
+                "sha256:0743b0035d4b0e32bc1df5de70fba3059662ace5b9a2a86a9f894cfe66569013",
+                "sha256:0f3736a5d34e091b0a611964c6262fd68ca4363df56185902528f0b75dbb9c1f",
+                "sha256:1127b16220f7bfb3f1049ed4a62d26d81970a723544e8252db0efde853268e21",
+                "sha256:172db976ae6327ed4728e2507daf8a4de73c7cc89796483e0a9198fd2e47b462",
+                "sha256:182eb9ac3f2b4874a1f41b78b87db20b66da6b9cdc32737fbbf4fea0c35b23fc",
+                "sha256:1bb1e77a9a311346294621be905ea8a2c30d3ad371fc15bb72e98bfcfae532df",
+                "sha256:1fd78b911aea9cec3b7e1e2622c8018d51c0d2bbcf8faaf53c2497eb114911c1",
+                "sha256:20d1a2a76bb4eb00e4d36b9699f9b7aba93271c9c29220ad4c6a9581a0320235",
+                "sha256:21b154aba06df42e4b96fc915512ab39595105f6c483991287021ed95776d934",
+                "sha256:2c2e58e45fe53fab81f85474e5d4d226eeab0f27b45aa062856c89389da2f0d9",
+                "sha256:2c3b2803e730dc2797a017335827e9da6da0e84c745ce0f552e66400abdfb9a1",
+                "sha256:3146b8e16fa60427e03884301bf8209221f5761ac754ee6b267642a2fd354c48",
+                "sha256:344e714bd0fe921fc72d97404ebbdbf9127bac0ca1ff66d7b79efc143cf7c0c4",
+                "sha256:387065e420aed3c71b61af7e82c7b6bc1c592f7e3c7a66e9f78dd178699da4fe",
+                "sha256:3f04becd4fcda03c0160d0da9c8f0c246bc78f2f7af0feea1ec0930e7c93fa4a",
+                "sha256:4a42e1eff0ca9a7cb7dc9ecda41dfc7cbc17cb1d02117214be0561bd1134772b",
+                "sha256:4ea748802cc0de4de92ef8244dd84ffd793bd2e7be784cd8394d557a3c751e21",
+                "sha256:55416d7385774285b6e2a5feca0af9652f7f444a4fa3d29d8ab052fafef9d00d",
+                "sha256:5d0391fb4cfc171ce40437f67eb050a340fdbd0f9f49d6353a387f1b7f9dd4fa",
+                "sha256:63cdeaac4ae85a179a8d6bc09b77b564c096250d759eed343a89d91bce8b6367",
+                "sha256:72fcae5bcac3333a4cf3b8f34eec99cea1187acd55af723bcbd559adfdcb5535",
+                "sha256:7c4ed4e9f3b123aa403ab424430b426a1992e6f4c8fd3cb56ea520446e04d152",
+                "sha256:83957d349838a636e768251c7e9979e899a569794b44c3728eaebd11d848e58e",
+                "sha256:87ecc7c9a1a9f912e306997ffee020297ccb5ea388421fe62a2a02747e4d5539",
+                "sha256:8f69770f5ca1994cb32c38965e95f57504d3aea96b6c024624fdd5bb1aa494a1",
+                "sha256:8f6c930fd70d91ddee53194e93029e3ef2aabe26725aa3c2753df057e296b925",
+                "sha256:965ee3e782c7892befc25575fa171b521d33798132692df428a09efacaffe8d0",
+                "sha256:974bc90d6f6c1e59ceb1516ab00cf1cdfbb2e555795d49fa9571d611f449bcb2",
+                "sha256:981b4df72c93e3bc04478153df516d385317628bd9c10be699c93c26ddcca8ab",
+                "sha256:aa784405f0c640940595fa0f14064d8e84aff0b0f762fa18393e2760a2cf5841",
+                "sha256:ae7863a1d8db6a014b6f2ff9c1582ab1aad55a6d25bac19710a8df68921b6e30",
+                "sha256:aeae2aa38395b18106e552833f2a50c27ea0000122bde421c31d11ed7e6f9c91",
+                "sha256:b2317d5ed777bf5a033e83d4f1389fd4ef045763141d8f10eb09a7035cee774c",
+                "sha256:be19931a8dcbe6ab464f3339966856996b12a00f9fe53f346ab3be872d03e257",
+                "sha256:be9824c1c874b73b96288c6d3de793bf7f3a597770205068c6163ea1f326e8b9",
+                "sha256:c0045f8f23a5fb30b2eb3b8a83664d8dc4fb58faddf8155d7109166adb9f2040",
+                "sha256:c86bd45d1659b1ae3d0ba1909326b03598affbc9ed71520e0ff8c31a993ad911",
+                "sha256:ca0f34363e2634deffd390a0fef1aa99168ae9ed2af01af4a1f5865e362f8623",
+                "sha256:d298c2815fa4891edd9abe5ad6e6cb4207104c7dd9fd13aea3fdebf6f9b91259",
+                "sha256:d2a3a6146fe9319926e1d477842ca2a63fe99af5ae690b1f5c11e6af074a6b5c",
+                "sha256:dfd393094cd82ceb9b40df4c77976015a314b267d498268a076e940fe7be6b79",
+                "sha256:e58c0d41d336569d63d1b113bd573db8363bc4146f39444125b7f8060e4e04f5",
+                "sha256:ea3f5bc91d7d457da7d48c7a732beaf79d0c8131df3ab278e6bba6297e23c6c4",
+                "sha256:ea53151d87c52e98133eb8ac78f1206498c015849662ca8dc246255265d9c3c4",
+                "sha256:eb0edc3ce9760d2f21637766c3aa04822030e7451981ce569a1b3456b7053f22",
+                "sha256:f649dd53833b495c3ebd04d6eec58479454a1784987af8afb77540d6c1767abd",
+                "sha256:f760073fcf8f3d6933178d67754f4f2d4e924e321f4bb0dcef0424ca0215eba1",
+                "sha256:fa546d66639d69aa967bf08156eb8c9d0cd6f6de84be9e8c9819f52ad499c910",
+                "sha256:fd214917cabdd6f673a29d708574e9fbdb892cb77eb426d0eae3490d95ca7859",
+                "sha256:fff5aaa6becf2c6a1699ae6a39e2e6fb0672c2d42eca8eb0cafa91cf2e9bd312"
             ],
             "index": "pypi",
-            "version": "==7.2.2"
+            "version": "==7.2.3"
         },
         "decorator": {
             "hashes": [
@@ -408,11 +409,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:892be14aa8efc01673b5ed6589dbccb95f9a8596f0507e232626155495c18105",
-                "sha256:bde48477b15fde2c7e5a0713cbe72721cb5a5ad32ee0b8f419907960b9d75536"
+                "sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37",
+                "sha256:f08a52314748335c6460fc8fe40cd5638b85001225db78c2aa01c8c0db83b318"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.10.7"
+            "version": "==3.11.0"
         },
         "flake8": {
             "hashes": [
@@ -471,11 +472,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156",
-                "sha256:735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04"
+                "sha256:1c183bf61b148b00bcebfa5d9b39312733ae97f6dad90d7e9b4d86c8647f498c",
+                "sha256:a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==8.11.0"
+            "version": "==8.12.0"
         },
         "isort": {
             "hashes": [
@@ -700,11 +701,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
-                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.0"
+            "version": "==23.1"
         },
         "parso": {
             "hashes": [
@@ -755,11 +756,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:a06a7fcce7f420047a71213c175714216498b49ebc81fe106f7716ca265f5bb6",
-                "sha256:b5aee7d75dbba21ee161ba641b01e7ae10c5b91967ebf7b2ab0dfae12d07e1f1"
+                "sha256:0b4210aea813fe81144e87c5a291f09ea66f199f367fa1df41b55e1d26e1e2b4",
+                "sha256:5b808fcbda4afbccf6d6633a56663fed35b6c2bc08096fd3d47ce197ac351d9d"
             ],
             "index": "pypi",
-            "version": "==3.2.1"
+            "version": "==3.2.2"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -793,11 +794,11 @@
         },
         "pyfakefs": {
             "hashes": [
-                "sha256:316c6026640d14a6b4fbde71fd9674576d1b5710deda8fabde8aad51d785dbc3",
-                "sha256:e6f34a8224b41f1b1ab25aa8d430121dac42e3c6e981e01eae76b3343fba47d0"
+                "sha256:0dcfb74e047e20b0755beeec3e3c0d7fc6f5029cdbb0cbf83d88431ee75b191d",
+                "sha256:92913ad26f2661b81080178421f00aa712d799e18e4b5bb2fcba128f435dd6a7"
             ],
             "index": "pypi",
-            "version": "==5.1.0"
+            "version": "==5.2.2"
         },
         "pyflakes": {
             "hashes": [
@@ -809,19 +810,19 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
-                "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"
+                "sha256:77a3299119af881904cd5ecd1ac6a66214b6e9bed1f2db16993b54adede64094",
+                "sha256:f7e36cffc4c517fbc252861b9a6e4644ca0e5abadf9a113c72d1358ad09b9500"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.14.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.15.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e",
-                "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"
+                "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362",
+                "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"
             ],
             "index": "pypi",
-            "version": "==7.2.2"
+            "version": "==7.3.1"
         },
         "pytest-mock": {
             "hashes": [
@@ -912,11 +913,11 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:0ceec6243ebf02f6a685507eec72f890ca9d9da4cafcfcfce640b1f027cec17d",
-                "sha256:95edfd76642cf7ae6b5cd40975545d8af58f6398cabfe83ff755e8eedb8ddd4e"
+                "sha256:4df597ee0a7b3dcc0d5315d7649df091efcb1b3ff08f0b51a698340727d17118",
+                "sha256:9137e343f98dd65b8ba3dda286739cb21b0b04fa1fc4a25ef4a8342556686f6b"
             ],
             "index": "pypi",
-            "version": "==1.2.1"
+            "version": "==1.3.1"
         },
         "seed-isort-config": {
             "hashes": [

--- a/changelog.d/20230417_123418_aurelien.gateau_cache_docker_successful_scan.md
+++ b/changelog.d/20230417_123418_aurelien.gateau_cache_docker_successful_scan.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- `ggshield secret scan docker` no longer rescan known-clean layers, speeding up subsequent scans. This cache is tied to GitGuardian secrets engine version, so all layers are rescanned when a new version of the secrets engine is deployed.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -16,4 +16,8 @@ def get_config_dir() -> str:
 
 
 def get_cache_dir() -> str:
-    return user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR)
+    try:
+        # See tests/conftest.py for details
+        return os.environ["TEST_CACHE_DIR"]
+    except KeyError:
+        return user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR)

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -10,7 +10,7 @@ APPAUTHOR = "GitGuardian"
 def get_config_dir() -> str:
     try:
         # See tests/conftest.py for details
-        return os.environ["TEST_CONFIG_DIR"]
+        return os.environ["GG_CONFIG_DIR"]
     except KeyError:
         return user_config_dir(appname=APPNAME, appauthor=APPAUTHOR)
 
@@ -18,6 +18,6 @@ def get_config_dir() -> str:
 def get_cache_dir() -> str:
     try:
         # See tests/conftest.py for details
-        return os.environ["TEST_CACHE_DIR"]
+        return os.environ["GG_CACHE_DIR"]
     except KeyError:
         return user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR)

--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -11,6 +11,7 @@ from click import UsageError
 from pygitguardian import GGClient
 
 from ggshield.core.cache import Cache
+from ggshield.core.dirs import get_cache_dir
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.file_utils import is_path_binary
 from ggshield.core.text_utils import display_heading, display_info
@@ -24,6 +25,7 @@ from ggshield.scan import (
     SecretScanner,
     StringScannable,
 )
+from ggshield.scan.id_cache import IDCache
 
 
 FILEPATH_BANLIST = [
@@ -251,6 +253,11 @@ def _get_layer_files(
         yield DockerContentScannable(layer_id, layer_archive, file_info)
 
 
+def _get_layer_id_cache(secrets_engine_version: str) -> IDCache:
+    cache_path = Path(get_cache_dir()) / "docker" / f"{secrets_engine_version}.json"
+    return IDCache(cache_path)
+
+
 def docker_pull_image(image_name: str, timeout: int) -> None:
     """
     Pull docker image and raise exception on timeout or failed to find image
@@ -313,16 +320,21 @@ def docker_scan_archive(
     scan_context: ScanContext,
     ignored_detectors: Optional[Set[str]] = None,
 ) -> ScanCollection:
+
+    scanner = SecretScanner(
+        client=client,
+        cache=cache,
+        scan_context=scan_context,
+        ignored_matches=matches_ignore,
+        ignored_detectors=ignored_detectors,
+    )
+    secrets_engine_version = client.secrets_engine_version
+    assert secrets_engine_version is not None
+    layer_id_cache = _get_layer_id_cache(secrets_engine_version)
+
     with tarfile.open(archive_path) as archive:
         docker_image = DockerImage(archive)
 
-        scanner = SecretScanner(
-            client=client,
-            cache=cache,
-            scan_context=scan_context,
-            ignored_matches=matches_ignore,
-            ignored_detectors=ignored_detectors,
-        )
         display_heading("Scanning Docker config")
         with RichSecretScannerUI(1) as ui:
             results = scanner.scan(
@@ -336,13 +348,15 @@ def docker_scan_archive(
             if file_count == 0:
                 continue
             print()
-            display_heading(f"Scanning layer {info.get_id()}")
-            with RichSecretScannerUI(file_count) as ui:
-                results.extend(
-                    scanner.scan(
-                        layer.files,
-                        scanner_ui=ui,
-                    )
-                )
+            layer_id = info.get_id()
+            if layer_id in layer_id_cache:
+                display_heading(f"Skipping layer {layer_id}: already scanned")
+            else:
+                display_heading(f"Scanning layer {info.get_id()}")
+                with RichSecretScannerUI(file_count) as ui:
+                    layer_results = scanner.scan(layer.files, scanner_ui=ui)
+                if not layer_results.has_policy_breaks:
+                    layer_id_cache.add(layer_id)
+                results.extend(layer_results)
 
     return ScanCollection(id=str(archive), type="scan_docker_archive", results=results)

--- a/ggshield/scan/id_cache.py
+++ b/ggshield/scan/id_cache.py
@@ -1,0 +1,42 @@
+import json
+import logging
+from pathlib import Path
+from typing import Set
+
+
+logger = logging.getLogger(__name__)
+
+
+class IDCache:
+    """
+    Stores a list of IDs as JSON in self.cache_path.
+    """
+
+    def __init__(self, cache_path: Path):
+        self.cache_path = cache_path
+        self._ids: Set[str] = set()
+        if self.cache_path.exists():
+            self._load()
+
+    def __contains__(self, id: str) -> bool:
+        return id in self._ids
+
+    def add(self, layer_id: str) -> None:
+        self._ids.add(layer_id)
+        self._save()
+
+    def _load(self) -> None:
+        try:
+            ids = json.loads(self.cache_path.read_text())
+        except Exception as exc:
+            logger.warning("Failed to load cache from %s: %s", self.cache_path, exc)
+            return
+        self._ids = set(ids)
+
+    def _save(self) -> None:
+        text = json.dumps(list(self._ids))
+        try:
+            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            self.cache_path.write_text(text)
+        except Exception as exc:
+            logger.warning("Failed to save cache to %s: %s", self.cache_path, exc)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ setup(
         "marshmallow>=3.18.0,<3.19.0",
         "marshmallow-dataclass>=8.5.8,<8.6.0",
         "oauthlib>=3.2.1,<3.3.0",
-        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git",  # TODO fix
+        # TODO: Make sure we release a new py-gitguardian before the next ggshield and
+        # add its version here
+        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@c6b941f8046de0188bc167d5a3d4ea7ebdd81e78",  # noqa: E501
         "python-dotenv>=0.21.0,<0.22.0",
         "pyyaml>=6.0,<6.1",
         "rich>=12.5.1,<12.6.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,11 @@ def do_not_use_real_config_dir(monkeypatch, tmp_path):
     `ggshield auth` stores credentials.
     """
     monkeypatch.setenv("TEST_CONFIG_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def do_not_use_real_cache_dir(monkeypatch, tmp_path):
+    """
+    This fixture ensures we do not use the real cache directory.
+    """
+    monkeypatch.setenv("TEST_CACHE_DIR", str(tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def do_not_use_real_config_dir(monkeypatch, tmp_path):
     This fixture ensures we do not use the real configuration directory, where
     `ggshield auth` stores credentials.
     """
-    monkeypatch.setenv("TEST_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("GG_CONFIG_DIR", str(tmp_path))
 
 
 @pytest.fixture(autouse=True)
@@ -32,4 +32,4 @@ def do_not_use_real_cache_dir(monkeypatch, tmp_path):
     """
     This fixture ensures we do not use the real cache directory.
     """
-    monkeypatch.setenv("TEST_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GG_CACHE_DIR", str(tmp_path))

--- a/tests/functional/secret/test_scan_docker.py
+++ b/tests/functional/secret/test_scan_docker.py
@@ -6,7 +6,8 @@ from string import Template
 
 import pytest
 
-from tests.conftest import GG_VALID_TOKEN
+from ggshield.core.dirs import get_cache_dir
+from tests.conftest import GG_VALID_TOKEN, skipwindows
 from tests.functional.conftest import FUNCTESTS_DATA_PATH, requires_docker
 from tests.functional.utils import (
     assert_is_valid_json,
@@ -19,6 +20,11 @@ TEST_DOCKER_IMAGE = os.getenv("GGTEST_DOCKER_IMAGE", "ubuntu:20.04")
 
 
 pytestmark = requires_docker()
+
+
+@pytest.fixture()
+def clear_layer_cache():
+    shutil.rmtree(Path(get_cache_dir()) / "docker", ignore_errors=True)
 
 
 def build_image(tmp_path: Path, name: str) -> None:
@@ -39,11 +45,11 @@ def build_image(tmp_path: Path, name: str) -> None:
     subprocess.run(["docker", "build", "-t", name, "."], cwd=image_path, check=True)
 
 
-def test_scan_docker() -> None:
+def test_scan_docker(clear_layer_cache) -> None:
     run_ggshield_scan("docker", TEST_DOCKER_IMAGE)
 
 
-def test_scan_docker_json() -> None:
+def test_scan_docker_json(clear_layer_cache) -> None:
     proc = run_ggshield_scan("docker", TEST_DOCKER_IMAGE, "--json")
     assert_is_valid_json(proc.stdout)
 
@@ -55,7 +61,9 @@ def test_scan_docker_json() -> None:
         "docker-leaking-in-layer",
     ),
 )
-def test_scan_docker_find_secret(tmp_path: Path, image_name: str) -> None:
+def test_scan_docker_find_secret(
+    clear_layer_cache, tmp_path: Path, image_name: str
+) -> None:
     build_image(tmp_path, image_name)
     proc = run_ggshield_scan("docker", image_name, expected_code=1, cwd=tmp_path)
 
@@ -63,3 +71,34 @@ def test_scan_docker_find_secret(tmp_path: Path, image_name: str) -> None:
         recreate_censored_content(f"token={GG_VALID_TOKEN}", GG_VALID_TOKEN)
         in proc.stdout
     )
+
+
+# Skip this test on Windows because on the CI the generated Docker image contains only
+# one layer, so there is no caching.
+# This is most likely related to the fact that the CI uses Windows Docker engine: the
+# same test passes on a Windows machine using Linux Docker engine.
+@skipwindows
+def test_scan_docker_uses_cache(clear_layer_cache, tmp_path: Path) -> None:
+    """
+    GIVEN a docker image with a secret in the last layer
+    WHEN scanned a second time
+    THEN only the last layer is re-scanned
+    """
+    image_name = "docker-leaking-in-layer"
+    scanning_snippet = "Scanning layer"
+    skipping_snippet = "Skipping layer"
+
+    build_image(tmp_path, image_name)
+    proc = run_ggshield_scan("docker", image_name, expected_code=1, cwd=tmp_path)
+
+    scanning_occurrences1 = proc.stderr.count(scanning_snippet)
+    skipping_occurrences = proc.stderr.count(skipping_snippet)
+
+    assert skipping_occurrences == 0
+
+    proc = run_ggshield_scan("docker", image_name, expected_code=1, cwd=tmp_path)
+    scanning_occurrences2 = proc.stderr.count(scanning_snippet)
+    skipping_occurrences = proc.stderr.count(skipping_snippet)
+
+    assert skipping_occurrences == 1
+    assert scanning_occurrences2 == scanning_occurrences1 - 1

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -10,17 +10,12 @@ from ggshield.core.errors import ExitCode
 from ggshield.scan import Files, ScanCollection, StringScannable
 from ggshield.scan.docker import LayerInfo, _validate_filepath
 from tests.unit.conftest import (
-    DATA_PATH,
+    DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH,
+    DOCKER_EXAMPLE_PATH,
     UNCHECKED_SECRET_PATCH,
     assert_invoke_exited_with,
     assert_invoke_ok,
     my_vcr,
-)
-
-
-DOCKER_EXAMPLE_PATH = DATA_PATH / "docker-example.tar.xz"
-DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
-    DATA_PATH / "docker-incomplete-manifest-example.tar.xz"
 )
 
 

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -99,16 +99,18 @@ class TestDockerCMD:
         assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert 'Image "ggshield-non-existant" not found' in result.output
 
+    @patch("ggshield.scan.docker._get_layer_infos")
     @patch("ggshield.scan.docker._get_config")
-    @patch("ggshield.scan.docker.DockerImage.get_layers")
+    @patch("ggshield.scan.docker.DockerImage.get_layer")
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
     @pytest.mark.parametrize("json_output", (False, True))
     def test_docker_scan_archive(
         self,
-        get_layers_mock: Mock,
+        get_layer_mock: Mock,
         _get_config_mock: Mock,
+        _get_layer_infos_mock: Mock,
         cli_fs_runner: click.testing.CliRunner,
         image_path: Path,
         json_output: bool,
@@ -118,16 +120,19 @@ class TestDockerCMD:
         layer_info = LayerInfo(filename="12345678/layer.tar", command="COPY foo")
         scannable = StringScannable(content=UNCHECKED_SECRET_PATCH, url="file_secret")
 
-        def get_layers():
-            yield (layer_info, Files([scannable]))
+        def get_layer(layer_info: LayerInfo):
+            return Files([scannable])
 
-        get_layers_mock.side_effect = get_layers
+        get_layer_mock.side_effect = get_layer
 
         _get_config_mock.return_value = (
             None,
             None,
             StringScannable(content="", url="Dockerfile or build-args"),
         )
+
+        _get_layer_infos_mock.return_value = [layer_info]
+
         with my_vcr.use_cassette("test_scan_file_secret"):
             json_arg = ["--json"] if json_output else []
             cli_fs_runner.mix_stderr = False
@@ -144,7 +149,7 @@ class TestDockerCMD:
             )
             assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
             _get_config_mock.assert_called_once()
-            get_layers_mock.assert_called_once()
+            get_layer_mock.assert_called_once_with(layer_info)
 
             if json_output:
                 output = json.loads(result.output)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,12 +2,13 @@ import os
 import platform
 from os.path import dirname, join, realpath
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 import pytest
 import vcr
 import yaml
 from click.testing import CliRunner, Result
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pygitguardian import GGClient
 from pygitguardian.models import ScanResult
 from requests.utils import DEFAULT_CA_BUNDLE_PATH, extract_zipped_paths
@@ -643,3 +644,13 @@ def assert_invoke_exited_with(result: Result, exit_code: int):
 
 def assert_invoke_ok(result: Result):
     assert_invoke_exited_with(result, 0)
+
+
+def make_fake_path_inaccessible(fs: FakeFilesystem, path: Union[str, Path]):
+    """
+    Make `path` inaccessible inside `fs`. This is useful to test IO permission errors.
+    """
+
+    # `force_unix_mode` is required for Windows.
+    # See <https://pytest-pyfakefs.readthedocs.io/en/latest/usage.html#set-file-as-inaccessible-under-windows>
+    fs.chmod(path, 0o0000, force_unix_mode=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -563,6 +563,24 @@ TWO_POLICY_BREAKS = ScanResult.SCHEMA.load(
     }
 )
 
+# Docker example constants
+DOCKER_EXAMPLE_PATH = DATA_PATH / "docker-example.tar.xz"
+DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
+    DATA_PATH / "docker-incomplete-manifest-example.tar.xz"
+)
+
+# Format is { layer_id: { path: content }}
+DOCKER_EXAMPLE_LAYER_FILES = {
+    "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc": {
+        "/app/file_one": "Hello, I am the first file!\n"
+    },
+    "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f": {
+        "/app/file_three.sh": "echo Life is beautiful.\n",
+        "/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",
+    },
+}
+
+
 my_vcr = vcr.VCR(
     cassette_library_dir=join(dirname(realpath(__file__)), "cassettes"),
     path_transformer=vcr.VCR.ensure_suffix(".yaml"),

--- a/tests/unit/scan/test_id_cache.py
+++ b/tests/unit/scan/test_id_cache.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+from ggshield.scan.id_cache import IDCache
+from tests.unit.conftest import make_fake_path_inaccessible
+
+
+def test_add(fs: FakeFilesystem):
+    """
+    GIVEN a cache instance
+    WHEN add() is called
+    THEN a cache file is created
+    """
+    cache_path = Path("/some_dir/cache.json")
+    cache = IDCache(cache_path)
+
+    some_id = "iam_an_id"
+    cache.add(some_id)
+
+    assert cache_path.exists()
+    ids = json.loads(cache_path.read_text())
+    assert ids == [some_id]
+
+
+def test_contains(fs: FakeFilesystem):
+    """
+    GIVEN a cache file
+    WHEN __contains__() is called
+    THEN the response is what was expected
+    """
+    cache_path = Path("/some_dir/cache.json")
+    some_id = "iam_an_id"
+
+    # Create the file on the disk
+    IDCache(cache_path).add(some_id)
+    assert cache_path.exists()
+
+    cache = IDCache(cache_path)
+    assert some_id in cache
+    assert "unknown_id" not in cache
+
+
+def test_does_not_fail_if_cache_file_cannot_be_written(caplog, fs: FakeFilesystem):
+    """
+    GIVEN an instance of IDCache created for a path which cannot be created
+    WHEN adding an entry
+    THEN it does not raise an exception
+    AND a log message is written
+    """
+    cache_path = Path("/some_dir/cache.json")
+    cache_path.parent.mkdir()
+    make_fake_path_inaccessible(fs, cache_path.parent)
+
+    cache = IDCache(cache_path)
+    cache.add("clean_id")
+    log_record = caplog.records[0]
+    assert log_record.levelname == "WARNING"
+    assert "Failed to save" in log_record.message
+    assert len(caplog.records) == 1
+
+
+def test_does_not_fail_if_cache_file_cannot_be_read(caplog, fs: FakeFilesystem):
+    """
+    GIVEN a non-readable cache file
+    WHEN an instance of IDCache is created using it
+    THEN it does not crash
+    AND a log message is written
+    AND the cache can be queried
+    """
+    cache_path = Path("/some_dir/cache.json")
+    cache_path.parent.mkdir()
+    cache_path.write_text('["hello"]')
+    make_fake_path_inaccessible(fs, cache_path)
+
+    cache = IDCache(cache_path)
+    log_record = caplog.records[0]
+    assert log_record.levelname == "WARNING"
+    assert "Failed to load" in log_record.message
+    assert len(caplog.records) == 1
+
+    assert "hello" not in cache

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -18,12 +18,10 @@ from ggshield.scan.docker import (
     docker_pull_image,
     docker_save_to_tmp,
 )
-from tests.unit.conftest import DATA_PATH
-
-
-DOCKER_EXAMPLE_PATH = DATA_PATH / "docker-example.tar.xz"
-DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
-    DATA_PATH / "docker-incomplete-manifest-example.tar.xz"
+from tests.unit.conftest import (
+    DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH,
+    DOCKER_EXAMPLE_LAYER_FILES,
+    DOCKER_EXAMPLE_PATH,
 )
 
 
@@ -92,17 +90,6 @@ class TestDockerScan:
         with tarfile.open(image_path) as archive:
             image = DockerImage(archive)
 
-            # Format is { layer_id => { path => content }}
-            expected_files_for_layers = {
-                "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc": {
-                    "/app/file_one": "Hello, I am the first file!\n"
-                },
-                "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f": {
-                    "/app/file_three.sh": "echo Life is beautiful.\n",
-                    "/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",
-                },
-            }
-
             # List of (LayerInfo, Files)
             # The filter is here to remove layers with no scannables
             infos_and_layers = list(
@@ -113,12 +100,11 @@ class TestDockerScan:
             )
 
             layer_ids = [x.get_id() for x, _ in infos_and_layers]
-            expected_layer_ids = list(expected_files_for_layers.keys())
-            assert layer_ids == expected_layer_ids
+            assert layer_ids == list(DOCKER_EXAMPLE_LAYER_FILES)
 
             layers = [l for _, l in infos_and_layers]
             for layer, expected_content_dict in zip(
-                layers, expected_files_for_layers.values()
+                layers, DOCKER_EXAMPLE_LAYER_FILES.values()
             ):
                 content_dict = {x.path.as_posix(): x.content for x in layer.files}
                 assert content_dict == expected_content_dict


### PR DESCRIPTION
## Description

This PR makes `ggshield secret scan docker` remember the IDs of layers which did not contain policy breaks so that it does not scan them again.

This is implemented by storing the IDs of clean layers in a cache file on disk. The file name is based on the secrets engine version so that when a new version of the secrets engine is deployed the cache is invalidated.

## Important commits

1st commit rework scanning a bit to avoid loading the content of a layer too early: we don't want to load the content if the layer is known to be clean.

2nd commit implements the cache itself and make use of it in the scan implementation.

3rd commit factorizes some test data used by docker tests. It was actually not needed after all, but the code is cleaner this way so I kept it.

4th commit adds a functional test. Unfortunately it does not pass on Windows in our CI. I tried to reproduce locally but could not, so I skipped it.

7th commit modifies our benchmark to ensure we always measure the performance of `secret scan docker` with an empty cache.