### PR TITLE
Fix: iac scan diff should only return an exit code 1 if new vulnerabilities are found

### DIFF
--- a/ggshield/iac/collection/iac_diff_scan_collection.py
+++ b/ggshield/iac/collection/iac_diff_scan_collection.py
@@ -4,10 +4,12 @@ from ggshield.iac.collection.iac_scan_collection import (
     CollectionType,
     IaCScanCollection,
 )
-from ggshield.iac.iac_scan_models import IaCDiffScanEntities, IaCDiffScanResult
+from ggshield.iac.iac_scan_models import IaCDiffScanResult
 
 
 class IaCDiffScanCollection(IaCScanCollection):
+    result: Optional[IaCDiffScanResult]
+
     def __init__(
         self,
         id: str,
@@ -18,13 +20,4 @@ class IaCDiffScanCollection(IaCScanCollection):
 
     @property
     def has_results(self) -> bool:
-        if self.result is None:
-            return False
-        if isinstance(self.result.entities_with_incidents, IaCDiffScanEntities):
-            return (
-                bool(self.result.entities_with_incidents.unchanged)
-                or bool(self.result.entities_with_incidents.new)
-                or bool(self.result.entities_with_incidents.deleted)
-            )
-        else:
-            return bool(self.result.entities_with_incidents)
+        return self.result is not None and bool(self.result.entities_with_incidents.new)

--- a/ggshield/iac/collection/iac_diff_scan_collection.py
+++ b/ggshield/iac/collection/iac_diff_scan_collection.py
@@ -8,15 +8,8 @@ from ggshield.iac.iac_scan_models import IaCDiffScanResult
 
 
 class IaCDiffScanCollection(IaCScanCollection):
+    type = CollectionType.DiffScan
     result: Optional[IaCDiffScanResult]
-
-    def __init__(
-        self,
-        id: str,
-        result: Optional[IaCDiffScanResult],
-    ):
-        super().__init__(id, result)
-        self.type = CollectionType.DiffScan
 
     @property
     def has_results(self) -> bool:

--- a/ggshield/iac/collection/iac_path_scan_collection.py
+++ b/ggshield/iac/collection/iac_path_scan_collection.py
@@ -9,6 +9,8 @@ from ggshield.iac.collection.iac_scan_collection import (
 
 
 class IaCPathScanCollection(IaCScanCollection):
+    result: Optional[IaCScanResult]
+
     def __init__(
         self,
         id: str,

--- a/ggshield/iac/collection/iac_path_scan_collection.py
+++ b/ggshield/iac/collection/iac_path_scan_collection.py
@@ -9,15 +9,8 @@ from ggshield.iac.collection.iac_scan_collection import (
 
 
 class IaCPathScanCollection(IaCScanCollection):
+    type = CollectionType.PathScan
     result: Optional[IaCScanResult]
-
-    def __init__(
-        self,
-        id: str,
-        result: Optional[IaCScanResult],
-    ):
-        super().__init__(id, result)
-        self.type = CollectionType.PathScan
 
     @property
     def has_results(self) -> bool:

--- a/ggshield/iac/collection/iac_scan_collection.py
+++ b/ggshield/iac/collection/iac_scan_collection.py
@@ -17,8 +17,8 @@ class CollectionType(Enum):
 
 
 class IaCScanCollection(ABC):
+    type = CollectionType.Unknown
     id: str
-    type: CollectionType
     # Can be None if the scan failed
     result: Optional[IaCResult]
 
@@ -28,7 +28,6 @@ class IaCScanCollection(ABC):
         result: Optional[IaCResult],
     ):
         self.id = id
-        self.type = CollectionType.Unknown
         self.result = result
 
     @abstractproperty

--- a/tests/functional/iac/test_iac_scan_all.py
+++ b/tests/functional/iac/test_iac_scan_all.py
@@ -45,7 +45,6 @@ def test_iac_scan_all_only_tracked_iac(tmp_path: Path) -> None:
     result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
 
     # THEN only the tracked file appears in the output
-    print(result.stdout)
     assert "should_appear.tf" in result.stdout
     assert "should_not_appear.tf" not in result.stdout
 

--- a/tests/functional/iac/test_iac_scan_diff.py
+++ b/tests/functional/iac/test_iac_scan_diff.py
@@ -53,7 +53,6 @@ def test_iac_scan_diff_new_vuln(tmp_path: Path) -> None:
     # THEN exit code is 1 (new vuln detected)
     result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
 
-    print(result.stdout)
     # AND vulnerability of file1.tf shows as unchanged
     # AND vulnerability of file2.tf shows as new
     assert "0 incidents deleted" in result.stdout

--- a/tests/functional/iac/test_iac_scan_diff.py
+++ b/tests/functional/iac/test_iac_scan_diff.py
@@ -50,10 +50,11 @@ def test_iac_scan_diff_new_vuln(tmp_path: Path) -> None:
     # WHEN scanning the diff between current and HEAD~1
     # (meaning reference should be one commit behind)
     args = ["diff", "--ref", "HEAD~1", str(tmp_path)]
+    # THEN exit code is 1 (new vuln detected)
     result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
 
     print(result.stdout)
-    # THEN vulnerability of file1.tf shows as unchanged
+    # AND vulnerability of file1.tf shows as unchanged
     # AND vulnerability of file2.tf shows as new
     assert "0 incidents deleted" in result.stdout
     assert "1 incident remaining" in result.stdout
@@ -85,9 +86,10 @@ def test_iac_scan_diff_removed_vuln(tmp_path: Path) -> None:
     # WHEN scanning the diff between current and HEAD~1
     # (meaning reference should be one commit behind)
     args = ["diff", "--ref", "HEAD~1", str(tmp_path)]
-    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
+    # THEN exit code is 0 (no new vuln)
+    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=0)
 
-    # THEN the output contains the vulnerability of file2.tf as unchanged
+    # AND the output contains the vulnerability of file2.tf as unchanged
     # AND the output contains the vulnerability of file1.tf as deleted
     assert "1 incident deleted" in result.stdout
     assert "1 incident remaining" in result.stdout
@@ -144,7 +146,7 @@ def test_iac_scan_diff_staged(tmp_path: Path, staged: bool) -> None:
     args = ["diff", "--ref", "HEAD", str(tmp_path)]
     if staged:
         args.append("--staged")
-    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=1)
+    result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=bool(staged))
 
     # THEN the staged file only appears with --staged flag enabled
     assert "0 incidents deleted" in result.stdout

