### PR TITLE
Improve help message for --ignore-path (iac) and --exclude (secret)

### DIFF
--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -62,7 +62,9 @@ _ignore_path_option = click.option(
     default=None,
     type=click.Path(),
     multiple=True,
-    help="Do not scan the specified paths.",
+    help="""
+    Do not scan paths that match the specified glob-like patterns.
+    """,
 )
 
 all_option = click.option(

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -61,7 +61,9 @@ _exclude_option = click.option(
     "--exclude",
     default=None,
     type=click.Path(),
-    help="Do not scan the specified path.",
+    help="""
+    Do not scan paths that match the specified glob-like patterns.
+    """,
     multiple=True,
     callback=_exclude_callback,
 )


### PR DESCRIPTION
`--ignore-path` and `--exclude` expect a pattern rather than a file path.

Regex patterns do not work, as special characters are escaped.

Here is how the input value is transformed:
```
# Handle start/end of pattern
if pattern[-1] != "/":
    pattern += "$"
if pattern[0] == "/":
    pattern = "^" + pattern[1:]
else:
    pattern = "(^|/)" + pattern

# Replace * and ** sequences
pattern = re.sub(r"\\\*\\\*/", "([^/]+/)*", pattern)
pattern = re.sub(r"\\\*", "([^/]+)", pattern)
```

And here is how the filtering is done:
```
def is_filepath_excluded(filepath: str, exclusion_regexes: Set[re.Pattern]) -> bool:
    return any(r.search(str(PurePosixPath(Path(filepath)))) for r in exclusion_regexes)
```