### PR TITLE
New diff scan mode

### DIFF
--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -126,7 +126,7 @@ def iac_scan_diff(
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,
-            scan_mode=ScanMode.IAC_DIRECTORY,
+            scan_mode=ScanMode.IAC_DIFF,
         ).get_http_headers(),
     )
 

--- a/ggshield/scan/scan_mode.py
+++ b/ggshield/scan/scan_mode.py
@@ -13,4 +13,5 @@ class ScanMode(Enum):
     PYPI = "pypi"
     ARCHIVE = "archive"
     IAC_DIRECTORY = "directory"
+    IAC_DIFF = "diff"
     DOCSET = "docset"


### PR DESCRIPTION
IaC diff scans must send a distinct scan mode header to GIM.
GIM uses the header for analytics.