### PR TITLE
teolohrer/iac 116 create ggshield iac scan pre receive command

### DIFF
--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -69,9 +69,10 @@ _ignore_path_option = click.option(
 
 all_option = click.option(
     "--all",
+    "scan_all",
     is_flag=True,
-    default=None,
-    help="Raise all vulnerabilities in the final state.",
+    default=False,
+    help="Reports all vulnerabilities in the final state.",
 )
 
 directory_argument = click.argument(

--- a/ggshield/cmd/iac/scan/precommit.py
+++ b/ggshield/cmd/iac/scan/precommit.py
@@ -25,7 +25,7 @@ def scan_pre_commit_cmd(
     minimum_severity: str,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
-    all: bool,
+    scan_all: bool,
     directory: Optional[Path] = None,
     **kwargs: Any,
 ) -> int:
@@ -38,7 +38,7 @@ def scan_pre_commit_cmd(
     if directory is None:
         directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
-    if all:
+    if scan_all:
         result = iac_scan_all(ctx, directory)
         return display_iac_scan_all_result(ctx, directory, result)
     result = iac_scan_diff(ctx, directory, "HEAD", include_staged=True)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -27,7 +27,7 @@ def scan_pre_push_cmd(
     minimum_severity: str,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
-    all: bool,
+    scan_all: bool,
     **kwargs: Any,
 ) -> int:
     """
@@ -46,7 +46,7 @@ def scan_pre_push_cmd(
         remote_commit is None or "~1" in remote_commit or remote_commit == EMPTY_SHA
     )
 
-    if all or has_no_remote_commit:
+    if scan_all or has_no_remote_commit:
         result = iac_scan_all(ctx, directory)
         return display_iac_scan_all_result(ctx, directory, result)
     else:

--- a/ggshield/cmd/iac/scan/prereceive.py
+++ b/ggshield/cmd/iac/scan/prereceive.py
@@ -1,42 +1,103 @@
+import logging
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 import click
+from pygitguardian.iac_models import IaCScanResult
 
-from ggshield.cmd.iac.scan.diff import display_iac_scan_diff_result, iac_scan_diff
+from ggshield.cmd.iac.scan.diff import iac_scan_diff
 from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     all_option,
-    directory_argument,
     update_context,
 )
-from ggshield.core.text_utils import display_warning
+from ggshield.cmd.iac.scan.iac_scan_utils import (
+    IaCSkipScanResult,
+    create_output_handler,
+)
+from ggshield.core.git_hooks.prereceive import get_breakglass_option, parse_stdin
+from ggshield.core.git_shell import check_git_ref, is_valid_git_commit_ref
+from ggshield.core.utils import EMPTY_TREE
+from ggshield.iac.collection.iac_diff_scan_collection import IaCDiffScanCollection
+from ggshield.iac.collection.iac_path_scan_collection import IaCPathScanCollection
+
+
+logger = logging.getLogger(__name__)
+
+REMEDIATION_MESSAGE = """  A pre-receive hook set server side prevented you from pushing IaC vulnerabilities.
+Apply the recommended remediation steps to remove the vulnerability."""
 
 
 @click.command()
 @add_iac_scan_common_options()
 @all_option
-@directory_argument
 @click.pass_context
 def scan_pre_receive_cmd(
     ctx: click.Context,
+    scan_all: bool,
     exit_zero: bool,
     minimum_severity: str,
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
-    all: bool,
-    directory: Optional[Path] = None,
     **kwargs: Any,
 ) -> int:
     """
-    Scan as pre-receive for IaC vulnerabilities.
-    By default, it will return vulnerabilities added in the received commits.
+    scan as a pre-receive git hook.
     """
-    display_warning(
-        "This feature is still in beta, its behavior may change in future versions."
-    )
-    if directory is None:
-        directory = Path().resolve()
+    if get_breakglass_option():
+        return 0
+
+    before_after = parse_stdin()
+    if before_after is None:
+        return 0
+    else:
+        before, after = before_after
+
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
-    result = iac_scan_diff(ctx, directory, "HEAD", include_staged=False)
-    return display_iac_scan_diff_result(ctx, directory, result)
+
+    if scan_all:
+        # In the pre-receive context, we do not have access to the files,
+        # only git objects. Instead of doing an `iac scan all` command,
+        # we perform a diff scan with the root of the git tree.
+        # Output is handled afterwards, as a scan all.
+        before = EMPTY_TREE
+
+    current_path = Path().resolve()
+
+    check_git_ref(wd=str(current_path), ref=after)
+    if not is_valid_git_commit_ref(wd=str(current_path), ref=before):
+        # When we have a single non-empty commit in the tree,
+        # `before` is set to the parent commit which does not exist
+        before = None
+
+    result = iac_scan_diff(
+        ctx=ctx,
+        directory=current_path,
+        previous_ref=before,
+        include_staged=False,
+        current_ref=after,
+    )
+
+    output_handler = create_output_handler(ctx)
+
+    if isinstance(result, IaCSkipScanResult):
+        return output_handler.process_skip_diff_scan()
+
+    scan = IaCDiffScanCollection(id=str(current_path), result=result)
+
+    if result is not None:
+        if scan_all:
+            # If we performed a scan all, we can convert the diff scan result to
+            # a path scan, extracting the new vulnerabilities.
+            result_all = IaCScanResult(
+                id=result.id,
+                iac_engine_version=result.iac_engine_version,
+                entities_with_incidents=result.entities_with_incidents.new,
+            )
+            result_all.status_code = result.status_code
+            scan_all_collection = IaCPathScanCollection(
+                id=str(current_path), result=result_all
+            )
+            return output_handler.process_scan(scan_all_collection)
+
+    return output_handler.process_diff_scan(scan)

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -3,7 +3,7 @@ import multiprocessing
 import os
 import re
 import sys
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, List, Set
 
 import click
 from pygitguardian import GGClient
@@ -14,10 +14,15 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.config import Config
-from ggshield.core.errors import UnexpectedError, handle_exception
-from ggshield.core.git_shell import get_list_commit_SHA, git
+from ggshield.core.errors import handle_exception
+from ggshield.core.git_hooks.prereceive import (
+    BYPASS_MESSAGE,
+    get_breakglass_option,
+    get_prereceive_timeout,
+    parse_stdin,
+)
+from ggshield.core.git_shell import get_list_commit_SHA
 from ggshield.core.text_utils import display_error
-from ggshield.core.utils import EMPTY_SHA, PRERECEIVE_TIMEOUT
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.secret.output import SecretGitLabWebUIOutputHandler, SecretOutputHandler
 from ggshield.secret.output.messages import remediation_message
@@ -26,48 +31,11 @@ from ggshield.secret.repo import scan_commit_range
 
 logger = logging.getLogger(__name__)
 
+
 REMEDIATION_MESSAGE = """  A pre-receive hook set server side prevented you from pushing secrets.
   Since the secret was detected during the push BUT after the commit, you need to:
   1. rewrite the git history making sure to replace the secret with its reference (e.g. environment variable).
   2. push again."""
-
-BYPASS_MESSAGE = """\n     git push -o breakglass"""
-
-
-def get_prereceive_timeout() -> float:
-    try:
-        return float(os.getenv("GITGUARDIAN_TIMEOUT", PRERECEIVE_TIMEOUT))
-    except BaseException as e:
-        display_error(f"Unable to parse GITGUARDIAN_TIMEOUT: {str(e)}")
-        return PRERECEIVE_TIMEOUT
-
-
-def get_breakglass_option() -> bool:
-    """Test all options passed to git for `breakglass`"""
-    raw_option_count = os.getenv("GIT_PUSH_OPTION_COUNT", None)
-    if raw_option_count is not None:
-        option_count = int(raw_option_count)
-        for option in range(option_count):
-            if os.getenv(f"GIT_PUSH_OPTION_{option}", "") == "breakglass":
-                return True
-
-    return False
-
-
-def find_branch_start(commit: str) -> Optional[str]:
-    """
-    Returns the first local-only commit of the branch.
-    Returns None if the branch does not contain any new commit.
-    """
-    # List all ancestors of `commit` which are not in any branches
-    output = git(
-        ["rev-list", commit, "--topo-order", "--reverse", "--not", "--branches"]
-    )
-    ancestors = output.splitlines()
-
-    if ancestors:
-        return ancestors[0]
-    return None
 
 
 def _execute_prereceive(
@@ -108,37 +76,6 @@ def _execute_prereceive(
         sys.exit(handle_exception(error, config.verbose))
 
 
-def parse_stdin() -> Optional[Tuple[str, str]]:
-    """
-    Parse stdin and return the first and last commit to scan,
-    or None if there is nothing to do
-    """
-    prereceive_input = sys.stdin.read().strip()
-    if not prereceive_input:
-        raise UnexpectedError(f"Invalid input arguments: '{prereceive_input}'")
-
-    # TODO There can be more than one line here, for example when pushing multiple
-    # branches. We should support this.
-    line = prereceive_input.splitlines()[0]
-    logger.debug("stdin: %s", line)
-    _old_commit, new_commit, _ = line.split(maxsplit=2)
-
-    if new_commit == EMPTY_SHA:
-        # Deletion event, nothing to do
-        return None
-
-    # ignore _old_commit because in case of a force-push, it is going to be overwritten
-    # and should not be scanned (see #437)
-    start_commit = find_branch_start(new_commit)
-    if start_commit is None:
-        # branch does not contain any new commit
-        old_commit = new_commit
-    else:
-        old_commit = f"{start_commit}~1"
-
-    return (old_commit, new_commit)
-
-
 @click.command()
 @click.argument("prereceive_args", nargs=-1, type=click.UNPROCESSED)
 @click.option(
@@ -166,27 +103,14 @@ def prereceive_cmd(
         )
 
     if get_breakglass_option():
-        click.echo(
-            "SKIP: breakglass detected. Skipping GitGuardian pre-receive hook.",
-            err=True,
-        )
         return 0
 
     before_after = parse_stdin()
     if before_after is None:
-        click.echo("Deletion event or nothing to scan.", err=True)
         return 0
+    else:
+        before, after = before_after
 
-    before, after = before_after
-    if before == after:
-        click.echo(
-            "Pushed branch does not contain any new commit.",
-            err=True,
-        )
-        return 0
-
-    assert before != EMPTY_SHA
-    assert after != EMPTY_SHA
     commit_list = get_list_commit_SHA(
         f"{before}...{after}", max_count=config.max_commits_for_hook + 1
     )

--- a/ggshield/core/file_utils.py
+++ b/ggshield/core/file_utils.py
@@ -1,5 +1,7 @@
 import os
 import re
+import tarfile
+from io import BytesIO
 from pathlib import Path
 from typing import List, Set, Union
 
@@ -50,3 +52,10 @@ def is_path_binary(path: str) -> bool:
     _, ext = os.path.splitext(path)
     # `[1:]` because `ext` starts with a "." but extensions in `BINARY_EXTENSIONS` do not
     return ext[1:] in BINARY_EXTENSIONS
+
+
+def get_empty_tar() -> bytes:
+    bytes = BytesIO()
+    file = tarfile.open(fileobj=bytes, mode="w:gz")
+    file.close()
+    return bytes.getvalue()

--- a/ggshield/core/git_hooks/prereceive.py
+++ b/ggshield/core/git_hooks/prereceive.py
@@ -1,0 +1,103 @@
+import logging
+import os
+import sys
+from typing import Optional, Tuple
+
+import click
+
+from ggshield.core.errors import UnexpectedError
+from ggshield.core.git_shell import git
+from ggshield.core.text_utils import display_error
+from ggshield.core.utils import EMPTY_SHA
+
+
+logger = logging.getLogger(__name__)
+
+
+# GitHub timeouts every pre-receive hook after 5s with an error.
+# We try and anticipate that so we can control the return code
+PRERECEIVE_TIMEOUT = 4.5
+
+
+BYPASS_MESSAGE = """\n     git push -o breakglass"""
+
+
+def get_prereceive_timeout() -> float:
+    try:
+        return float(os.getenv("GITGUARDIAN_TIMEOUT", PRERECEIVE_TIMEOUT))
+    except BaseException as e:
+        display_error(f"Unable to parse GITGUARDIAN_TIMEOUT: {str(e)}")
+        return PRERECEIVE_TIMEOUT
+
+
+def get_breakglass_option() -> bool:
+    """Test all options passed to git for `breakglass`"""
+    raw_option_count = os.getenv("GIT_PUSH_OPTION_COUNT", None)
+    if raw_option_count is not None:
+        option_count = int(raw_option_count)
+        for option in range(option_count):
+            if os.getenv(f"GIT_PUSH_OPTION_{option}", "") == "breakglass":
+                click.echo(
+                    "SKIP: breakglass detected. Skipping GitGuardian pre-receive hook.",
+                    err=True,
+                )
+                return True
+
+    return False
+
+
+def find_branch_start(commit: str) -> Optional[str]:
+    """
+    Returns the first local-only commit of the branch.
+    Returns None if the branch does not contain any new commit.
+    """
+    # List all ancestors of `commit` which are not in any branches
+    output = git(
+        ["rev-list", commit, "--topo-order", "--reverse", "--not", "--branches"]
+    )
+    ancestors = output.splitlines()
+
+    if ancestors:
+        return ancestors[0]
+    return None
+
+
+def parse_stdin() -> Optional[Tuple[str, str]]:
+    """
+    Parse stdin and return the first and last commit to scan,
+    or None if there is nothing to do, allowing for early stopping.
+    """
+    prereceive_input = sys.stdin.read().strip()
+    if not prereceive_input:
+        raise UnexpectedError(f"Invalid input arguments: '{prereceive_input}'")
+
+    # TODO There can be more than one line here, for example when pushing multiple
+    # branches. We should support this.
+    line = prereceive_input.splitlines()[0]
+    logger.debug("stdin: %s", line)
+    _old_commit, new_commit, _ = line.split(maxsplit=2)
+
+    if new_commit == EMPTY_SHA:
+        # Deletion event, nothing to do
+        click.echo("Deletion event or nothing to scan.", err=True)
+        return None
+
+    # ignore _old_commit because in case of a force-push, it is going to be overwritten
+    # and should not be scanned (see #437)
+    start_commit = find_branch_start(new_commit)
+    if start_commit is None:
+        # branch does not contain any new commit
+        old_commit = new_commit
+    else:
+        old_commit = f"{start_commit}~1"
+
+    assert old_commit != EMPTY_SHA
+    assert new_commit != EMPTY_SHA
+    if old_commit == new_commit:
+        click.echo(
+            "Pushed branch does not contain any new commit.",
+            err=True,
+        )
+        return None
+
+    return (old_commit, new_commit)

--- a/ggshield/core/utils.py
+++ b/ggshield/core/utils.py
@@ -35,10 +35,6 @@ REGEX_HEADER_INFO = re.compile(
 EMPTY_SHA = "0000000000000000000000000000000000000000"
 EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-# GitHub timeouts every pre-receive hook after 5s with an error.
-# We try and anticipate that so we can control the return code
-PRERECEIVE_TIMEOUT = 4.5
-
 IGNORED_DEFAULT_WILDCARDS = [
     "**/.git/**/*",
     "**/.pytest_cache/**/*",

--- a/ggshield/iac/output/iac_text_output_handler.py
+++ b/ggshield/iac/output/iac_text_output_handler.py
@@ -376,7 +376,7 @@ def iac_vulnerability_location_failed(
     line_start: int,
     line_end: int,
 ) -> str:
-    return f"\nFailed to read from the original file.\nThe incident was found between lines {line_start} and {line_end}\n"  # noqa: E501
+    return f"\nThe incident was found between lines {line_start} and {line_end}\n"  # noqa: E501
 
 
 def iac_engine_version(iac_engine_version: str) -> str:

--- a/tests/functional/iac/test_iac_scan_diff.py
+++ b/tests/functional/iac/test_iac_scan_diff.py
@@ -180,7 +180,7 @@ def test_iac_scan_diff_only_tracked_iac_with_ignore(tmp_path: Path) -> None:
     assert "No IaC files changed" in result.stdout
 
 
-@pytest.mark.parametrize("staged", (True, False))
+@pytest.mark.parametrize("staged", (False, True))
 def test_iac_scan_diff_staged(tmp_path: Path, staged: bool) -> None:
     # GIVEN a git repository
     repo = Repository.create(tmp_path)
@@ -203,10 +203,10 @@ def test_iac_scan_diff_staged(tmp_path: Path, staged: bool) -> None:
     result = run_ggshield_iac_scan(*args, cwd=tmp_path, expected_code=bool(staged))
 
     # THEN the staged file only appears with --staged flag enabled
-    assert "0 incidents deleted" in result.stdout
-    assert "1 incident remaining" in result.stdout
     if staged:
+        assert "0 incidents deleted" in result.stdout
+        assert "1 incident remaining" in result.stdout
         assert "1 new incident detected" in result.stdout
     else:
-        assert "0 new incidents detected" in result.stdout
+        assert "No IaC files changed" in result.stdout
     assert ("staged.tf" in result.stdout) == staged

--- a/tests/functional/iac/test_iac_scan_prereceive.py
+++ b/tests/functional/iac/test_iac_scan_prereceive.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import Tuple
+
+import pytest
+
+from tests.conftest import _IAC_NO_VULNERABILITIES, _IAC_SINGLE_VULNERABILITY
+from tests.repository import Repository
+
+
+HOOK_CONTENT = """#!/usr/bin/env sh
+ggshield iac scan pre-receive
+"""
+
+HOOK_CONTENT_ALL = """#!/usr/bin/env sh
+ggshield iac scan pre-receive --all
+"""
+
+
+@pytest.fixture
+def repo_with_hook(tmp_path: Path) -> Tuple[Repository, Repository]:
+    return repo_with_hook_content(tmp_path=tmp_path, hook_content=HOOK_CONTENT)
+
+
+@pytest.fixture
+def repo_with_hook_all(tmp_path: Path) -> Tuple[Repository, Repository]:
+    return repo_with_hook_content(tmp_path=tmp_path, hook_content=HOOK_CONTENT_ALL)
+
+
+def repo_with_hook_content(tmp_path: Path, hook_content: str) -> Repository:
+    """
+    Helper function that initialize a repo with a remote.
+    The remote contains the pre-receive with the corresponding hook content.
+
+    :param tmp_path: the root path
+    :param hook_content: the pre-receive hook content
+    :return: the local Repository object
+    """
+    remote_repo = Repository.create(tmp_path / "remote", bare=True)
+    local_repo = Repository.clone(remote_repo.path, tmp_path / "local")
+
+    hook_path = remote_repo.path / "hooks" / "pre-receive"
+    hook_path.write_text(hook_content)
+    hook_path.chmod(0o700)
+    return local_repo
+
+
+def test_iac_scan_prereceive(repo_with_hook) -> None:
+    # GIVEN a repo and remote with pre-receive hook
+    # WHEN I add a vulnerable file to my local repo
+    vuln_file_name = "file1.tf"
+    vuln_path = repo_with_hook.path / vuln_file_name
+
+    vuln_path.write_text(_IAC_SINGLE_VULNERABILITY)
+
+    repo_with_hook.add(str(vuln_path))
+    repo_with_hook.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook prevents the push
+    with pytest.raises(CalledProcessError) as exc:
+        repo_with_hook.push()
+
+    # AND the error message contains the vulnerability details
+    stderr = exc.value.stderr.decode()
+    assert "1 new incident" in stderr
+    assert vuln_file_name in stderr
+
+
+def test_iac_scan_prereceive_no_vuln(repo_with_hook) -> None:
+    # GIVEN a repo and remote with pre-receive hook
+    # WHEN I add a non vulnerable IaC file to my local repo
+    non_vuln_file_name = "file_no_vuln.tf"
+    non_vuln_path = repo_with_hook.path / non_vuln_file_name
+
+    non_vuln_path.write_text(_IAC_NO_VULNERABILITIES)
+
+    repo_with_hook.add(str(non_vuln_path))
+    repo_with_hook.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook accepts the push
+    repo_with_hook.push()
+
+
+def test_iac_scan_prereceive_no_iac(repo_with_hook) -> None:
+    # GIVEN a repo and remote with pre-receive hook
+    # WHEN I add a non IaC file to my local repo
+    non_iac_file_name = "file1.txt"
+    non_iac_path = repo_with_hook.path / non_iac_file_name
+
+    non_iac_path.write_text("Not an IaC file.")
+
+    repo_with_hook.add(str(non_iac_path))
+    repo_with_hook.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook accepts the push
+    repo_with_hook.push()
+
+
+def test_iac_scan_prereceive_all(repo_with_hook_all) -> None:
+    # GIVEN a repo and remote with pre-receive hook set with the --all option
+    # WHEN I add a vulnerable file to my local repo
+    vuln_file_name = "file1.tf"
+    vuln_path = repo_with_hook_all.path / vuln_file_name
+
+    vuln_path.write_text(_IAC_SINGLE_VULNERABILITY)
+
+    repo_with_hook_all.add(str(vuln_path))
+    repo_with_hook_all.create_commit()
+
+    # WHEN I try to push
+    # THEN the hook, set to scan all, prevents the push
+    with pytest.raises(CalledProcessError) as exc:
+        repo_with_hook_all.push()
+
+    # AND the error message contains the leaked secret
+    stderr = exc.value.stderr.decode()
+    # testing the all variant of the output
+    assert "1 incident detected" in stderr
+    assert vuln_file_name in stderr
+
+
+def test_iac_scan_prereceive_branch_without_new_commits(repo_with_hook) -> None:
+    # GIVEN a repo and remote with pre-receive hook
+    # WHEN I push a new branch with a single empty commit
+    branch_name = "topic"
+    repo_with_hook.create_branch(branch_name)
+    repo_with_hook.create_commit()
+
+    # WHEN I try to push the branch
+    # THEN the hook does not crash
+    repo_with_hook.push("-u", "origin", branch_name)

--- a/tests/unit/core/test_file_utils.py
+++ b/tests/unit/core/test_file_utils.py
@@ -1,0 +1,21 @@
+import sys
+import tarfile
+from io import BytesIO
+
+from ggshield.core.file_utils import get_empty_tar
+
+
+def test_get_empty_tar():
+    # WHEN creating an empty tar
+    empty_tar_bytes = get_empty_tar()
+    tar_stream = BytesIO(empty_tar_bytes)
+
+    # THEN the file is considered as a .tar
+    version = sys.version_info
+    # `tarfile.is_tarfile` won't work until Python 3.9
+    if version.major > 3 or version.major == 3 and version.minor > 8:
+        assert tarfile.is_tarfile(tar_stream)
+
+    # AND it contains no file
+    with tarfile.open(fileobj=tar_stream, mode="w:gz") as tar:
+        assert len(tar.getmembers()) == 0

--- a/tests/unit/core/test_file_utils.py
+++ b/tests/unit/core/test_file_utils.py
@@ -11,9 +11,8 @@ def test_get_empty_tar():
     tar_stream = BytesIO(empty_tar_bytes)
 
     # THEN the file is considered as a .tar
-    version = sys.version_info
     # `tarfile.is_tarfile` won't work until Python 3.9
-    if version.major > 3 or version.major == 3 and version.minor > 8:
+    if sys.version_info >= (3, 9):
         assert tarfile.is_tarfile(tar_stream)
 
     # AND it contains no file


### PR DESCRIPTION
# Feature: add `ggshield iac scan pre-receive` command

## Description

In the pre-receive case, the command is executed in the `.git/` directory, not in the working tree.
This has several impacts on the existing `iac scan diff` implementation.

## Changes

- change `git_shell` commands to handle the case where the current directory is a `.git/` and not a working tree
- change `iac scan diff` to include the possibility to force the current state to a given reference. In prereceive context, we cannot move the HEAD (due to quarantine) so we have to explicitly dump the given reference.
- update a message about the impossibility to read a file: since we do not have direct access to the files in pre-receive context, we only hint at the location, but display no error.
- add tests
- add a workaround for the `--all` option on pre-receive, as we do not have access to the files. We perform a diff scan with unspecified reference, which defaults to only scanning the current files. We then convert the diff scan result into a path scan result for proper display.


