### PR TITLE
jgriffe/sca 871/ignore paths declared in configuration

### DIFF
--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -154,8 +154,11 @@ def sca_scan_diff(
     if current_ref == ref:
         display_info("SCA scan diff comparing identical versions, scan skipped.")
         return SCAScanDiffOutput(scanned_files=[], added_vulns=[], removed_vulns=[])
-    ref_tar = tar_sca_files_from_git_repo(directory, ref, client)
-    current_tar = tar_sca_files_from_git_repo(directory, current_ref, client)
+    exclusion_regexes = ctx.obj["exclusion_regexes"]
+    ref_tar = tar_sca_files_from_git_repo(directory, ref, client, exclusion_regexes)
+    current_tar = tar_sca_files_from_git_repo(
+        directory, current_ref, client, exclusion_regexes
+    )
 
     scan_parameters = SCAScanParameters(config.user_config.sca.minimum_severity)
 

--- a/ggshield/sca/client.py
+++ b/ggshield/sca/client.py
@@ -25,6 +25,11 @@ class SCAClient:
         files: List[str],
         extra_headers: Optional[Dict[str, str]] = None,
     ) -> Union[Detail, ComputeSCAFilesResult]:
+        if len(files) == 0:
+            result = ComputeSCAFilesResult(sca_files=[], potential_siblings=[])
+            result.status_code = 200
+            return result
+
         response = self._client.post(
             endpoint="sca/compute_sca_files/",
             data={"files": files},

--- a/tests/unit/cassettes/test_sca_scan_diff_ignore.yaml
+++ b/tests/unit/cassettes/test_sca_scan_diff_ignore.yaml
@@ -1,0 +1,189 @@
+interactions:
+  - request:
+      body: '{"files": ["dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '28'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.12)
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":[],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '40'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Fri, 28 Jul 2023 07:50:27 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.35.1
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '21'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.15.0
+        x-secrets-engine-version:
+          - 2.94.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"files": ["dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '28'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.12)
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":[],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '40'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Fri, 28 Jul 2023 07:50:27 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.35.1
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '16'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.15.0
+        x-secrets-engine-version:
+          - 2.94.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS0wMzg5Mjg3NmEwNzk5NWYwYmQyZjdiODA1MmJkNDAxYQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJyZWZlcmVuY2UiOyBmaWxlbmFtZT0icmVmZXJlbmNlIg0KDQofiwgA
+        Q3PDZAL/7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tMDM4OTI4NzZhMDc5
+        OTVmMGJkMmY3YjgwNTJiZDQwMWENCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFt
+        ZT0iY3VycmVudCI7IGZpbGVuYW1lPSJjdXJyZW50Ig0KDQofiwgAQ3PDZAL/7cEBDQAAAMKg909t
+        DjegAAAAAAAAAAAAgDcDmt4dJwAoAAANCi0tMDM4OTI4NzZhMDc5OTVmMGJkMmY3YjgwNTJiZDQw
+        MWEtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '348'
+        Content-Type:
+          - multipart/form-data; boundary=03892876a07995f0bd2f7b8052bd401a
+        User-Agent:
+          - pygitguardian/1.8.0 (Linux;py3.10.12)
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_diff/
+    response:
+      body:
+        string: '{"scanned_files":[],"added_vulns":[],"removed_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '56'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Fri, 28 Jul 2023 07:50:27 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.35.1
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '291'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.15.0
+        x-secrets-engine-version:
+          - 2.94.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1


### PR DESCRIPTION
There is a bit of a weird behavior in the tests. All files are ignored, but an API call will still be made to filter the SCA files. This is probably fine as it will never happen in real cases, but makes the cassette necessary in the tests even though the API calls are useless.