### PR TITLE
feat(oauth): #COR-1425 Support max lifetime on access tokens

### DIFF
--- a/changelog.d/20230615_104700_arnaud.lustrat_support_max_lifetime_tokens.md
+++ b/changelog.d/20230615_104700_arnaud.lustrat_support_max_lifetime_tokens.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ggshield auth login` now displays a warning message if the token expiration date has been adjusted to comply with the personal access token maximum lifetime setting of the user's workspace.

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -75,6 +75,8 @@ class OAuthClient:
 
         self._handler_wrapper = RequestHandlerWrapper(oauth_client=self)
         self._access_token: Optional[str] = None
+        # If the PAT expiration date has been enforced to respect the workspace policy
+        self._expire_at_downsized: bool = False
         self._port = USABLE_PORT_RANGE[0]
         self.server: Optional[HTTPServer] = None
 
@@ -247,6 +249,10 @@ class OAuthClient:
         if response.ok:
             try:
                 response_json = response.json()
+                self._expire_at_downsized = response_json.get(
+                    "expire_at_downsized",
+                    False,
+                )
                 self._access_token = response_json["key"]
             except (json.decoder.JSONDecodeError, ValueError):
                 raise_error = True
@@ -358,11 +364,20 @@ class OAuthClient:
         else:
             str_date = "never"
 
+        expiration_warning = ""
+        if self._expire_at_downsized:
+            expiration_warning = (
+                " Warning: the expiration date has been adjusted to comply with your workspace's"
+                " setting for the maximum lifetime of personal access tokens.\n"
+            )
+
         message = (
             "Success! You are now authenticated.\n"
             "The personal access token has been created and stored in your ggshield config.\n\n"
             f"token name: {self._token_name}\n"
-            f"token expiration date: {str_date}\n\n"
+            f"token expiration date: {str_date}\n"
+            f"{expiration_warning}"
+            "\n"
             'You do not need to run "ggshield auth login" again. Future requests will automatically use the token.'
         )
 


### PR DESCRIPTION
## What
These changes aim to support the maximum lifetime feature that will be added to the business workspace. This setting enforces the maximum allowed lifetime for all personal access tokens created on the workspace.

## How
Information about if the new personal access token expiration date has been downsized to fit the workspace setting is added to the API. Following this information, a warning message is added to the login output to inform the client.

## When
The maximum lifetime feature is still in development and should be released soon. But these changes should not be breaking even if the API is not yet updated.
