### PR TITLE
`iac scan prepush` command

### DIFF
--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -18,12 +18,7 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
     handle_scan_error,
 )
 from ggshield.core.filter import is_filepath_excluded
-from ggshield.core.git_shell import (
-    INDEX_REF,
-    Filemode,
-    get_diff_files_status,
-    get_empty_tar,
-)
+from ggshield.core.git_shell import INDEX_REF, Filemode, get_diff_files_status
 from ggshield.core.text_utils import display_info, display_warning
 from ggshield.iac.collection.iac_diff_scan_collection import IaCDiffScanCollection
 from ggshield.iac.filter import is_iac_file_path
@@ -72,7 +67,7 @@ def scan_diff_cmd(
 
 
 def iac_scan_diff(
-    ctx: click.Context, directory: Path, ref: Optional[str], include_staged: bool
+    ctx: click.Context, directory: Path, ref: str, include_staged: bool
 ) -> Union[IaCDiffScanResult, IaCSkipScanResult, None]:
     config = ctx.obj["config"]
     client = ctx.obj["client"]
@@ -80,18 +75,11 @@ def iac_scan_diff(
 
     verbose = config.user_config.verbose if config and config.user_config else False
     if verbose:
-        if ref is None:
-            display_info(
-                "> No file to scan in reference. This might be a new repository."
-            )
-        else:
-            display_info(f"> Scanned files in reference {ref}")
-            filepaths = filter_iac_filepaths(
-                directory, get_git_filepaths(directory, ref)
-            )
-            for filepath in filepaths:
-                display_info(f"- {click.format_filename(filepath)}")
-            display_info("")
+        display_info(f"> Scanned files in reference {ref}")
+        filepaths = filter_iac_filepaths(directory, get_git_filepaths(directory, ref))
+        for filepath in filepaths:
+            display_info(f"- {click.format_filename(filepath)}")
+        display_info("")
 
     current_ref = INDEX_REF if include_staged else "HEAD"
     if verbose:
@@ -106,32 +94,22 @@ def iac_scan_diff(
             display_info(f"- {click.format_filename(filepath)}")
 
     # Check if IaC files were created, deleted or modified
-    if ref is None:
-        # This means we are scanning all commits up to now.
-        # TODO: We might want to check that some changes exist
-        # to prevent from scanning a new and empty git repository
-        pass
-    else:
-        files_status = get_diff_files_status(
-            wd=str(directory), ref=ref, staged=include_staged, similarity=100
-        )
-        modified_modes = [Filemode.NEW, Filemode.DELETE, Filemode.MODIFY]
-        modified_iac_files = [
-            file
-            for file, mode in files_status.items()
-            if mode in modified_modes
-            and not is_filepath_excluded(str(file), exclusion_regexes)
-            and is_iac_file_path(file)
-        ]
-
-        if len(modified_iac_files) == 0:
-            return IaCSkipScanResult()
-
-    reference_tar = (
-        get_iac_tar(directory, ref, exclusion_regexes)
-        if ref is not None
-        else get_empty_tar()
+    files_status = get_diff_files_status(
+        wd=str(directory), ref=ref, staged=include_staged, similarity=100
     )
+    modified_modes = [Filemode.NEW, Filemode.DELETE, Filemode.MODIFY]
+    modified_iac_files = [
+        file
+        for file, mode in files_status.items()
+        if mode in modified_modes
+        and not is_filepath_excluded(str(file), exclusion_regexes)
+        and is_iac_file_path(file)
+    ]
+
+    if len(modified_iac_files) == 0:
+        return IaCSkipScanResult()
+
+    reference_tar = get_iac_tar(directory, ref, exclusion_regexes)
     current_tar = get_iac_tar(directory, current_ref, exclusion_regexes)
 
     scan_parameters = IaCScanParameters(

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -40,15 +40,15 @@ def scan_pre_push_cmd(
     directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    if all:
+    _, remote_commit = collect_commits_refs(prepush_args)
+    # Will happen if this is the first push on the branch
+    has_no_remote_commit = (
+        remote_commit is None or "~1" in remote_commit or remote_commit == EMPTY_SHA
+    )
+
+    if all or has_no_remote_commit:
         result = iac_scan_all(ctx, directory)
         return display_iac_scan_all_result(ctx, directory, result)
     else:
-        _, remote_commit = collect_commits_refs(prepush_args)
-
-        # Will happen if this is the first push on the branch
-        if "~1" in remote_commit or remote_commit == EMPTY_SHA:
-            remote_commit = None
-
         result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
         return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -11,6 +11,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 )
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.text_utils import display_warning
+from ggshield.core.utils import EMPTY_SHA
 
 
 @click.command()
@@ -38,11 +39,11 @@ def scan_pre_push_cmd(
     _, remote_commit = collect_commits_refs(prepush_args)
 
     # Will happen if this is the first push on the branch
-    if "~1" in remote_commit:
+    if "~1" in remote_commit or remote_commit == EMPTY_SHA:
         remote_commit = None
 
     directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    result = iac_scan_diff(ctx, directory, "@{upstream}", include_staged=False)
+    result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, List, Sequence
 
 import click
 
@@ -7,25 +7,25 @@ from ggshield.cmd.iac.scan.diff import display_iac_scan_diff_result, iac_scan_di
 from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     all_option,
-    directory_argument,
     update_context,
 )
+from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.text_utils import display_warning
 
 
 @click.command()
+@click.argument("prepush_args", nargs=-1, type=click.UNPROCESSED)
 @add_iac_scan_common_options()
 @all_option
-@directory_argument
 @click.pass_context
 def scan_pre_push_cmd(
     ctx: click.Context,
+    prepush_args: List[str],
     exit_zero: bool,
     minimum_severity: str,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
     all: bool,
-    directory: Optional[Path] = None,
     **kwargs: Any,
 ) -> int:
     """
@@ -35,8 +35,13 @@ def scan_pre_push_cmd(
         "This feature is still in beta, its behavior may change in future versions."
     )
 
-    if directory is None:
-        directory = Path().resolve()
+    _, remote_commit = collect_commits_refs(prepush_args)
+
+    # Will happen if this is the first push on the branch
+    if "~1" in remote_commit:
+        remote_commit = None
+
+    directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
     result = iac_scan_diff(ctx, directory, "@{upstream}", include_staged=False)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -3,6 +3,7 @@ from typing import Any, List, Sequence
 
 import click
 
+from ggshield.cmd.iac.scan.all import display_iac_scan_all_result, iac_scan_all
 from ggshield.cmd.iac.scan.diff import display_iac_scan_diff_result, iac_scan_diff
 from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
@@ -36,14 +37,18 @@ def scan_pre_push_cmd(
         "This feature is still in beta, its behavior may change in future versions."
     )
 
-    _, remote_commit = collect_commits_refs(prepush_args)
-
-    # Will happen if this is the first push on the branch
-    if "~1" in remote_commit or remote_commit == EMPTY_SHA:
-        remote_commit = None
-
     directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
-    return display_iac_scan_diff_result(ctx, directory, result)
+    if all:
+        result = iac_scan_all(ctx, directory)
+        return display_iac_scan_all_result(ctx, directory, result)
+    else:
+        _, remote_commit = collect_commits_refs(prepush_args)
+
+        # Will happen if this is the first push on the branch
+        if "~1" in remote_commit or remote_commit == EMPTY_SHA:
+            remote_commit = None
+
+        result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
+        return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -1,7 +1,5 @@
 import logging
-import os
-import sys
-from typing import Any, List, Optional, Tuple
+from typing import Any, List
 
 import click
 
@@ -10,13 +8,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.core.errors import handle_exception
-from ggshield.core.git_shell import (
-    check_git_dir,
-    get_list_commit_SHA,
-    git,
-    is_valid_git_commit_ref,
-)
-from ggshield.core.text_utils import display_warning
+from ggshield.core.git_hooks.prepush import BYPASS_MESSAGE, collect_commits_refs
+from ggshield.core.git_shell import check_git_dir, get_list_commit_SHA
 from ggshield.core.utils import EMPTY_SHA, EMPTY_TREE
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.secret.output.messages import remediation_message
@@ -25,27 +18,10 @@ from ggshield.secret.repo import scan_commit_range
 
 logger = logging.getLogger(__name__)
 
-OUTDATED_HOOK_MESSAGE = """The installed pre-push hook did not pass its command-line arguments to ggshield. This can cause the hook to fail if the name of the remote you are pushing to is not "origin".
-
-This can happen if the hook has been created manually or by an old version of ggshield.
-
-To fix it, either edit the hook manually or make a backup of it and reinstall it with the following command:
-
-    ggshield install -m local -t pre-push -f
-"""  # noqa: E501
-
 
 REMEDIATION_STEPS = """  Since the secret was detected before the push BUT after the commit, you need to:
   1. rewrite the git history making sure to replace the secret with its reference (e.g. environment variable).
   2. push again."""
-
-BYPASS_MESSAGE = """  - if you use the pre-commit framework:
-
-     SKIP=ggshield-push git push
-
-  - otherwise (warning: the following command bypasses all pre-push hooks):
-
-     git push --no-verify"""
 
 
 @click.command()
@@ -58,14 +34,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
     """
     config = ctx.obj["config"]
 
-    local_commit, remote_commit = collect_from_precommit_env()
-    if local_commit is None or remote_commit is None:
-        if len(prepush_args) == 0:
-            display_warning(OUTDATED_HOOK_MESSAGE)
-            remote_name = "origin"
-        else:
-            remote_name = prepush_args[0]
-        local_commit, remote_commit = collect_from_stdin(remote_name)
+    local_commit, remote_commit = collect_commits_refs(prepush_args)
     logger.debug("refs=(%s, %s)", local_commit, remote_commit)
 
     if local_commit == EMPTY_SHA:
@@ -139,72 +108,3 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
         return return_code
     except Exception as error:
         return handle_exception(error, config.verbose)
-
-
-def find_branch_start(commit: str, remote: str) -> Optional[str]:
-    """
-    Returns the first local-only commit of the branch.
-    Returns None if the branch does not contain any new commit.
-    """
-    # List all ancestors of `commit` which are not in `remote`
-    # Based on _pre_push_ns() from pre-commit
-    #
-    # Note: The `--remotes` argument MUST be set using a `=`: `--remotes={remote}` works,
-    # but `--remotes {remote}` fails.
-    output = git(
-        [
-            "rev-list",
-            commit,
-            "--topo-order",
-            "--reverse",
-            "--not",
-            f"--remotes={remote}",
-        ]
-    )
-    ancestors = output.splitlines()
-
-    if ancestors:
-        return ancestors[0]
-    return None
-
-
-def collect_from_stdin(remote_name: str) -> Tuple[str, str]:
-    """
-    Collect pre-commit variables from stdin.
-    """
-    prepush_input = sys.stdin.read().strip()
-    logger.debug("input=%s", prepush_input)
-    if not prepush_input:
-        # Happens when there's nothing to push
-        return (EMPTY_SHA, EMPTY_SHA)
-
-    # TODO There can be more than one line here, for example when pushing multiple
-    # branches. We should support this.
-    line = prepush_input.splitlines()[0]
-    _, local_commit, _, remote_commit = line.split(maxsplit=3)
-
-    if is_valid_git_commit_ref(remote_commit):
-        # Pushing to an existing branch
-        return (local_commit, remote_commit)
-
-    # Pushing to a new branch
-    start_commit = find_branch_start(local_commit, remote_name)
-    if start_commit is None:
-        return local_commit, local_commit
-    return (local_commit, f"{start_commit}~1")
-
-
-def collect_from_precommit_env() -> Tuple[Optional[str], Optional[str]]:
-    """
-    Collect from pre-commit framework environment.
-    """
-    # pre-commit framework <2.2.0
-    local_commit = os.getenv("PRE_COMMIT_SOURCE", None)
-    remote_commit = os.getenv("PRE_COMMIT_ORIGIN", None)
-
-    if local_commit is None or remote_commit is None:
-        # pre-commit framework >=2.2.0
-        local_commit = os.getenv("PRE_COMMIT_FROM_REF", None)
-        remote_commit = os.getenv("PRE_COMMIT_TO_REF", None)
-
-    return (local_commit, remote_commit)

--- a/ggshield/core/git_hooks/prepush.py
+++ b/ggshield/core/git_hooks/prepush.py
@@ -1,0 +1,110 @@
+import logging
+import os
+import sys
+from typing import List, Optional, Tuple
+
+from ggshield.core.git_shell import git, is_valid_git_commit_ref
+from ggshield.core.text_utils import display_warning
+from ggshield.core.utils import EMPTY_SHA
+
+
+logger = logging.getLogger(__name__)
+
+
+OUTDATED_HOOK_MESSAGE = """The installed pre-push hook did not pass its command-line arguments to ggshield. This can cause the hook to fail if the name of the remote you are pushing to is not "origin".
+
+This can happen if the hook has been created manually or by an old version of ggshield.
+
+To fix it, either edit the hook manually or make a backup of it and reinstall it with the following command:
+
+    ggshield install -m local -t pre-push -f
+"""  # noqa: E501
+
+BYPASS_MESSAGE = """  - if you use the pre-commit framework:
+
+     SKIP=ggshield-push git push
+
+  - otherwise (warning: the following command bypasses all pre-push hooks):
+
+     git push --no-verify"""
+
+
+def find_branch_start(commit: str, remote: str) -> Optional[str]:
+    """
+    Returns the first local-only commit of the branch.
+    Returns None if the branch does not contain any new commit.
+    """
+    # List all ancestors of `commit` which are not in `remote`
+    # Based on _pre_push_ns() from pre-commit
+    #
+    # Note: The `--remotes` argument MUST be set using a `=`: `--remotes={remote}` works,
+    # but `--remotes {remote}` fails.
+    output = git(
+        [
+            "rev-list",
+            commit,
+            "--topo-order",
+            "--reverse",
+            "--not",
+            f"--remotes={remote}",
+        ]
+    )
+    ancestors = output.splitlines()
+
+    if ancestors:
+        return ancestors[0]
+    return None
+
+
+def collect_commits_from_stdin(remote_name: str) -> Tuple[str, str]:
+    """
+    Collect pre-commit variables from stdin.
+    """
+    prepush_input = sys.stdin.read().strip()
+    logger.debug("input=%s", prepush_input)
+    if not prepush_input:
+        # Happens when there's nothing to push
+        return (EMPTY_SHA, EMPTY_SHA)
+
+    # TODO There can be more than one line here, for example when pushing multiple
+    # branches. We should support this.
+    line = prepush_input.splitlines()[0]
+    _, local_commit, _, remote_commit = line.split(maxsplit=3)
+
+    if is_valid_git_commit_ref(remote_commit):
+        # Pushing to an existing branch
+        return (local_commit, remote_commit)
+
+    # Pushing to a new branch
+    start_commit = find_branch_start(local_commit, remote_name)
+    if start_commit is None:
+        return local_commit, local_commit
+    return (local_commit, f"{start_commit}~1")
+
+
+def collect_commits_from_precommit_env() -> Tuple[Optional[str], Optional[str]]:
+    """
+    Collect from pre-commit framework environment.
+    """
+    # pre-commit framework <2.2.0
+    local_commit = os.getenv("PRE_COMMIT_SOURCE", None)
+    remote_commit = os.getenv("PRE_COMMIT_ORIGIN", None)
+
+    if local_commit is None or remote_commit is None:
+        # pre-commit framework >=2.2.0
+        local_commit = os.getenv("PRE_COMMIT_FROM_REF", None)
+        remote_commit = os.getenv("PRE_COMMIT_TO_REF", None)
+
+    return (local_commit, remote_commit)
+
+
+def collect_commits_refs(prepush_args: List[str] = []) -> Tuple[str, str]:
+    local_commit, remote_commit = collect_commits_from_precommit_env()
+    if local_commit is None or remote_commit is None:
+        if len(prepush_args) == 0:
+            display_warning(OUTDATED_HOOK_MESSAGE)
+            remote_name = "origin"
+        else:
+            remote_name = prepush_args[0]
+        local_commit, remote_commit = collect_commits_from_stdin(remote_name)
+    return (local_commit, remote_commit)

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -321,6 +321,7 @@ def tar_from_ref_and_filepaths(
     return tar_stream.getvalue()
 
 
+@lru_cache(None)
 def get_empty_tar() -> bytes:
     bytes = BytesIO()
     file = tarfile.open(fileobj=bytes, mode="w:gz")

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -235,7 +235,6 @@ def get_diff_files_status(
     check_git_ref(wd=wd, ref=ref)
 
     def parse_name_status_patch(patch: str) -> Dict[Path, Filemode]:
-
         status_to_filemode = {
             "A": Filemode.NEW,
             "D": Filemode.DELETE,
@@ -320,3 +319,10 @@ def tar_from_ref_and_filepaths(
             tar.addfile(tarinfo, fileobj=data)
 
     return tar_stream.getvalue()
+
+
+def get_empty_tar() -> bytes:
+    bytes = BytesIO()
+    file = tarfile.open(fileobj=bytes, mode="w:gz")
+    file.close()
+    return bytes.getvalue()

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -319,11 +319,3 @@ def tar_from_ref_and_filepaths(
             tar.addfile(tarinfo, fileobj=data)
 
     return tar_stream.getvalue()
-
-
-@lru_cache(None)
-def get_empty_tar() -> bytes:
-    bytes = BytesIO()
-    file = tarfile.open(fileobj=bytes, mode="w:gz")
-    file.close()
-    return bytes.getvalue()

--- a/tests/functional/iac/test_iac_scan_prepush.py
+++ b/tests/functional/iac/test_iac_scan_prepush.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from subprocess import CalledProcessError
+from typing import List, Optional
 
 import pytest
 
-from tests.conftest import _IAC_SINGLE_VULNERABILITY
+from tests.conftest import _IAC_NO_VULNERABILITIES, _IAC_SINGLE_VULNERABILITY
 from tests.functional.utils import create_local_hook
 from tests.repository import Repository
 
@@ -59,3 +60,38 @@ def test_iac_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:
     # WHEN I try to push the branch
     # THEN the hook does not crash
     local_repo.push("-u", "origin", branch_name)
+
+
+@pytest.mark.parametrize("scan_args", [None, ["--all"]])
+def test_iac_scan_prepush_vuln_before_hook(
+    tmp_path: Path, scan_args: Optional[List[str]]
+) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone with a vulnerability
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+    file = local_repo.path / "vuln_before_hook.tf"
+    file.write_text(_IAC_SINGLE_VULNERABILITY)
+    local_repo.add("vuln_before_hook.tf")
+    local_repo.create_commit()
+    local_repo.push()
+
+    # AND ggshield later installed as a pre-push hook
+    create_local_hook(tmp_path / "local" / ".git" / "hooks", "pre-push", args=scan_args)
+
+    # AND changes to IaC files introducing no new vulnerability
+    file = local_repo.path / "no_vuln.tf"
+    file.write_text(_IAC_NO_VULNERABILITIES)
+    local_repo.add("no_vuln.tf")
+    local_repo.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook prevents the push if and only if --all is specified
+    if scan_args is None:
+        local_repo.push()
+    else:
+        with pytest.raises(CalledProcessError) as exc:
+            local_repo.push()
+            stdout = exc.value.stdout.decode()
+            assert "vuln_before_hook.tf" in stdout

--- a/tests/functional/iac/test_iac_scan_prepush.py
+++ b/tests/functional/iac/test_iac_scan_prepush.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from subprocess import CalledProcessError
+
+import pytest
+
+from tests.conftest import _IAC_SINGLE_VULNERABILITY
+from tests.functional.utils import create_local_hook
+from tests.repository import Repository
+
+
+def test_iac_scan_prepush(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+    local_repo.create_commit()
+    local_repo.push()
+
+    # AND ggshield installed as a pre-push hook
+    create_local_hook(tmp_path / "local" / ".git" / "hooks", "pre-push")
+
+    # AND a vulnerability committed
+    file = local_repo.path / "vuln.tf"
+    file.write_text(_IAC_SINGLE_VULNERABILITY)
+    local_repo.add("vuln.tf")
+    local_repo.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook prevents the push
+    with pytest.raises(CalledProcessError) as exc:
+        local_repo.push()
+
+    # AND the error message contains the vulnerability
+    stdout = exc.value.stdout.decode()
+    assert "1 new incident" in stdout
+    assert "vuln.tf" in stdout
+
+
+def test_iac_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    # Add a commit to the remote repository, otherwise git complains the branch does not
+    # contain anything
+    local_repo.create_commit()
+    local_repo.push()
+
+    # AND ggshield installed as a pre-push hook
+    create_local_hook(tmp_path / "local" / ".git" / "hooks", "pre-push")
+
+    # AND a branch without new commits
+    branch_name = "topic"
+    local_repo.create_branch(branch_name)
+
+    # WHEN I try to push the branch
+    # THEN the hook does not crash
+    local_repo.push("-u", "origin", branch_name)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import Optional, Union
@@ -64,3 +65,19 @@ def recreate_censored_content(content: str, matched_string: str) -> str:
     """Applies ggshield censoring to any occurrence of `matched_string` inside
     `content`. Returns the censored string."""
     return content.replace(matched_string, recreate_censored_string(matched_string))
+
+
+# Use this in iac tests until iac hooks are added to the install command
+# Meaning they are added to install.py
+def create_local_hook(
+    hook_dir_path: Path,
+    hook_type: str,
+) -> None:
+    """Create hook directory (if needed) and pre-commit/pre-push file."""
+    hook_dir_path.mkdir(parents=True, exist_ok=True)
+    hook_path = hook_dir_path / hook_type
+
+    with hook_path.open("w") as f:
+        f.write("#!/usr/bin/env sh\n")
+        f.write(f'ggshield iac scan {hook_type} "$@"\n')
+        os.chmod(hook_path, 0o700)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import pytest
 from pygitguardian.models import Match
@@ -70,14 +70,15 @@ def recreate_censored_content(content: str, matched_string: str) -> str:
 # Use this in iac tests until iac hooks are added to the install command
 # Meaning they are added to install.py
 def create_local_hook(
-    hook_dir_path: Path,
-    hook_type: str,
+    hook_dir_path: Path, hook_type: str, args: Optional[List[str]] = None
 ) -> None:
     """Create hook directory (if needed) and pre-commit/pre-push file."""
     hook_dir_path.mkdir(parents=True, exist_ok=True)
     hook_path = hook_dir_path / hook_type
 
+    args = args or []
+
     with hook_path.open("w") as f:
         f.write("#!/usr/bin/env sh\n")
-        f.write(f'ggshield iac scan {hook_type} "$@"\n')
+        f.write(f'ggshield iac scan {hook_type} {" ".join(args)} "$@"\n')
         os.chmod(hook_path, 0o700)

--- a/tests/unit/cassettes/test_iac_scan_prepush_no_iac_changes_all.yaml
+++ b/tests/unit/cassettes/test_iac_scan_prepush_no_iac_changes_all.yaml
@@ -1,0 +1,85 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS1iZmM0NTQ1NTM0ZGI0ZDljNTcwZDdmNzk5YzRkOWYyNQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS1iZmM0NTQ1NTM0ZGI0ZDljNTcwZDdm
+        Nzk5YzRkOWYyNQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAa4K2ZAL/7dSxboMwEAZgZp7C4gEINtgh
+        Q6SOHfsGlnFMi2JiZIwSqeq71zRNmqFVp0Rq83+L4Q7fTT/5Il88PKnDo1Eb45OrKI5+OouirL6e
+        5zotGGUJOSQ3MI1B+bg+uU+sJn3oerOmol6JmvGyzpdLKpjgaQL/Xqe0bEzrvJEvzm3z0F4n/0J8
+        ZJwuOb08j/GnPKFVxTkvKOVlzD8XZZmQ4pb5H9RkGzPabvf9d7/1/6jUm9FNXhuSqf0odybsnd9K
+        pa30kzUZyRq1keag+mF+e00JMc/xzkhO1qRVdjSxMXgXnHb23MiCHrLYaL3r5eB8ODUYi9XgLmrn
+        6rw1rg+d230OUda6/TxGdxsvG+v09jSfspyWOa1yyrP0DT8sAAAAAAAAAAAAAAAAAAAAuEfvYZie
+        hwAoAAANCi0tYmZjNDU0NTUzNGRiNGQ5YzU3MGQ3Zjc5OWM0ZDlmMjUtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '615'
+        Content-Type:
+          - multipart/form-data; boundary=bfc4545534db4d9c570d7f799c4d9f25
+        GGShield-Command-Id:
+          - d3c05eec-7daa-40ee-9b89-fb73709e5085
+        GGShield-Command-Path:
+          - cli iac scan pre-push
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.4
+        GGShield-Version:
+          - 1.17.2
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.4) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_scan
+    response:
+      body:
+        string: '{"id":"8c6248ed-8ba1-45d7-953b-0392f6f392f6","iac_engine_version":"1.10.2","type":"path_scan","entities_with_incidents":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '123'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 18 Jul 2023 12:15:41 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.34.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '1522'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.93.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_iac_scan_prepush_output_all.yaml
+++ b/tests/unit/cassettes/test_iac_scan_prepush_output_all.yaml
@@ -1,0 +1,87 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS1mMjk2ODY0N2M4YjZiNTQ4ZDZmYjJiY2Y3ZTZhNDdiOQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS1mMjk2ODY0N2M4YjZiNTQ4ZDZmYjJi
+        Y2Y3ZTZhNDdiOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJlY3Rv
+        cnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAJ4G2ZAL/7dS7asMwGAVgzX4KoQdwdLcz
+        BDpmzJDdyIkKBvmCLDeG0Hev3Q7t0NIpKW3PtxzxS/BPR/km3zwc3Lz37uwjuQn+5qvkXKn38zoX
+        XApB6EzuYBqTi8t68j/Jgrapaf1O2HJrSymFzgtVllZnBP6+pyl0eXq86Y611NbqNUVhxMd8Jbgi
+        QmtjDOdaF0v/lZFL//k9+z+4KdR+DE33+bvv7n+pLPqxn+LJU+YuY+VCXYVmTL7zkVFWu3PlZ9cO
+        wTN6zSgdYp/6Ux/ojrL98Xhg2TP+CQAAAAAAAAAAAAAAAAAAAICf9AK/GCfDACgAAA0KLS1mMjk2
+        ODY0N2M4YjZiNTQ4ZDZmYjJiY2Y3ZTZhNDdiOS0tDQo=
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '545'
+        Content-Type:
+          - multipart/form-data; boundary=f2968647c8b6b548d6fb2bcf7e6a47b9
+        GGShield-Command-Id:
+          - 5b095f38-fbfc-408f-9d23-b46511d82839
+        GGShield-Command-Path:
+          - cli iac scan pre-push
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.4
+        GGShield-Version:
+          - 1.17.2
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.4) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_scan
+    response:
+      body:
+        string:
+          '{"id":"df40575d-b1e6-4f3d-ad75-34a487ad43be","iac_engine_version":"1.10.2","type":"path_scan","entities_with_incidents":[{"filename":"vuln.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '487'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 18 Jul 2023 12:10:16 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.34.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '1337'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.93.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_iac_scan_prepush_output_diff.yaml
+++ b/tests/unit/cassettes/test_iac_scan_prepush_output_diff.yaml
@@ -1,0 +1,88 @@
+interactions:
+  - request:
+      body: !!binary |
+        LS0xNzAzNDFiZmMxZWYwNjVjYWI5M2U5NjIwN2ZlMDA5NA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsiaWdub3JlZF9wb2xpY2llcyI6
+        IFtdLCAibWluaW11bV9zZXZlcml0eSI6ICJMT1cifQ0KLS0xNzAzNDFiZmMxZWYwNjVjYWI5M2U5
+        NjIwN2ZlMDA5NA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJyZWZlcmVu
+        Y2UiOyBmaWxlbmFtZT0icmVmZXJlbmNlIg0KDQofiwgAI4G2ZAL/7cEBDQAAAMKg909tDjegAAAA
+        AAAAAAAAgDcDmt4dJwAoAAANCi0tMTcwMzQxYmZjMWVmMDY1Y2FiOTNlOTYyMDdmZTAwOTQNCkNv
+        bnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iY3VycmVudCI7IGZpbGVuYW1lPSJj
+        dXJyZW50Ig0KDQofiwgAI4G2ZAL/7c2xCsIwGMTxzH2KjzyAxNLq5O7o0L2kNYIQG0lSFcR3tyg4
+        uKuD/99yxy13Gv0wyzv1SWayqKpHTt7TzE356s99Wda1EqO+YEzZxulS/aciuhTG2DvR9pxa67vW
+        71N2g4tadGe3rbvYw9E7LddC5BhDDn3wshK9bpqNLm4KAAAAAAAAAAAAAAAAAPADd8FEniIAKAAA
+        DQotLTE3MDM0MWJmYzFlZjA2NWNhYjkzZTk2MjA3ZmUwMDk0LS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '610'
+        Content-Type:
+          - multipart/form-data; boundary=170341bfc1ef065cab93e96207fe0094
+        GGShield-Command-Id:
+          - babd44f0-f2d8-4d4d-ae67-2efdf35a3a90
+        GGShield-Command-Path:
+          - cli iac scan pre-push
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '20.04'
+        GGShield-Python-Version:
+          - 3.10.4
+        GGShield-Version:
+          - 1.17.2
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.4) ggshield
+        mode:
+          - diff
+      method: POST
+      uri: https://api.gitguardian.com/v1/iac_diff_scan
+    response:
+      body:
+        string:
+          '{"id":"1c35cf53-d150-43d0-936b-a587e56b2332","iac_engine_version":"1.10.2","type":"diff_scan","entities_with_incidents":{"unchanged":[],"deleted":[],"new":[{"filename":"vuln.tf","incidents":[{"policy":"Plain
+          HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '523'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Tue, 18 Jul 2023 12:10:14 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.34.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '2220'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.93.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/iac/test_scan_prepush.py
+++ b/tests/unit/cmd/iac/test_scan_prepush.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+from click.testing import CliRunner
+
+from ggshield.cmd.main import cli
+from ggshield.secret.repo import cd
+from tests.conftest import _IAC_NO_VULNERABILITIES, _IAC_SINGLE_VULNERABILITY
+from tests.repository import Repository
+from tests.unit.conftest import my_vcr
+
+
+@pytest.mark.parametrize(
+    "scan_arg,cassette",
+    [
+        (None, "test_iac_scan_prepush_output_diff"),
+        ("--all", "test_iac_scan_prepush_output_all"),
+    ],
+)
+def test_iac_scan_prepush_output(
+    tmp_path: Path,
+    cli_fs_runner: CliRunner,
+    scan_arg: Optional[List[str]],
+    cassette: str,
+) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    # AND a commit with a vulnerability
+    sha = local_repo.create_commit()
+    file = local_repo.path / "vuln.tf"
+    file.write_text(_IAC_SINGLE_VULNERABILITY)
+    local_repo.add("vuln.tf")
+    local_repo.create_commit()
+
+    # WHEN executing the prepush command with or without the '--all' option
+    with cd(str(tmp_path / "local")):
+        args = ["iac", "scan", "pre-push"]
+        if scan_arg is not None:
+            args.append(scan_arg)
+
+        with my_vcr.use_cassette(cassette):
+            result = cli_fs_runner.invoke(
+                cli,
+                args,
+                env={"PRE_COMMIT_FROM_REF": "", "PRE_COMMIT_TO_REF": sha},
+            )
+        # THEN the scan output format is correct
+        if scan_arg is None:
+            assert result.exit_code == 1
+            assert "1 new incident detected" in result.stdout
+            assert "vuln.tf" in result.stdout
+            assert "1 incident detected" not in result.stdout
+        else:
+            assert result.exit_code == 1
+            assert "1 incident detected" in result.stdout
+            assert "vuln.tf" in result.stdout
+            assert "1 new incident detected" not in result.stdout
+
+
+@pytest.mark.parametrize("scan_arg", [None, "--all"])
+@my_vcr.use_cassette("test_iac_scan_prepush_no_iac_changes_all")
+def test_iac_scan_prepush_no_iac_changes(
+    tmp_path: Path, cli_fs_runner: CliRunner, scan_arg: Optional[List[str]]
+) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+    file = local_repo.path / "iac_before_hook.tf"
+    file.write_text(_IAC_NO_VULNERABILITIES)
+    local_repo.add("iac_before_hook.tf")
+    local_repo.create_commit()
+    local_repo.push()
+
+    # WHEN executing the prepush command with no IaC file in commits
+    file = local_repo.path / "non_iac.txt"
+    file.write_text("This should not be detected")
+    local_repo.add("non_iac.txt")
+    sha = local_repo.create_commit()
+
+    with cd(str(tmp_path / "local")):
+        args = ["iac", "scan", "pre-push"]
+        if scan_arg is not None:
+            args.append(scan_arg)
+
+        result = cli_fs_runner.invoke(
+            cli,
+            args,
+            env={"PRE_COMMIT_FROM_REF": "", "PRE_COMMIT_TO_REF": sha},
+        )
+        # THEN the scan is performed if and only if '--all' is specified
+        if scan_arg is None:
+            assert result.exit_code == 0
+            assert "No IaC files changed" in result.stdout
+            assert "iac_before_hook.tf" not in result.stdout
+        else:
+            assert result.exit_code == 0
+            assert "No incidents have been found" in result.stdout
+            assert "iac_before_hook.tf" not in result.stdout
+
+
+def test_iac_scan_prepush_no_iac_files(
+    tmp_path: Path, cli_fs_runner: CliRunner
+) -> None:
+    # GIVEN a remote repository
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+
+    # AND a local clone
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+    file = local_repo.path / "before_hook.txt"
+    file.write_text("This should not be detected")
+    local_repo.add("before_hook.txt")
+    local_repo.create_commit()
+    local_repo.push()
+
+    # WHEN executing the prepush command with --all option and no IaC file in repo
+    file = local_repo.path / "non_iac.txt"
+    file.write_text("This should not be detected")
+    local_repo.add("non_iac.txt")
+    sha = local_repo.create_commit()
+
+    with cd(str(tmp_path / "local")):
+        result = cli_fs_runner.invoke(
+            cli,
+            ["iac", "scan", "pre-push", "--all"],
+            env={"PRE_COMMIT_FROM_REF": "", "PRE_COMMIT_TO_REF": sha},
+        )
+        # THEN no scan is performed
+        assert result.exit_code == 0
+        assert "No IaC files detected" in result.stdout
+        assert "before_hook.tf" not in result.stdout
+        assert "non_iac.tf" not in result.stdout

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import tarfile
 from io import BytesIO
 from pathlib import Path
@@ -10,7 +9,6 @@ from click import UsageError
 from ggshield.core.git_shell import (
     check_git_dir,
     check_git_ref,
-    get_empty_tar,
     get_filepaths_from_ref,
     get_staged_filepaths,
     git,
@@ -177,19 +175,3 @@ def test_tar_from_ref_and_filepaths(tmp_path):
         filenames = tar.getnames()
         # THEN only first file in in tar
         assert filenames == [first_file_name]
-
-
-def test_get_empty_tar():
-    # WHEN creating an empty tar
-    empty_tar_bytes = get_empty_tar()
-    tar_stream = BytesIO(empty_tar_bytes)
-
-    # THEN the file is considered as a .tar
-    version = sys.version_info
-    # `tarfile.is_tarfile` won't work until Python 3.9
-    if version.major > 3 or version.major == 3 and version.minor > 8:
-        assert tarfile.is_tarfile(tar_stream)
-
-    # AND it contains no file
-    with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
-        assert len(tar.getmembers()) == 0

--- a/tests/unit/core/test_git_shell.py
+++ b/tests/unit/core/test_git_shell.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tarfile
 from io import BytesIO
 from pathlib import Path
@@ -9,6 +10,7 @@ from click import UsageError
 from ggshield.core.git_shell import (
     check_git_dir,
     check_git_ref,
+    get_empty_tar,
     get_filepaths_from_ref,
     get_staged_filepaths,
     git,
@@ -175,3 +177,19 @@ def test_tar_from_ref_and_filepaths(tmp_path):
         filenames = tar.getnames()
         # THEN only first file in in tar
         assert filenames == [first_file_name]
+
+
+def test_get_empty_tar():
+    # WHEN creating an empty tar
+    empty_tar_bytes = get_empty_tar()
+    tar_stream = BytesIO(empty_tar_bytes)
+
+    # THEN the file is considered as a .tar
+    version = sys.version_info
+    # `tarfile.is_tarfile` won't work until Python 3.9
+    if version.major > 3 or version.major == 3 and version.minor > 8:
+        assert tarfile.is_tarfile(tar_stream)
+
+    # AND it contains no file
+    with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
+        assert len(tar.getmembers()) == 0


### PR DESCRIPTION
Command meant to be used in a pre-push git hook to scan iac files for vulnerabilities.

Some parts to focus on:
- moved some functions from `ggshield/cmd/secret/scan/prepush.py` to `ggshield/core/git_hooks/prepush.py` in order for them to be used both in secrets and iac (and maybe sca in the future)