### PR TITLE
Perf (implementation 4): in iac diff scan, allow file filter to operate without opening the files

### DIFF
--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -12,7 +12,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 from ggshield.cmd.iac.scan.iac_scan_utils import (
     create_output_handler,
     filter_iac_filepaths,
-    get_iac_filepaths,
+    get_git_filepaths,
     get_iac_tar,
     handle_scan_error,
 )
@@ -127,9 +127,7 @@ def iac_scan_diff(
     verbose = config.user_config.verbose if config and config.user_config else False
     if verbose:
         display_info(f"> Scanned files in reference {ref}")
-        filepaths = filter_iac_filepaths(
-            directory, ref, get_iac_filepaths(directory, ref)
-        )
+        filepaths = filter_iac_filepaths(directory, get_git_filepaths(directory, ref))
         for filepath in filepaths:
             display_info(f"- {click.format_filename(filepath)}")
         display_info("")
@@ -141,7 +139,7 @@ def iac_scan_diff(
         else:
             display_info("> Scanned files in current state")
         filepaths = filter_iac_filepaths(
-            directory, current_ref, get_iac_filepaths(directory, current_ref)
+            directory, get_git_filepaths(directory, current_ref)
         )
         for filepath in filepaths:
             display_info(f"- {click.format_filename(filepath)}")

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -162,16 +162,12 @@ def test_tar_from_ref_and_filepaths(tmp_path):
     repo.add(second_file_name)
     repo.create_commit()
 
-    # AND a filter function
-    def filter(path, content):
-        return "ignored" not in str(path)
-
     # AND a list of filepaths
-    filepaths = [first_file_name, first_ignored_file_name]
+    filepaths = [first_file_name]
 
     # WHEN creating a tar
     tarbytes = tar_from_ref_and_filepaths(
-        "HEAD~1", [Path(path_str) for path_str in filepaths], filter, tmp_path
+        "HEAD~1", [Path(path_str) for path_str in filepaths], wd=tmp_path
     )
 
     tar_stream = BytesIO(tarbytes)


### PR DESCRIPTION
Fourth (and last) attempt to solve the same issue as https://github.com/GitGuardian/ggshield/pull/602.
This time, all filters are done before the tar_from_ref_and_filepaths function.
The acceptation_func is removed.

Pros:
- Simpler, clearer
- Files are still opened once at most (due to caching)
Cons:
- We iterate through the paths twice (once during filter, then for tar construction).