### PR TITLE
Improve consistency of --help messages

### DIFF
--- a/ggshield/cmd/iac/scan.py
+++ b/ggshield/cmd/iac/scan.py
@@ -44,7 +44,7 @@ def validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[s
     "--minimum-severity",
     "minimum_severity",
     type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
-    help="Minimum severity of the policies",
+    help="Minimum severity of the policies.",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose display mode.")
 @click.option(

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -31,18 +31,18 @@ fi
     "--mode",
     "-m",
     type=click.Choice(["local", "global"]),
-    help="Hook installation mode",
+    help="Hook installation mode.",
     required=True,
 )
 @click.option(
     "--hook-type",
     "-t",
     type=click.Choice(["pre-commit", "pre-push"]),
-    help="Type of hook to install",
+    help="Type of hook to install.",
     default="pre-commit",
 )
-@click.option("--force", "-f", is_flag=True, help="Force override")
-@click.option("--append", "-a", is_flag=True, help="Append to existing script")
+@click.option("--force", "-f", is_flag=True, help="Force override.")
+@click.option("--append", "-a", is_flag=True, help="Append to existing script.")
 @add_common_options()
 def install_cmd(
     mode: str, hook_type: str, force: bool, append: bool, **kwargs: Any

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -12,7 +12,7 @@ from ggshield.core.text_utils import pluralize
 @click.option(
     "--last-found",
     is_flag=True,
-    help="Ignore secrets found in the last ggshield secret scan run",
+    help="Ignore secrets found in the last ggshield secret scan run.",
 )
 @add_common_options()
 @click.pass_context

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -17,8 +17,8 @@ from ggshield.secret import RichSecretScannerUI, SecretScanCollection, SecretSca
 @click.argument(
     "paths", nargs=-1, type=click.Path(exists=True, resolve_path=True), required=True
 )
-@click.option("--recursive", "-r", is_flag=True, help="Scan directory recursively")
-@click.option("--yes", "-y", is_flag=True, help="Confirm recursive scan")
+@click.option("--recursive", "-r", is_flag=True, help="Scan directory recursively.")
+@click.option("--yes", "-y", is_flag=True, help="Confirm recursive scan.")
 @add_secret_scan_common_options()
 @click.pass_context
 def path_cmd(

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -145,7 +145,7 @@ def parse_stdin() -> Optional[Tuple[str, str]]:
     "--web",
     is_flag=True,
     default=None,
-    help="Deprecated",
+    help="Deprecated.",
     hidden=True,
 )
 @add_secret_scan_common_options()

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -89,7 +89,7 @@ _ignore_known_secrets_option = click.option(
     "--ignore-known-secrets",
     is_flag=True,
     default=None,
-    help="Ignore secrets already known by GitGuardian dashboard",
+    help="Ignore secrets already known by GitGuardian dashboard.",
     callback=create_config_callback("secret", "ignore_known_secrets"),
 )
 


### PR DESCRIPTION
Click default help messages are sentences: they start with an upper-case letter and end with a point. Make our help messages follow the same format for consistency.
