### PR TITLE
Post release fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -65,7 +65,7 @@ jobs:
           fetch-depth: 10
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -139,7 +139,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -61,6 +61,11 @@ jobs:
     needs: build_packages
     continue-on-error: true
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+
+    # This is required for `gh release create` to work
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -78,26 +83,21 @@ jobs:
         with:
           name: packages
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@master
+      - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.tags.outputs.tag }}
-          release_name: ${{ steps.tags.outputs.tag }}
-          draft: true
-          prerelease: false
+        run: |
+          gh release create --draft ${{ steps.tags.outputs.tag }}
 
-      - uses: xresloader/upload-to-github-release@v1
+      - name: Upload release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          file: 'packages/ggshield-*.pyz;packages/ggshield_*.deb;packages/ggshield-*.rpm'
-          release_id: ${{ steps.create_release.outputs.id }}
-          overwrite: true
-          verbose: true
-          draft: true
+        run: |
+          gh release upload \
+            ${{ steps.tags.outputs.tag }} \
+            packages/ggshield-*.pyz \
+            packages/ggshield_*.deb \
+            packages/ggshield-*.rpm
 
   push_to_docker_hub:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
## Description

This PR fixes a few minor issues found during 1.15.0 release:

- Extend tests to Python 3.11.0.
- Fix GitHub deprecation warnings about `set-output` usage (see https://github.com/GitGuardian/ggshield/actions/runs/4795329835: scroll the page to the "Annotations" section to see what I mean)

## Testing

One of the deprecation fixes replaces usage of GitHub actions with `gh`. I tested this change in a [sandbox repository](https://github.com/agateau-gg/ci-sandbox).