### PR TITLE
docs(honeytoken): Honeytoken improve help textes and error 

### DIFF
--- a/changelog.d/20230612_161810_antonin.lacombe_update_honeytoken_helps_and_error.md
+++ b/changelog.d/20230612_161810_antonin.lacombe_update_honeytoken_helps_and_error.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Honeytoken creation help texts have been updated
+- Honeytoken token errors are now more explicit

--- a/ggshield/cmd/honeytoken/create.py
+++ b/ggshield/cmd/honeytoken/create.py
@@ -31,16 +31,22 @@ def _dict_to_string(data: Dict, space: bool = False) -> str:
     "name",
     required=False,
     type=str,
-    help="give a name to your honeytoken. Default ggshield-xxxxxxxx",
+    help="Specify a name for your honeytoken. If this option is not provided, a unique name will be generated with a \
+'ggshield-' prefix.",
 )
 @click.option(
     "--type",
     "type_",
     required=True,
     type=click.Choice(("AWS",)),
+    help="Specify the type of honeytoken that you want to create. (For now only AWS honeytokens are supported!)",
 )
 @click.option(
-    "--description", "description", required=False, type=str, help="250 characters max"
+    "--description",
+    "description",
+    required=False,
+    type=str,
+    help="Add a description to your honeytoken (250 characters max).",
 )
 @click.option(
     "-o",
@@ -50,6 +56,8 @@ def _dict_to_string(data: Dict, space: bool = False) -> str:
         path_type=Path, file_okay=True, dir_okay=False, readable=True, writable=True
     ),
     required=False,
+    help="Specify a filename to append your honeytoken directly to the content of this file. \
+If the file does not exist, it will be created.",
 )
 @add_common_options()
 @click.pass_context
@@ -62,7 +70,9 @@ def create_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Create a honeytoken
+    Command to create a honeytoken.
+    This action is restricted to authorized users only. To learn more, visit
+    <https://docs.gitguardian.com/honeytoken/getting-started>
     """
     # if name is not given, generate a random one
     if not name:
@@ -72,7 +82,17 @@ def create_cmd(
     if not isinstance(response, (Detail, HoneytokenResponse)):
         raise UnexpectedError("Unexpected honeytoken response")
 
-    if isinstance(response, Detail):
+    if isinstance(response, Detail) and response.status_code == 403:
+        raise UnexpectedError(
+            """ggshield does not have permissions to create honeytokens on your workspace. Make sure that:
+
+- the honeytoken module is enabled for your GitGuardian workspace,
+- you have the necessary permissions as a user,
+- the personal access token used by ggshield has the required scopes (honeytoken:write).
+
+To learn more, visit https://docs.gitguardian.com/honeytoken/getting-started."""
+        )
+    elif isinstance(response, Detail):
         raise UnexpectedError(response.detail)
     honeytoken: HoneytokenResponse = response
 

--- a/tests/unit/cassettes/test_honeytoken_create_error_403.yaml
+++ b/tests/unit/cassettes/test_honeytoken_create_error_403.yaml
@@ -1,0 +1,59 @@
+interactions:
+  - request:
+      body: '{"name": "test_honey_token_error_403", "type": "AWS", "description": "description"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '83'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.7.0 (Darwin;py3.10.4) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/honeytokens
+    response:
+      body:
+        string: '{"detail":"Token is missing the following scope: honeytokens:read"}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, POST, HEAD, OPTIONS
+        content-length:
+          - '67'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 14 Jun 2023 07:52:01 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.32.1
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '16'
+        x-frame-options:
+          - DENY
+        x-secrets-engine-version:
+          - 2.91.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 403
+        message: Forbidden
+version: 1

--- a/tests/unit/cmd/honeytoken/test_honeytoken.py
+++ b/tests/unit/cmd/honeytoken/test_honeytoken.py
@@ -60,3 +60,28 @@ def test_honeytoken_create_ok(cli_fs_runner: CliRunner) -> None:
         ],
     )
     assert_invoke_ok(result)
+
+
+@my_vcr.use_cassette("test_honeytoken_create_error_403")
+def test_honeytoken_create_error_403(cli_fs_runner: CliRunner) -> None:
+    """
+    GIVEN a token without honeytoken scope
+    WHEN running the honeytoken command with all needed arguments
+    THEN the return code is 1 and the error message match the needed message
+    """
+
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "honeytoken",
+            "create",
+            "--description",
+            "description",
+            "--type",
+            "AWS",
+            "--name",
+            "test_honey_token_error_403",
+        ],
+    )
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
+    assert "ggshield does not have permissions to create honeytokens" in result.stdout


### PR DESCRIPTION
This PR improve the `honeytoken create` command, 
The help text has been updated by the product team. 
The error displayed when a 403 is received has changed to help the user to setup honeytokens on their account.