### PR TITLE
feat(sca): add CI params for sca scan commands

### DIFF
--- a/ggshield/cmd/common_options.py
+++ b/ggshield/cmd/common_options.py
@@ -10,6 +10,7 @@ To use it:
 The `kwargs` argument is required because due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
+from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar, cast
 
 import click
@@ -151,6 +152,24 @@ exit_zero_option = click.option(
 )
 
 
+minimum_severity_option = click.option(
+    "--minimum-severity",
+    "minimum_severity",
+    type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
+    help="Minimum severity of the policies.",
+)
+
+ignore_path_option = click.option(
+    "--ignore-path",
+    "--ipa",
+    "ignore_paths",
+    default=None,
+    type=click.Path(),
+    multiple=True,
+    help="Do not scan the specified paths.",
+)
+
+
 def add_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         _verbose_option(cmd)
@@ -176,3 +195,10 @@ json_option = click.option(
 def use_json(ctx: click.Context) -> bool:
     """Tells whether --json has been set"""
     return bool(ctx.obj.get("use_json", False))
+
+
+directory_argument = click.argument(
+    "directory",
+    type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),
+    required=False,
+)

--- a/ggshield/cmd/iac/scan/__init__.py
+++ b/ggshield/cmd/iac/scan/__init__.py
@@ -2,11 +2,9 @@ from typing import Any
 
 import click
 
+from ggshield.cmd.common_options import directory_argument
 from ggshield.cmd.iac.scan.diff import scan_diff_cmd
-from ggshield.cmd.iac.scan.iac_scan_common_options import (
-    add_iac_scan_common_options,
-    directory_argument,
-)
+from ggshield.cmd.iac.scan.iac_scan_common_options import add_iac_scan_common_options
 from ggshield.cmd.iac.scan.scan import scan_all_cmd
 from ggshield.core.clickutils.default_command_group import DefaultCommandGroup
 from ggshield.core.client import create_client_from_config

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -4,9 +4,9 @@ from typing import Any, Optional, Sequence, Union
 import click
 from pygitguardian.iac_models import IaCScanParameters
 
+from ggshield.cmd.common_options import directory_argument
 from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
-    directory_argument,
     update_context,
 )
 from ggshield.cmd.iac.scan.iac_scan_utils import (

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -6,33 +6,25 @@ To use it:
     calls of the command function.
 - Add a `**kwargs: Any` argument to the command function.
 
-The `kwargs` argument is required because due to the way click works,
+The `kwargs` argument is required due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
-from pathlib import Path
 from typing import Any, Callable, Sequence
 
 import click
 
 from ggshield.cmd.common_options import (
+    AnyFunction,
     add_common_options,
     exit_zero_option,
+    ignore_path_option,
     json_option,
+    minimum_severity_option,
 )
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config.config import Config
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.iac.policy_id import POLICY_ID_PATTERN, validate_policy_id
-
-
-AnyFunction = Callable[..., Any]
-
-_minimum_severity_option = click.option(
-    "--minimum-severity",
-    "minimum_severity",
-    type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
-    help="Minimum severity of the policies.",
-)
 
 
 def _validate_exclude(_ctx: Any, _param: Any, value: Sequence[str]) -> Sequence[str]:
@@ -55,30 +47,14 @@ _ignore_policy_option = click.option(
     callback=_validate_exclude,
 )
 
-_ignore_path_option = click.option(
-    "--ignore-path",
-    "--ipa",
-    "ignore_paths",
-    default=None,
-    type=click.Path(),
-    multiple=True,
-    help="Do not scan the specified paths.",
-)
-
-directory_argument = click.argument(
-    "directory",
-    type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),
-    required=False,
-)
-
 
 def add_iac_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
         exit_zero_option(cmd)
-        _minimum_severity_option(cmd)
+        minimum_severity_option(cmd)
         _ignore_policy_option(cmd)
-        _ignore_path_option(cmd)
+        ignore_path_option(cmd)
         json_option(cmd)
         return cmd
 

--- a/ggshield/cmd/iac/scan/scan.py
+++ b/ggshield/cmd/iac/scan/scan.py
@@ -4,9 +4,9 @@ from typing import Any, Optional, Sequence
 import click
 from pygitguardian.iac_models import IaCScanParameters, IaCScanResult
 
+from ggshield.cmd.common_options import directory_argument
 from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
