### PR TITLE
Make `ggshield secret scan docker` honor $GG_MAX_WORKERS

### DIFF
--- a/changelog.d/20230704_152111_aurelien.gateau_docker_max_workers.md
+++ b/changelog.d/20230704_152111_aurelien.gateau_docker_max_workers.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield secret scan docker` now runs as many scans in parallel as the other scan commands.

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -8,7 +8,6 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.scan import ScanContext, ScanMode, Scannable, StringScannable
@@ -40,10 +39,7 @@ def create_scans_from_docset_files(
             display_info(f"- {click.format_filename(input_file.name)}")
 
         files = generate_files_from_docsets(input_file, verbose)
-        results = scanner.scan(
-            files,
-            scan_threads=MAX_WORKERS,
-        )
+        results = scanner.scan(files)
         scans.append(
             SecretScanCollection(id=input_file.name, type="docset", results=results)
         )

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -6,7 +6,6 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.file import get_files_from_paths
@@ -57,11 +56,7 @@ def path_cmd(
                 scan_context=scan_context,
                 ignored_detectors=config.secret.ignored_detectors,
             )
-            results = scanner.scan(
-                files.files,
-                scanner_ui=ui,
-                scan_threads=MAX_WORKERS,
-            )
+            results = scanner.scan(files.files, scanner_ui=ui)
         scan = SecretScanCollection(
             id=" ".join(paths), type="path_scan", results=results
         )

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -13,7 +13,6 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.config import Config
-from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import UnexpectedError
 from ggshield.scan import Files, ScanContext, ScanMode
 from ggshield.scan.file import get_files_from_paths
@@ -120,11 +119,7 @@ def pypi_cmd(
                 scan_context=scan_context,
                 ignored_detectors=config.secret.ignored_detectors,
             )
-            results = scanner.scan(
-                files.files,
-                scanner_ui=ui,
-                scan_threads=MAX_WORKERS,
-            )
+            results = scanner.scan(files.files, scanner_ui=ui)
         scan = SecretScanCollection(id=package_name, type="path_scan", results=results)
 
         return output_handler.process_scan(scan)

--- a/ggshield/secret/docker.py
+++ b/ggshield/secret/docker.py
@@ -346,10 +346,7 @@ def docker_scan_archive(
 
         display_heading("Scanning Docker config")
         with RichSecretScannerUI(1) as ui:
-            results = scanner.scan(
-                [docker_image.config_scannable],
-                scanner_ui=ui,
-            )
+            results = scanner.scan([docker_image.config_scannable], scanner_ui=ui)
 
         for info in docker_image.layer_infos:
             layer = docker_image.get_layer(info)

--- a/ggshield/secret/secret_scanner.py
+++ b/ggshield/secret/secret_scanner.py
@@ -99,7 +99,7 @@ class SecretScanner:
         Reports progress through `scanner_ui`.
         Returns a Results instance.
         """
-        logger.debug("files=%s command_id=%s", self, self.command_id)
+        logger.debug("command_id=%s scan_threads=%d", self.command_id, scan_threads)
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=scan_threads, thread_name_prefix="content_scan"

--- a/ggshield/secret/secret_scanner.py
+++ b/ggshield/secret/secret_scanner.py
@@ -12,6 +12,7 @@ from pygitguardian.models import Detail, MultiScanResult
 
 from ggshield.core.cache import Cache
 from ggshield.core.client import check_client_api_key
+from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.filter import (
     remove_ignored_from_result,
@@ -92,13 +93,16 @@ class SecretScanner:
         self,
         files: Iterable[Scannable],
         scanner_ui: SecretScannerUI = DefaultSecretScannerUI(),
-        scan_threads: int = 4,
+        scan_threads: Optional[int] = None,
     ) -> Results:
         """
-        Starts the scan, using at most scan_threads.
+        Starts the scan, using at most `scan_threads`. If `scan_threads` is not set,
+        defaults to MAX_WORKERS.
         Reports progress through `scanner_ui`.
         Returns a Results instance.
         """
+        if scan_threads is None:
+            scan_threads = MAX_WORKERS
         logger.debug("command_id=%s scan_threads=%d", self.command_id, scan_threads)
 
         with concurrent.futures.ThreadPoolExecutor(


### PR DESCRIPTION
## Description

While investigating a bug which eventually proved to be unrelated, I found out `secret scan docker` did not honor the $GG_MAX_WORKERS environment variable.

## What has been done

Change the default value for the `scan_threads` argument of `SecretScanner.scan()` to use `ggshield.constants.MAX_WORKERS` (which is initialized from $GG_MAX_WORKERS) instead of 4. This makes it possible to simplify all scan callers since they do not have to pass a value for the `scan_threads` argument.

~I also improved logging a bit, so that logging with --debug produce a less messy output.~
Update: just removed that part because it was not reliable.