### PR TITLE
Mmillet/ /fixes

### DIFF
--- a/ggshield/cmd/sca/scan.py
+++ b/ggshield/cmd/sca/scan.py
@@ -171,7 +171,7 @@ def get_sca_scan_all_filepaths(
     )
 
     # API Call to filter SCA files
-    response = client.compute_sca_files(touched_files=all_filepaths)
+    response = client.compute_sca_files(files=all_filepaths)
 
     if not isinstance(response, ComputeSCAFilesResult):
         if response.status_code == 401:

--- a/tests/unit/cassettes/test_sca_get_scan_all_filepaths.yaml
+++ b/tests/unit/cassettes/test_sca_get_scan_all_filepaths.yaml
@@ -1,6 +1,6 @@
 interactions:
   - request:
-      body: '{"touched_files": ["Pipfile", "Some_other_file.txt"]}'
+      body: '{"files": ["Pipfile", "Some_other_file.txt"]}'
       headers:
         Accept:
           - '*/*'

--- a/tests/unit/cassettes/test_sca_scan_all_no_file.yaml
+++ b/tests/unit/cassettes/test_sca_scan_all_no_file.yaml
@@ -1,6 +1,6 @@
 interactions:
   - request:
-      body: '{"touched_files": []}'
+      body: '{"files": []}'
       headers:
         Accept:
           - '*/*'

--- a/tests/unit/cassettes/test_sca_scan_all_valid.yaml
+++ b/tests/unit/cassettes/test_sca_scan_all_valid.yaml
@@ -1,7 +1,7 @@
 interactions:
   - request:
       body:
-        '{"touched_files": ["tests/unit/cmd/iac/test_scan_diff.py", "build/lib/ggshield/cmd/__init__.py",
+        '{"files": ["tests/unit/cmd/iac/test_scan_diff.py", "build/lib/ggshield/cmd/__init__.py",
         "tests/unit/data/patches/chmod.patch", "tests/unit/cassettes/test_files_verbose.yaml",
         "ggshield/core/clickutils/default_command_group.py", "tests/unit/cmd/test_status.py",
         "build/lib/ggshield/cmd/config/config_get.py", "ggshield/iac/__init__.py", "build/lib/tests/unit/output/test_message.py",


### PR DESCRIPTION
- fix `compute_sca_files` call and cassettes
- remove fix for python 3.7, whose support was just dropped (https://github.com/GitGuardian/ggshield/pull/613)