### PR TITLE
feat(color): Enable color output in GitLab CI

### DIFF
--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -101,15 +101,37 @@ def cli(
 
     config = ctx.obj["config"]
 
-    if os.getenv("NO_COLOR"):
-        ctx.color = False
-    else:
-        if os.getenv("GL_USERNAME"):
-            ctx.color = True
+    _set_color(ctx)
 
     if config.debug:
         # if `debug` is set in the configuration file, then setup logs now.
         setup_debug_logs(filename=None)
+
+
+def _set_color(ctx: click.Context):
+    """
+    Helper function to override the default click default output color setting.
+        If NO_COLOR is set, we disable color output (see https://no-color.org/).
+    If we are in a CI environment, certain variables are set, and we enable colors for
+    the logs.
+    """
+    ci_env_vars = [
+        "CI",  # Often set to indicate a generic CI environment
+        "GITLAB_CI",
+        "GITHUB_ACTIONS",
+        "TRAVIS",
+        "JENKINS_HOME",
+        "JENKINS_URL",
+        "CIRCLECI",
+        "BITBUCKET_COMMIT",
+        "DRONE",
+        "BUILD_BUILDID",  # Azure Pipelines
+    ]
+
+    if os.getenv("NO_COLOR"):
+        ctx.color = False
+    elif any(os.getenv(env) for env in ci_env_vars):
+        ctx.color = True
 
 
 def _display_deprecation_message(cfg: Config) -> None:

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -100,6 +100,13 @@ def cli(
     load_dot_env()
 
     config = ctx.obj["config"]
+
+    if os.getenv("NO_COLOR"):
+        ctx.color = False
+    else:
+        if os.getenv("GL_USERNAME"):
+            ctx.color = True
+
     if config.debug:
         # if `debug` is set in the configuration file, then setup logs now.
         setup_debug_logs(filename=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def do_not_use_real_cache_dir(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def do_not_use_colors(monkeypatch, tmp_path):
+def do_not_use_colors(monkeypatch):
     """
     This fixture ensures we do not print colors for easier testing.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,3 +79,11 @@ def do_not_use_real_cache_dir(monkeypatch, tmp_path):
     This fixture ensures we do not use the real cache directory.
     """
     monkeypatch.setenv("GG_CACHE_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def do_not_use_colors(monkeypatch, tmp_path):
+    """
+    This fixture ensures we do not print colors for easier testing.
+    """
+    monkeypatch.setenv("NO_COLOR", "1")


### PR DESCRIPTION
enables color output in CI.
Adds the option to disable color entirely with NO_COLOR (https://no-color.org/)