### PR TITLE
feat(iac): Improved color output of iac diff scan

### DIFF
--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -15,6 +15,9 @@ from rich.progress import (
 
 LINE_DISPLAY = {"file": "{} | ", "patch": "{} {} | "}
 
+LIGHT_GREY = (146, 146, 146)
+ORANGE = (255, 128, 80)
+
 STYLE: Dict[str, Dict[str, Any]] = {
     "nb_secrets": {"fg": "bright_blue", "bold": True},
     "filename": {"fg": "bright_yellow", "bold": True},
@@ -36,11 +39,15 @@ STYLE: Dict[str, Dict[str, Any]] = {
     "policy_break_type": {"fg": "bright_yellow", "bold": True},
     "occurrence_count": {"fg": "bright_yellow", "bold": True},
     "ignore_sha": {"fg": "bright_yellow", "bold": True},
-    "iac_vulnerability_critical": {"fg": (255, 0, 0), "bold": True},  # red
-    "iac_vulnerability_high": {"fg": (255, 128, 0), "bold": True},  # orange
+    "iac_vulnerability_critical": {"fg": "red", "bold": True},
+    "iac_vulnerability_high": {"fg": ORANGE, "bold": True},
     "iac_vulnerability_medium": {"fg": "bright_yellow", "bold": True},
-    "iac_vulnerability_low": {"fg": (146, 146, 146), "bold": True},  # light-grey
+    "iac_vulnerability_low": {"fg": LIGHT_GREY, "bold": True},
     "iac_vulnerability_unknown": {"fg": "bright_yellow", "bold": True},
+    "iac_deleted_vulnerability": {"fg": "green", "bold": True},
+    "iac_remaining_vulnerability": {"fg": "yellow", "bold": True},
+    "iac_new_vulnerability": {"fg": "bright_red", "bold": True},
+    "iac_dim_summary": {"fg": LIGHT_GREY, "dim": True},
 }
 
 

--- a/ggshield/iac/output/iac_text_output_handler.py
+++ b/ggshield/iac/output/iac_text_output_handler.py
@@ -1,8 +1,17 @@
 import shutil
-from collections import defaultdict
+from collections import Counter, defaultdict
 from io import StringIO
 from pathlib import Path
-from typing import ClassVar, DefaultDict, Dict, Generator, List, NamedTuple, Optional
+from typing import (
+    Any,
+    ClassVar,
+    DefaultDict,
+    Dict,
+    Generator,
+    List,
+    NamedTuple,
+    Optional,
+)
 
 from pygitguardian.iac_models import (
     IaCDiffScanEntities,
@@ -387,12 +396,18 @@ def diff_scan_summary(
     deleted: List[IaCFileResult],
 ) -> str:
     def detail(entries: List[IaCFileResult]) -> str:
-        count: Dict[str, int] = dict()
-        for entry in entries:
-            for incident in entry.incidents:
-                count.setdefault(incident.severity, 0)
-                count[incident.severity] += 1
-        formatted_count = [f"{key}: {val}" for key, val in count.items()]
+        def _get_style(severity: str) -> Dict[str, Dict[str, Any]]:
+            return STYLE.get(
+                f"iac_vulnerability_{severity.lower()}",
+                STYLE["iac_vulnerability_unknown"],
+            )
+
+        count = Counter(
+            incident.severity for entry in entries for incident in entry.incidents
+        )
+        formatted_count = [
+            format_text(f"{key}: {val}", _get_style(key)) for key, val in count.items()
+        ]
         if len(formatted_count) == 0:
             return ""
         return f" ({', '.join(formatted_count)})"
@@ -407,10 +422,30 @@ def diff_scan_summary(
     buf = StringIO()
     buf.write("\nSummary of changes:\n")
     buf.write(
-        f"[-] {num_deleted} {label_incident(num_deleted)} deleted{detail(deleted)}\n"
+        format_text(
+            f"[-] {num_deleted} {label_incident(num_deleted)} deleted",
+            STYLE[
+                "iac_deleted_vulnerability" if num_deleted > 0 else "iac_dim_summary"
+            ],
+        )
     )
+    buf.write(f"{detail(deleted)}\n")
     buf.write(
-        f"[~] {num_unchanged} {label_incident(num_unchanged)} remaining{detail(unchanged)}\n"
+        format_text(
+            f"[~] {num_unchanged} {label_incident(num_unchanged)} remaining",
+            STYLE[
+                "iac_remaining_vulnerability"
+                if num_unchanged > 0
+                else "iac_dim_summary"
+            ],
+        )
     )
-    buf.write(f"[+] {num_new} new {label_incident(num_new)} detected{detail(new)}\n")
+    buf.write(f"{detail(unchanged)}\n")
+    buf.write(
+        format_text(
+            f"[+] {num_new} new {label_incident(num_new)} detected",
+            STYLE["iac_new_vulnerability" if num_new > 0 else "iac_dim_summary"],
+        )
+    )
+    buf.write(f"{detail(new)}\n")
     return buf.getvalue()


### PR DESCRIPTION
Update colors in `ggshield iac scan diff`.
<img width="476" alt="before_no_color" src="https://github.com/GitGuardian/ggshield/assets/135315119/b801cd8f-ed6c-49a6-8824-9cdb82658363">
<img width="476" alt="fixed_color" src="https://github.com/GitGuardian/ggshield/assets/135315119/aefa13f5-a3b0-41ed-ad80-9b570908edde">
