### PR TITLE
feat(iac): github action should now use the new CI command

### DIFF
--- a/changelog.d/20230725_144801_paul.beslin.ext_update_github_action_iac_command.md
+++ b/changelog.d/20230725_144801_paul.beslin.ext_update_github_action_iac_command.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The IaC Github Action now executes the new `ggshield iac scan ci` command. This means the action will fail only if the changes introduce a new vulnerability. To fail if any vulnerability is detected, use the `ggshield iac scan ci --all` command

--- a/docker/actions-iac-entrypoint.sh
+++ b/docker/actions-iac-entrypoint.sh
@@ -12,4 +12,4 @@ git config --global --add safe.directory "$PWD"
 
 
 args=("$@")
-ggshield iac scan all -v ${args[@]}
+ggshield iac scan ci -v ${args[@]}

--- a/docker/actions-iac-entrypoint.sh
+++ b/docker/actions-iac-entrypoint.sh
@@ -12,4 +12,4 @@ git config --global --add safe.directory "$PWD"
 
 
 args=("$@")
-ggshield iac scan ci -v ${args[@]}
+ggshield iac scan ci ${args[@]}


### PR DESCRIPTION
Depends on #628 to be deployed for the stable action to work.

Updates the IaC Github Action to use the new `ggshield iac scan ci` command instead of `ggshield iac scan all`.