### PR TITLE
Fix error when executing a diff scan in a subfolder of a git repository

### DIFF
--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -232,7 +232,7 @@ def tar_from_ref_and_filepaths(
 
     with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
         for path in filepaths:
-            raw_file_content = git(["show", f"{ref}:{path}"], cwd=wd)
+            raw_file_content = git(["show", f"{ref}:./{path}"], cwd=wd)
 
             if acceptation_func is not None and not (
                 acceptation_func(path, raw_file_content)


### PR DESCRIPTION
Scanning a subfolder should work as long as it is inside a git repository. This is the (working) behaviour for the `iac scan all` command.
However, it fails with the `iac scan diff` command, and throws an ugly error message

Currently, the only fix in this PR is to throw a prettier message to the user, suggesting them to execute the scan at the git root.
However, we might prefer fixing the issue.

It comes from the `git show` command used to create the tars. This only works with a path relative to the git root (not relative to the cwd).