### PR TITLE
Perf (implementation 2): in iac diff scan, allow file filter to operate without opening the files

### DIFF
--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from re import Pattern
-from typing import Callable, Iterable, Set, Type
+from typing import Iterable, Set, Type
 
 import click
 from pygitguardian import GGClient
@@ -64,9 +64,11 @@ def filter_iac_filepaths(
 def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> bytes:
     filepaths = get_iac_filepaths(directory, ref)
 
-    def _accept_file(path: Path, open_file: Callable[[], str]) -> bool:
+    def _accept_path(path: Path) -> bool:
         return is_iac_file_path(path) and not is_filepath_excluded(
             str(directory / path), exclusion_regexes
         )
 
-    return tar_from_ref_and_filepaths(ref, filepaths, _accept_file, str(directory))
+    return tar_from_ref_and_filepaths(
+        ref, filepaths, accept_path=_accept_path, wd=str(directory)
+    )

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -280,7 +280,8 @@ def read_git_file(ref: str, path: Path, wd: Optional[str] = None) -> str:
 def tar_from_ref_and_filepaths(
     ref: str,
     filepaths: Iterable[Path],
-    acceptation_func: Optional[Callable[[Path, Callable[[], str]], bool]] = None,
+    accept_path: Optional[Callable[[Path], bool]] = None,
+    accept_content: Optional[Callable[[str, Path], bool]] = None,
     wd: Optional[str] = None,
 ) -> bytes:
     """
@@ -291,9 +292,12 @@ def tar_from_ref_and_filepaths(
     :param ref: git reference, like a commit SHA, a relative reference like HEAD~1,\
         or any argument accepted as <ref> by git show <ref>:<filepath>
     :param filepaths: string paths to selected files
-    :param acceptation_func: provided a file path and a function to read\
-        its raw content, returns whether the file should be included\
-        in the archive
+    :param accept_path: provided a file path, returns whether the file should be\
+        included in the archive. This does not open the file.
+    :param accept_content: provided a file raw content and its path,\
+        returns whether the file should be included in the archive.\
+        If you do not need the file content to accept,\
+        please use `accept_path` instead.
     :param wd: string path to the git repository. Defaults to current directory
     """
     if not wd:
@@ -308,15 +312,15 @@ def tar_from_ref_and_filepaths(
 
     with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
         for path in filepaths:
-
-            def _readfile() -> str:
-                return read_git_file(ref, path, wd)
-
-            if acceptation_func is not None and not acceptation_func(path, _readfile):
+            if accept_path is not None and not accept_path(path):
                 continue
 
-            raw_file_content = _readfile()
-            data = BytesIO(raw_file_content.encode())
+            content = read_git_file(ref, path, wd)
+
+            if accept_content is not None and not accept_content(content, path):
+                continue
+
+            data = BytesIO(content.encode())
 
             tarinfo = tarfile.TarInfo(str(path))
             tarinfo.size = len(data.getbuffer())

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -163,7 +163,7 @@ def test_tar_from_ref_and_filepaths(tmp_path):
     repo.create_commit()
 
     # AND a filter function
-    def filter(path, content):
+    def filter(path):
         return "ignored" not in str(path)
 
     # AND a list of filepaths
@@ -171,7 +171,10 @@ def test_tar_from_ref_and_filepaths(tmp_path):
 
     # WHEN creating a tar
     tarbytes = tar_from_ref_and_filepaths(
-        "HEAD~1", [Path(path_str) for path_str in filepaths], filter, tmp_path
+        "HEAD~1",
+        [Path(path_str) for path_str in filepaths],
+        accept_path=filter,
+        wd=tmp_path,
     )
 
     tar_stream = BytesIO(tarbytes)


### PR DESCRIPTION
This attempts to solve the same issue as #602.
This time, we provide two distinct acceptation functions as arguments to the `tar_from_ref_and_filepaths` function:
- One filtering on filepath only (does not open the file)
- One filtering on file content. The file is opened once. The filepath is also provided as an argument, because cross-validation on path and content might be needed in the future.

Pros:
- When validating on path only, there is no longer an unused `file_opener` argument in the acceptation function
Cons:
- However, the `path` argument in the second acceptation function might be unused.