--- a/tests/unit/iac/collection/test_iac_scan_collection.py
+++ b/tests/unit/iac/collection/test_iac_scan_collection.py
@@ -1,68 +1,146 @@
+import pytest
 from pygitguardian.iac_models import IaCFileResult, IaCScanResult, IaCVulnerability
 
 from ggshield.iac.collection.iac_diff_scan_collection import IaCDiffScanCollection
 from ggshield.iac.collection.iac_path_scan_collection import IaCPathScanCollection
-from ggshield.iac.collection.iac_scan_collection import CollectionType
+from ggshield.iac.collection.iac_scan_collection import (
+    CollectionType,
+    IaCScanCollection,
+)
 from ggshield.iac.iac_scan_models import IaCDiffScanEntities, IaCDiffScanResult
 
 
-def test_iac_path_scan_collection_type() -> None:
-    """
-    GIVEN an IaC path scan collection
-    WHEN accessing its type
-    THEN the type is CollectionType.PathScan
-    """
-    collection = IaCPathScanCollection("0", IaCScanResult("0", "path_scan", "", []))
-    assert collection.type == CollectionType.PathScan
+def _generate_empty_path_collection() -> IaCPathScanCollection:
+    return IaCPathScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="path_scan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=[],
+        ),
+    )
 
 
-def test_iac_diff_scan_collection_type() -> None:
-    """
-    GIVEN an IaC diff scan collection
-    WHEN accessing its type
-    THEN the type is CollectionType.DiffScan
-    """
-    collection = IaCDiffScanCollection("0", IaCDiffScanResult("0", "diff_scan", "", []))
-    assert collection.type == CollectionType.DiffScan
+def _generate_empty_diff_collection() -> IaCDiffScanCollection:
+    return IaCDiffScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCDiffScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="diff_scan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=IaCDiffScanEntities(
+                unchanged=[], deleted=[], new=[]
+            ),
+        ),
+    )
 
 
-def test_iac_path_scan_collection_has_no_results() -> None:
+def _generate_file_result_with_vulnerability() -> IaCFileResult:
+    return IaCFileResult(
+        "a.py",
+        [
+            IaCVulnerability(
+                policy="Leaving public access open exposes your service to the internet",
+                policy_id="GG_IAC_0024",
+                line_end=35,
+                line_start=1,
+                description="The API server of an AKS cluster [...]",
+                documentation_url="https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0024",
+                component="azurerm_kubernetes_cluster.k8s_cluster",
+                severity="HIGH",
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "collection,expected_type",
+    [
+        (_generate_empty_path_collection(), CollectionType.PathScan),
+        (_generate_empty_diff_collection(), CollectionType.DiffScan),
+    ],
+)
+def test_iac_path_scan_collection_type(
+    collection: IaCScanCollection, expected_type: CollectionType
+) -> None:
+    """
+    GIVEN an IaC scan collection
+    THEN the type is either 'path_scan' or 'diff_scan'
+    """
+    assert collection.type == expected_type
+
+
+@pytest.mark.parametrize(
+    "collection",
+    [
+        _generate_empty_path_collection(),
+        _generate_empty_diff_collection(),
+    ],
+)
+def test_iac_scan_collection_has_no_results(collection: IaCScanCollection) -> None:
     """
     GIVEN an IaC scan collection with no result
     THEN has_results returns False
     """
-    collection = IaCPathScanCollection("0", IaCScanResult("0", "path_scan", "", []))
-    assert not collection.has_results
-
-    collection = IaCPathScanCollection("0", IaCDiffScanResult("0", "diffscan", "", []))
     assert not collection.has_results
 
 
 def test_iac_path_scan_collection_has_results() -> None:
     """
-    GIVEN an IaC scan collection with some results
+    GIVEN an IaC path scan collection with some results
     THEN has_results returns True
     """
-    file_result = IaCFileResult(
-        "a.py", [IaCVulnerability("", "", 0, 0, "", "", "", "")]
-    )
 
     collection = IaCPathScanCollection(
-        "0", IaCScanResult("0", "path_scan", "", [file_result])
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="path_scan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=[_generate_file_result_with_vulnerability()],
+        ),
     )
     assert collection.has_results
 
-    collection = IaCPathScanCollection(
-        "0",
+
+def test_iac_diff_scan_collection_no_new_results() -> None:
+    """
+    GIVEN an IaC diff scan collection with some results in unchanged/deleted only
+    THEN has_results returns False
+    """
+    collection = IaCDiffScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
         IaCDiffScanResult(
-            "0",
-            "diffscan",
-            "",
-            [
-                IaCDiffScanEntities(
-                    unchanged=file_result, deleted=file_result, new=file_result
-                )
-            ],
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="diffscan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=IaCDiffScanEntities(
+                unchanged=[_generate_file_result_with_vulnerability()],
+                deleted=[_generate_file_result_with_vulnerability()],
+                new=[],
+            ),
+        ),
+    )
+    assert not collection.has_results
+
+
+def test_iac_diff_scan_collection_new_results() -> None:
+    """
+    GIVEN an IaC diff scan collection with some results in new
+    THEN has_results returns True
+    """
+    collection = IaCDiffScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCDiffScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="diffscan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=IaCDiffScanEntities(
+                unchanged=[],
+                deleted=[],
+                new=[_generate_file_result_with_vulnerability()],
+            ),
         ),
     )
     assert collection.has_results


### PR DESCRIPTION
Currently, having unchanged or deleted vulnerabilities would also trigger an exit code 1.
This makes it more difficult to use the command in CI, as only new vulnerabilities should throw an alert.