### PR TITLE
Add incident url to json output

### DIFF
--- a/changelog.d/20230517_105917_pierrelalanne_add_incident_url_to_json_output.md
+++ b/changelog.d/20230517_105917_pierrelalanne_add_incident_url_to_json_output.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- The JSON output now includes an "incident_url" key for incidents. If a matching incident was found in the user's dashboard it contains the URL to the incident. Otherwise, it defaults to an empty string.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/changelog.d/20230517_105917_pierrelalanne_add_incident_url_to_json_output.md
+++ b/changelog.d/20230517_105917_pierrelalanne_add_incident_url_to_json_output.md
@@ -13,7 +13,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 <!--
 ### Added
 
-- The JSON output now includes an "incident_url" key for incidents. If a matching incident was found in the user's dashboard it contains the URL to the incident. Otherwise, it defaults to an empty string.
+- The JSON output now includes an "incident_url" key for incidents. If a matching incident was found in the user's dashboard it contains the URL to the incident. Otherwise, it defaults to an empty string. The "known_secret" key is now always present, it will default to False if the incident is unknown to the dashboard.
 
 -->
 <!--

--- a/ggshield/output/json/json_output_handler.py
+++ b/ggshield/output/json/json_output_handler.py
@@ -51,7 +51,6 @@ class JSONOutputHandler(OutputHandler):
                 scan_dict.setdefault("scans", []).append(inner_scan_dict)
                 scan_dict["total_incidents"] += inner_scan_dict["total_incidents"]
                 scan_dict["total_occurrences"] += inner_scan_dict["total_occurrences"]
-
         return scan_dict
 
     def process_result(self, result: Result) -> Dict[str, Any]:
@@ -82,7 +81,6 @@ class JSONOutputHandler(OutputHandler):
             )
             result_dict["incidents"].append(flattened_dict)
             result_dict["total_occurrences"] += flattened_dict["total_occurrences"]
-
         return result_dict
 
     @staticmethod
@@ -119,6 +117,7 @@ class JSONOutputHandler(OutputHandler):
 
         if policy_breaks[0].known_secret:
             flattened_dict["known_secret"] = policy_breaks[0].known_secret
+            flattened_dict["incident_url"] = policy_breaks[0].incident_url
 
         for policy_break in policy_breaks:
             matches = JSONOutputHandler.make_matches(

--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -77,7 +77,7 @@ class FlattenedPolicyBreak(BaseSchema):
     ignore_sha = fields.String(required=True)
     total_occurrences = fields.Integer(required=True)
     incident_url = fields.String(required=True, default="")
-    known_secret = fields.Bool(required=False)
+    known_secret = fields.Bool(required=True, default=False)
 
 
 class JSONResultSchema(BaseSchema):

--- a/ggshield/output/json/schemas.py
+++ b/ggshield/output/json/schemas.py
@@ -76,6 +76,7 @@ class FlattenedPolicyBreak(BaseSchema):
     validity = fields.String(required=False, allow_none=True)
     ignore_sha = fields.String(required=True)
     total_occurrences = fields.Integer(required=True)
+    incident_url = fields.String(required=True, default="")
     known_secret = fields.Bool(required=False)
 
 

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -230,10 +230,9 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
         ].startswith("https://dashboard.gitguardian.com/workspace/1/incidents/")
 
     for policy_break in new_policy_breaks:
-        assert (
+        assert not incident_for_policy_break_type[policy_break.break_type][
             "known_secret"
-            not in incident_for_policy_break_type[policy_break.break_type]
-        )
+        ]
         assert not incident_for_policy_break_type[policy_break.break_type][
             "incident_url"
         ]

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 from pytest_voluptuous import Partial, S
-from voluptuous import Optional, validators
+from voluptuous import Optional, Required, validators
 
 from ggshield.core.utils import Filemode
 from ggshield.output import JSONOutputHandler, OutputHandler
@@ -85,6 +85,9 @@ SCHEMA_WITH_INCIDENTS = S(
                                     "break_type": str,
                                     "policy": str,
                                     "total_occurrences": validators.All(int, min=1),
+                                    Required("incident_url"): validators.Match(
+                                        r"^($|https://)"
+                                    ),
                                 }
                             ],
                             validators.Length(min=1),
