### PR TITLE
ignore-policy-gg-iac-0079-on-self-scan

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,9 @@
+# Required, otherwise ggshield considers the file to use the deprecated v1 format
+version: 2
+
+iac:
+  # IaC vulnerabilities to ignore
+  # We don't want to fix this vulnerability because many CI systems (including GitHub action and Azure pipelines)
+  # expect the user inside the container to be root.
+  ignored-policies:
+    - GG_IAC_0079


### PR DESCRIPTION
In the iac scan tests, we need to test the CI integration. To do this we scan the HEAD of this repo.
However with the update of iac-api, new policies have been added.
Among them, the policy GG_IAC_0079 is detected in this repo.
Information on the policy :
https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0079
Present in these files :
Dockerfile
scripts/update-pipfile-lock/Dockerfile
tests/functional/data/docker-leaking-in-env/Dockerfile
tests/functional/data/docker-leaking-in-layer/Dockerfile 

For now, we chose to ignore it  to enable the CI to pass but another solution would be to correct this vulnerabilities.