### PR TITLE
alacombe/expl-187/Logout HMSL when calling GGshield auth logout

### DIFF
--- a/changelog.d/20230720_140628_antonin.lacombe_logout_hmsl_when_auth_logout.md
+++ b/changelog.d/20230720_140628_antonin.lacombe_logout_hmsl_when_auth_logout.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The logout command now also logout HMSL

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -3,6 +3,7 @@ from typing import Any
 import click
 from requests.exceptions import ConnectionError
 
+import ggshield.hmsl.utils as hmsl_utils
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
@@ -59,6 +60,7 @@ def logout(config: Config, instance_url: str, revoke: bool) -> None:
     check_account_config_exists(config, instance_url)
     if revoke:
         revoke_token(config, instance_url)
+        hmsl_utils.remove_token_from_disk()
     delete_account_config(config, instance_url)
 
     click.echo(

--- a/ggshield/hmsl/utils.py
+++ b/ggshield/hmsl/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from typing import Optional
 
@@ -17,6 +18,9 @@ from ggshield.hmsl.client import HMSLClient
 
 
 logger = logging.getLogger(__name__)
+
+
+TOKEN_PATH = f"{get_cache_dir()}/hmsl_token"
 
 
 def get_client(config: Config) -> HMSLClient:
@@ -89,7 +93,7 @@ def is_token_valid(token: Optional[str], audience: str) -> bool:
 
 def load_token_from_disk() -> Optional[str]:
     try:
-        return open(get_cache_dir() + "/hmsl_token").read()
+        return open(TOKEN_PATH).read()
     except FileNotFoundError:
         return None
     except Exception as e:
@@ -99,6 +103,15 @@ def load_token_from_disk() -> Optional[str]:
 
 def save_token(token: str) -> None:
     try:
-        open(get_cache_dir() + "/hmsl_token", "w").write(token)
+        open(TOKEN_PATH, "w").write(token)
     except Exception as e:
         logger.warning(f"Error while saving token: {e}")
+
+
+def remove_token_from_disk() -> None:
+    try:
+        os.remove(TOKEN_PATH)
+    except OSError:
+        pass
+    except Exception as e:
+        logger.warning(f"Error while removing token: {e}")

--- a/tests/unit/hmsl/test_hmsl_utils.py
+++ b/tests/unit/hmsl/test_hmsl_utils.py
@@ -6,7 +6,12 @@ from pygitguardian.client import GGClient
 from pygitguardian.models import JWTResponse
 
 from ggshield.core.config.config import Config
-from ggshield.hmsl.utils import get_token, is_token_valid, load_token_from_disk
+from ggshield.hmsl.utils import (
+    get_token,
+    is_token_valid,
+    load_token_from_disk,
+    remove_token_from_disk,
+)
 
 
 @pytest.fixture
@@ -74,6 +79,21 @@ def test_get_token(isolated_fs, create_jwt_mock: MagicMock):
     token = get_token(config)
     create_jwt_mock.assert_called_once()
     assert token == "dummy_token"
+
+
+def test_remove_token(isolated_fs, create_jwt_mock: MagicMock):
+    """
+    GIVEN a logged in session to GIM
+    WHEN I'm calling remove_token_from_disk
+    THEN the token has been removed
+    """
+    config = Config()
+    assert load_token_from_disk() is None
+    token = get_token(config)
+    create_jwt_mock.assert_called_once()
+    assert token == "dummy_token"
+    remove_token_from_disk()
+    assert load_token_from_disk() is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove the JWT token when doing a ggshield logout 