### PR TITLE
fix(iac-scan): exit-zero option was ignored for both iac scans

### DIFF
--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -140,6 +140,17 @@ _check_for_updates = click.option(
 )
 
 
+exit_zero_option = click.option(
+    "--exit-zero",
+    is_flag=True,
+    default=None,
+    envvar="GITGUARDIAN_EXIT_ZERO",
+    help="Always return a 0 (non-error) status code, even if incidents are found."
+    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
+    callback=create_config_callback("exit_zero"),
+)
+
+
 def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         _verbose_option(cmd)

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -14,7 +14,11 @@ from typing import Any, Callable, Sequence
 
 import click
 
-from ggshield.cmd.common_options import add_common_options, json_option
+from ggshield.cmd.common_options import (
+    add_common_options,
+    exit_zero_option,
+    json_option,
+)
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config.config import Config
 from ggshield.core.filter import init_exclusion_regexes
@@ -22,12 +26,6 @@ from ggshield.iac.policy_id import POLICY_ID_PATTERN, validate_policy_id
 
 
 AnyFunction = Callable[..., Any]
-
-_exit_zero_option = click.option(
-    "--exit-zero",
-    is_flag=True,
-    help="Always return 0 (non-error) status code.",
-)
 
 _minimum_severity_option = click.option(
     "--minimum-severity",
@@ -77,7 +75,7 @@ directory_argument = click.argument(
 def add_iac_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
-        _exit_zero_option(cmd)
+        exit_zero_option(cmd)
         _minimum_severity_option(cmd)
         _ignore_policy_option(cmd)
         _ignore_path_option(cmd)

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -7,6 +7,7 @@ from ggshield.cmd.common_options import (
     add_common_options,
     create_config_callback,
     create_ctx_callback,
+    exit_zero_option,
     get_config_from_context,
     json_option,
     use_json,
@@ -41,17 +42,6 @@ _show_secrets_option = click.option(
     default=None,
     help="Show secrets in plaintext instead of hiding them.",
     callback=create_config_callback("secret", "show_secrets"),
-)
-
-
-_exit_zero_option = click.option(
-    "--exit-zero",
-    is_flag=True,
-    default=None,
-    envvar="GITGUARDIAN_EXIT_ZERO",
-    help="Always return a 0 (non-error) status code, even if incidents are found."
-    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
-    callback=create_config_callback("exit_zero"),
 )
 
 
@@ -112,7 +102,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         json_option(cmd)
         _output_option(cmd)
         _show_secrets_option(cmd)
-        _exit_zero_option(cmd)
+        exit_zero_option(cmd)
         _exclude_option(cmd)
         _ignore_known_secrets_option(cmd)
         _banlist_detectors_option(cmd)

--- a/tests/unit/cassettes/test_iac_scan_all_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_all_exit_zero.yaml
@@ -1,0 +1,87 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS1jZDk0YmFkYzg4ZGRjYzA0OWMxY2VjYjFkN2IxNDgzYg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS1jZDk0YmFkYzg4ZGRjYzA0OWMxY2Vj
+        YjFkN2IxNDgzYg0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAHd+aZAL/7dSxasMwFAVQzf4KoQ9wJEuW
+        sgQ6ZsyQ3cjJCxjk2EgyNYT8e+N2aIeWTklpe89yxZPgTVflqlw97fy8JX+kyO5CvvkqpdT6/bzM
+        layUYnxmDzCl7ONtPfufKsf73PW0UXbt1k5VVpVWmsq4gsHfd+oClfl01x1Lqa01SypXq4/5SknN
+        lDHG1rUz2t76r421jMtH9n/0U2gphe78+bvv7n+pIlIapnggLvxzanxom9ClTGeKgovWHxuafT8G
+        EvxScD7GIQ+HIfANF9v9fieKK/4JAAAAAAAAAAAAAAAAAAAAgJ/0Ag/K9uoAKAAADQotLWNkOTRi
+        YWRjODhkZGNjMDQ5YzFjZWNiMWQ3YjE0ODNiLS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '544'
+        Content-Type:
+          - multipart/form-data; boundary=cd94badc88ddcc049c1cecb1d7b1483b
+        GGShield-Command-Id:
+          - d2d1028d-47a1-4955-b948-d82d94e6290a
+        GGShield-Command-Path:
+          - cli iac scan all
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.11
+        GGShield-Version:
+          - 1.16.0
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.11) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_scan
+    response:
+      body:
+        string:
+          '{"id":"88ec59ba-5b30-4225-8c0e-ba0bc81cb1b2","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"file.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '486'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 27 Jun 2023 13:07:43 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.33.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '1242'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.92.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_iac_scan_diff_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_diff_exit_zero.yaml
@@ -1,0 +1,86 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS0zOWI2NzA5Mjg2ZTJmODFjY2NkNjliN2YxYThhYzlhNg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJyZWZlcmVuY2UiOyBmaWxlbmFtZT0icmVmZXJlbmNlIg0KDQofiwgA
+        Id+aZAL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tMzliNjcwOTI4NmUy
+        ZjgxY2NjZDY5YjdmMWE4YWM5YTYNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFt
+        ZT0iY3VycmVudCI7IGZpbGVuYW1lPSJjdXJyZW50Ig0KDQofiwgAId+aZAL/7c2xCsIwGMTxzH2K
+        jzyApKXo5O7o0L2kNYVCNCVJURDf3aLg4K4O/n/LHbfcMHq3yoP6JLNY1/UjF+9pSlO9+nPfVKVR
+        YtQXzCnbuFyq/1REl8IceyfanlNrfdf6MWV3clGL7uyhdRd7nLzTci1Ephhy6IOXrehd0+x1cVMA
+        AAAAAAAAAAAAAAAAgB+4AzC8zAUAKAAADQotLTM5YjY3MDkyODZlMmY4MWNjY2Q2OWI3ZjFhOGFj
+        OWE2LS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '463'
+        Content-Type:
+          - multipart/form-data; boundary=39b6709286e2f81cccd69b7f1a8ac9a6
+        GGShield-Command-Id:
+          - ac56e0e5-6f1b-4872-b732-04bfae3d0233
+        GGShield-Command-Path:
+          - cli iac scan diff
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.11
+        GGShield-Version:
+          - 1.16.0
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.11) ggshield
+        mode:
+          - diff
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_diff_scan
+    response:
+      body:
+        string:
+          '{"id":"2bb3badd-82f5-46d9-acd9-64aa92d0c714","iac_engine_version":"1.8.0","type":"diff_scan","entities_with_incidents":{"unchanged":[],"deleted":[],"new":[{"filename":"file.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '522'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 27 Jun 2023 13:07:47 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.33.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '2066'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.92.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_iac_scan_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_exit_zero.yaml
@@ -1,0 +1,87 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS0zMzNhNTg1NTVlMzEzZjg1MmVhNjcyNzY0MzJjM2ZmNA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0zMzNhNTg1NTVlMzEzZjg1MmVhNjcy
+        NzY0MzJjM2ZmNA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAGt+aZAL/7dSxasMwEAZgzX4KoQdwJFmW
+        vAQyZsyQ3cjJBQxybCSbGkrePU46tENLp6S0/b/lxN3BTb/yVb7a7Py8JX+kyB5CvvmqSlmY9/et
+        r6RWmvGZPcGURh+X8+x/0hXvxrajtbKVq5zSpcudqbRzOmPw553aQPl4euiNW6itvWdcuVJ9rHdK
+        FkwZY2xZOlPoJf+FsUv+5TPzP/gpNJRCe/5877v5L5VFSv0UD8SFf0m1D00d2jTSmaLgovHHmmbf
+        DYEEf804H2I/9oc+8DUX2/1+J7ILvgkAAAAAAAAAAAAAAAAAAACAn3QFrANbdAAoAAANCi0tMzMz
+        YTU4NTU1ZTMxM2Y4NTJlYTY3Mjc2NDMyYzNmZjQtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '546'
+        Content-Type:
+          - multipart/form-data; boundary=333a58555e313f852ea67276432c3ff4
+        GGShield-Command-Id:
+          - 39e51dad-d309-48d0-8f23-47dfbbbb6dd7
+        GGShield-Command-Path:
+          - cli iac scan <>
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.11
+        GGShield-Version:
+          - 1.16.0
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.11) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_scan
+    response:
+      body:
+        string:
+          '{"id":"b5d256d9-5cbe-4efa-8bf9-f9bf7d2a48e3","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"file.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '486'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 27 Jun 2023 13:07:40 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.33.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '1624'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.92.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/iac/test_scan_common.py
+++ b/tests/unit/cmd/iac/test_scan_common.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typing import List
+
+import pytest
+from click.testing import CliRunner
+
+from ggshield.cmd.main import cli
+from tests.repository import Repository
+from tests.unit.conftest import _IAC_SINGLE_VULNERABILITY, my_vcr
+
+
+_SCAN_COMMAND = ["scan"]
+_SCAN_ALL_COMMAND = ["scan", "all"]
+_SCAN_DIFF_COMMAND = ["scan", "diff", "--ref", "HEAD~1"]
+
+
+@pytest.mark.parametrize("exit_zero", [True, False])
+@pytest.mark.parametrize(
+    "command,cassette",
+    [
+        (_SCAN_COMMAND, "test_iac_scan_exit_zero"),
+        (_SCAN_ALL_COMMAND, "test_iac_scan_all_exit_zero"),
+        (_SCAN_DIFF_COMMAND, "test_iac_scan_diff_exit_zero"),
+    ],
+)
+def test_iac_scan_exit_zero(
+    cli_fs_runner: CliRunner,
+    tmp_path: Path,
+    exit_zero: bool,
+    command: List[str],
+    cassette: str,
+) -> None:
+    """
+    GIVEN a directory with vulnerabilities
+    WHEN running the iac scan command with --exit-zero
+    THEN the return code is 0
+    """
+    repo = Repository.create(tmp_path)
+    repo.create_commit()
+    first_file = repo.path / "file.tf"
+    first_content = _IAC_SINGLE_VULNERABILITY
+    first_file.write_text(first_content)
+    repo.add("file.tf")
+    repo.create_commit()
+
+    args = ["iac"] + command + [str(tmp_path)]
+    if exit_zero:
+        args.append("--exit-zero")
+
+    with my_vcr.use_cassette(cassette):
+        result = cli_fs_runner.invoke(cli, args)
+
+    assert result.exit_code == (not exit_zero)


### PR DESCRIPTION
How it works:
We connect the exit-zero option for iac  scans to the existing callback for secret scans.
The option is then handled in main.py

Depends on #569 for some tests to work