### PR TITLE
chore(functest): Install ggshield with all extras before functional tests

### DIFF
--- a/scripts/run-functional-tests
+++ b/scripts/run-functional-tests
@@ -37,7 +37,7 @@ create_venv() {
 install_packages() {
     log_progress "Installing packages"
     # Install ggshield and test dependencies
-    pip install dist/*.whl pytest
+    pip install "dist/`ls dist`[all]" pytest
 }
 
 run_tests() {


### PR DESCRIPTION
Fix the functional tests in the CI. `cryptography` wasn't installed and the tests failed.