### PR TITLE
Make `ggshield secret scan docker` use DiffID for layers

### DIFF
--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -8,7 +8,7 @@ import pytest
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
 from ggshield.scan import Files, ScanCollection, StringScannable
-from ggshield.scan.docker import LayerInfo, _validate_filepath
+from ggshield.scan.docker import DockerImage, LayerInfo, _validate_filepath
 from tests.unit.conftest import (
     DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH,
     DOCKER_EXAMPLE_PATH,
@@ -94,18 +94,14 @@ class TestDockerCMD:
         assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert 'Image "ggshield-non-existant" not found' in result.output
 
-    @patch("ggshield.scan.docker._get_layer_infos")
-    @patch("ggshield.scan.docker._get_config")
-    @patch("ggshield.scan.docker.DockerImage.get_layer")
+    @patch("ggshield.scan.docker.DockerImage")
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
     @pytest.mark.parametrize("json_output", (False, True))
     def test_docker_scan_archive(
         self,
-        get_layer_mock: Mock,
-        _get_config_mock: Mock,
-        _get_layer_infos_mock: Mock,
+        _docker_image_class_mock: Mock,
         cli_fs_runner: click.testing.CliRunner,
         image_path: Path,
         json_output: bool,
@@ -113,20 +109,24 @@ class TestDockerCMD:
         assert image_path.exists()
 
         layer_info = LayerInfo(filename="12345678/layer.tar", command="COPY foo")
-        scannable = StringScannable(content=UNCHECKED_SECRET_PATCH, url="file_secret")
 
-        def get_layer(layer_info: LayerInfo):
-            return Files([scannable])
+        def create_docker_image() -> Mock(spec=DockerImage):
+            docker_image = Mock(spec=DockerImage)
+            docker_image.config_scannable = StringScannable(
+                content="", url="Dockerfile or build-args"
+            )
+            docker_image.layer_infos = [layer_info]
 
-        get_layer_mock.side_effect = get_layer
+            scannable = StringScannable(
+                content=UNCHECKED_SECRET_PATCH, url="file_secret"
+            )
+            docker_image.get_layer.return_value = Files([scannable])
 
-        _get_config_mock.return_value = (
-            None,
-            None,
-            StringScannable(content="", url="Dockerfile or build-args"),
-        )
+            return docker_image
 
-        _get_layer_infos_mock.return_value = [layer_info]
+        docker_image = create_docker_image()
+
+        _docker_image_class_mock.return_value = docker_image
 
         with my_vcr.use_cassette("test_scan_file_secret"):
             json_arg = ["--json"] if json_output else []
@@ -143,8 +143,7 @@ class TestDockerCMD:
                 ],
             )
             assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
-            _get_config_mock.assert_called_once()
-            get_layer_mock.assert_called_once_with(layer_info)
+            docker_image.get_layer.assert_called_once_with(layer_info)
 
             if json_output:
                 output = json.loads(result.output)

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -108,7 +108,9 @@ class TestDockerCMD:
     ):
         assert image_path.exists()
 
-        layer_info = LayerInfo(filename="12345678/layer.tar", command="COPY foo")
+        layer_info = LayerInfo(
+            filename="12345678/layer.tar", command="COPY foo", diff_id="sha256:1234"
+        )
 
         def create_docker_image() -> Mock(spec=DockerImage):
             docker_image = Mock(spec=DockerImage)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -571,10 +571,10 @@ DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH = (
 
 # Format is { layer_id: { path: content }}
 DOCKER_EXAMPLE_LAYER_FILES = {
-    "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc": {
+    "sha256:4e850fb0fe03eae7a9a505d114b342ecdf7fd6e5a3ed2a1967e40083d63c7abe": {
         "/app/file_one": "Hello, I am the first file!\n"
     },
-    "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f": {
+    "sha256:f1c86b269b6a35c2158e8cd69b5e276d6c238272adcdd44efa21e5d79d099ddb": {
         "/app/file_three.sh": "echo Life is beautiful.\n",
         "/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",
     },

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -13,7 +13,6 @@ from ggshield.scan.docker import (
     DockerImage,
     InvalidDockerArchiveException,
     LayerInfo,
-    _should_scan_layer,
     docker_pull_image,
     docker_save_to_tmp,
 )
@@ -58,7 +57,8 @@ class TestDockerScan:
         ],
     )
     def test_should_scan_layer(self, op: str, want: bool):
-        assert _should_scan_layer(LayerInfo(filename="dummy", command=op)) is want
+        layer_info = LayerInfo(filename="dummy", command=op)
+        assert layer_info.should_scan() is want
 
     @pytest.mark.parametrize(
         ["members", "match"],

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -57,7 +57,7 @@ class TestDockerScan:
         ],
     )
     def test_should_scan_layer(self, op: str, want: bool):
-        layer_info = LayerInfo(filename="dummy", command=op)
+        layer_info = LayerInfo(filename="dummy", command=op, diff_id="sha256:1234")
         assert layer_info.should_scan() is want
 
     @pytest.mark.parametrize(
@@ -98,7 +98,7 @@ class TestDockerScan:
                 )
             )
 
-            layer_ids = [x.get_id() for x, _ in infos_and_layers]
+            layer_ids = [x.diff_id for x, _ in infos_and_layers]
             assert layer_ids == list(DOCKER_EXAMPLE_LAYER_FILES)
 
             layers = [l for _, l in infos_and_layers]

--- a/tests/unit/scan/test_scan_docker.py
+++ b/tests/unit/scan/test_scan_docker.py
@@ -13,7 +13,6 @@ from ggshield.scan.docker import (
     DockerImage,
     InvalidDockerArchiveException,
     LayerInfo,
-    _get_config,
     _should_scan_layer,
     docker_pull_image,
     docker_save_to_tmp,
@@ -81,7 +80,7 @@ class TestDockerScan:
     def test_get_config(self, members, match):
         tarfile = TarMock(members)
         with pytest.raises(InvalidDockerArchiveException, match=match):
-            _get_config(tarfile)
+            DockerImage(tarfile)
 
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]


### PR DESCRIPTION
## Description

The current implementation of the Docker cache refers to layers using the random ID used as a folder name to store layer tarballs. This PR changes this to use the [layer DiffID](https://github.com/moby/moby/blob/master/image/spec/v1.2.md#terminology). There are two benefits to this:

- The ID is generated from the content: no risk of (unlikely) clash, higher chances of cache hits
- This ID is more likely to be known by the user: it is visible in the output of `docker inspect` for example

## What has been done

First two commits do some more cleanups to the code reading the Docker archives: they turn many helper functions into class members of either DockerImage or LayerInfo. They also makes it clearer which JSON files are read.

Third commit introduces the use of DiffID.