@@ -188,8 +191,11 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
             known_policy_breaks = all_policy_breaks[:1]
             new_policy_breaks = all_policy_breaks[1:]
 
-    for policy_break in known_policy_breaks:
+    for index, policy_break in enumerate(known_policy_breaks):
         policy_break.known_secret = True
+        policy_break.incident_url = (
+            f"https://dashboard.gitguardian.com/workspace/1/incidents/{index}"
+        )
 
     # call output handler
     output = output_handler._process_scan_impl(
@@ -219,9 +225,15 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
 
     for policy_break in known_policy_breaks:
         assert incident_for_policy_break_type[policy_break.break_type]["known_secret"]
+        assert incident_for_policy_break_type[policy_break.break_type][
+            "incident_url"
+        ].startswith("https://dashboard.gitguardian.com/workspace/1/incidents/")
 
     for policy_break in new_policy_breaks:
         assert (
             "known_secret"
             not in incident_for_policy_break_type[policy_break.break_type]
         )
+        assert not incident_for_policy_break_type[policy_break.break_type][
+            "incident_url"
+        ]


### PR DESCRIPTION
Closes #525 

## What we did
We included an `incident_url` key in the `FlattenedPolicyBreak` schema.  
This key will always be present and defaults to "N/A" if no matching incident exists in the dashboard.  
We chose "N/A" to have a consistent `str` type, to match the text output and to ease validation with voluptuous. 

We adapted tests in consequence.

## What it looks like

Given this input (fake creds):  

```python
# known secret
apikey=rk_live_VZpzxUqUVrzX2eajXf4MCGgyxJlBoIspDEso68lKmE8RxPEYHHf3IMEuKXOzA4P5Vz2VRB7GyAPAs

# unknown secret
apikey=rk_live_VZpzxUqUVrzX2eajXf4MCGgyxJlBoIspDEso68lKmE8RxPEYHHf3IMEuKXOzA4P5Vz2VRB7GyAPAz
```

This command :
```shell
ggshield secret scan path --ignore-known-secrets dummy.py --json | jq '.'
```

Will generate this json:
```json
{
  "id": "........./dummy.py",
  "type": "path_scan",
  "entities_with_incidents": [
    {
      "mode": "FILE",
      "filename": "......../dummy.py",
      "incidents": [
        {
          "policy": "Secrets detection",
          "occurrences": [
            {
              "match": "rk_live_VZpzxUq*******************************************************P5Vz2VRB7GyAPAs",
              "type": "apikey",
              "line_start": 2,
              "line_end": 2,
              "index_start": 7,
              "index_end": 92,
              "pre_line_start": 2,
              "pre_line_end": 2
            }
          ],
          "type": "Stripe Keys",
          "validity": "invalid",
          "ignore_sha": "06c3bab1ae6708d44f0cd0eee8b5de81a396faa5c320dc410a35ed68b0b0b1a9",
          "total_occurrences": 1,
          "incident_url": "https://dashboard.gitguardian.com/workspace/8/incidents/6666699",
          "known_secret": true
        },
        {
          "policy": "Secrets detection",
          "occurrences": [
            {
              "match": "rk_live_VZpzxUq*******************************************************P5Vz2VRB7GyAPAz",
              "type": "apikey",
              "line_start": 5,
              "line_end": 5,
              "index_start": 7,
              "index_end": 92,
              "pre_line_start": 5,
              "pre_line_end": 5
            }
          ],
          "type": "Stripe Keys",
          "validity": "invalid",
          "ignore_sha": "af131b38cc6106b083f105dc2f1b46f877780d59e99724eceb805b1f375feda2",
          "total_occurrences": 1,
          "incident_url": "N/A"
        }
      ],
      "total_incidents": 2,
      "total_occurrences": 2
    }
  ],
  "total_incidents": 2,
  "total_occurrences": 2,
  "secrets_engine_version": "2.89.0"
}
```

## Open questions
This is more for product:
- Is this expected that the ignore-known-secrets flag does not remove secret in the json ?
- I find it weird now that the `incident_url` is always present, but the `known_secret` is not. they kind of go along...