### PR TITLE
fix(json_output_handler): Compute the ignore sha before censoring the matches

### DIFF
--- a/changelog.d/20230526_113935_samuel.guillaume_json_and_text_outputs_dont_display_the_same_sha.md
+++ b/changelog.d/20230526_113935_samuel.guillaume_json_and_text_outputs_dont_display_the_same_sha.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Correctly compute the secret ignore sha in the json output.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/secret/output/secret_json_output_handler.py
+++ b/ggshield/secret/output/secret_json_output_handler.py
@@ -63,14 +63,12 @@ class SecretJSONOutputHandler(SecretOutputHandler):
         }
         content = result.content
         is_patch = result.filemode != Filemode.FILE
+        sha_dict = leak_dictionary_by_ignore_sha(result.scan.policy_breaks)
+        result_dict["total_incidents"] = len(sha_dict)
 
         if not self.show_secrets:
             content = censor_content(result.content, result.scan.policy_breaks)
-
         lines = get_lines_from_content(content, result.filemode, is_patch)
-        sha_dict = leak_dictionary_by_ignore_sha(result.scan.policy_breaks)
-
-        result_dict["total_incidents"] = len(sha_dict)
 
         for ignore_sha, policy_breaks in sha_dict.items():
             flattened_dict = self.flattened_policy_break(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ import pytest
 
 # This is a test token, it is always reported as a valid secret
 GG_VALID_TOKEN = "ggtt-v-12345azert"  # ggignore
+GG_VALID_TOKEN_IGNORE_SHA = (
+    "56c126cef75e3d17c3de32dac60bab688ecc384a054c2c85b688c1dd7ac4eefd"
+)
 
 
 def is_windows():

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -47,9 +47,13 @@ def assert_is_valid_json(txt: str) -> None:
         pytest.fail(f"Text is not a valid JSON document:\n---\n{txt}\n---\n{exc}")
 
 
+def recreate_censored_string(matched_string: str) -> str:
+    """Applies ggshield censoring to `matched_string`"""
+    match = Match(match=matched_string, match_type="")
+    return censor_match(match)
+
+
 def recreate_censored_content(content: str, matched_string: str) -> str:
     """Applies ggshield censoring to any occurrence of `matched_string` inside
     `content`. Returns the censored string."""
-    match = Match(match=matched_string, match_type="")
-    censored_string = censor_match(match)
-    return content.replace(matched_string, censored_string)
+    return content.replace(matched_string, recreate_censored_string(matched_string))

--- a/tests/unit/secret/output/test_text_output.py
+++ b/tests/unit/secret/output/test_text_output.py
@@ -4,6 +4,7 @@ from unittest import mock
 import click
 import pytest
 
+from ggshield.core.filter import leak_dictionary_by_ignore_sha
 from ggshield.core.utils import Filemode
 from ggshield.scan import StringScannable
 from ggshield.secret import Result, Results, SecretScanCollection
@@ -134,6 +135,12 @@ def test_leak_message(result_input, snapshot, show_secrets, verbose):
     output = click.unstyle(output)
 
     snapshot.assert_match(output)
+
+    # all ignore sha should be in the output
+    assert all(
+        ignore_sha in output
+        for ignore_sha in leak_dictionary_by_ignore_sha(result_input.scan.policy_breaks)
+    )
 
 
 def assert_policies_displayed(output, verbose, ignore_known_secrets, policy_breaks):


### PR DESCRIPTION
## Description

The field `ignore_sha` in the JSON output differs from the one outputted by the text output when `--show-secrets` is not used, because it is computed after censoring the matches.

The PR fixes the bug and add both unit and functional tests to prevent regression.