### PR TITLE
fix: no changed iac files leads to empty diff iac scan

### DIFF
--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -119,7 +119,7 @@ def scan_diff_cmd(
 
 def iac_scan_diff(
     ctx: click.Context, directory: Path, ref: str, include_staged: bool
-) -> Optional[Union[IaCDiffScanResult, IaCSkipDiffScanResult]]:
+) -> Union[IaCDiffScanResult, IaCSkipDiffScanResult, None]:
     config = ctx.obj["config"]
     client = ctx.obj["client"]
     exclusion_regexes = ctx.obj["exclusion_regexes"]

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -18,7 +18,7 @@ from ggshield.core.git_shell import (
     tar_from_ref_and_filepaths,
 )
 from ggshield.core.text_utils import display_error
-from ggshield.iac.filter import is_file_content_iac_file
+from ggshield.iac.filter import is_iac_file_content
 from ggshield.iac.output import (
     IaCJSONOutputHandler,
     IaCOutputHandler,
@@ -61,8 +61,8 @@ def filter_iac_filepaths(
     filtered_filepaths = []
 
     for filepath in filepaths:
-        filepath_content = git(["show", f"{ref}:./{filepath}"], cwd=str(directory))
-        if is_file_content_iac_file(filepath, filepath_content):
+        filepath_content = git(["show", f"{ref}:{filepath}"], cwd=str(directory))
+        if is_iac_file_content(filepath, filepath_content):
             filtered_filepaths.append(filepath)
     return filtered_filepaths
 
@@ -71,7 +71,7 @@ def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> b
     filepaths = get_iac_filepaths(directory, ref)
 
     def _accept_file(path: Path, content: str) -> bool:
-        return is_file_content_iac_file(path, content) and not is_filepath_excluded(
+        return is_iac_file_content(path, content) and not is_filepath_excluded(
             str(directory / path), exclusion_regexes
         )
 

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -14,11 +14,10 @@ from ggshield.core.git_shell import (
     INDEX_REF,
     get_filepaths_from_ref,
     get_staged_filepaths,
-    git,
     tar_from_ref_and_filepaths,
 )
 from ggshield.core.text_utils import display_error
-from ggshield.iac.filter import is_iac_file_content
+from ggshield.iac.filter import is_iac_file_path
 from ggshield.iac.output import (
     IaCJSONOutputHandler,
     IaCOutputHandler,
@@ -58,20 +57,15 @@ def filter_iac_filepaths(
     ref: str,
     filepaths: Iterable[Path],
 ) -> Iterable[Path]:
-    filtered_filepaths = []
 
-    for filepath in filepaths:
-        filepath_content = git(["show", f"{ref}:{filepath}"], cwd=str(directory))
-        if is_iac_file_content(filepath, filepath_content):
-            filtered_filepaths.append(filepath)
-    return filtered_filepaths
+    return filter(is_iac_file_path, filepaths)
 
 
 def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> bytes:
     filepaths = get_iac_filepaths(directory, ref)
 
     def _accept_file(path: Path, content: str) -> bool:
-        return is_iac_file_content(path, content) and not is_filepath_excluded(
+        return is_iac_file_path(path) and not is_filepath_excluded(
             str(directory / path), exclusion_regexes
         )
 

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -217,7 +217,7 @@ def get_staged_filepaths(wd: Optional[str] = None) -> List[Path]:
 
 
 def get_diff_files_status(
-    wd: Optional[str], ref: str, staged: bool = False, similarity: int = 100
+    ref: str, staged: bool = False, similarity: int = 100, wd: Optional[str] = None
 ) -> Dict[Path, Filemode]:
     """
     Fetches the statuses of modified files since a given ref.

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 from datetime import datetime
-from enum import Enum
 from itertools import islice
 from typing import Iterable, List, NamedTuple, Optional, TypeVar
 from urllib.parse import ParseResult, urlparse
@@ -13,7 +12,7 @@ from pygitguardian.models import Match
 
 from ggshield.core.constants import ON_PREMISE_API_URL_PATH_PREFIX
 
-from .git_shell import get_git_root, is_git_dir
+from .git_shell import Filemode, get_git_root, is_git_dir
 from .text_utils import Line, LineCategory, display_error, display_warning
 
 
@@ -58,18 +57,6 @@ IGNORED_DEFAULT_WILDCARDS = [
 ]
 
 GITGUARDIAN_DOMAINS = ["gitguardian.com", "gitguardian.tech"]
-
-
-class Filemode(Enum):
-    """
-    Enum class for git filemode.
-    """
-
-    MODIFY = "modified file"
-    DELETE = "deleted file"
-    NEW = "new file"
-    RENAME = "renamed file"
-    FILE = "file"
 
 
 def get_lines_from_content(

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -42,12 +42,12 @@ def get_iac_files_from_paths(
         yes=True,
         verbose=verbose,
         ignore_git=ignore_git,
-    ).apply_filter(is_file_iac_file)
+    ).apply_filter(is_iac_file)
 
     return [str(x.relative_to(path)) for x in files.paths]
 
 
-def is_file_path_iac_file_path(path: Path) -> bool:
+def is_iac_file_path(path: Path) -> bool:
     if any(ext in IAC_EXTENSIONS for ext in path.suffixes):
         return True
     if any(path.name.endswith(iac_ext) for iac_ext in IAC_EXTENSIONS):
@@ -56,10 +56,10 @@ def is_file_path_iac_file_path(path: Path) -> bool:
     return any(keyword in name for keyword in IAC_FILENAME_KEYWORDS)
 
 
-def is_file_iac_file(scannable: Scannable) -> bool:
-    return is_file_path_iac_file_path(scannable.path)
+def is_iac_file(scannable: Scannable) -> bool:
+    return is_iac_file_path(scannable.path)
 
 
-def is_file_content_iac_file(path: Path, content: str) -> bool:
+def is_iac_file_content(path: Path, content: str) -> bool:
     scannable = StringScannable(str(path), content)
-    return is_file_iac_file(scannable)
+    return is_iac_file(scannable)

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -47,13 +47,17 @@ def get_iac_files_from_paths(
     return [str(x.relative_to(path)) for x in files.paths]
 
 
-def is_file_iac_file(scannable: Scannable) -> bool:
-    if any(ext in IAC_EXTENSIONS for ext in scannable.path.suffixes):
+def is_file_path_iac_file_path(path: Path) -> bool:
+    if any(ext in IAC_EXTENSIONS for ext in path.suffixes):
         return True
-    if any(scannable.path.name.endswith(iac_ext) for iac_ext in IAC_EXTENSIONS):
+    if any(path.name.endswith(iac_ext) for iac_ext in IAC_EXTENSIONS):
         return True
-    name = scannable.path.name.lower()
+    name = path.name.lower()
     return any(keyword in name for keyword in IAC_FILENAME_KEYWORDS)
+
+
+def is_file_iac_file(scannable: Scannable) -> bool:
+    return is_file_path_iac_file_path(scannable.path)
 
 
 def is_file_content_iac_file(path: Path, content: str) -> bool:

--- a/ggshield/iac/filter.py
+++ b/ggshield/iac/filter.py
@@ -4,7 +4,6 @@ from typing import List, Set
 
 from ggshield.scan import Scannable
 from ggshield.scan.file import get_files_from_paths
-from ggshield.scan.scannable import StringScannable
 
 
 IAC_EXTENSIONS = {
@@ -58,8 +57,3 @@ def is_iac_file_path(path: Path) -> bool:
 
 def is_iac_file(scannable: Scannable) -> bool:
     return is_iac_file_path(scannable.path)
-
-
-def is_iac_file_content(path: Path, content: str) -> bool:
-    scannable = StringScannable(str(path), content)
-    return is_iac_file(scannable)

--- a/ggshield/iac/iac_scan_models.py
+++ b/ggshield/iac/iac_scan_models.py
@@ -41,6 +41,11 @@ class IaCDiffScanResult(Base):
     )
 
 
+@dataclass
+class IaCSkipDiffScanResult:
+    id: str = ""
+
+
 # TODO: move this schema into pygitguardian
 IaCDiffScanResultSchema = marshmallow_dataclass.class_schema(
     IaCDiffScanResult, BaseSchema

--- a/ggshield/iac/output/iac_json_output_handler.py
+++ b/ggshield/iac/output/iac_json_output_handler.py
@@ -18,6 +18,9 @@ class IaCJSONOutputHandler(IaCOutputHandler):
         text = IaCJSONScanResultSchema().dumps(scan_dict)
         return cast(str, text)
 
+    def _process_skip_diff_scan_impl(self) -> str:
+        return "{}"
+
     def _process_diff_scan_impl(self, scan: IaCDiffScanCollection) -> str:
         scan_dict = IaCJSONOutputHandler.create_diff_scan_dict(scan)
         text = IaCJSONScanDiffResultSchema().dumps(scan_dict)

--- a/ggshield/iac/output/iac_output_handler.py
+++ b/ggshield/iac/output/iac_output_handler.py
@@ -42,6 +42,26 @@ class IaCOutputHandler(ABC):
         text = self._process_diff_scan_impl(scan)
         return self._handle_process_scan_result(scan, text)
 
+    def process_skip_diff_scan(self) -> ExitCode:
+        """Process the case where we skip the scan,
+        write the report to :attr:`self.output`
+
+        :return: The exit code
+        """
+        text = self._process_skip_diff_scan_impl()
+        return self._handle_process_skip_scan(text)
+
+    @abstractmethod
+    def _process_skip_diff_scan_impl(self) -> str:
+        """Implementation of displaying a skipped scan,
+        called by :meth:`OutputHandler.process_skip_diff_scan`
+
+        Must return a string for the report.
+
+        :return: The content
+        """
+        raise NotImplementedError()
+
     @abstractmethod
     def _process_scan_impl(self, scan: IaCPathScanCollection) -> str:
         """Implementation of scan processing,
@@ -82,3 +102,11 @@ class IaCOutputHandler(ABC):
         else:
             click.echo(text)
         return self._get_exit_code(scan)
+
+    def _handle_process_skip_scan(self, text: str) -> ExitCode:
+        if self.output:
+            with open(self.output, "w+") as f:
+                f.write(text)
+        else:
+            click.echo(text)
+        return ExitCode.SUCCESS

--- a/ggshield/iac/output/iac_text_output_handler.py
+++ b/ggshield/iac/output/iac_text_output_handler.py
@@ -6,6 +6,7 @@ from typing import ClassVar, DefaultDict, Dict, Generator, List, NamedTuple, Opt
 
 from pygitguardian.iac_models import IaCFileResult, IaCVulnerability
 
+from ggshield.core.git_shell import Filemode
 from ggshield.core.text_utils import (
     STYLE,
     Line,
@@ -17,7 +18,7 @@ from ggshield.core.text_utils import (
     get_padding,
     pluralize,
 )
-from ggshield.core.utils import Filemode, get_lines_from_content
+from ggshield.core.utils import get_lines_from_content
 from ggshield.iac.collection.iac_diff_scan_collection import IaCDiffScanCollection
 from ggshield.iac.collection.iac_path_scan_collection import IaCPathScanCollection
 from ggshield.iac.iac_scan_models import IaCDiffScanEntities

--- a/ggshield/iac/output/iac_text_output_handler.py
+++ b/ggshield/iac/output/iac_text_output_handler.py
@@ -185,6 +185,9 @@ class IaCTextOutputHandler(IaCOutputHandler):
             return self._process_diff_scan_impl_verbose(scan)
         return self._process_diff_scan_impl_not_verbose(scan)
 
+    def _process_skip_diff_scan_impl(self) -> str:
+        return "> No IaC files changed. Skipping."
+
     def process_iac_file_result(
         self, file_path: Path, file_result: IaCFileResult, prefix: Optional[str] = None
     ) -> str:

--- a/ggshield/scan/commit.py
+++ b/ggshield/scan/commit.py
@@ -2,9 +2,9 @@ import re
 from typing import Iterable, List, NamedTuple, Optional, Set, Tuple
 
 from ggshield.core.filter import is_filepath_excluded
-from ggshield.core.git_shell import git
+from ggshield.core.git_shell import Filemode, git
 from ggshield.core.text_utils import STYLE, format_text
-from ggshield.core.utils import REGEX_HEADER_INFO, Filemode
+from ggshield.core.utils import REGEX_HEADER_INFO
 
 from .scannable import Files, Scannable, StringScannable
 

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -8,7 +8,7 @@ from typing import BinaryIO, Callable, List, Optional, Tuple
 import charset_normalizer
 from charset_normalizer import CharsetMatch
 
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 
 
 logger = logging.getLogger(__name__)

--- a/ggshield/secret/output/secret_json_output_handler.py
+++ b/ggshield/secret/output/secret_json_output_handler.py
@@ -4,8 +4,9 @@ from pygitguardian.client import VERSIONS
 from pygitguardian.models import Match, PolicyBreak
 
 from ggshield.core.filter import censor_content, leak_dictionary_by_ignore_sha
+from ggshield.core.git_shell import Filemode
 from ggshield.core.text_utils import Line
-from ggshield.core.utils import Filemode, find_match_indices, get_lines_from_content
+from ggshield.core.utils import find_match_indices, get_lines_from_content
 
 from ..secret_scan_collection import Error, Result, SecretScanCollection
 from .schemas import ExtendedMatch, JSONScanCollectionSchema

--- a/ggshield/secret/output/secret_text_output_handler.py
+++ b/ggshield/secret/output/secret_text_output_handler.py
@@ -8,6 +8,7 @@ from pygitguardian.models import Match, PolicyBreak
 
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import censor_content, leak_dictionary_by_ignore_sha
+from ggshield.core.git_shell import Filemode
 from ggshield.core.text_utils import (
     STYLE,
     Line,
@@ -19,7 +20,7 @@ from ggshield.core.text_utils import (
     pluralize,
     translate_validity,
 )
-from ggshield.core.utils import Filemode, find_match_indices, get_lines_from_content
+from ggshield.core.utils import find_match_indices, get_lines_from_content
 
 from ..secret_scan_collection import Result, SecretScanCollection
 from .secret_output_handler import SecretOutputHandler

--- a/ggshield/secret/secret_scan_collection.py
+++ b/ggshield/secret/secret_scan_collection.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
 from pygitguardian.models import ScanResult
 
 from ggshield.core.filter import leak_dictionary_by_ignore_sha
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 from ggshield.scan.scannable import Scannable
 
 

--- a/tests/functional/iac/test_iac_scan_diff.py
+++ b/tests/functional/iac/test_iac_scan_diff.py
@@ -24,12 +24,10 @@ def test_iac_scan_diff_unchanged(tmp_path: Path) -> None:
     # WHEN scanning the diff between current and HEAD
     # (meaning both states should be the same)
     args = ["diff", "--ref", "HEAD", str(tmp_path)]
-    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
+    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=0)
 
-    # THEN the output shows two unchanged vulnerabilities
-    assert "0 incidents deleted" in result.stdout
-    assert "2 incidents remaining" in result.stdout
-    assert "0 new incidents detected" in result.stdout
+    # THEN the output shows no vulnerabilities
+    assert "No IaC files changed" in result.stdout
 
 
 def test_iac_scan_diff_new_vuln(tmp_path: Path) -> None:
@@ -120,12 +118,10 @@ def test_iac_scan_diff_only_tracked_iac(tmp_path: Path) -> None:
 
     # WHEN scanning it
     args = ["diff", "--ref", "HEAD", "--ignore-path", "ignored_file.tf", str(tmp_path)]
-    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
+    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=0)
 
-    # THEN only the tracked file appears in the output
-    assert "0 incidents deleted" in result.stdout
-    assert "1 incident remaining" in result.stdout
-    assert "0 new incidents detected" in result.stdout
+    # THEN the scan is skipped, since no tracked IaC file changed
+    assert "No IaC files changed" in result.stdout
 
 
 @pytest.mark.parametrize("staged", (True, False))

--- a/tests/unit/iac/test_filter.py
+++ b/tests/unit/iac/test_filter.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ggshield.iac.filter import get_iac_files_from_paths, is_iac_file_content
+from ggshield.iac.filter import get_iac_files_from_paths, is_iac_file_path
 
 
 FILE_NAMES = [
@@ -84,6 +84,6 @@ def test_get_iac_files_from_paths_ignore_git(tmp_path, ignore_git):
         assert "file3.yaml" in files
 
 
-def test_is_iac_file_content(tmp_path):
-    assert is_iac_file_content(tmp_path / "file1.json", "")
-    assert not is_iac_file_content(tmp_path / "file1.jpg", "")
+def test_is_iac_file_path(tmp_path):
+    assert is_iac_file_path(tmp_path / "file1.json")
+    assert not is_iac_file_path(tmp_path / "file1.jpg")

--- a/tests/unit/iac/test_filter.py
+++ b/tests/unit/iac/test_filter.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ggshield.iac.filter import get_iac_files_from_paths, is_file_content_iac_file
+from ggshield.iac.filter import get_iac_files_from_paths, is_iac_file_content
 
 
 FILE_NAMES = [
@@ -84,6 +84,6 @@ def test_get_iac_files_from_paths_ignore_git(tmp_path, ignore_git):
         assert "file3.yaml" in files
 
 
-def test_is_file_content_iac_file(tmp_path):
-    assert is_file_content_iac_file(tmp_path / "file1.json", "")
-    assert not is_file_content_iac_file(tmp_path / "file1.jpg", "")
+def test_is_iac_file_content(tmp_path):
+    assert is_iac_file_content(tmp_path / "file1.json", "")
+    assert not is_iac_file_content(tmp_path / "file1.jpg", "")

--- a/tests/unit/scan/test_commit.py
+++ b/tests/unit/scan/test_commit.py
@@ -4,7 +4,7 @@ import pytest
 from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core.filter import init_exclusion_regexes
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 from ggshield.scan import Commit
 from ggshield.scan.commit import _parse_patch_header_line
 from tests.unit.conftest import DATA_PATH

--- a/tests/unit/secret/output/test_json_output.py
+++ b/tests/unit/secret/output/test_json_output.py
@@ -8,7 +8,7 @@ from pytest_voluptuous import Partial, S
 from voluptuous import Optional, Required, validators
 
 from ggshield.core.filter import leak_dictionary_by_ignore_sha
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 from ggshield.scan import Commit, ScanContext, ScanMode, StringScannable
 from ggshield.secret import Result, Results, SecretScanCollection, SecretScanner
 from ggshield.secret.output import SecretJSONOutputHandler, SecretOutputHandler

--- a/tests/unit/secret/output/test_text_output.py
+++ b/tests/unit/secret/output/test_text_output.py
@@ -5,7 +5,7 @@ import click
 import pytest
 
 from ggshield.core.filter import leak_dictionary_by_ignore_sha
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 from ggshield.scan import StringScannable
 from ggshield.secret import Result, Results, SecretScanCollection
 from ggshield.secret.output import SecretTextOutputHandler

--- a/tests/unit/secret/test_secret_scanner.py
+++ b/tests/unit/secret/test_secret_scanner.py
@@ -6,7 +6,7 @@ import pytest
 from pygitguardian.models import Detail
 
 from ggshield.core.errors import ExitCode
-from ggshield.core.utils import Filemode
+from ggshield.core.git_shell import Filemode
 from ggshield.scan import (
     Commit,
     DecodeError,


### PR DESCRIPTION
This PR fixes a problematic behavior in IaC diff scans.

# Problem description

When no IaC files have been changed and a diff scan is requested, the tar archives are still built and sent for scanning even though no additional IaC incident will be found.

While it is true the scanning backend could have gotten new vulnerability detectors in the meantime, we generally do not want the scan to raise warnings when no IaC files have been touched.

# Solution

With an additional function in `git_shell.py`, we can detect the status of files relative to the given git reference.

If any file has been added/removed/modified AND is an IaC file, we perform the diff scan as usual. Else, we notify that the scan was skipped and return 0.

# Implementation details

- the `git_diff_file_status(...)` function has been added to `git_shell.py`. This function returns the associated `Filemode`s associated with each file.
- the `Filemode` enum has been moved from `utils.py` to `git_shell.py` to avoid circular imports. As `Filemode` describes git file modes, it feels coherent with the scope of `git_shell.py`. Consequently, `from ggshield.core.utils import Filemode` have been changed to `from ggshield.core.git_shell import Filemode`.
- IaC diff scanning has been updated.
- "Skip diff scan" output handlers have been added.
- tests were updated.