### PR TITLE
Add functional tests for --ignore-known-secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 GITGUARDIAN_API_KEY=__________FILL ME__________
 GITGUARDIAN_API_URL=https://api.gitguardian.com
+
+# Used by functional tests for the --ignore-known-secrets feature
+# Set this to a single-match secret known by your dashboard
+#TEST_KNOWN_SECRET=
+# Set this to a single-match secret unknown by your dashboard. Unlike
+# TEST_KNOWN_SECRET, this one has a default value, so you do not have to set
+# it unless the default value does not work for you
+#TEST_UNKNOWN_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,11 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         shell: bash
         run: |
-          make functest GITGUARDIAN_API_KEY=${{ secrets.GITGUARDIAN_API_KEY }} GITGUARDIAN_API_URL=${{ secrets.GITGUARDIAN_API_URL }}
+          make functest
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
+          TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
 
   build_packages:
     # This job ensures the build-packages script is tested on each build, not only at release time

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -31,6 +31,8 @@ The `GITGUARDIAN_API_KEY` environment variable must be defined to run functional
 
 If you want to run tests against another GitGuardian instance, define the `GITGUARDIAN_API_URL` environment variable.
 
+The `TEST_KNOWN_SECRET` environment variable must also be defined to run functional tests. It must point to a single-match secret known on the dashboard linked to `GITGUARDIAN_API_KEY`.
+
 ### Running unit tests
 
 You can run unit tests with `make unittest`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ GG_VALID_TOKEN_IGNORE_SHA = (
     "56c126cef75e3d17c3de32dac60bab688ecc384a054c2c85b688c1dd7ac4eefd"
 )
 
+# This secret must be a secret known by the dashboard running functional tests
+KNOWN_SECRET = os.environ.get("TEST_KNOWN_SECRET", "")
+
+# This secret must not be not known by the dashboard running our tests
+UNKNOWN_SECRET = os.environ.get("TEST_UNKNOWN_SECRET", "ggtt-v-0frijgo789")  # ggignore
+
 
 def is_windows():
     return platform.system() == "Windows"


### PR DESCRIPTION
This PR adds a functional test for the `--ignore-known-secrets` option.

Since testing this requires a known secret, it adds a new test environment variable: `TEST_KNOWN_SECRET`, containing the known secret. I added it to our CI configuration so that the test can pass.