### PR TITLE
fix(cli): # Fix the common scan option --ignore-known-secrets

### DIFF
--- a/changelog.d/20230510_161532_samuel.guillaume_fix_scan_option_ignore_known_secrets.md
+++ b/changelog.d/20230510_161532_samuel.guillaume_fix_scan_option_ignore_known_secrets.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Fix the option `--ignore-known-secrets` which was ignored
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -86,7 +86,7 @@ _ignore_known_secrets_option = click.option(
     is_flag=True,
     default=None,
     help="Ignore secrets already known by GitGuardian dashboard",
-    callback=create_config_callback("ignore_known_secrets"),
+    callback=create_config_callback("secret", "ignore_known_secrets"),
 )
 
 


### PR DESCRIPTION
## Description

The flag `--ignore-known-secrets` does not work because the path of the corresponding value in the config is now `config.secret.ignore_known_secrets` since b37d1a1b52a4ed591d55fccc986c85cf9f545521
