### PR TITLE
Perf (implementation 3): in iac diff scan, allow file filter to operate without opening the files

### DIFF
--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from re import Pattern
-from typing import Callable, Iterable, Set, Type
+from typing import Iterable, Set, Type
 
 import click
 from pygitguardian import GGClient
@@ -64,9 +64,11 @@ def filter_iac_filepaths(
 def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> bytes:
     filepaths = get_iac_filepaths(directory, ref)
 
-    def _accept_file(path: Path, open_file: Callable[[], str]) -> bool:
+    def _accept_file(path: Path) -> bool:
         return is_iac_file_path(path) and not is_filepath_excluded(
             str(directory / path), exclusion_regexes
         )
 
-    return tar_from_ref_and_filepaths(ref, filepaths, _accept_file, str(directory))
+    filtered_filepaths = filter(_accept_file, filepaths)
+
+    return tar_from_ref_and_filepaths(ref, filtered_filepaths, wd=str(directory))


### PR DESCRIPTION
This attempts to solve the same issue as https://github.com/GitGuardian/ggshield/pull/602.
This time, we pre-filter the filepaths list provided to the `tar_from_ref_and_filepaths` function.
The `acceptation_func` still exists, but must be used only for filters based on content.

Pros:
- One unique acceptation function. A filepath filtering function was not necessary, as we already have to provide the filepath list.
Cons:
- The path argument in the second acceptation function might be unused.