### PR TITLE
Improve error reporting

### DIFF
--- a/changelog.d/20230607_193232_aurelien.gateau_improve_error_reporting.md
+++ b/changelog.d/20230607_193232_aurelien.gateau_improve_error_reporting.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Errors are no longer reported twice: first using human-friendly message and then using log output. Log output is now off by default, unless `--debug` or `--log-file` is set (#213).

--- a/ggshield/cmd/debug_logs.py
+++ b/ggshield/cmd/debug_logs.py
@@ -10,10 +10,21 @@ LOG_FORMAT = "%(asctime)s %(levelname)s %(process)x:%(thread)x %(name)s:%(funcNa
 logger = logging.getLogger(__name__)
 
 
+def disable_logs() -> None:
+    """By default, disable all logs, because when an error occurs we log an error
+    message and also print a human-friendly message using display_errors(). If we don't
+    disable all logs, then error logs are printed, resulting in the error being shown
+    twice.
+    """
+    logging.disable()
+
+
 def setup_debug_logs(*, filename: Optional[str]) -> None:
     """Configure Python logger to log to stderr if filename is None, or to filename if
     it's set.
     """
+    # Re-enable logging, reverting the call to disable_logs()
+    logging.disable(logging.NOTSET)
 
     if sys.version_info[:2] < (3, 8):
         # Simulate logging.basicConfig() `force` argument, introduced in Python 3.8

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -9,7 +9,7 @@ import click
 from ggshield.cmd.auth import auth_group
 from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.config import config_group
-from ggshield.cmd.debug_logs import setup_debug_logs
+from ggshield.cmd.debug_logs import disable_logs, setup_debug_logs
 from ggshield.cmd.honeytoken import honeytoken_group
 from ggshield.cmd.iac import iac_group
 from ggshield.cmd.install import install_cmd
@@ -82,20 +82,13 @@ def config_path_callback(
 @click.pass_context
 def cli(
     ctx: click.Context,
-    debug: Optional[bool],
     **kwargs: Any,
 ) -> None:
     load_dot_env()
 
     config = ctx.obj["config"]
-    if debug:
-        # --debug was set. Update the config to reflect this. Unlike other options, this
-        # can't be done in the debug_callback() because --debug is eager, so its
-        # callback can be called *before* the configuration has been loaded.
-        config.debug = True
-    elif config.debug:
-        # if --debug is not set but `debug` is set in the configuration file, then
-        # we must setup logs now.
+    if config.debug:
+        # if `debug` is set in the configuration file, then setup logs now.
         setup_debug_logs(filename=None)
 
 
@@ -136,6 +129,7 @@ def main(args: Optional[List[str]] = None) -> Any:
 
     `args` is only used by unit-tests.
     """
+    disable_logs()
     show_crash_log = os.getenv("GITGUARDIAN_CRASH_LOG", "False").lower() == "true"
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)
 

--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -75,7 +75,7 @@ class Cache:
                 json.dump(self.to_dict(), f)
             except Exception as e:
                 raise UnexpectedError(
-                    f"Error while saving cache in {self.cache_filename}:\n{str(e)}"
+                    f"Failed to save cache in {self.cache_filename}:\n{str(e)}"
                 )
 
     def purge(self) -> None:

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -48,9 +48,7 @@ def save_yaml_dict(data: Dict[str, Any], path: str) -> None:
             stream = yaml.dump(data, indent=2, default_flow_style=False)
             f.write(stream)
         except Exception as e:
-            raise UnexpectedError(
-                f"Error while saving config in {path}:\n{str(e)}"
-            ) from e
+            raise UnexpectedError(f"Failed to save config to {path}:\n{str(e)}") from e
 
 
 def get_auth_config_filepath() -> str:

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -134,7 +134,7 @@ def handle_exception(exc: Exception, verbose: bool) -> int:
     )
     click.echo()
 
-    display_error(f"ERROR: {exc}")
+    display_error(f"Error: {exc}")
     if isinstance(exc, UnicodeEncodeError) and platform.system() == "Windows":
         display_error(
             "\n"

--- a/ggshield/secret/secret_scanner.py
+++ b/ggshield/secret/secret_scanner.py
@@ -232,11 +232,11 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[Scannable]) -> None:
     if detail.status_code == 401:
         raise click.UsageError(detail.detail)
     if detail.status_code is None:
-        raise UnexpectedError(f"Error scanning: {detail.detail}")
+        raise UnexpectedError(f"Scanning failed: {detail.detail}")
 
     details = None
 
-    display_error("\nError scanning. Results may be incomplete.")
+    display_error("\nScanning failed. Results may be incomplete.")
     try:
         # try to load as list of dicts to get per file details
         details = literal_eval(detail.detail)

--- a/tests/unit/secret/snapshots/snap_test_secret_scanner.py
+++ b/tests/unit/secret/snapshots/snap_test_secret_scanner.py
@@ -8,13 +8,13 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots['test_handle_scan_error[single file exception] 1'] = '''
-Error scanning. Results may be incomplete.
+Scanning failed. Results may be incomplete.
 Add the following files to your paths-ignore:
 - /home/user/too/long/file/name: filename:: [ErrorDetail(string='Ensure this field has no more than 256 characters.', code='max_length')]
 '''
 
 snapshots['test_handle_scan_error[too many documents] 1'] = '''
-Error scanning. Results may be incomplete.
+Scanning failed. Results may be incomplete.
 The following chunk is affected:
 /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example, /example
 400:Too many documents to scan


### PR DESCRIPTION
## The problem

When an error occurs, for example a network timeout, sometimes the error is reported twice: as a human-friendly message and using the logger. This can be seen in this example:

```
$ ggshield secret scan path -ry .
status_code=None detail=HTTPSConnectionPool(host='api.gitguardian.com', port=443): Read timed out. (read timeout=60)
Scanning Path... ━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  10% 45 files scanned out of 469 0:00:14

ERROR: Error scanning: HTTPSConnectionPool(host='api.gitguardian.com', port=443): Read timed out. (read timeout=60)
```

## What has been done

This PR disables logging by default, unless --debug or --log-file is set. It also rework some exception messages to make them more user-friendly. The error from above is now reported like this:

```
$ ggshield secret scan path -ry .
Scanning Path... ━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  10% 45 files scanned out of 468 0:00:12

Error: Scanning failed: HTTPSConnectionPool(host='api.gitguardian.com', port=443): Read timed out. (read timeout=60)
```

The message still uses a bit too much of tech-speak, but it's no longer duplicated and it no longer starts with "ERROR: Error".