### PR TITLE
fix(pre-receive): #417 Execute pre-receive within a sub-process to accurately enforce the timeout

### DIFF
--- a/changelog.d/20230517_164846_samuel.guillaume_417_pre_receive_timeout_is_not_precise_enough.md
+++ b/changelog.d/20230517_164846_samuel.guillaume_417_pre_receive_timeout_is_not_precise_enough.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Accurately enforce the timeout of the pre-receive secret scan command (#417)
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -80,6 +80,8 @@ def git(
             env=env,
             cwd=cwd,
         )
+        if result.stderr:
+            logger.debug("stderr=%s", result.stderr.decode("utf-8", errors="ignore"))
         return result.stdout.decode("utf-8", errors="ignore").rstrip()
     except subprocess.CalledProcessError as e:
         if "detected dubious ownership in repository" in e.stderr.decode(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,10 @@
+import http.server
 import shutil
+import socketserver
+import time
+from multiprocessing import Process
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
@@ -13,3 +18,49 @@ HAS_DOCKER = shutil.which("docker") is not None
 
 # Use this as a decorator for tests which call the `docker` binary
 requires_docker = pytest.mark.skipif(not HAS_DOCKER, reason="This test requires Docker")
+
+
+class SlowGGAPIHandler(http.server.BaseHTTPRequestHandler):
+    def do_HEAD(self):
+        self.send_response(200)
+
+    def do_GET(self):
+        if "health" in self.path:
+            content = b'{"detail":"Valid API key."}'
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_response(418)
+
+    def do_POST(self):
+        if "multiscan" in self.path:
+            content = b'{"detail":"Sorry, I overslept!"}'
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            time.sleep(60)
+            self.wfile.write(content)
+        else:
+            self.send_response(418)
+
+
+def _start_slow_gitguardian_api(host: str, port: int):
+    with socketserver.TCPServer((host, port), SlowGGAPIHandler) as httpd:
+        httpd.serve_forever()
+
+
+@pytest.fixture
+@pytest.mark.allow_hosts(["localhost"])
+def slow_gitguardian_api() -> Generator[str, None, None]:
+    host, port = "localhost", 8123
+    server_process = Process(target=_start_slow_gitguardian_api, args=(host, port))
+    server_process.start()
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server_process.kill()
+        server_process.join()

--- a/tests/functional/secret/test_scan_prereceive.py
+++ b/tests/functional/secret/test_scan_prereceive.py
@@ -1,5 +1,8 @@
+import os
+import subprocess
 from pathlib import Path
 from subprocess import CalledProcessError
+from unittest.mock import patch
 
 import pytest
 
@@ -100,3 +103,44 @@ def test_scan_prereceive_push_force(tmp_path: Path) -> None:
     # THEN the push is accepted because the commit containing the secret has not been
     # scanned
     local_repo.push("--force")
+
+
+def test_scan_prereceive_timeout(tmp_path: Path, slow_gitguardian_api: str) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    # AND ggshield installed as a pre-receive hook
+    hook_path = remote_repo.path / "hooks" / "pre-receive"
+    hook_path.write_text(HOOK_CONTENT)
+    hook_path.chmod(0o755)
+
+    # AND a secret committed
+    secret_file = local_repo.path / "secret.conf"
+    secret_content = f"password = {GG_VALID_TOKEN}"
+    secret_file.write_text(secret_content)
+    local_repo.add("secret.conf")
+    local_repo.create_commit()
+
+    # Prepare to mock process.run to access the stderr of the push
+    stderr = b""
+    subprocess_run = subprocess.run
+
+    def run_and_copy_stderr(*args, **kwargs):
+        process = subprocess_run(*args, **kwargs)
+        nonlocal stderr
+        stderr = process.stderr
+        return process
+
+    # WHEN I try to push
+    # THEN the hook timeouts and allows the push
+    with patch.dict(
+        os.environ, {**os.environ, "GITGUARDIAN_API_URL": slow_gitguardian_api}
+    ), patch("ggshield.core.git_shell.subprocess.run") as mock_subprocess_run:
+        mock_subprocess_run.side_effect = run_and_copy_stderr
+        local_repo.push()
+
+    # AND the error message contains timeout message
+    assert b"Pre-receive hook took too long" in stderr


### PR DESCRIPTION
Fixes #417 

I first tried the solution proposed in the issue, but it did not work. Threads can not be killed and Python will always wait for all of its threads to end before exiting. If an API call is stuck, nothing can be done from the same process.

I've implemented a more brutal solution: move the logic within a sub-process which can be killed when it takes too long. To test it, I've added a functional test with a fake server which won't response in the middle of a request.

In the unit tests, to not rewrite the existing tests, the `multiprocessing.Process` is mock to run in the main-process and `multiprocessing.Pipe` to not use a unix socket.