### PR TITLE
IaC scans: display a link to the policy documentation

### DIFF
--- a/ggshield/iac/output/iac_text_output_handler.py
+++ b/ggshield/iac/output/iac_text_output_handler.py
@@ -221,6 +221,9 @@ class IaCTextOutputHandler(IaCOutputHandler):
             result_buf.write(
                 iac_vulnerability_header(issue_n, vulnerability, prefix=prefix)
             )
+            result_buf.write(
+                iac_vulnerability_documentation(vulnerability.documentation_url)
+            )
             result_buf.write(iac_vulnerability_severity_line(vulnerability.severity))
             if len(lines) == 0:
                 result_buf.write(
@@ -265,6 +268,9 @@ class IaCTextOutputHandler(IaCOutputHandler):
             result_buf.write(
                 iac_vulnerability_header(issue_n, vulnerability, prefix=prefix)
             )
+            result_buf.write(
+                iac_vulnerability_documentation(vulnerability.documentation_url)
+            )
             result_buf.write(iac_vulnerability_severity_line(vulnerability.severity))
             if len(lines) == 0:
                 result_buf.write(
@@ -301,6 +307,10 @@ def iac_vulnerability_header(
         format_text(vulnerability.policy, STYLE["policy"]),
         format_text(vulnerability.policy_id, STYLE["policy"]),
     )
+
+
+def iac_vulnerability_documentation(doc_url: str) -> str:
+    return f"More at {doc_url}\n"
 
 
 def iac_vulnerability_severity_line(severity: str) -> str:

--- a/tests/unit/iac/output/test_iac_diff_text_output.py
+++ b/tests/unit/iac/output/test_iac_diff_text_output.py
@@ -11,6 +11,27 @@ from ggshield.iac.collection.iac_diff_scan_collection import IaCDiffScanCollecti
 from ggshield.iac.output.iac_text_output_handler import IaCTextOutputHandler
 
 
+POLICY_DOC_URL = "https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0021"
+
+
+def _generate_iac_file_result() -> IaCFileResult:
+    return IaCFileResult(
+        filename="FILENAME.tf",
+        incidents=[
+            IaCVulnerability(
+                policy="Unrestricted ingress traffic leave assets exposed to remote attacks",
+                policy_id="GG_IAC_0021",
+                line_start=0,
+                line_end=1,
+                description="Having open ingress means that your asset is exposed[...]",
+                component="azurerm_network_security_group.bad_sg",
+                severity="HIGH",
+                documentation_url=POLICY_DOC_URL,
+            )
+        ],
+    )
+
+
 def test_iac_scan_diff_no_vuln_not_verbose():
     """
     GIVEN a response from the GIM api after a iac scan diff
@@ -52,57 +73,9 @@ def test_iac_scan_diff_vuln_not_verbose():
                 type="TYPE",
                 iac_engine_version="1.0.0",
                 entities_with_incidents=IaCDiffScanEntities(
-                    new=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
-                    unchanged=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
-                    deleted=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
+                    new=[_generate_iac_file_result()],
+                    unchanged=[_generate_iac_file_result()],
+                    deleted=[_generate_iac_file_result()],
                 ),
             ),
         )
@@ -111,6 +84,7 @@ def test_iac_scan_diff_vuln_not_verbose():
     assert_iac_diff_version_displayed(output)
     assert re.search(r"FILENAME\.tf.*1 new incident detected", output)
     assert_iac_diff_summary_displayed(output, new=1, unchanged=1, deleted=1)
+    assert_documentation_url_displayed(output, POLICY_DOC_URL)
 
 
 def test_iac_scan_diff_no_vuln_verbose():
@@ -154,57 +128,9 @@ def test_iac_scan_diff_vuln_verbose():
                 type="TYPE",
                 iac_engine_version="1.0.0",
                 entities_with_incidents=IaCDiffScanEntities(
-                    new=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
-                    unchanged=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
-                    deleted=[
-                        IaCFileResult(
-                            filename="FILENAME.tf",
-                            incidents=[
-                                IaCVulnerability(
-                                    policy="POLICY",
-                                    policy_id="POLICY_ID",
-                                    line_start=0,
-                                    line_end=1,
-                                    description="DESCRIPTION",
-                                    component="COMPONENT",
-                                    severity="SEVERITY",
-                                    documentation_url="DOCUMENT_URL",
-                                )
-                            ],
-                        )
-                    ],
+                    new=[_generate_iac_file_result()],
+                    unchanged=[_generate_iac_file_result()],
+                    deleted=[_generate_iac_file_result()],
                 ),
             ),
         )
@@ -213,6 +139,7 @@ def test_iac_scan_diff_vuln_verbose():
     assert_iac_diff_version_displayed(output)
     assert re.search(r"FILENAME\.tf.*1 new incident detected", output)
     assert_iac_diff_summary_displayed(output, new=1, unchanged=1, deleted=1)
+    assert_documentation_url_displayed(output, POLICY_DOC_URL)
 
 
 def assert_iac_diff_version_displayed(output: str):
@@ -231,3 +158,7 @@ def assert_iac_diff_summary_displayed(output: str, new=0, unchanged=0, deleted=0
     assert re.search(r"\[-\] " + str(deleted) + " incidents? deleted", output)
     assert re.search(r"\[~\] " + str(unchanged) + " incidents? remaining", output)
     assert re.search(r"\[\+\] " + str(new) + " new incidents? detected", output)
+
+
+def assert_documentation_url_displayed(output: str, expected_url: str):
+    assert re.search(expected_url, output, re.S)

--- a/tests/unit/iac/output/test_iac_text_output.py
+++ b/tests/unit/iac/output/test_iac_text_output.py
@@ -30,6 +30,7 @@ def test_display_single_vulnerability(tmp_path, cli_fs_runner: CliRunner):
     )
     assert_iac_version_displayed(result)
     assert_file_single_vulnerability_displayed(result)
+    assert_documentation_url_displayed(result)
 
 
 @my_vcr.use_cassette("test_iac_scan_single_vulnerability")
@@ -122,6 +123,16 @@ def assert_iac_version_displayed(result: Result):
 
 def assert_no_failures_displayed(result: Result):
     assert "Error scanning. Results may be incomplete." not in result.stdout
+
+
+def assert_documentation_url_displayed(result: Result):
+    base_doc_url = "https://docs.gitguardian.com/iac-scanning/policies/"
+    regex = r"\((GG_IAC_\d{4})\).+" + base_doc_url.replace(".", r"\.") + r"\1"
+    assert re.search(
+        regex,
+        result.stdout,
+        re.S,
+    )
 
 
 def assert_file_single_vulnerability_displayed(result: Result):


### PR DESCRIPTION
https://linear.app/gitguardian/issue/IAC-136/ggshield-add-link-to-the-policy-documentation