### PR TITLE
Improve handling of quota limit reached errors

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ flake8-isort = "*"
 flake8-quotes = "*"
 ipdb = "*"
 pre-commit = "*"
-pytest = "7.2.1" # pinning because of conflicting dependencies with exceptiongroup 
+pytest = "==7.2.1" # pinning because of conflicting dependencies with exceptiongroup
 pytest-mock = "*"
 pytest-socket = "*"
 pytest-voluptuous = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00b5f7737a59737d59e4eda47bd6aefbbe8555d523d10e7ded4b358cde40b4ab"
+            "sha256": "5ec1db68730e3cda22d3b52f02a81d55e718ab1e98549bdf4150594fe141b93e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -221,6 +221,9 @@
         },
         "ggshield": {
             "editable": true,
+            "extras": [
+                "all"
+            ],
             "path": "."
         },
         "idna": {
@@ -373,11 +376,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
-                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.6.3"
+            "version": "==4.7.1"
         },
         "typing-inspect": {
             "hashes": [
@@ -650,11 +653,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
-                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
+                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.1.1"
+            "version": "==1.1.2"
         },
         "executing": {
             "hashes": [
@@ -998,11 +1001,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
-                "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"
+                "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac",
+                "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.0.38"
+            "version": "==3.0.39"
         },
         "ptyprocess": {
             "hashes": [
@@ -1060,11 +1063,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32",
-                "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"
+                "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5",
+                "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
             ],
             "index": "pypi",
-            "version": "==7.4.0"
+            "version": "==7.2.1"
         },
         "pytest-mock": {
             "hashes": [
@@ -1226,11 +1229,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
-                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.6.3"
+            "version": "==4.7.1"
         },
         "urllib3": {
             "hashes": [

--- a/changelog.d/20230705_120528_samuel.guillaume_scrt_3734_ggshield_improve_handling_of_quota_limit_reached_errors.md
+++ b/changelog.d/20230705_120528_samuel.guillaume_scrt_3734_ggshield_improve_handling_of_quota_limit_reached_errors.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Improve handling of "quota limit reached" errors (#309)
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -66,6 +66,14 @@ class AuthError(_ExitError):
         self.instance = instance
 
 
+class QuotaLimitReachedError(_ExitError):
+    def __init__(self):
+        super().__init__(
+            ExitCode.UNEXPECTED_ERROR,
+            "Could not perform the requested action: no more API calls available.",
+        )
+
+
 class UnknownInstanceError(AuthError):
     """
     Raised when the requested instance does not exist

--- a/ggshield/secret/secret_scanner.py
+++ b/ggshield/secret/secret_scanner.py
@@ -13,7 +13,7 @@ from pygitguardian.models import Detail, MultiScanResult
 from ggshield.core.cache import Cache
 from ggshield.core.client import check_client_api_key
 from ggshield.core.constants import MAX_WORKERS
-from ggshield.core.errors import UnexpectedError
+from ggshield.core.errors import QuotaLimitReachedError, UnexpectedError
 from ggshield.core.filter import (
     remove_ignored_from_result,
     remove_results_from_ignore_detectors,
@@ -238,6 +238,8 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[Scannable]) -> None:
         raise click.UsageError(detail.detail)
     if detail.status_code is None:
         raise UnexpectedError(f"Scanning failed: {detail.detail}")
+    if detail.status_code == 403 and detail.detail == "Quota limit reached.":
+        raise QuotaLimitReachedError()
 
     details = None
 

--- a/tests/functional/secret/test_scan_repo.py
+++ b/tests/functional/secret/test_scan_repo.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 from tests.conftest import GG_VALID_TOKEN
 from tests.functional.utils import recreate_censored_content, run_ggshield_scan
@@ -24,3 +26,37 @@ def test_scan_repo(tmp_path: Path) -> None:
     proc = run_ggshield_scan("repo", str(repo.path), expected_code=1, cwd=repo.path)
 
     assert recreate_censored_content(leak_content, GG_VALID_TOKEN) in proc.stdout
+
+
+def test_scan_repo_quota_limit_reached(
+    tmp_path: Path, no_quota_gitguardian_api: str, caplog
+) -> None:
+    # GIVEN a repository
+    repo = Repository.create(tmp_path)
+
+    # AND a commit containing a leak
+    secret_file = repo.path / "secret.conf"
+    leak_content = f"password = {GG_VALID_TOKEN}"
+    secret_file.write_text(leak_content)
+    repo.add("secret.conf")
+
+    # AND some clean commits on top of it
+    for _ in range(3):
+        repo.create_commit()
+
+    # WHEN scanning the repo
+    # THEN error code is 128
+    with patch.dict(
+        os.environ, {**os.environ, "GITGUARDIAN_API_URL": no_quota_gitguardian_api}
+    ):
+        proc = run_ggshield_scan(
+            "repo", str(repo.path), "--json", expected_code=128, cwd=repo.path
+        )
+
+    # AND stderr contains an error message
+    assert (
+        "Error: Could not perform the requested action: no more API calls available."
+        in proc.stderr
+    )
+    # AND stdout is empty
+    assert proc.stdout.strip() == ""

--- a/tests/unit/secret/test_secret_scanner.py
+++ b/tests/unit/secret/test_secret_scanner.py
@@ -5,7 +5,7 @@ import click
 import pytest
 from pygitguardian.models import Detail
 
-from ggshield.core.errors import ExitCode
+from ggshield.core.errors import ExitCode, QuotaLimitReachedError
 from ggshield.core.git_shell import Filemode
 from ggshield.scan import (
     Commit,
@@ -186,3 +186,9 @@ def test_handle_scan_error(detail, status_code, chunk, capsys, snapshot):
     handle_scan_chunk_error(detail, chunk)
     captured = capsys.readouterr()
     snapshot.assert_match(captured.err)
+
+
+def test_handle_scan_quota_limit_reached():
+    detail = Detail(detail="Quota limit reached.", status_code=403)
+    with pytest.raises(QuotaLimitReachedError):
+        handle_scan_chunk_error(detail, Mock())


### PR DESCRIPTION
closes #309 

# Problem

The output of ggshield when the quota limit is reached can be confusing:
```shell
$ ggshield secret scan path setup.py
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0 files scanned out of 1 -:--:--
Scanning failed. Results may be incomplete.
The following chunk is affected:
/Users/sguillaume/gg-src/ggshield/setup.py
403:Quota limit reached.
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1 files scanned out of 1 0:00:00

No secrets have been found
```
Even more with the JSON output:
```shell
$ ggshield secret scan path setup.py --json
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0 files scanned out of 1 -:--:--
Scanning failed. Results may be incomplete.
The following chunk is affected:
/Users/sguillaume/gg-src/ggshield/setup.py
403:Quota limit reached.
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1 files scanned out of 1 0:00:00
{"id": "/Users/sguillaume/gg-src/ggshield/setup.py", "type": "path_scan", "total_incidents": 0, "total_occurrences": 0}
```

The error code is 0, and ggshield say that no secret have been found, when no file have been scanned.

# Solution

I've added an exception `QuotaLimitReachedError` which is raised by `SecretScanner._collect_results` when ggshield receives a 403 with the message `Quota limit reached.`.  This exception is then passed all the way to up and `scan_commit_range` has been updated to stop as soon as an exception occurs.

The new output is:
```
▶ ggshield secret scan path setup.py       
Scanning Path... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1 files scanned out of 1 0:00:00

Error: Could not perform the requested action: no more API calls available.
```
The  output handler is not called and the exit code is 128.

It also stop a large scan if the error happens in the middle of the scan:
![demo](https://github.com/GitGuardian/ggshield/assets/12242908/4a0f6f81-bb8b-46ae-b8db-bb2f011efe15)

---

The PR also include a small commit to fix the a version specifier in the Pipfile. My version of pipenv didn't like the missing `==`.