-    directory_argument,
     update_context,
 )
 from ggshield.cmd.iac.scan.iac_scan_utils import (

--- a/ggshield/cmd/sca/scan_common_options.py
+++ b/ggshield/cmd/sca/scan_common_options.py
@@ -1,0 +1,59 @@
+"""
+This module defines options which should be available on all sca scan subcommands.
+
+To use it:
+- Add the `@add_common_sca_scan_options()` decorator after all the `click.option()`
+    calls of the command function.
+- Add a `**kwargs: Any` argument to the command function.
+
+The `kwargs` argument is required due to the way click works,
+`add_common_options()` adds an argument for each option it defines.
+"""
+from typing import Callable, Sequence
+
+import click
+
+from ggshield.cmd.common_options import (
+    AnyFunction,
+    add_common_options,
+    exit_zero_option,
+    ignore_path_option,
+    minimum_severity_option,
+)
+from ggshield.core.client import create_client_from_config
+from ggshield.core.config import Config
+from ggshield.core.filter import init_exclusion_regexes
+
+
+def add_sca_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
+    def decorator(cmd: AnyFunction) -> AnyFunction:
+        add_common_options()(cmd)
+        exit_zero_option(cmd)
+        minimum_severity_option(cmd)
+        ignore_path_option(cmd)
+        return cmd
+
+    return decorator
+
+
+def update_context(
+    ctx: click.Context,
+    exit_zero: bool,
+    minimum_severity: str,
+    ignore_paths: Sequence[str],
+) -> None:
+    config: Config = ctx.obj["config"]
+    ctx.obj["client"] = create_client_from_config(config)
+
+    if ignore_paths is not None:
+        config.user_config.sca.ignored_paths.update(ignore_paths)
+
+    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(
+        config.user_config.sca.ignored_paths
+    )
+
+    if exit_zero is not None:
+        config.user_config.exit_zero = exit_zero
+
+    if minimum_severity is not None:
+        config.user_config.sca.minimum_severity = minimum_severity

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -82,6 +82,17 @@ class IaCConfig(FilteredConfig):
 
 
 @marshmallow_dataclass.dataclass
+class SCAConfig(FilteredConfig):
+    """
+    Holds the sca config as defined .gitguardian.yaml files
+    (local and global).
+    """
+
+    ignored_paths: Set[str] = field(default_factory=set)
+    minimum_severity: str = "LOW"
+
+
+@marshmallow_dataclass.dataclass
 class UserConfig(FilteredConfig):
     """
     Holds all ggshield settings defined by the user in the .gitguardian.yaml files
@@ -94,6 +105,7 @@ class UserConfig(FilteredConfig):
     verbose: bool = False
     allow_self_signed: bool = False
     max_commits_for_hook: int = 50
+    sca: SCAConfig = field(default_factory=SCAConfig)
     secret: SecretConfig = field(default_factory=SecretConfig)
     debug: bool = False
 

--- a/ggshield/sca/client.py
+++ b/ggshield/sca/client.py
@@ -80,12 +80,16 @@ class SCAClient:
         self,
         reference: bytes,
         current: bytes,
+        scan_parameters: SCAScanParameters,
     ) -> Union[Detail, SCAScanDiffOutput]:
         result: Union[Detail, SCAScanDiffOutput]
         try:
             response = self._client.post(
                 endpoint="sca/sca_scan_diff/",
                 files={"reference": reference, "current": current},
+                data={
+                    "scan_parameters": SCAScanParameters.SCHEMA.dumps(scan_parameters)
+                },
             )
         except requests.exceptions.ReadTimeout:
             result = Detail("The request timed out.")

--- a/ggshield/sca/sca_scan_models.py
+++ b/ggshield/sca/sca_scan_models.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal
 
 @dataclass
 class SCAScanParameters(Base, FromDictMixin):
-    pass
+    minimum_severity: Optional[str] = None
 
 
 SCAScanParameters.SCHEMA = cast(

--- a/tests/unit/sca/test_client.py
+++ b/tests/unit/sca/test_client.py
@@ -129,10 +129,18 @@ class TestSCAClient:
 
     @my_vcr.use_cassette
     def test_scan_diff(self, client: GGClient):
+        """
+        GIVEN a directory in two different states
+        WHEN calling scan_diff on it
+        THEN the scan succeeds
+        """
         sca_client = SCAClient(client)
+        scan_params = SCAScanParameters()
+
         result = sca_client.scan_diff(
             reference=make_tar_bytes(reference_files),
             current=make_tar_bytes(current_files),
+            scan_parameters=scan_params,
         )
         assert isinstance(result, SCAScanDiffOutput), result.content
         assert result.scanned_files == ["Pipfile", "Pipfile.lock"]


### PR DESCRIPTION
Added CI params common to `secrets` and `iac` scans as well as `ignore-paths` and `minimum-severity` to `sca`'s scan commands.