### PR TITLE
add vulnerability identifier in text output for SCA scans

### DIFF
--- a/changelog.d/20230801_185552_henri.hubert_add_ghsa_id.md
+++ b/changelog.d/20230801_185552_henri.hubert_add_ghsa_id.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add the identifier of the SCA vulnerability in the text output

--- a/ggshield/sca/output/text_handler.py
+++ b/ggshield/sca/output/text_handler.py
@@ -104,6 +104,7 @@ class SCATextOutputHandler(SCAOutputHandler):
                 result_buf.write(sca_incident_severity_line(vulnerability))
                 result_buf.write(sca_incident_summary_line(vulnerability))
                 result_buf.write(sca_incident_fix_version_line(vulnerability))
+                result_buf.write(sca_incident_identifier(vulnerability))
                 result_buf.write(sca_incident_cve_ids(vulnerability))
 
                 incident_n += 1
@@ -185,3 +186,11 @@ def sca_incident_cve_ids(vulnerability: SCAVulnerability) -> str:
     else:
         cve_str = ", ".join(vulnerability.cve_ids)
     return f"CVE IDs: {cve_str}\n"
+
+
+def sca_incident_identifier(vulnerability: SCAVulnerability) -> str:
+    identifier = vulnerability.identifier
+    # TODO Remove clause when identifier field is in production on backend side (v2.36)
+    if identifier is None:
+        return ""
+    return f"Identifier: {vulnerability.identifier}\n"

--- a/ggshield/sca/output/text_handler.py
+++ b/ggshield/sca/output/text_handler.py
@@ -193,4 +193,4 @@ def sca_incident_identifier(vulnerability: SCAVulnerability) -> str:
     # TODO Remove clause when identifier field is in production on backend side (v2.36)
     if identifier is None:
         return ""
-    return f"Identifier: {vulnerability.identifier}\n"
+    return f"Identifier: {identifier}\n"

--- a/tests/functional/sca/test_sca_scan_all.py
+++ b/tests/functional/sca/test_sca_scan_all.py
@@ -1,12 +1,7 @@
-import pytest
-
 from tests.functional.utils import run_ggshield
 from tests.repository import Repository
 
 
-@pytest.mark.skip(
-    reason="waiting for sca scan all to be deployed, and output to be completed."
-)
 def test_sca_scan_all_with_vuln(dummy_sca_repo: Repository) -> None:
     """
     GIVEN a folder containing a file with vulnerabilities
@@ -18,13 +13,10 @@ def test_sca_scan_all_with_vuln(dummy_sca_repo: Repository) -> None:
     result = run_ggshield(
         "sca", "scan", "all", cwd=dummy_sca_repo.path, expected_code=1
     )
-    assert "Pipfile.lock" in result.stderr
-    assert "sqlparse" in result.stderr
+    assert "Pipfile.lock" in result.stdout
+    assert "sqlparse" in result.stdout
 
 
-@pytest.mark.skip(
-    reason="waiting for sca scan all to be deployed, and output to be completed."
-)
 def test_sca_scan_all_without_dependency_file(dummy_sca_repo: Repository) -> None:
     """
     GIVEN a folder containing a file with vulnerabilities

--- a/tests/unit/cmd/sca/test_precommit.py
+++ b/tests/unit/cmd/sca/test_precommit.py
@@ -133,6 +133,7 @@ def test_sca_scan_pre_commit_with_added_vulns(
 Severity: Critical
 Summary: a vuln
 No fix is currently available.
+Identifier: GHSA-abcd-1234-xxxx
 CVE IDs: CVE-2023"""
             in result.stdout
         )
@@ -144,6 +145,7 @@ CVE IDs: CVE-2023"""
 Severity: Low
 Summary: another vuln
 No fix is currently available.
+Identifier: GHSA-efgh-5678-xxxx
 CVE IDs: CVE-2023-bis"""
             in result.stdout
         )

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -215,6 +215,7 @@ def test_sca_scan_all_cmd(
 Severity: Medium
 Summary: sqlparse contains a regular expression that is vulnerable to Regular Expression Denial of Service
 A fix is available at version 0.4.4
+Identifier: GHSA-rrm6-wvj7-cwh2
 CVE IDs: CVE-2023-30608"""
         in result.stdout
     )


### PR DESCRIPTION
Add the vulnerability identifier in the text output when present.

It should appear with the next release