### PR TITLE
Use server-side configuration

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -106,11 +106,7 @@
         },
         "pygitguardian": {
             "git": "https://github.com/GitGuardian/py-gitguardian.git",
-            "hashes": [
-                "sha256:ba3c84b19ecae90e03c06160c02837e1625709ef9126e89cdc830baa5552dadb",
-                "sha256:f82b8bd6de359c9d566941eec60e9ed19a6ac5d40213b2cfd776c1e37f9aa801"
-            ],
-            "ref": "067188cc34a9a20e83ca983160152799bd3fe7d4"
+            "ref": "0c54209c86ea292ba4f375d4ca44f1d4440e1cb1"
         },
         "pygments": {
             "hashes": [
@@ -192,18 +188,18 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:558bc0c4145f01e6405f4a5fdbd82050bd221b119f4bf72a961a1cfd471349d6",
-                "sha256:6bac751f4789b135c43228e72de18637e9a6c29d12777023a703fd1a6858469f"
+                "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c",
+                "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.6.1"
+            "version": "==4.6.2"
         },
         "typing-inspect": {
             "hashes": [
-                "sha256:5fbf9c1e65d4fa01e701fe12a5bca6c6e08a4ffd5bc60bfac028253a447c5188",
-                "sha256:8b1ff0c400943b6145df8119c41c244ca8207f1f10c9c057aeed1560e4806e3d"
+                "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f",
+                "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"
             ],
-            "version": "==0.8.0"
+            "version": "==0.9.0"
         },
         "urllib3": {
             "hashes": [
@@ -375,7 +371,7 @@
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.7'",
+            "markers": "python_version > '3.6' and python_version < '3.11'",
             "version": "==5.1.1"
         },
         "distlib": {
@@ -475,7 +471,7 @@
                 "sha256:7dff3fad32b97f6488e02f87b970f309d082f758d7b7fc252e3b19ee0e432dbb",
                 "sha256:ffca270240fbd21b06b2974e14a86494d6d29290184e788275f55e0b55914926"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.7'",
+            "markers": "python_version > '3.6' and python_version < '3.11'",
             "version": "==8.13.2"
         },
         "isort": {
@@ -940,7 +936,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "snapshottest": {
@@ -1023,11 +1019,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:558bc0c4145f01e6405f4a5fdbd82050bd221b119f4bf72a961a1cfd471349d6",
-                "sha256:6bac751f4789b135c43228e72de18637e9a6c29d12777023a703fd1a6858469f"
+                "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c",
+                "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.6.1"
+            "version": "==4.6.2"
         },
         "urllib3": {
             "hashes": [
@@ -1039,11 +1035,11 @@
         },
         "vcrpy": {
             "hashes": [
-                "sha256:7cd3e81a2c492e01c281f180bcc2a86b520b173d2b656cb5d89d99475423e013",
-                "sha256:efac3e2e0b2af7686f83a266518180af7a048619b2f696e7bad9520f5e2eac09"
+                "sha256:49c270ce67e826dba027d83e20d25b67a5885487697e97bca6dbdf53d750a0ac",
+                "sha256:8fbd4be412e8a7f35f623dd61034e6380a1c8dbd0edf6e87277a3289f6e98093"
             ],
             "index": "pypi",
-            "version": "==4.2.1"
+            "version": "==4.3.0"
         },
         "virtualenv": {
             "hashes": [

--- a/changelog.d/20230523_142939_aurelien.gateau_use_server_side_cfg.md
+++ b/changelog.d/20230523_142939_aurelien.gateau_use_server_side_cfg.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ggshield secret scan` commands can now use server-side configuration for the maximum document size and maximum document count per scan.

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -73,14 +73,15 @@ def check_client_api_key(client: GGClient) -> None:
     (either it is invalid or unset). Raises UnexpectedError if the API is down.
     """
     try:
-        response = client.health_check()
+        response = client.read_metadata()
     except requests.exceptions.ConnectionError as e:
         raise UnexpectedError(
             "Failed to connect to GitGuardian server. Check your"
             f" instance URL settings.\nDetails: {e}."
         )
 
-    if response.success:
+    if response is None:
+        # None means success
         return
 
     if response.status_code == 401:

--- a/ggshield/secret/repo.py
+++ b/ggshield/secret/repo.py
@@ -8,7 +8,6 @@ from typing import Callable, Iterable, Iterator, List, Optional, Set
 
 from click import UsageError
 from pygitguardian import GGClient
-from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 
 from ggshield.core.cache import Cache
 from ggshield.core.client import check_client_api_key
@@ -120,11 +119,11 @@ def scan_commits_content(
 
 def get_commits_by_batch(
     commits: Iterable[Commit],
-    batch_max_size: int = MULTI_DOCUMENT_LIMIT,
+    batch_max_size: int,
 ) -> Iterator[List[Commit]]:
     """
     Given a list of commit shas yield the commit files
-    by biggest batches possible of length at most MULTI_DOCUMENT_LIMIT
+    by biggest batches possible of length at most `batch_max_size`
     """
     current_count = 0
     batch = []
@@ -161,6 +160,7 @@ def scan_commit_range(
     :param verbose: Display successful scan's message
     """
     check_client_api_key(client)
+    max_documents = client.secret_scan_preferences.maximum_documents_per_scan
 
     with create_progress_bar(doc_type="commits") as progress:
 
@@ -173,6 +173,7 @@ def scan_commit_range(
                 Commit(sha=sha, exclusion_regexes=exclusion_regexes)
                 for sha in commit_list
             ),
+            batch_max_size=max_documents,
         )
         scans: List[SecretScanCollection] = []
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "marshmallow-dataclass>=8.5.8,<8.6.0",
         "oauthlib>=3.2.1,<3.3.0",
         # TODO: replace this with a real version number as soon as a new version of py-gitguardian is out
-        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@067188cc34a9a20e83ca983160152799bd3fe7d4",  # noqa: E501
+        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@0c54209c86ea292ba4f375d4ca44f1d4440e1cb1",  # noqa: E501
         "python-dotenv>=0.21.0,<0.22.0",
         "pyyaml>=6.0,<6.1",
         "requests>=2.31.0,<2.32.0",

--- a/tests/unit/cassettes/multiple_secrets.yaml
+++ b/tests/unit/cassettes/multiple_secrets.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:20 GMT
+          - Mon, 22 May 2023 12:28:00 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '30'
+          - '27'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -69,7 +71,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - d1e10b5b-3731-472a-9bb0-7f63ed062f82
+          - 6c955e95-c705-4026-89f2-b7a89be107d8
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -79,9 +81,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -101,8 +103,10 @@ interactions:
           - '598'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:23 GMT
+          - Mon, 22 May 2023 12:28:03 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -112,17 +116,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '3054'
+          - '3101'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/no_newline_before_secret.yaml
+++ b/tests/unit/cassettes/no_newline_before_secret.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:14 GMT
+          - Mon, 22 May 2023 12:29:08 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '21'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -68,7 +70,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - f30ccae3-61dc-4cc2-b253-0f9e222d63b7
+          - c0ad80c5-98b0-4b5c-a64c-c4729dfaa16b
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -78,9 +80,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -99,8 +101,10 @@ interactions:
           - '355'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:14 GMT
+          - Mon, 22 May 2023 12:29:08 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -110,17 +114,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '47'
+          - '81'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/no_secret.yaml
+++ b/tests/unit/cassettes/no_secret.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:26 GMT
+          - Mon, 22 May 2023 12:28:06 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 75b7a4b6-d283-4c63-adf3-8223d2f54626
+          - fdbdfaf6-617d-4801-b719-1369b24f1a8d
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -98,8 +100,10 @@ interactions:
           - '108'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:26 GMT
+          - Mon, 22 May 2023 12:28:06 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -109,17 +113,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '38'
+          - '66'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/one_line_and_multiline_patch.yaml
+++ b/tests/unit/cassettes/one_line_and_multiline_patch.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:25 GMT
+          - Mon, 22 May 2023 12:28:05 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '21'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -68,7 +70,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 4ee49210-d7de-4858-9102-25926744c546
+          - edce266f-f6af-4456-bbd3-bf926c9f7370
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -78,9 +80,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -102,8 +104,10 @@ interactions:
           - '1049'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:26 GMT
+          - Mon, 22 May 2023 12:28:05 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -115,17 +119,17 @@ interactions:
         vary:
           - Accept-Encoding,Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '223'
+          - '360'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/quota.yaml
+++ b/tests/unit/cassettes/quota.yaml
@@ -9,25 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
       uri: https://api.gitguardian.com/v1/quotas
     response:
       body:
-        string: '{"content":{"count":70097,"limit":1000000,"remaining":929903,"since":"2023-02-05"}}'
+        string: '{"content":{"count":152495,"limit":1000000,"remaining":847505,"since":"2023-04-22"}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '83'
+          - '84'
         content-type:
           - application/json
         cross-origin-opener-policy:
           - same-origin
         date:
-          - Tue, 07 Mar 2023 16:45:26 GMT
+          - Mon, 22 May 2023 12:28:46 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -37,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.25.0
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '19'
+          - '15'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.85.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/simple_secret.yaml
+++ b/tests/unit/cassettes/simple_secret.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:23 GMT
+          - Mon, 22 May 2023 12:28:04 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '33'
+          - '43'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 4404db4b-295a-4ca4-8e0c-7b373eb22cc1
+          - 7e8f4e87-d8ab-42f8-9bf6-877ff8f4ee79
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -99,8 +101,10 @@ interactions:
           - '573'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:24 GMT
+          - Mon, 22 May 2023 12:28:04 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -110,17 +114,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '53'
+          - '67'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/single_add.yaml
+++ b/tests/unit/cassettes/single_add.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:10 GMT
+          - Mon, 22 May 2023 12:28:26 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -65,7 +67,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - c023925e-e193-4f03-809c-470f9210b1f8
+          - c6fe0a97-2a57-47c4-a2cd-b5a012191c2a
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -75,9 +77,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -96,8 +98,10 @@ interactions:
           - '354'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:10 GMT
+          - Mon, 22 May 2023 12:28:26 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -107,17 +111,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '104'
+          - '77'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/single_delete.yaml
+++ b/tests/unit/cassettes/single_delete.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:12 GMT
+          - Mon, 22 May 2023 12:28:27 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '28'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 8859d9ce-1201-4b30-b802-70c07cc53421
+          - b769f201-948d-484b-9e59-2afa5629b42c
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -98,8 +100,10 @@ interactions:
           - '355'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:12 GMT
+          - Mon, 22 May 2023 12:28:27 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -109,17 +113,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '65'
+          - '75'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/single_file.yaml
+++ b/tests/unit/cassettes/single_file.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:13 GMT
+          - Mon, 22 May 2023 12:29:07 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '21'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -65,7 +67,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - d2c7ef97-5dae-4d06-bb6b-3d3b64bf88ac
+          - 0fd16d38-46ae-4859-9e31-f72d5ba30328
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -75,9 +77,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -96,8 +98,10 @@ interactions:
           - '354'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:13 GMT
+          - Mon, 22 May 2023 12:29:07 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -107,17 +111,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '66'
+          - '75'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/single_move.yaml
+++ b/tests/unit/cassettes/single_move.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:11 GMT
+          - Mon, 22 May 2023 12:28:28 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '30'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - a5679b78-96d8-4ae1-af75-f9d47709e4f4
+          - bccd6a6b-8cb3-4d3e-b0da-6f731d1c0a2f
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -98,8 +100,10 @@ interactions:
           - '355'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:11 GMT
+          - Mon, 22 May 2023 12:28:28 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -109,17 +113,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '81'
+          - '49'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_directory_verbose.yaml
+++ b/tests/unit/cassettes/test_directory_verbose.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:58 GMT
+          - Mon, 22 May 2023 12:29:03 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '29'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,10 +55,10 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmpakdvu16p/dir/file2", "document": "This is a file
-        with no secrets."}, {"filename": "/tmp/tmpakdvu16p/dir/subdir/file3", "document":
-        "This is a file with no secrets."}, {"filename": "/tmp/tmpakdvu16p/dir/subdir/file4",
-        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmpakdvu16p/file1",
+        '[{"filename": "/tmp/tmp98c9keg_/dir/subdir/file4", "document": "This is
+        a file with no secrets."}, {"filename": "/tmp/tmp98c9keg_/dir/subdir/file3",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmp98c9keg_/dir/file2",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmp98c9keg_/file1",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - db99fe8b-193b-4142-848e-ab22c39258ec
+          - 5b1d04eb-9bca-40cb-9b26-a46f725f2b7b
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -104,8 +106,10 @@ interactions:
           - '429'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:58 GMT
+          - Mon, 22 May 2023 12:29:03 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -115,17 +119,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '48'
+          - '56'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_directory_verbose_yes.yaml
+++ b/tests/unit/cassettes/test_directory_verbose_yes.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:59 GMT
+          - Mon, 22 May 2023 12:29:03 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '27'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,10 +55,10 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmpynkveevh/file1", "document": "This is a file with
-        no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/subdir/file4", "document":
-        "This is a file with no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/file2",
-        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmpynkveevh/dir/subdir/file3",
+        '[{"filename": "/tmp/tmp0tjp4jff/dir/subdir/file4", "document": "This is
+        a file with no secrets."}, {"filename": "/tmp/tmp0tjp4jff/dir/file2", "document":
+        "This is a file with no secrets."}, {"filename": "/tmp/tmp0tjp4jff/dir/subdir/file3",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmp0tjp4jff/file1",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 96f89e8f-74e2-4d00-8d2e-4c9960b3384e
+          - dafa6644-c7d9-4d98-a9af-788710719f65
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -104,8 +106,10 @@ interactions:
           - '429'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:59 GMT
+          - Mon, 22 May 2023 12:29:04 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -115,17 +119,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '47'
+          - '55'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_directory_yes.yaml
+++ b/tests/unit/cassettes/test_directory_yes.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:57 GMT
+          - Mon, 22 May 2023 12:29:02 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '13'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,10 +55,10 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmp10iyogkx/dir/subdir/file3", "document": "This is
-        a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/dir/file2", "document":
-        "This is a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/file1", "document":
-        "This is a file with no secrets."}, {"filename": "/tmp/tmp10iyogkx/dir/subdir/file4",
+        '[{"filename": "/tmp/tmpmc6f2tef/file1", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmpmc6f2tef/dir/file2", "document": "This
+        is a file with no secrets."}, {"filename": "/tmp/tmpmc6f2tef/dir/subdir/file4",
+        "document": "This is a file with no secrets."}, {"filename": "/tmp/tmpmc6f2tef/dir/subdir/file3",
         "document": "This is a file with no secrets."}]'
       headers:
         Accept:
@@ -70,9 +72,9 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - df47ca9f-494d-4cdd-9e96-c2acb8d89fec
+          - 5b02528b-2aa4-4873-aad7-fd7aa118a375
         GGShield-Command-Path:
-          - cli scan path
+          - cli secret scan path
         GGShield-OS-Name:
           - ubuntu
         GGShield-OS-Version:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -104,8 +106,10 @@ interactions:
           - '429'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:57 GMT
+          - Mon, 22 May 2023 12:29:02 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -115,17 +119,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '47'
+          - '65'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_files_verbose.yaml
+++ b/tests/unit/cassettes/test_files_verbose.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:55 GMT
+          - Mon, 22 May 2023 12:28:59 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,8 +55,8 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmph3z167km/file2", "document": "This is a file with
-        no secrets."}, {"filename": "/tmp/tmph3z167km/file1", "document": "This is a
+        '[{"filename": "/tmp/tmpwzv06ft1/file1", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmpwzv06ft1/file2", "document": "This is a
         file with no secrets."}]'
       headers:
         Accept:
@@ -68,7 +70,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 082cc817-ad9b-4666-a022-8462629d156f
+          - 7d9868c7-3b8d-49c7-b66f-691aa562d913
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -78,9 +80,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -100,8 +102,10 @@ interactions:
           - '215'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:55 GMT
+          - Mon, 22 May 2023 12:29:00 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -111,17 +115,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '44'
+          - '50'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_files_verbose_yes.yaml
+++ b/tests/unit/cassettes/test_files_verbose_yes.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:56 GMT
+          - Mon, 22 May 2023 12:29:01 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '12'
+          - '25'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,8 +55,8 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmptw7s4r08/file2", "document": "This is a file with
-        no secrets."}, {"filename": "/tmp/tmptw7s4r08/file1", "document": "This is a
+        '[{"filename": "/tmp/tmp8q7bmcia/file1", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmp8q7bmcia/file2", "document": "This is a
         file with no secrets."}]'
       headers:
         Accept:
@@ -68,7 +70,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - ef111652-d429-4de4-ad15-78334c87995e
+          - e87f842f-d1b0-4552-98b1-f17a22dfea29
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -78,9 +80,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -100,8 +102,10 @@ interactions:
           - '215'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:56 GMT
+          - Mon, 22 May 2023 12:29:01 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -111,17 +115,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '43'
+          - '50'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_files_yes.yaml
+++ b/tests/unit/cassettes/test_files_yes.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:54 GMT
+          - Mon, 22 May 2023 12:28:58 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,8 +55,8 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmp6fbfbwg3/file1", "document": "This is a file with
-        no secrets."}, {"filename": "/tmp/tmp6fbfbwg3/file2", "document": "This is a
+        '[{"filename": "/tmp/tmptk1foibc/file2", "document": "This is a file with
+        no secrets."}, {"filename": "/tmp/tmptk1foibc/file1", "document": "This is a
         file with no secrets."}]'
       headers:
         Accept:
@@ -68,7 +70,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 0d77354a-2c49-4887-8d77-635f78b29f59
+          - d1c29087-0a28-4728-803d-a26a70c6177c
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -78,9 +80,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -100,8 +102,10 @@ interactions:
           - '215'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:54 GMT
+          - Mon, 22 May 2023 12:28:59 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -111,17 +115,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '42'
+          - '59'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_health_check.yaml
+++ b/tests/unit/cassettes/test_health_check.yaml
@@ -9,7 +9,7 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
       uri: https://api.gitguardian.com/v1/health
     response:
@@ -24,8 +24,10 @@ interactions:
           - '27'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:43 GMT
+          - Mon, 22 May 2023 12:28:47 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '13'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_empty_directory.yaml
+++ b/tests/unit/cassettes/test_iac_scan_empty_directory.yaml
@@ -1,10 +1,10 @@
 interactions:
   - request:
       body: !!binary |
-        LS1lZTJiYzcxOTQ5MTIyYmYxNDc4ZDY5Y2JlM2I0NGNmOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS01YjUxYmI2OTNlNDA2NWNjNmJhMWIyYzE2ZWQ3OGMzYg0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        sdzgYwL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tZWUyYmM3MTk0OTEy
-        MmJmMTQ3OGQ2OWNiZTNiNDRjZjktLQ0K
+        BGBrZAL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tNWI1MWJiNjkzZTQw
+        NjVjYzZiYTFiMmMxNmVkNzhjM2ItLQ0K
       headers:
         Accept:
           - '*/*'
@@ -15,9 +15,9 @@ interactions:
         Content-Length:
           - '195'
         Content-Type:
-          - multipart/form-data; boundary=ee2bc71949122bf1478d69cbe3b44cf9
+          - multipart/form-data; boundary=5b51bb693e4065cc6ba1b2c16ed78c3b
         GGShield-Command-Id:
-          - c998ce48-fffb-4a13-8642-7c3bdb4cacb6
+          - b87b2b2a-bdb2-4c77-b8f2-cfae4062a1cc
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
@@ -27,9 +27,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -46,8 +46,10 @@ interactions:
           - '87'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:46 GMT
+          - Mon, 22 May 2023 12:28:52 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -57,17 +59,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '186'
+          - '181'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
@@ -1,18 +1,17 @@
 interactions:
   - request:
       body: !!binary |
-        LS1lNzQ4MTk3NWE2ZjdiMjQ4MmU0ODgzNWMwNDRmYzJhYg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS00M2QzMDUzOTk5NzljNDU5M2YyZDVjMTUxM2I5YzAyNw0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        0tzgYwL/7ZjNbqMwEIA58xQWD0A85reHSnvssYfeVpVliImsGoxss0m16rvXtJtsNps2qpS26u58
-        HAwe8FwYvjHpIl18uxabKymW0kbvAn3mpZHSLP99Ps8DZcAisok+gMl5YUP66P+E1aT3qpeXUFZF
-        WdOLqk6BVlVd13GE/PMo0fJOackHw39MepBWNEorr6RLfXe++i/LpxqHqoD98bn8oYggzyoKRZkx
-        FlFGqxwiQj+y/oUWopFDJ3wvjt13Kv5Fia10ZrKtJIlYOz5Ivzb2jotWcztpmZCkEUsuN6If56uf
-        MSFyFZ5xZMsl6YR2MgRGa7xpjd4FEt+OSQh01vR8NNZvA4yFWW/25nazc9aQ3isz/FpEaG3W8zKt
-        WlreaNPebdcHlkKWQp5CkcQP+MF6Oyn6H/2P/kf/OzWswrDfA9yfqQM45X+g2YH/gVXo/8/wv9AN
-        18p5GV6CY+7fKT7I9+rm5hqti/5H/6P/ka/u/37SXo0HHcB5/gKc3v/Dgf8ZFDn6/xP872Q72dD5
-        8ZU10/jK7n8+3d+Ru9ARfE9o+nQsaHIb4g+hOYjJawle/Mfg70c59xihKZ3T/bn7/ztXyIOljCAI
-        giAIgiAIgiAIcpRHao+D4gAoAAANCi0tZTc0ODE5NzVhNmY3YjI0ODJlNDg4MzVjMDQ0ZmMyYWIt
-        LQ0K
+        GGBrZAL/7ZjNbuMgEIB99lMgHoAAtnF7iLTHHHvobbVCxCERKjYW4E2iVd99cdps05+0VdUfpTuf
+        D2DGZi4efx6TCZn8uFCbmVYL7bMPgd5wbKS0KO7m4zqjnLEMbbJPYAhR+ZQ++z/hNWqjafWUibOy
+        rs6qipOKnlMu8gz4/hjVyKWxWraDjaZPk9+D7bRXc2NNNDqQuHyP+heiHEdWV+xwvCn/VOysLAsu
+        xHiSUZ7iIkP0M+tfrVTUajh63UvxEyX3OrjBNxphtQ4y6GbwJm7lyruhxwjP1ULqjWrTk4HRnxwh
+        vUp3hN0UocYsvJxb11wFNEU/MSW7Y0LxrxS/zq/zHD2XQPph3PdxlrjtddoRm26XDufP50p5oJTf
+        BAH/g//B/+D/kF61D+y/fQf3v8b/jBb3/c/qghXg/y/wv7JzaU2IOj0ET3m59y66xtnRzbPLywuc
+        1AtFBP4H/4P/gVP2f+c+oPN/bf9fPfC/qAX4/yv83+m4dv5KqsYe7c1v/wDsmaKlskEffhzsAzg2
+        /di6L71rZe983Ac4H3t8d7D2b3XMmtJH47rbTZS1bn3/D8B+f8YJKwgrCavgSwQAAAAAAAAAAAAA
+        AOBJ/gJaaXpKACgAAA0KLS00M2QzMDUzOTk5NzljNDU5M2YyZDVjMTUxM2I5YzAyNy0tDQo=
       headers:
         Accept:
           - '*/*'
@@ -21,11 +20,11 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '630'
+          - '623'
         Content-Type:
-          - multipart/form-data; boundary=e7481975a6f7b2482e48835c044fc2ab
+          - multipart/form-data; boundary=43d305399979c4593f2d5c1513b9c027
         GGShield-Command-Id:
-          - 19c59999-7621-4b1c-ae95-b8daa4e2dc34
+          - 3bc9ce4b-3dbf-41e1-a602-0c110face343
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
@@ -35,9 +34,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -65,8 +64,10 @@ interactions:
           - '1557'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:19 GMT
+          - Mon, 22 May 2023 12:29:13 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -78,17 +79,17 @@ interactions:
         vary:
           - Accept-Encoding,Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '366'
+          - '359'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
@@ -1,15 +1,14 @@
 interactions:
   - request:
       body: !!binary |
-        LS04MGJhNTkyNmQwNTBhZDcwYWY1ODhmZjNkN2M1ZTY0NA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS0yZDQ4NzJhZDgxOTczZTc5ZTkwZmJjMWEwNDM0ODI0YQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        0NzgYwL/7dO7TsMwGAXgzH4Kyw+Q2knjhKESIyM7QpaTupVF0la+QCvUd8dNB5CAskAl2vNl8K84
-        9lly8kk+ub3X2zuj58Zlf4IffbdyXk7f58N7wQtRZHSbnUH0QbsUn12noqFDsIOZCVlXsuE3tcyF
-        LGUzbUgGF8/qTi1sb9QQ+2A3aXiO/co43dreBmt8Hha/0X8px46LuhIf12P9hcjEtKy5qGRZpP4X
-        hahS//k5+697rVuzWugw6K+++2n/nyLO+HV0naFMv3jlTRedDTu1dOu4YZS1eq7MVg/pz2D0lVBq
-        lumEH0dKOzt3qu3X3ZOnM/rAeD4+E84e0/6e7AmhpwKUi4d7P6eE3cakG5ldjXGMnM5KOagyAAAA
-        AAAAAAAAAAAAAAAAXKk3RwiykQAoAAANCi0tODBiYTU5MjZkMDUwYWQ3MGFmNTg4ZmYzZDdjNWU2
-        NDQtLQ0K
+        FmBrZAL/7dO7bsIwGAVgz34Kyw8QbOcCC1LHjt2ryjLBIKsJQb60oIp3rwlDK1XQpUVqOZ8H/4oT
+        nyWnmBSTuwezu7dmaT35FeLk3C5EWX3Mx+dSKKkI25ErSCEan+PJbVIz1kfX27lsZtW0ntW1KFRZ
+        iqksKYF/z5lWr1xndZ+66LZ5eEndxnqzcJ2LzoYirn6i/00zdlxOa/l5P9VfSiKrqlRNI4RqiFDH
+        RZi4Zv/N2kRr0tn3vjv/o6i3YUi+tYyb16CDbZN3ca/XfkhbzvjCLLXdmT7/GZy9UcbsOn8RxpGx
+        1i29XnRD+xzYnD1yUYxrIvhTPj/QA6XsUoD26Xjv15S439p8I3ebMY7Ty1k5B1UGAAAAAAAAAAAA
+        AAAAAACAG/UOOzvp2QAoAAANCi0tMmQ0ODcyYWQ4MTk3M2U3OWU5MGZiYzFhMDQzNDgyNGEtLQ0K
       headers:
         Accept:
           - '*/*'
@@ -18,11 +17,11 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '462'
+          - '456'
         Content-Type:
-          - multipart/form-data; boundary=80ba5926d050ad70af588ff3d7c5e644
+          - multipart/form-data; boundary=2d4872ad81973e79e90fbc1a0434824a
         GGShield-Command-Id:
-          - 8c328f6e-01e2-431c-a925-7582b9c6c1a0
+          - a320dc8c-719b-405b-84d3-613efb153913
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
@@ -32,9 +31,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -60,8 +59,10 @@ interactions:
           - '1167'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:17 GMT
+          - Mon, 22 May 2023 12:29:11 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -73,17 +74,17 @@ interactions:
         vary:
           - Accept-Encoding,Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '331'
+          - '363'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_no_argument.yaml
+++ b/tests/unit/cassettes/test_iac_scan_no_argument.yaml
@@ -1,10 +1,10 @@
 interactions:
   - request:
       body: !!binary |
-        LS0xYWZiMmVkNzFkMWVlMmM2ZGM1MmMzM2FjYjgyMGM3Zg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS04YjE4YTRlNTc0YjMzZDdhNDYzYmI2OTY1OWQ2NjA1YQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        cen4YwL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tMWFmYjJlZDcxZDFl
-        ZTJjNmRjNTJjMzNhY2I4MjBjN2YtLQ0K
+        A2BrZAL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tOGIxOGE0ZTU3NGIz
+        M2Q3YTQ2M2JiNjk2NTlkNjYwNWEtLQ0K
       headers:
         Accept:
           - '*/*'
@@ -15,21 +15,21 @@ interactions:
         Content-Length:
           - '195'
         Content-Type:
-          - multipart/form-data; boundary=1afb2ed71d1ee2c6dc52c33acb820c7f
+          - multipart/form-data; boundary=8b18a4e574b33d7a463bb69659d6605a
         GGShield-Command-Id:
-          - 0c0fcd4d-5e4c-43b4-b2ff-ebbce62370dc
+          - 2eb3e1eb-b851-4ddc-9f84-924fec1da1e1
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
           - ubuntu
         GGShield-OS-Version:
-          - '20.04'
+          - '22.04'
         GGShield-Python-Version:
-          - 3.8.10
+          - 3.10.6
         GGShield-Version:
-          - 1.14.4
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.8.10) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -46,8 +46,10 @@ interactions:
           - '87'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Fri, 24 Feb 2023 16:44:34 GMT
+          - Mon, 22 May 2023 12:28:52 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -57,17 +59,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.24.1
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '173'
+          - '208'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.85.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_no_vulnerabilities.yaml
+++ b/tests/unit/cassettes/test_iac_scan_no_vulnerabilities.yaml
@@ -1,15 +1,15 @@
 interactions:
   - request:
       body: !!binary |
-        LS01NGM3ZTA4MWEwYTAyMmQ0NmRhZmFjNGQ3Y2Y5Zjg4NA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS00NTQ3NzVmZjIzMTNlOWM2ZjU3YzlkNzY2YjlkNTJiNA0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        0dzgYwL/7dRNboMwEAVg1jmFxQGIbf6SRaQuu+wNrIGYyorByJgmUtW7F5omzaJVN22kNu/bGN7g
-        mdWQLJPl3QMd7jVttY9+BT/66uQ8zT6e51xwKWTEDtEVjEMgP42PbpNcsTaYVm9EUebFiq/LMhGr
-        tEzX2SKCf89QrRpjteqcehptpz1Vxppg9JCE5uf2vyjedlyUubg8j+sv8khkaclFXqRyyiUvMx4x
-        fs39J0tU6a6h0NJn331X/6MWXg9u9LVmMe0H1emwd36nqLbKj1bHLK5oq/SB2n5+e14wph+nOwM7
-        2bCG7KCnQu9dcLWz50Ic6j6eCo13reqdD6eClFMa3EV2Tuep0/hgXPfehKx1+7lNbbZeVdbVu1N/
-        IRORJiJLRB4vXvDDAgAAAAAAAAAAAAAAAAAAgFv0Cr7ECy8AKAAADQotLTU0YzdlMDgxYTBhMDIy
-        ZDQ2ZGFmYWM0ZDdjZjlmODg0LS0NCg==
+        F2BrZAL/7dSxboMwEAZgZp7C4gGI7WCTDpE6duwbWA4xkRWDkTElUtV3LzRNmiXq0kZq83+L4Q7f
+        TT/5Il88PuvDk9FbE5JfQY+unZQui6/nuc4oZzwhh+QGhj7qMK1P7hNfkSbaxqyZXBWlWAnBci4f
+        qKAyTeDfs7pStXVGtV69DK41QW+ss9GaPo/1z+Vfyo+Ms1Kwy/MYfyYSVhRLLiWlvJzyL8uSJoTe
+        Mv96p6PRw9Xvvuv/UWkwvR9CZUimx161Jo4+7JWunAqDMxnJNnqrzEE33fz2mhJidtOdnpysSa1d
+        b6ZGF3z0lXfnRharLpsadfCN6nyIpwbnUzX6i9q5Om+d1kfr288h2jk/zmMquw1q43y1P81nPGfL
+        nBU5E1n6hh8WAAAAAAAAAAAAAAAAAAAA3KN30RaWOQAoAAANCi0tNDU0Nzc1ZmYyMzEzZTljNmY1
+        N2M5ZDc2NmI5ZDUyYjQtLQ0K
       headers:
         Accept:
           - '*/*'
@@ -18,11 +18,11 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '478'
+          - '474'
         Content-Type:
-          - multipart/form-data; boundary=54c7e081a0a022d46dafac4d7cf9f884
+          - multipart/form-data; boundary=454775ff2313e9c6f57c9d766b9d52b4
         GGShield-Command-Id:
-          - 11f19f95-6fea-42be-b4b4-63b085be29b8
+          - 6a68619d-9bbf-4639-8846-e6a522dd3e05
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
@@ -32,9 +32,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -51,8 +51,10 @@ interactions:
           - '87'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:18 GMT
+          - Mon, 22 May 2023 12:29:12 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -62,17 +64,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '291'
+          - '348'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
+++ b/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
@@ -1,14 +1,14 @@
 interactions:
   - request:
       body: !!binary |
-        LS1mNzU2YjMzMzI0MjZmZWUzZDAyMmYxYTFlY2JhM2YyZA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        LS00N2Y1OTEzYTIwZDQ2MjkyZTU4OWY2NDMzM2NiN2JlNA0KQ29udGVudC1EaXNwb3NpdGlvbjog
         Zm9ybS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgA
-        z9zgYwL/7dQxT4QwGAbgzvyKhh/AtUBbGC5xvPGG28kHV0yTAhcoijH+d7lz0EHjomfU91nepm3S
-        5XubbJLNzZ6WnaWjHdm3EC8+SiGy/HV93pcilSnjC7uCeQo0rs+z/ykteBdcZ7dSG6ULUZo8KZXS
-        siwiBn+eo6ZqnbfV5PrbNe5m39uRauddeEhC+1X91/rScWmUfJsXUmRM5pkRUulMGnZuv1GMi2v2
-        nzxRbfuWQkfv3fvs/JeKRjsN89hYHtP9VJGvK++mYNchiHlc07GyC3Unb2P+GHF+GocwNIPnWx7v
-        Dod9HD3hmwAAAAAAAAAAAAAAAAAAAAD4Sc+t46KUACgAAA0KLS1mNzU2YjMzMzI0MjZmZWUzZDAy
-        MmYxYTFlY2JhM2YyZC0tDQo=
+        FWBrZAL/7dS9TsMwFAVgz3kKyw+Q2vlx2qESY8cO3aOb9Lay5DSV40AQ4t0JZYClYoEi4HzLsWxL
+        Xu5xukgXd1uaNkx7DuJb6DfXUuu8eF+/7hudmUzISdzAOEQK8/Pif8qWsouu47Wxy6Iql2WxSrWp
+        9KrMEwF/nqO2PjjP9eBOxznuR3/iQI3zLj6m8fBV/bf20nFTleZjXhidC1MUeWat1lk597/KjRVS
+        37L/dKTINF6999n5L5UEHvoxtCwVPQw1+ab2bog8D4GSqqF9zRN1Z89KPiVSnkMf+7b3ci3VZrfb
+        quQZ3wQAAAAAAAAAAAAAAAAAAADAT3oBSev1gAAoAAANCi0tNDdmNTkxM2EyMGQ0NjI5MmU1ODlm
+        NjQzMzNjYjdiZTQtLQ0K
       headers:
         Accept:
           - '*/*'
@@ -17,11 +17,11 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '416'
+          - '414'
         Content-Type:
-          - multipart/form-data; boundary=f756b3332426fee3d022f1a1ecba3f2d
+          - multipart/form-data; boundary=47f5913a20d46292e589f64333cb7be4
         GGShield-Command-Id:
-          - b5bf5d67-52a2-447e-b061-4f136dc4c4b7
+          - e8667c62-7886-43ec-9569-6ad6892f620e
         GGShield-Command-Path:
           - cli iac scan
         GGShield-OS-Name:
@@ -31,9 +31,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - directory
       method: POST
@@ -53,8 +53,10 @@ interactions:
           - '476'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:16 GMT
+          - Mon, 22 May 2023 12:29:10 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -64,17 +66,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '357'
+          - '339'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file.yaml
+++ b/tests/unit/cassettes/test_scan_file.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:49 GMT
+          - Mon, 22 May 2023 12:28:54 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '29'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,7 +55,7 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmpo6icvcox/file", "document": "This is a file with
+        '[{"filename": "/tmp/tmpjp56zyzn/file", "document": "This is a file with
         no secrets."}]'
       headers:
         Accept:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - e707351a-b085-4b22-a9f3-ec1565208d8b
+          - 75127dd0-75ea-4f07-be8b-8dff68f5b14e
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -98,8 +100,10 @@ interactions:
           - '108'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:50 GMT
+          - Mon, 22 May 2023 12:28:55 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -109,17 +113,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '37'
+          - '69'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file_secret-False.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-False.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:53 GMT
+          - Mon, 22 May 2023 12:28:58 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '9'
+          - '21'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,7 +55,7 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmpwiqo1tre/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        '[{"filename": "/tmp/tmpe8ln3lc5/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
         GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
         message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
         a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - cda2e266-836b-4e4f-b395-f2635c0d38ca
+          - ed1ebf25-668d-4ab0-acca-42cd4bff0134
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -102,8 +104,10 @@ interactions:
           - '576'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:53 GMT
+          - Mon, 22 May 2023 12:28:58 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -113,7 +117,7 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
@@ -123,7 +127,7 @@ interactions:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file_secret-True.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-True.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:52 GMT
+          - Mon, 22 May 2023 12:28:57 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '39'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,7 +55,7 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmp76tsr31l/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        '[{"filename": "/tmp/tmplhjislsp/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
         GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
         message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
         a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 7fe1d4a9-2ca2-4557-a38a-26de57ff0d67
+          - 5bb03b04-8182-47d8-82fe-113521ffca3a
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -102,8 +104,10 @@ interactions:
           - '319'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:52 GMT
+          - Mon, 22 May 2023 12:28:57 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -113,17 +117,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '51'
+          - '52'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file_secret.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:48 GMT
+          - Mon, 22 May 2023 12:28:53 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '10'
+          - '42'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - e634899f-2982-4791-a3f6-3998013f25a5
+          - 5e8051d6-7ccf-4b69-9251-9a2afc61b62a
         GGShield-Command-Path:
           - cli secret scan docker-archive
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - docker
       method: POST
@@ -102,8 +104,10 @@ interactions:
           - '576'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:49 GMT
+          - Mon, 22 May 2023 12:28:54 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -113,17 +117,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '74'
+          - '82'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file_secret_with_validity.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret_with_validity.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:24 GMT
+          - Mon, 22 May 2023 12:28:25 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '11'
+          - '28'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -67,7 +69,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 1df80264-012e-4f8b-9da3-ab87d8bce5cc
+          - 510633f7-4b3f-4b32-98af-ddbd5e938652
         GGShield-Command-Path:
           - external
         GGShield-OS-Name:
@@ -77,9 +79,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6)
+          - pygitguardian/1.6.0 (Linux;py3.10.6)
         mode:
           - path
       method: POST
@@ -99,8 +101,10 @@ interactions:
           - '315'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:25 GMT
+          - Mon, 22 May 2023 12:28:25 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -110,17 +114,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '79'
+          - '104'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_path_file_one_line_and_multiline_patch.yaml
+++ b/tests/unit/cassettes/test_scan_path_file_one_line_and_multiline_patch.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:00 GMT
+          - Mon, 22 May 2023 12:29:04 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '12'
+          - '20'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,7 +55,7 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmp5jpbcpdc/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        '[{"filename": "/tmp/tmp280jass6/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
         GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
         message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
         a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
@@ -72,7 +74,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 6521902d-a744-4e5d-add7-be99251f6f78
+          - 417fc4e6-61e4-4f15-8559-6be261fc310d
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -82,9 +84,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -106,8 +108,10 @@ interactions:
           - '1051'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:56:00 GMT
+          - Mon, 22 May 2023 12:29:05 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -119,17 +123,17 @@ interactions:
         vary:
           - Accept-Encoding,Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '307'
+          - '135'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
+++ b/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
@@ -9,23 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
       method: GET
-      uri: https://api.gitguardian.com/v1/health
+      uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"detail":"Valid API key."}'
+        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '27'
+          - '446'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:51 GMT
+          - Mon, 22 May 2023 12:28:56 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -35,17 +37,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '13'
+          - '35'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -53,7 +55,7 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "/tmp/tmpjbzs68_0/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
+        '[{"filename": "/tmp/tmp0zw_weft/file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
         GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
         message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
         a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
@@ -70,7 +72,7 @@ interactions:
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - cffba95a-a087-4f28-ac9e-3509a477fd4a
+          - aedea591-2fd6-41e4-b31d-f12c4f48003f
         GGShield-Command-Path:
           - cli secret scan path
         GGShield-OS-Name:
@@ -80,9 +82,9 @@ interactions:
         GGShield-Python-Version:
           - 3.10.6
         GGShield-Version:
-          - 1.14.2
+          - 1.15.1
         User-Agent:
-          - pygitguardian/1.5.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
         mode:
           - path
       method: POST
@@ -102,8 +104,10 @@ interactions:
           - '319'
         content-type:
           - application/json
+        cross-origin-opener-policy:
+          - same-origin
         date:
-          - Mon, 06 Feb 2023 10:55:51 GMT
+          - Mon, 22 May 2023 12:28:56 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -113,17 +117,17 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.22.2
+          - v2.30.2
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '90'
+          - '84'
         x-frame-options:
           - DENY
           - SAMEORIGIN
         x-secrets-engine-version:
-          - 2.83.0
+          - 2.89.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -57,9 +57,18 @@ VALID_TOKEN_INVALID_SCOPE_RESPONSE = create_json_response(
 
 INVALID_TOKEN_RESPONSE = create_json_response({"detail": "Invalid API key."}, 401)
 
-HEALTH_ENDPOINT = "/v1/health"
+METADATA_ENDPOINT = "/v1/metadata"
 
-HEALTH_VALID_TOKEN_RESPONSE = create_json_response({"detail": "Valid API key."})
+VALID_METADATA_RESPONSE = create_json_response(
+    {
+        "version": "1.2.3",
+        "preferences": {},
+        "secret_scan_preferences": {
+            "max_document_size": 1 * 1024 * 1024,
+            "max_documents_per_scan": 20,
+        },
+    }
+)
 
 
 @pytest.fixture(autouse=True)
@@ -269,7 +278,7 @@ class TestAuthLoginWeb:
     def test_existing_token_no_expiry(self, instance_url, cli_fs_runner, monkeypatch):
 
         self._instance_url = instance_url
-        self._request_mock.add_GET(HEALTH_ENDPOINT, HEALTH_VALID_TOKEN_RESPONSE)
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
 
         add_instance_config(instance_url=instance_url)
 
@@ -301,7 +310,7 @@ class TestAuthLoginWeb:
         dt = datetime.strptime(f"2100-{month}-{day}T00:00:00+0000", DT_FORMAT)
 
         self._instance_url = instance_url
-        self._request_mock.add_GET(HEALTH_ENDPOINT, HEALTH_VALID_TOKEN_RESPONSE)
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
 
         add_instance_config(instance_url=instance_url, expiry_date=dt)
 
@@ -325,7 +334,7 @@ class TestAuthLoginWeb:
         """
 
         # Insert the call to check the stored token
-        self._request_mock.add_GET(HEALTH_ENDPOINT, INVALID_TOKEN_RESPONSE)
+        self._request_mock.add_GET(METADATA_ENDPOINT, INVALID_TOKEN_RESPONSE)
         self.prepare_mocks(monkeypatch)
 
         add_instance_config()

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock
 
 import pytest
 import requests.exceptions
-from pygitguardian.models import HealthCheckResponse
+from pygitguardian import GGClient
+from pygitguardian.models import Detail
 
 from ggshield.core.client import check_client_api_key
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
@@ -12,21 +13,20 @@ from ggshield.core.errors import APIKeyCheckError, UnexpectedError
 @pytest.mark.parametrize(
     ("response", "error_class"),
     (
-        (HealthCheckResponse("Guru Meditation", 500), UnexpectedError),
-        (HealthCheckResponse("Nobody here", 404), UnexpectedError),
-        (HealthCheckResponse("Unauthorized", 401), APIKeyCheckError),
+        (Detail("Guru Meditation", 500), UnexpectedError),
+        (Detail("Nobody here", 404), UnexpectedError),
+        (Detail("Unauthorized", 401), APIKeyCheckError),
     ),
 )
-def test_check_client_api_key_error(
-    response: HealthCheckResponse, error_class: Type[Exception]
-):
+def test_check_client_api_key_error(response: Detail, error_class: Type[Exception]):
     """
     GIVEN a client returning an error when its healthcheck endpoint is called
     WHEN check_client_api_key() is called
     THEN it raises the appropriate exception
     """
-    client_mock = Mock()
-    client_mock.health_check.return_value = response
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "http://localhost"
+    client_mock.read_metadata.return_value = response
     with pytest.raises(error_class):
         check_client_api_key(client_mock)
 

--- a/tests/unit/request_mock.py
+++ b/tests/unit/request_mock.py
@@ -104,7 +104,9 @@ class RequestMock:
         request = self._requests.pop(0)
 
         # Check the current request matches the expected one
-        assert url.endswith(request.endpoint)
+        assert url.endswith(
+            request.endpoint
+        ), f"Received call to this URL: {url} but expected a call to this endpoint: {request.endpoint}"
         assert method == request.method
         if request.data_checker:
             request.data_checker(data)


### PR DESCRIPTION
## Description

This PR makes the `secret scan` commands use server-side configuration if available. This makes it possible for on-prem instances to change the maximum document size or the maximum number of documents to scan in one batch.

This PR depends on this [py-gitguardian PR](https://github.com/GitGuardian/py-gitguardian/pull/55).