### PR TITLE
Fix ggshield secret scan trying to scan too large documents

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "12b3ddffa6eb5dfb81bfe851b5df635e17a92a0873514b27bfaab9bfd5809f35"
+            "sha256": "5ec1db68730e3cda22d3b52f02a81d55e718ab1e98549bdf4150594fe141b93e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -181,11 +181,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+                "sha256:2739815aaa5d2c986a88f1e9230c55e17f0caad3d958a5e13ad0797c166db9e3",
+                "sha256:b97d0c74955da062a7d4ef92fadb583806a585b2ea81958a81bd72726cbb8e37"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.3"
+            "version": "==8.1.4"
         },
         "commonmark": {
             "hashes": [
@@ -196,28 +196,32 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db",
-                "sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a",
-                "sha256:1a8e6c2de6fbbcc5e14fd27fb24414507cb3333198ea9ab1258d916f00bc3039",
-                "sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c",
-                "sha256:5d092fdfedaec4cbbffbf98cddc915ba145313a6fdaab83c6e67f4e6c218e6f3",
-                "sha256:5f0ff6e18d13a3de56f609dd1fd11470918f770c6bd5d00d632076c727d35485",
-                "sha256:7bfc55a5eae8b86a287747053140ba221afc65eb06207bedf6e019b8934b477c",
-                "sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca",
-                "sha256:8dde71c4169ec5ccc1087bb7521d54251c016f126f922ab2dfe6649170a3b8c5",
-                "sha256:8f4ab7021127a9b4323537300a2acfb450124b2def3756f64dc3a3d2160ee4b5",
-                "sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3",
-                "sha256:9a6c7a3c87d595608a39980ebaa04d5a37f94024c9f24eb7d10262b92f739ddb",
-                "sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43",
-                "sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31",
-                "sha256:cb33ccf15e89f7ed89b235cff9d49e2e62c6c981a6061c9c8bb47ed7951190bc",
-                "sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b",
-                "sha256:d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006",
-                "sha256:eb8163f5e549a22888c18b0d53d6bb62a20510060a22fd5a995ec8a05268df8a",
-                "sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699"
+                "sha256:01f1d9e537f9a15b037d5d9ee442b8c22e3ae11ce65ea1f3316a41c78756b711",
+                "sha256:079347de771f9282fbfe0e0236c716686950c19dee1b76240ab09ce1624d76d7",
+                "sha256:182be4171f9332b6741ee818ec27daff9fb00349f706629f5cbf417bd50e66fd",
+                "sha256:192255f539d7a89f2102d07d7375b1e0a81f7478925b3bc2e0549ebf739dae0e",
+                "sha256:2a034bf7d9ca894720f2ec1d8b7b5832d7e363571828037f9e0c4f18c1b58a58",
+                "sha256:342f3767e25876751e14f8459ad85e77e660537ca0a066e10e75df9c9e9099f0",
+                "sha256:439c3cc4c0d42fa999b83ded80a9a1fb54d53c58d6e59234cfe97f241e6c781d",
+                "sha256:49c3222bb8f8e800aead2e376cbef687bc9e3cb9b58b29a261210456a7783d83",
+                "sha256:674b669d5daa64206c38e507808aae49904c988fa0a71c935e7006a3e1e83831",
+                "sha256:7a9a3bced53b7f09da251685224d6a260c3cb291768f54954e28f03ef14e3766",
+                "sha256:7af244b012711a26196450d34f483357e42aeddb04128885d95a69bd8b14b69b",
+                "sha256:7d230bf856164de164ecb615ccc14c7fc6de6906ddd5b491f3af90d3514c925c",
+                "sha256:84609ade00a6ec59a89729e87a503c6e36af98ddcd566d5f3be52e29ba993182",
+                "sha256:9a6673c1828db6270b76b22cc696f40cde9043eb90373da5c2f8f2158957f42f",
+                "sha256:9b6d717393dbae53d4e52684ef4f022444fc1cce3c48c38cb74fca29e1f08eaa",
+                "sha256:9c3fe6534d59d071ee82081ca3d71eed3210f76ebd0361798c74abc2bcf347d4",
+                "sha256:a719399b99377b218dac6cf547b6ec54e6ef20207b6165126a280b0ce97e0d2a",
+                "sha256:b332cba64d99a70c1e0836902720887fb4529ea49ea7f5462cf6640e095e11d2",
+                "sha256:d124682c7a23c9764e54ca9ab5b308b14b18eba02722b8659fb238546de83a76",
+                "sha256:d73f419a56d74fef257955f51b18d046f3506270a5fd2ac5febbfa259d6c0fa5",
+                "sha256:f0dc40e6f7aa37af01aba07277d3d64d5a03dc66d682097541ec4da03cc140ee",
+                "sha256:f14ad275364c8b4e525d018f6716537ae7b6d369c094805cae45300847e0894f",
+                "sha256:f772610fe364372de33d76edcd313636a25684edb94cee53fd790195f5989d14"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==41.0.1"
+            "version": "==41.0.2"
         },
         "ggshield": {
             "editable": true,
@@ -283,7 +287,7 @@
         },
         "pygitguardian": {
             "git": "https://github.com/GitGuardian/py-gitguardian.git",
-            "ref": "da5d95daf4d0a9697214b91e5acebd1934a11614"
+            "ref": "ccd3e47b6237ea4996d4bd27a0a5dbf4d8e2a557"
         },
         "pygments": {
             "hashes": [
@@ -554,11 +558,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+                "sha256:2739815aaa5d2c986a88f1e9230c55e17f0caad3d958a5e13ad0797c166db9e3",
+                "sha256:b97d0c74955da062a7d4ef92fadb583806a585b2ea81958a81bd72726cbb8e37"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.3"
+            "version": "==8.1.4"
         },
         "click-log": {
             "hashes": [
@@ -974,11 +978,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc",
-                "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"
+                "sha256:cec7b889196b9144d088e4c57d9ceef7374f6c39694ad1577a0aab50d27ea28c",
+                "sha256:f87ca4fcff7d2b0f81c6a748a77973d7af0f4d526f98f308477c3c436c74d528"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.0"
+            "version": "==3.8.1"
         },
         "pluggy": {
             "hashes": [
@@ -1028,11 +1032,11 @@
         },
         "pyfakefs": {
             "hashes": [
-                "sha256:0dcfb74e047e20b0755beeec3e3c0d7fc6f5029cdbb0cbf83d88431ee75b191d",
-                "sha256:92913ad26f2661b81080178421f00aa712d799e18e4b5bb2fcba128f435dd6a7"
+                "sha256:101a91d8e454934fe2435392c38d505beacfc27dad71a0ad2a6215d0b750f2f1",
+                "sha256:f4d677645e44c56fd47d579c7586ff0daef1546d3100df2af50969f794368fc6"
             ],
             "index": "pypi",
-            "version": "==5.2.2"
+            "version": "==5.2.3"
         },
         "pyflakes": {
             "hashes": [

--- a/changelog.d/20230712_171932_aurelien.gateau_fix_maximum_size_check.md
+++ b/changelog.d/20230712_171932_aurelien.gateau_fix_maximum_size_check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield secret scan` no longer tries to scan files that are longer than the maximum document size (#561).

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "marshmallow>=3.18.0,<3.19.0",
         "marshmallow-dataclass>=8.5.8,<8.6.0",
         "oauthlib>=3.2.1,<3.3.0",
-        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@da5d95d",
+        "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@ccd3e47b62",
         "pyjwt>=2.6.0,<2.7.0",
         "python-dotenv>=0.21.0,<0.22.0",
         "pyyaml>=6.0,<6.1",

--- a/tests/unit/scan/test_scannable.py
+++ b/tests/unit/scan/test_scannable.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from ggshield.scan import Files, StringScannable
 
 
@@ -21,3 +23,22 @@ def test_string_scannable_path():
     """
     scannable = StringScannable(url="custom:/some/path", content="")
     assert scannable.path == Path("/some/path")
+
+
+@pytest.mark.parametrize(
+    ("content", "is_longer"),
+    (
+        ("x" * 100, True),
+        ("x" * 10, False),
+        ("é" * 40, True),  # Longer than 50 as utf-8
+        ("\uD800", False),  # Triggers an encoding error
+    ),
+)
+def test_string_scannable_is_longer_than(content, is_longer):
+    """
+    GIVEN a StringScannable
+    WHEN is_longer_than() is called
+    THEN it returns the expected value
+    """
+    scannable = StringScannable(content=content, url="u")
+    assert scannable.is_longer_than(50) == is_longer


### PR DESCRIPTION
## Description

`Scannable.is_longer_than()` currently compares the size passed to it to the decoded size, but what we actually want to compare it to is the *UTF-8 encoded size*.

To implement this without reading the content multiple times, `Scannable` implementations now store the UTF-8 encoded size, and `Scannable` helper methods (`_is_file_longer_than()` and `_decode_bytes()`) return the UTF-8 encoded size in addition to their current return value.

When the content they work on is already UTF-8, the helpers try to avoid reading it until necessary.

This PR also integrates the latest py-gitguardian changes, which are also related to this issue.

Issue: #561