### PR TITLE
Move ignore-known-secrets configuration key

### DIFF
--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -40,7 +40,7 @@ def precommit_cmd(
         show_secrets=config.secret.show_secrets,
         verbose=config.verbose,
         output=None,
-        ignore_known_secrets=config.ignore_known_secrets,
+        ignore_known_secrets=config.secret.ignore_known_secrets,
     )
     try:
         check_git_dir()

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -136,5 +136,5 @@ def create_output_handler(ctx: click.Context) -> OutputHandler:
         show_secrets=config.secret.show_secrets,
         verbose=config.verbose,
         output=output,
-        ignore_known_secrets=config.ignore_known_secrets,
+        ignore_known_secrets=config.secret.ignore_known_secrets,
     )

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -258,3 +258,37 @@ class TestUserConfig:
         assert "Unrecognized key in config: match_invalid_key" in captured.err
         assert "Unrecognized key in config: hashed-key" in captured.err
         assert "Unrecognized key in config: nested-hashed" in captured.err
+
+    def test_can_load_ignored_known_secrets_from_root(self, local_config_path):
+        """
+        GIVEN a config file containing the `ignore_known_secrets` key in the root mapping
+        WHEN deserializing it
+        THEN UserConfig.secret.ignore_known_secrets has the correct value
+        """
+        write_yaml(
+            local_config_path,
+            {
+                "version": 2,
+                "ignore_known_secrets": True,
+            },
+        )
+        config, _ = UserConfig.load(local_config_path)
+        assert config.secret.ignore_known_secrets
+
+    def test_can_load_ignored_known_secrets_from_secret(self, local_config_path):
+        """
+        GIVEN a config file containing the `ignore_known_secrets` key in the `secret` mapping
+        WHEN deserializing it
+        THEN UserConfig.secret.ignore_known_secrets has the correct value
+        """
+        write_yaml(
+            local_config_path,
+            {
+                "version": 2,
+                "secret": {
+                    "ignore-known-secrets": True,
+                },
+            },
+        )
+        config, _ = UserConfig.load(local_config_path)
+        assert config.secret.ignore_known_secrets


### PR DESCRIPTION
## Description

When we added the `--ignore-known-secrets` option, we made a small mistake: the `ignore-known-secrets` configuration key should have been created in `UserConfig.secret` instead of `UserConfig`.

This PR fixes that. It silently loads the key from UserConfig if it's there to avoid any breakage.
