### PR TITLE
Expand developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,131 +2,36 @@
 
 ## Submitting a bug report
 
-Make sure you can reproduce it in the latest version of GGShield.
+Found a bug? Before reporting it:
 
-Open an issue on the [issue tracker](https://github.com/GitGuardian/ggshield/issues).
+1. Verify you can reproduce it in the latest version of GGShield.
+2. Search for other issues in GGShield [issue tracker](https://github.com/GitGuardian/ggshield/issues) to make sure it has not already been reported.
+3. File a [bug report](https://github.com/GitGuardian/ggshield/issues/new?assignees=&labels=type%3Abug%2Cstatus%3Anew&template=bug_report.md&title=).
 
-## Fixing an open and confirmed bug
+## Writing code
 
-This bug will have a `confirmed` tag on the issue tracker.
+The [doc/dev](doc/dev) directory contains high-level documentation to help you get started with writing code for GGShield.
+
+- [architecture.md](doc/dev/architecture.md): high-level overview of the code base.
+- [getting-started.md](doc/dev/getting-started.md): how to set up your environment.
+- [dependencies.md](doc/dev/dependencies.md): how to update dependencies, in particular how to use unreleased versions of py-gitguardian.
+
+If you notice any outdated or unclear information, please file an issue or a pull request!
+
+## Fixing reported bugs
+
+Confirmed bugs have a `confirmed` label on the issue tracker.
 
 Leave a message on the issue tracker that you're interested in fixing this bug.
 
 ## Proposing a new feature
 
-- Open an issue on the [issue tracker](https://github.com/GitGuardian/ggshield/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=Feature+Request) with a `feature request` label.
+Open an issue on the [issue tracker](https://github.com/GitGuardian/ggshield/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=Feature+Request) with a `feature request` label.
 
 ## Implementing new CI integration
 
-Open an issue on the [issue tracker](https://github.com/GitGuardian/ggshield/issues/new?assignees=&labels=CI+integration&template=feature_request.md&title=CI+Integration:).
-
-Submit a Pull request.
+Open an issue on the [issue tracker](https://github.com/GitGuardian/ggshield/issues/new?assignees=&labels=CI+integration&template=feature_request.md&title=CI+Integration:), then submit a pull request.
 
 ## Implementing a new feature
 
-Follow `Propose a new feature`.
-
-Submit a Pull Request.
-
-## Writing code
-
-### Setup your development environment
-
-1. Install pipenv (https://github.com/pypa/pipenv#installation)
-
-1. Install the pre-commit framework (https://pre-commit.com/#install)
-
-1. Fork and clone the repository
-
-1. Install dev packages and environment
-
-   ```sh
-   pipenv install --dev
-   ```
-
-1. Install pre-commit hooks
-
-   ```sh
-   pre-commit install
-   ```
-
-1. Install pre-commit hooks for messages
-
-   ```sh
-   pre-commit install --hook-type commit-msg
-   ```
-
-### Running tests
-
-The test suite contains two kinds of tests: unit tests and functional tests.
-
-Unit tests must execute fast, so they do not access the network and try to limit IO access. They are in the `tests/unit` directory.
-
-Functional tests exercise the whole product, so they need access to GitGuardian API and are slow. They are in the `tests/functional` directory.
-
-#### Unit tests
-
-Set the `TEST_GITGUARDIAN_API_KEY` environment variable to a valid GitGuardian API key.
-
-```sh
-make unittest
-```
-
-#### Verifying code coverage
-
-```sh
-make coverage
-```
-
-Then open [htmlcov/index.html](htmlcov/index.html).
-
-#### Running functional tests
-
-Set the `GITGUARDIAN_API_KEY` environment variable to a valid GitGuardian API key.
-
-You can also set the `GITGUARDIAN_API_URL` environment variable to test against another GitGuardian instance.
-
-```sh
-make functest
-```
-
-#### Running linters
-
-This runs all configured linters at once.
-
-```sh
-make lint
-```
-
-### Writing git commit messages
-
-- Use the present tense ("Add feature" not "Added feature")
-- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
-- [Use conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope), examples:
-  - feat(integration): Add Azure Pipelines support
-  - fix(ggshield): add pre-push mode header
-
-### Python
-
-We're committed to support python 3.7+ for now.
-
-If you add, update or remove dependencies:
-
-- add the dependency to `setup.py`
-- update the `Pipfile.lock` file by running `make update-pipfile-lock`
-
-## Opening a pull request
-
-### Changelog
-
-We use [scriv](https://github.com/nedbat/scriv) to manage our changelog. It is automatically installed by `pipenv install --dev`.
-
-All user visible changes must be documented in a changelog fragment. You can create one with `scriv create`. If your pull request only contains non-visible changes (such as refactors or fixes for regressions introduced _after_ the latest release), then apply the `skip-changelog` label to the pull request.
-
-### Check list
-
-Before submitting a pull request, make sure that:
-
-- All tests pass
-- Linters are happy
-- You added a changelog fragment or applied the `skip-changelog` label
+Open an issue as described in "Proposing a new feature", then submit a pull request.

--- a/doc/dev/architecture.md
+++ b/doc/dev/architecture.md
@@ -1,0 +1,46 @@
+# Architecture
+
+## Introduction
+
+This document provides an high-level overview of GGShield code base.
+
+## Git repositories
+
+- [py-gitguardian](https://github.com/GitGuardian/py-gitguardian): provides the Python package wrapping GitGuardian REST API. All API calls should be implemented in this package.
+- [ggshield](https://github.com/GitGuardian/ggshield): uses py-gitguardian to implement the GitGuardian CLI.
+
+## GGShield project tree
+
+### `ggshield` directory
+
+- ggshield
+  - cmd: Implementation of the commands. Python modules in this directory provide commands in the form of `<command_name>_cmd` functions.
+  - scan: Scan-specific modules. To be refactored to hold only secret specific modules.
+  - iac: Infrastructure-as-Code specific modules.
+  - core: Basic modules used by others.
+
+`cmd` modules can depend on all others.
+
+`scan` and `iac` modules can only depend on `core` modules.
+
+`core` modules cannot depend on any other GGShield modules.
+
+### `tests` directory
+
+GGShield has two test suites: Unit tests exercise parts of the code. Functional tests exercise complete commands.
+
+Both test suites can be run using `pytest`.
+
+#### Unit tests
+
+Unit tests must execute fast, so they do not access the network (mostly, see note below) and try to limit IO access. They can mock functions and uses [VCR.py](https://vcrpy.readthedocs.io/en/latest/index.html) to replay network communications.
+
+Unit tests modules follow more-or-less closely the hierarchy of the `ggshield` directory.
+
+About network access: network access is required to record VCR.py cassettes, but this only happens when writing new tests. The CI runs the unit test suite in a way which disables all network access.
+
+#### Functional tests
+
+Functional tests run the real `ggshield` commands without mocking anything. This means they access GitGuardian API for real, making them slow.
+
+They are organized to match `ggshield` commands.

--- a/doc/dev/dependencies.md
+++ b/doc/dev/dependencies.md
@@ -1,0 +1,43 @@
+# Dependencies
+
+## Updating dependencies
+
+To update a dependency:
+
+- Update the dependency version in `setup.py`.
+- Make any necessary changes.
+- Run `make update-pipfile-lock` to update the `Pipfile.lock` file.
+- File a PR.
+
+## Using an unreleased version of py-gitguardian
+
+If you made changes to py-gitguardian and want to use them in GGShield there are a few steps you need to perform.
+
+### Locally
+
+To use your changes locally:
+
+- Activate `ggshield` virtual environment.
+- Run `pip install -e path/to/your/py-gitguardian/checkout`.
+
+You only need to do this once. From now on, changes you make in py-gitguardian are immediately available in ggshield.
+
+### In the CI
+
+For the changes to pass on CI, you need to:
+
+1. Update py-gitguardian dependency in `setup.py` to use a git+https URL, like this:
+
+   ```python
+   setup(
+       ...,
+       # TODO: replace this with a real version number as soon as a new version of
+       # py-gitguardian is out
+       "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@c6b941f8046de0188bc167d5a3d4ea7ebdd81e78",  # noqa: E501
+       ...,
+   )
+   ```
+
+2. Update the `Pipfile.lock` with `make update-pipfile-lock`.
+
+Remember to do what the `TODO` comment says!

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -1,0 +1,78 @@
+# Getting started
+
+## Setup your development environment
+
+1. Install [pipenv](https://github.com/pypa/pipenv#installation)
+
+1. Install the [pre-commit framework](https://pre-commit.com/#install)
+
+1. Fork and clone the repository
+
+1. Install dev packages and environment
+
+   ```sh
+   pipenv install --dev --skip-lock
+   ```
+
+1. Install pre-commit hooks
+
+   ```sh
+   pre-commit install
+   pre-commit install --hook-type commit-msg
+   ```
+
+You should be good to go. Verify it is the case by running unit tests. See below.
+
+## Running tests
+
+### Environment variables
+
+The `GITGUARDIAN_API_KEY` environment variable must be defined to run functional tests. It is also required when recording VCR.py cassettes or updating existing ones.
+
+If you want to run tests against another GitGuardian instance, define the `GITGUARDIAN_API_URL` environment variable.
+
+### Running unit tests
+
+You can run unit tests with `make unittest`.
+
+### Verifying code coverage
+
+Run `make coverage`. This runs the unit tests through [coverage](https://pypi.org/project/coverage/) and generates an HTML report in `htmlcov/index.html`.
+
+### Running functional tests
+
+Run `make functest`.
+
+## Running linters
+
+Run `make lint`to run all configured linters at once.
+
+## Writing git commit messages
+
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- [Use conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope), examples:
+  - feat(integration): Add Azure Pipelines support
+  - fix(ggshield): add pre-push mode header
+
+## Python version
+
+We're committed to support python 3.7+ for now.
+
+## Opening a pull request
+
+### Changelog
+
+We use [scriv](https://github.com/nedbat/scriv) to manage our changelog. It is automatically installed by `pipenv install --dev`.
+
+All user-visible changes must be documented in a changelog fragment. You can create one with `scriv create`.
+
+The CI rejects any pull request without changelog fragments unless it has been assigned the `skip-changelog` label. The `skip-changelog` label should only be used if your pull request only contains non-visible changes such as refactors, or fixes for regressions introduced _after_ the latest release.
+
+### Check list
+
+Before submitting a pull request, make sure that:
+
+- All tests pass
+- Linters are happy
+- You added a changelog fragment or applied the `skip-changelog` label

--- a/scripts/release
+++ b/scripts/release
@@ -107,15 +107,9 @@ def run_tests() -> None:
     still match production reality.
     """
 
-    # Set the TEST_GITGUARDIAN_API_KEY environment variable: some tests rely on
-    # it
-    try:
-        api_key = os.environ["GITGUARDIAN_API_KEY"]
-    except KeyError:
+    # Check we have an API key
+    if "GITGUARDIAN_API_KEY" not in os.environ:
         fail("Environment variable $GITGUARDIAN_API_KEY is not set")
-
-    env = dict(os.environ)
-    env["TEST_GITGUARDIAN_API_KEY"] = api_key
 
     # If CASSETTES_DIR does not exist, tests fail, so recreate it
     log_progress("Removing cassettes")
@@ -123,10 +117,10 @@ def run_tests() -> None:
     CASSETTES_DIR.mkdir()
 
     log_progress("Running unit tests")
-    check_run(["pytest", "tests/unit"], cwd=ROOT_DIR, env=env)
+    check_run(["pytest", "tests/unit"], cwd=ROOT_DIR)
 
     log_progress("Running functional tests")
-    check_run(["pytest", "tests/functional"], cwd=ROOT_DIR, env=env)
+    check_run(["pytest", "tests/functional"], cwd=ROOT_DIR)
 
     log_progress("Restoring cassettes")
     check_run(["git", "restore", CASSETTES_DIR], cwd=ROOT_DIR)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import warnings
 from os.path import dirname, join, realpath
 from pathlib import Path
 from typing import Any, Union
@@ -595,8 +596,13 @@ my_vcr = vcr.VCR(
 
 @pytest.fixture(scope="session")
 def client() -> GGClient:
-    api_key = os.getenv("TEST_GITGUARDIAN_API_KEY", "1234567890")
-    base_uri = os.getenv("TEST_GITGUARDIAN_API_URL", "https://api.gitguardian.com")
+    if "GITGUARDIAN_API_KEY" not in os.environ:
+        warnings.warn(
+            "GITGUARDIAN_API_KEY is not set, recording VCR cassettes won't work."
+        )
+        os.environ["GITGUARDIAN_API_KEY"] = "not-a-real-key"
+    api_key = os.environ["GITGUARDIAN_API_KEY"]
+    base_uri = os.getenv("GITGUARDIAN_API_URL", "https://api.gitguardian.com")
     return GGClient(api_key, base_uri)
 
 
@@ -609,9 +615,6 @@ def cache() -> Cache:
 
 @pytest.fixture()
 def cli_runner():
-    os.environ["GITGUARDIAN_API_KEY"] = os.getenv(
-        "TEST_GITGUARDIAN_API_KEY", "1234567890"
-    )
     return CliRunner()
 
 


### PR DESCRIPTION
## Description

This MR splits the `CONTRIBUTE.md` file and expands its content.

It also removes the need to define the `$TEST_GITGUARDIAN_API_KEY` to run tests. This makes running tests for the first time simpler.

## Review

To get a better preview of what the end result looks like, here is a direct link to  [CONTRIBUTE.md](https://github.com/GitGuardian/ggshield/blob/agateau/expand-dev-doc/CONTRIBUTING.md) on this branch.