### PR TITLE
Fix performance benchmark

### DIFF
--- a/scripts/perfbench/run_cmd.py
+++ b/scripts/perfbench/run_cmd.py
@@ -25,7 +25,7 @@ DEFAULT_GGSHIELD_VERSIONS = ["prod", "current"]
 
 REPO_BENCHMARK_COMMANDS = [
     ("secret", "scan", "--exit-zero", "path", "-ry", "."),
-    ("secret", "scan", "--exit-zero", "commit-range", "HEAD~9.."),
+    ("secret", "scan", "--exit-zero", "commit-range", "HEAD~6.."),
     ("iac", "scan", "--exit-zero", "."),
 ]
 

--- a/scripts/perfbench/setup_cmd.py
+++ b/scripts/perfbench/setup_cmd.py
@@ -10,7 +10,7 @@ BENCHMARK_REPOSITORIES = [
     ("https://github.com/python-pillow/Pillow", "9.3.0"),
     ("https://github.com/docker/compose", "v2.12.2"),
     ("https://github.com/sqlite/sqlite", "version-3.39.4"),
-    ("https://github.com/ZGuardian/leaky-repo", "1.1.2"),
+    ("https://github.com/GitGuardian/sample_secrets", "ggshield-perfbench"),
 ]
 
 


### PR DESCRIPTION
## Description

The performance benchmark is broken because one of the repo (`leaky-repo`) it uses has been removed. Replace it with the `sample_secrets` repository.
