### PR TITLE
Fix GitLab web UI output handler

### DIFF
--- a/changelog.d/20230529_173848_pierrelalanne_fix_gitlab_web_ui_output.md
+++ b/changelog.d/20230529_173848_pierrelalanne_fix_gitlab_web_ui_output.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- GitLab WebUI Output Handler now behaves correctly when using the `ignore-known-secrets` flag, it also no longer displays empty messages in the UI.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -150,11 +150,11 @@ def prereceive_cmd(
     """
     config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)
-
     if os.getenv("GL_PROTOCOL") == "web":
         # We are inside GitLab web UI
         output_handler = SecretGitLabWebUIOutputHandler(
-            show_secrets=config.secret.show_secrets
+            show_secrets=config.secret.show_secrets,
+            ignore_known_secrets=config.secret.ignore_known_secrets,
         )
 
     if get_breakglass_option():

--- a/ggshield/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/secret/output/secret_gitlab_webui_output_handler.py
@@ -30,25 +30,46 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
     See https://docs.gitlab.com/ee/administration/server_hooks.html#custom-error-messages
     """
 
-    def __init__(self, show_secrets: bool = False) -> None:
-        super().__init__(show_secrets=show_secrets, verbose=False)
+    def __init__(
+        self, show_secrets: bool = False, ignore_known_secrets: bool = False
+    ) -> None:
+        super().__init__(
+            show_secrets=show_secrets,
+            verbose=False,
+            ignore_known_secrets=ignore_known_secrets,
+        )
 
-    def _process_scan_impl(self, scan_collection: SecretScanCollection) -> str:
-        results = list(scan_collection.get_all_results())
-        if not results:
+    def _process_scan_impl(self, scan: SecretScanCollection) -> str:
+        results = list(scan.get_all_results())
+        # If no secrets or no new secrets were found
+        if not results or (self.ignore_known_secrets and not scan.has_new_secrets):
             return ""
 
-        policy_breaks = []
+        policy_breaks_to_report = []
         for result in results:
-            policy_breaks += result.scan.policy_breaks
+            if not self.ignore_known_secrets:
+                # Populate GL-HOOK-ERR with all policy breaks found
+                policy_breaks_to_report += result.scan.policy_breaks
+            else:
+                for policy_break in result.scan.policy_breaks:
+                    known = policy_break.known_secret
+                    # Populate GL-HOOK-ERR with only new policy breaks
+                    if not known:
+                        policy_breaks_to_report.append(policy_break)
 
         # Use a set to ensure we do not report duplicate incidents.
         # (can happen when the secret is present in both the old and the new version of
         # the document)
-        formatted_policy_breaks = {format_policy_break(x) for x in policy_breaks}
+        formatted_policy_breaks = {
+            format_policy_break(x) for x in policy_breaks_to_report
+        }
+        break_count = len(formatted_policy_breaks)
 
         break_count = len(formatted_policy_breaks)
-        summary_str = f"{break_count} {pluralize('incident', break_count)}"
+        if self.ignore_known_secrets:
+            summary_str = f"{break_count} new {pluralize('incident', break_count)}"
+        else:
+            summary_str = f"{break_count} {pluralize('incident', break_count)}"
 
         # Putting each policy break on its own line would be more readable, but we can't
         # do this because of a bug in GitLab Web IDE which causes newline characters to

--- a/ggshield/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/secret/output/secret_gitlab_webui_output_handler.py
@@ -30,6 +30,8 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
     See https://docs.gitlab.com/ee/administration/server_hooks.html#custom-error-messages
     """
 
+    use_stderr = True
+
     def __init__(
         self, show_secrets: bool = False, ignore_known_secrets: bool = False
     ) -> None:
@@ -65,7 +67,6 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
         }
         break_count = len(formatted_policy_breaks)
 
-        break_count = len(formatted_policy_breaks)
         if self.ignore_known_secrets:
             summary_str = f"{break_count} new {pluralize('incident', break_count)}"
         else:

--- a/ggshield/secret/output/secret_output_handler.py
+++ b/ggshield/secret/output/secret_output_handler.py
@@ -11,6 +11,7 @@ class SecretOutputHandler(ABC):
     show_secrets: bool = False
     verbose: bool = False
     output: Optional[str] = None
+    use_stderr: bool = False
 
     def __init__(
         self,
@@ -35,7 +36,7 @@ class SecretOutputHandler(ABC):
             with open(self.output, "w+") as f:
                 f.write(text)
         else:
-            click.echo(text)
+            click.echo(text, err=self.use_stderr)
         return self._get_exit_code(scan)
 
     @abstractmethod

--- a/tests/unit/secret/output/test_gitlab_webui_output.py
+++ b/tests/unit/secret/output/test_gitlab_webui_output.py
@@ -1,8 +1,15 @@
+from copy import deepcopy
+
+import pytest
 from pygitguardian.models import Match, PolicyBreak
 
+from ggshield.scan import StringScannable
+from ggshield.secret import Result, Results, SecretScanCollection
 from ggshield.secret.output.secret_gitlab_webui_output_handler import (
+    SecretGitLabWebUIOutputHandler,
     format_policy_break,
 )
+from tests.unit.conftest import _ONE_LINE_AND_MULTILINE_PATCH_CONTENT, TWO_POLICY_BREAKS
 
 
 def test_format_policy_break():
@@ -23,3 +30,98 @@ def test_format_policy_break():
         assert match.match_type in out
         # match value itself must be obfuscated
         assert match.match not in out
+
+
+@pytest.mark.parametrize("ignore_known_secrets", [True, False])
+def test_gitlab_web_ui_output_no_secrets(ignore_known_secrets):
+    """
+    GIVEN a content with no secret
+    WHEN GitLabWebUIOutputHandler manipulates the corresponding scan
+    THEN the error message is empty as expected and the status code is zero
+    """
+    output_handler = SecretGitLabWebUIOutputHandler(
+        show_secrets=True, ignore_known_secrets=ignore_known_secrets
+    )
+    scan = SecretScanCollection(
+        id="scan",
+        type="test",
+        results=Results(results=[], errors=[]),
+    )
+    # call output handler
+    exit_code = output_handler._get_exit_code(
+        SecretScanCollection(
+            id="outer_scan",
+            type="outer_scan",
+            results=Results(results=[], errors=[]),
+            scans=[scan],
+        )
+    )
+    error_msg = output_handler._process_scan_impl(scan=scan)
+
+    assert exit_code == 0
+    assert error_msg == ""
+
+
+@pytest.mark.parametrize("ignore_known_secrets", [True, False])
+@pytest.mark.parametrize(
+    "secrets_types",
+    ["only_new_secrets", "only_known_secrets", "mixed_secrets"],
+)
+def test_gitlab_web_ui_output_ignore_known_secrets(secrets_types, ignore_known_secrets):
+    """
+    GIVEN a content with secrets
+    WHEN GitLabWebUIOutputHandler manipulates the corresponding scan
+    THEN the error message warns about secrets or about only new secrets depending
+    on the ignore_known_secrets parameter
+    """
+    result: Result = Result(
+        StringScannable(content=_ONE_LINE_AND_MULTILINE_PATCH_CONTENT, url="leak.txt"),
+        scan=deepcopy(TWO_POLICY_BREAKS),  # 2 policy breaks
+    )
+
+    all_policy_breaks = result.scan.policy_breaks
+
+    if secrets_types == "only_known_secrets":
+        known_policy_breaks = all_policy_breaks
+        new_policy_breaks = []
+    elif secrets_types == "mixed_secrets":
+        # set only first policy break as known
+        known_policy_breaks = all_policy_breaks[:1]
+        new_policy_breaks = all_policy_breaks[1:]
+    else:
+        known_policy_breaks = []
+        new_policy_breaks = all_policy_breaks
+
+    for index, policy_break in enumerate(known_policy_breaks):
+        policy_break.known_secret = True
+        policy_break.incident_url = (
+            f"https://dashboard.gitguardian.com/workspace/1/incidents/{index}"
+        )
+
+    output_handler = SecretGitLabWebUIOutputHandler(
+        show_secrets=True, ignore_known_secrets=ignore_known_secrets
+    )
+    output = output_handler._process_scan_impl(
+        SecretScanCollection(
+            id="outer_scan",
+            type="outer_scan",
+            results=Results(results=[], errors=[]),
+            scans=[
+                SecretScanCollection(
+                    id="scan",
+                    type="test",
+                    results=Results(
+                        results=[result],
+                        errors=[],
+                    ),
+                )
+            ],
+        )
+    )
+    if ignore_known_secrets:
+        if len(new_policy_breaks):
+            assert f"ggshield found {len(new_policy_breaks)} new" in output
+        else:
+            assert output == ""
+    else:
+        assert f"ggshield found {len(all_policy_breaks)}" in output


### PR DESCRIPTION
## Context  
We recently experienced a bug where one of our users could not correctly visualize the results of a `scan pre-receive` in the GitLab UI. Especially, an error message was still displayed when pushing known secrets with the `ignore-known-secrets` option. Indeed, this option had not been ported to the GitLab web UI handler.  
While reproducing the bug, we realized that a regression now simply made it impossible to visualize the `GL-HOOK-ERR` message in the UI.   

## What we did
This PR does mainly two things:  
1. We adapt GitLab Web UI output handler to behave as expected when used with the `ignore-known-secrets` option  
To do so, we add an `ignore_known_secrets` property to the `SecretGitLabWebUIOutputHandler` object. We also modify `_process_scan_impl` to make sure that only relevant secrets incidents are raised by the GitLab web UI.  

2. We adapt GitLab Web UI output handler to fix the issue of unreadable error messages in the UI.
According to the [documentation](https://docs.gitlab.com/ee/administration/server_hooks.html#custom-error-messages), the `GL-HOOK-ERR` message needs to be output to `stderr` or `stdout`. We force this behavior by re-implementing the `process_scan` method.

## Testing the feature
In all the following tests, we have beed using a self hosted version of GitLab. A `pre-receive` hook was deployed globally. 
We mostly used two invalid secrets: 
- One is known: `apikey=key-bb3dcff54bdae26f4f4a4d3b93d148da`
- One is new    : `apikey=key-bb3dcff54bdae26f4f4a4d3b93d148db`

### Regular pre-receive hook
1. With no secret
Commit is accepted as expected ✅ 
![image](https://github.com/GitGuardian/ggshield/assets/24247716/400ff2b8-8ca4-4aca-80c7-7ae6d7d5a483)
![image](https://github.com/GitGuardian/ggshield/assets/24247716/8bca52be-80a0-40a9-8dfb-9ce045992db0)

2. With a known secret
Commit is rejected as expected, no matter if the secret is already known ✅ 
![image](https://github.com/GitGuardian/ggshield/assets/24247716/25f7f956-8035-4429-bc44-fef8d90296a1)


### pre-receive hook with ignore-known-secrets flag
1. With no secret
Commit is accepted as expected ✅ 
![image](https://github.com/GitGuardian/ggshield/assets/24247716/de01e067-ec90-439c-b114-ba9755ac7e41)
![image](https://github.com/GitGuardian/ggshield/assets/24247716/37083c85-42db-4689-8b89-6c4d47064dec)

2. With a known secret
Commit is accepted as expected, known secret is ignored ✅ 
![image](https://github.com/GitGuardian/ggshield/assets/24247716/4b1aa763-dd73-4d1a-a100-45a4c193a06b)
![image](https://github.com/GitGuardian/ggshield/assets/24247716/01afea42-7194-45af-8e1b-770a55d6ebf4)

3. With a new secret
Commit is rejected as expected ✅ 
![image](https://github.com/GitGuardian/ggshield/assets/24247716/7dc2a9d8-208a-4871-b095-dc83025cff1a)

Note that we also tested the Web IDE:
![image](https://github.com/GitGuardian/ggshield/assets/24247716/cb0a4e51-ca8c-46e9-8b0c-50b658348be9)


## Other considerations  
I don't understand why we had empty messages. This should have been fixed in [this PR](https://github.com/GitGuardian/ggshield/pull/172), but when checking out the corresponding commit (00826608e) and testing, I get an unexpected error or an empty message.

![image](https://github.com/GitGuardian/ggshield/assets/24247716/6eebb913-685e-413d-b019-4c0568bfe5ac)
