### PR TITLE
Factorize all --json option decorators

### DIFF
--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -128,3 +128,18 @@ def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
         return cmd
 
     return decorator
+
+
+json_option = click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=None,
+    help="Use JSON output.",
+    callback=create_ctx_callback("use_json"),
+)
+
+
+def use_json(ctx: click.Context) -> bool:
+    """Tells whether --json has been set"""
+    return bool(ctx.obj.get("use_json", False))

--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -6,7 +6,7 @@ from pygitguardian import GGClient
 from pygitguardian.iac_models import IaCScanParameters, IaCScanResult
 from pygitguardian.models import Detail
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.common_options import add_common_options, json_option, use_json
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.errors import APIKeyCheckError
@@ -64,7 +64,7 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[s
     multiple=True,
     help="Do not scan the specified paths.",
 )
-@click.option("--json", is_flag=True, help="JSON output.")
+@json_option
 @click.argument(
     "directory",
     type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),
@@ -78,7 +78,6 @@ def scan_cmd(
     minimum_severity: str,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
-    json: bool,
     directory: Optional[Path],
     **kwargs: Any,
 ) -> int:
@@ -92,7 +91,7 @@ def scan_cmd(
     scan = IaCScanCollection(id=str(directory), type="path_scan", result=result)
 
     output_handler_cls: Type[IaCOutputHandler]
-    if json:
+    if use_json(ctx):
         output_handler_cls = IaCJSONOutputHandler
     else:
         output_handler_cls = IaCTextOutputHandler

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -5,18 +5,17 @@ import click
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, Quota, QuotaResponse
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.common_options import add_common_options, json_option, use_json
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import format_text
-from ggshield.core.utils import json_output_option_decorator
 
 
 @click.command()
-@json_output_option_decorator
+@json_option
 @add_common_options()
 @click.pass_context
-def quota_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
+def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """Show quotas overview."""
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()
@@ -31,7 +30,7 @@ def quota_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
 
     click.echo(
         quota.to_json()
-        if json_output
+        if use_json(ctx)
         else (
             f"Quota available: {format_quota_color(quota.remaining, quota.limit)}\n"
             f"Quota used in the last 30 days: {quota.count}\n"

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -8,6 +8,8 @@ from ggshield.cmd.common_options import (
     create_config_callback,
     create_ctx_callback,
     get_config_from_context,
+    json_option,
+    use_json,
 )
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.filter import init_exclusion_regexes
@@ -21,16 +23,6 @@ from ggshield.secret.output import (
 
 def _get_secret_config(ctx: click.Context) -> SecretConfig:
     return get_config_from_context(ctx).secret
-
-
-_json_option = click.option(
-    "--json",
-    "json_output",
-    is_flag=True,
-    default=None,
-    help="JSON output results",
-    callback=create_ctx_callback("use_json"),
-)
 
 
 _output_option = click.option(
@@ -117,7 +109,7 @@ _banlist_detectors_option = click.option(
 def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
-        _json_option(cmd)
+        json_option(cmd)
         _output_option(cmd)
         _show_secrets_option(cmd)
         _exit_zero_option(cmd)
@@ -132,9 +124,8 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
 def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     """Read objects defined in ctx.obj and create the appropriate OutputHandler
     instance"""
-    use_json = ctx.obj.get("use_json", False)
     output_handler_cls = (
-        SecretJSONOutputHandler if use_json else SecretTextOutputHandler
+        SecretJSONOutputHandler if use_json(ctx) else SecretTextOutputHandler
     )
     config = ctx.obj["config"].user_config
     output = ctx.obj.get("output")

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -5,17 +5,17 @@ import click
 from pygitguardian import GGClient
 from pygitguardian.models import HealthCheckResponse
 
-from ggshield.cmd.common_options import add_common_options
+from ggshield.cmd.common_options import add_common_options, json_option, use_json
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import STYLE, format_text
-from ggshield.core.utils import json_output_option_decorator
 
 
 @click.command()
+@json_option
 @add_common_options()
 @click.pass_context
-def status_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
+def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """Show API status."""
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: HealthCheckResponse = client.health_check()
@@ -25,7 +25,7 @@ def status_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
 
     click.echo(
         response.to_json()
-        if json_output
+        if use_json(ctx)
         else (
             f"{format_text('API URL:', STYLE['key'])} {client.base_uri}\n"
             f"{format_text('Status:', STYLE['key'])} {format_healthcheck_status(response)}\n"
@@ -36,9 +36,6 @@ def status_cmd(ctx: click.Context, json_output: bool, **kwargs: Any) -> int:
     )
 
     return 0
-
-
-status = json_output_option_decorator(status_cmd)
 
 
 def format_healthcheck_status(health_check: HealthCheckResponse) -> str:

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -6,7 +6,6 @@ from enum import Enum
 from typing import Iterable, List, NamedTuple, Optional
 from urllib.parse import ParseResult, urlparse
 
-import click
 from click import UsageError
 from dotenv import load_dotenv
 from pygitguardian.models import Match
@@ -207,16 +206,6 @@ def find_match_indices(match: Match, lines: List[Line], is_patch: bool) -> Match
         index_start,
         index_end,
     )
-
-
-json_output_option_decorator = click.option(
-    "--json",
-    "json_output",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="JSON output results",
-)
 
 
 def _find_dot_env() -> Optional[str]:


### PR DESCRIPTION
Defining `--json` in 3 different places is a bit too much :)

Move `utils.json_output_option_decorator()` to common_options, renaming it `json_option()`. Make it use `create_ctx_callback()`.

Add a `use_json()` helper function to common_options, to know if `--json` has been set.

Uses these new functions in:
- cmd.iac.scan
- cmd.secret.scan.secret_scan_common_options
- cmd.status
- cmd.quota
