### PR TITLE
Fix gitlab functional tests

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -41,3 +41,10 @@ secret:
     - .gitignore
     - .env
     - 'tests/cassettes/*'
+
+iac:
+  ignored-policies:
+    # We don't want to fix this vulnerability because many CI systems
+    # (including GitHub action and Azure pipelines) expect the user inside the
+    # container to be root.
+    - GG_IAC_0079

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,9 +1,0 @@
-# Required, otherwise ggshield considers the file to use the deprecated v1 format
-version: 2
-
-iac:
-  # IaC vulnerabilities to ignore
-  # We don't want to fix this vulnerability because many CI systems (including GitHub action and Azure pipelines)
-  # expect the user inside the container to be root.
-  ignored-policies:
-    - GG_IAC_0079


### PR DESCRIPTION
Merge .gitguardian.yml into .gitguardian.yaml and remove .gitguardian.yml.

Having both causes .gitguardian.yaml to not be loaded, causing the `tests/functional/test_docker_image.py` tests to fail (they did not fail in the PR because the test clones ggshield `main` branch).