### PR TITLE
sort paths to enable iac scan all caching

### DIFF
--- a/ggshield/cmd/iac/scan/scan.py
+++ b/ggshield/cmd/iac/scan/scan.py
@@ -70,7 +70,9 @@ def iac_scan_all(
     scan_parameters = IaCScanParameters(
         config.user_config.iac.ignored_policies, config.user_config.iac.minimum_severity
     )
-
+    # If paths are not sorted, the tar bytes order will be different when calling the function twice
+    # Different bytes order will cause different tarfile hash_key resulting in a GIM cache bypass.
+    paths.sort()
     scan = client.iac_directory_scan(
         directory,
         paths,


### PR DESCRIPTION
When receiving tar files in GIM, we first hash the tarfile bytes content to generate a key used for caching.
The goal is to not scan the same tar file twice.

However, the order of bytes are important and if we do not generate the tarfile using always the same path order, the tarfile will have different bytes order (event if the uncompressed directory is the same)