### PR TITLE
Perf: in iac diff scan, allow file filter to operate without opening the files

### DIFF
--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -12,7 +12,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 from ggshield.cmd.iac.scan.iac_scan_utils import (
     create_output_handler,
     filter_iac_filepaths,
-    get_iac_filepaths,
+    get_git_filepaths,
     get_iac_tar,
     handle_scan_error,
 )
@@ -127,9 +127,7 @@ def iac_scan_diff(
     verbose = config.user_config.verbose if config and config.user_config else False
     if verbose:
         display_info(f"> Scanned files in reference {ref}")
-        filepaths = filter_iac_filepaths(
-            directory, ref, get_iac_filepaths(directory, ref)
-        )
+        filepaths = filter_iac_filepaths(directory, get_git_filepaths(directory, ref))
         for filepath in filepaths:
             display_info(f"- {click.format_filename(filepath)}")
         display_info("")
@@ -141,7 +139,7 @@ def iac_scan_diff(
         else:
             display_info("> Scanned files in current state")
         filepaths = filter_iac_filepaths(
-            directory, current_ref, get_iac_filepaths(directory, current_ref)
+            directory, get_git_filepaths(directory, current_ref)
         )
         for filepath in filepaths:
             display_info(f"- {click.format_filename(filepath)}")

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from re import Pattern
-from typing import Iterable, Set, Type
+from typing import Iterable, Optional, Set, Type
 
 import click
 from pygitguardian import GGClient
@@ -44,7 +44,7 @@ def handle_scan_error(client: GGClient, detail: Detail) -> None:
     display_error(str(detail))
 
 
-def get_iac_filepaths(directory: Path, ref: str) -> Iterable[Path]:
+def get_git_filepaths(directory: Path, ref: str) -> Iterable[Path]:
     return (
         get_staged_filepaths(str(directory))
         if ref == INDEX_REF
@@ -52,21 +52,39 @@ def get_iac_filepaths(directory: Path, ref: str) -> Iterable[Path]:
     )
 
 
+def _accept_iac_file_on_path(
+    path: Path, directory: Path, exclusion_regexes: Optional[Set[Pattern]] = None
+) -> bool:
+    return is_iac_file_path(path) and (
+        exclusion_regexes is None
+        or not is_filepath_excluded(str(directory / path), exclusion_regexes)
+    )
+
+
 def filter_iac_filepaths(
     directory: Path,
-    ref: str,
     filepaths: Iterable[Path],
+    exclusion_regexes: Optional[Set[Pattern]] = None,
 ) -> Iterable[Path]:
-
-    return filter(is_iac_file_path, filepaths)
+    # You can filter based on file's content here
+    # using read_git_file (result will be cached)
+    # You should filter on path first, in order to read
+    # the content only if necessary
+    return [
+        path
+        for path in filepaths
+        if _accept_iac_file_on_path(
+            path, directory, exclusion_regexes=exclusion_regexes
+        )
+    ]
 
 
 def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> bytes:
-    filepaths = get_iac_filepaths(directory, ref)
+    filepaths = get_git_filepaths(directory, ref)
+    filtered_paths = filter_iac_filepaths(
+        directory=directory,
+        filepaths=filepaths,
+        exclusion_regexes=exclusion_regexes,
+    )
 
-    def _accept_file(path: Path, content: str) -> bool:
-        return is_iac_file_path(path) and not is_filepath_excluded(
-            str(directory / path), exclusion_regexes
-        )
-
-    return tar_from_ref_and_filepaths(ref, filepaths, _accept_file, str(directory))
+    return tar_from_ref_and_filepaths(ref, filtered_paths, wd=str(directory))

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -162,16 +162,12 @@ def test_tar_from_ref_and_filepaths(tmp_path):
     repo.add(second_file_name)
     repo.create_commit()
 
-    # AND a filter function
-    def filter(path, content):
-        return "ignored" not in str(path)
-
     # AND a list of filepaths
-    filepaths = [first_file_name, first_ignored_file_name]
+    filepaths = [first_file_name]
 
     # WHEN creating a tar
     tarbytes = tar_from_ref_and_filepaths(
-        "HEAD~1", [Path(path_str) for path_str in filepaths], filter, tmp_path
+        "HEAD~1", [Path(path_str) for path_str in filepaths], wd=tmp_path
     )
 
     tar_stream = BytesIO(tarbytes)


### PR DESCRIPTION
When executing a `iac scan diff`,
- all files in the repo are listed
- non-IaC files are filtered out of the list
- remaining files are added to a tar

Currently, files are filtered based on their path only, but their content is read and passed to the filter function anyway.

This PR removes the `acceptation_func` from the tar creation function, which now expects the filepaths list to be already filtered.
Also, caching is added to the file opening function, in case the iac filter requires to read them in the future.

Execution time for `iac scan diff --ref 253d331b8b44e87d11238f715b904828330ed84e` on the ggshield repo:
- with the old behaviour: ~7,5s
- with this new behaviour: ~5,8s