### PR TITLE
chore(pre-commit): reorder pre-commit to fail fast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,18 +12,6 @@ repos:
     hooks:
       - id: flake8
 
-  # use a "local" repo and not the pyright hook to ensure pyright runs in the same virtualenv
-  # as the rest of the code
-  - repo: local
-    hooks:
-      - id: pyright
-        name: pyright
-        entry: 'pipenv run pyright'
-        language: system
-        types: [python]
-        # do not pass filenames, otherwise Pyright might scan files we don't want it to scan
-        pass_filenames: false
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
@@ -42,6 +30,37 @@ repos:
     rev: v2.4.1
     hooks:
       - id: prettier
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/thlorenz/doctoc
+    rev: v2.2.0
+    hooks:
+      - id: doctoc
+        types: [markdown]
+        # Can't use "args: [README.md]" because it *adds* the
+        # argument to the list
+        files: '^README\.md$'
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.19.0
+    hooks:
+      - id: check-github-workflows
+
+  # use a "local" repo and not the pyright hook to ensure pyright runs in the same virtualenv
+  # as the rest of the code
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: 'pipenv run pyright'
+        language: system
+        types: [python]
+        # do not pass filenames, otherwise Pyright might scan files we don't want it to scan
+        pass_filenames: false
 
   - repo: local
     hooks:
@@ -68,22 +87,3 @@ repos:
       - id: ggshield
         language_version: python3
         stages: [commit]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/thlorenz/doctoc
-    rev: v2.2.0
-    hooks:
-      - id: doctoc
-        types: [markdown]
-        # Can't use "args: [README.md]" because it *adds* the
-        # argument to the list
-        files: '^README\.md$'
-
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.19.0
-    hooks:
-      - id: check-github-workflows


### PR DESCRIPTION
Pyright and ggshield are the slowest pre-commit tasks, having them at the end of the file makes them run last.

Having those last allows to have error from linters (most common IMO) first, leading to a more pleasant experience. WDYT ?