### PR TITLE
Allow defining the default config instance

### DIFF
--- a/changelog.d/20230807_180315_aurelien.gateau_config_set_instance.md
+++ b/changelog.d/20230807_180315_aurelien.gateau_config_set_instance.md
@@ -1,0 +1,3 @@
+### Added
+
+- It is now possible to define the default instance using `ggshield config set instance <THE_INSTANCE_URL>`.

--- a/ggshield/cmd/config/__init__.py
+++ b/ggshield/cmd/config/__init__.py
@@ -4,19 +4,19 @@ import click
 
 from ggshield.cmd.common_options import add_common_options
 
-from .config_get import config_get_command
+from .config_get import config_get_cmd
 from .config_list import config_list_cmd
 from .config_migrate import config_migrate_cmd
-from .config_set import config_set_command
-from .config_unset import config_unset_command
+from .config_set import config_set_cmd
+from .config_unset import config_unset_cmd
 
 
 @click.group(
     commands={
         "list": config_list_cmd,
-        "set": config_set_command,
-        "unset": config_unset_command,
-        "get": config_get_command,
+        "set": config_set_cmd,
+        "unset": config_unset_cmd,
+        "get": config_get_cmd,
         "migrate": config_migrate_cmd,
     }
 )

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -20,7 +20,7 @@ from ggshield.core.errors import UnknownInstanceError
 )
 @add_common_options()
 @click.pass_context
-def config_get_command(
+def config_get_cmd(
     ctx: click.Context, field_name: str, instance_url: Optional[str], **kwargs: Any
 ) -> int:
     """

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -3,13 +3,13 @@ from typing import Any, Optional
 import click
 
 from ggshield.cmd.common_options import add_common_options
-from ggshield.cmd.config.constants import FIELD_OPTIONS
+from ggshield.cmd.config.constants import FIELD_NAMES
 from ggshield.core.config import Config
 from ggshield.core.errors import UnknownInstanceError
 
 
 @click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_OPTIONS), required=True)
+@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
 @click.option(
     "--instance",
     "instance_url",

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -21,7 +21,7 @@ from .constants import FIELD_OPTIONS
 )
 @add_common_options()
 @click.pass_context
-def config_set_command(
+def config_set_cmd(
     ctx: click.Context,
     field_name: str,
     value: str,

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -1,16 +1,18 @@
 from typing import Any, Optional
 
 import click
-from click import UsageError
+from click import BadParameter
 
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
+from ggshield.core.config.user_config import UserConfig
+from ggshield.core.config.utils import find_global_config_path
 
-from .constants import FIELD_OPTIONS
+from .constants import FIELD_NAMES, FIELDS
 
 
 @click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_OPTIONS), required=True)
+@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
 @click.argument("value", nargs=1, type=click.STRING, required=True)
 @click.option(
     "--instance",
@@ -33,19 +35,28 @@ def config_set_cmd(
     """
     config: Config = ctx.obj["config"]
 
+    field = FIELDS[field_name]
+
     # value type checking must be done per case
     if field_name == "default_token_lifetime":
         try:
             value = int(value)  # type: ignore
         except ValueError:
-            raise UsageError("default_token_lifetime must be an int")
+            raise BadParameter("default_token_lifetime must be an int")
 
-    if instance is None:
-        setattr(config.auth_config, field_name, value)
-
+    if instance:
+        if field.per_instance_ok:
+            instance_config = config.auth_config.get_instance(instance)
+            setattr(instance_config, field_name, value)
+        else:
+            raise BadParameter(f"{field_name} cannot be set per instance")
+        config.auth_config.save()
+    elif field.auth_config:
+        setattr(config.auth_config, field.name, value)
+        config.auth_config.save()
     else:
-        instance_config = config.auth_config.get_instance(instance)
-        setattr(instance_config, field_name, value)
-
-    config.auth_config.save()
+        config_path = find_global_config_path(to_write=True)
+        user_config, _ = UserConfig.load(config_path)
+        setattr(user_config, field.name, value)
+        user_config.save(config_path)
     return 0

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -5,11 +5,11 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
-from .constants import FIELD_OPTIONS
+from .constants import FIELD_NAMES
 
 
 @click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_OPTIONS), required=True)
+@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
 @click.option(
     "--instance",
     "instance_url",

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -21,7 +21,7 @@ from .constants import FIELD_OPTIONS
 @click.option("--all", "all_", is_flag=True, help="Iterate over every instances.")
 @add_common_options()
 @click.pass_context
-def config_unset_command(
+def config_unset_cmd(
     ctx: click.Context,
     field_name: str,
     instance_url: Optional[str],

--- a/ggshield/cmd/config/constants.py
+++ b/ggshield/cmd/config/constants.py
@@ -1,3 +1,39 @@
+from dataclasses import dataclass
+
+
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-FIELD_OPTIONS = ("default_token_lifetime",)
+
+@dataclass
+class ConfigField:
+    """Meta-information about a config field, used by `ggshield config` commands to
+    manipulate configuration files.
+    """
+
+    # The name of the field in the config file.
+    name: str
+
+    # True if this field is stored in auth_config.yaml, False if it's in the global
+    # user config file.
+    auth_config: bool = False
+
+    # True if this field can be set for an individual instance. Only valid for
+    # auth_config fields.
+    per_instance_ok: bool = False
+
+
+# All editable config fields
+_FIELDS = (
+    ConfigField(
+        "instance",
+    ),
+    ConfigField(
+        "default_token_lifetime",
+        auth_config=True,
+        per_instance_ok=True,
+    ),
+)
+
+FIELDS = {x.name: x for x in _FIELDS}
+
+FIELD_NAMES = sorted(FIELDS.keys())

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -8,18 +7,15 @@ from marshmallow import ValidationError
 from pygitguardian.models import FromDictMixin
 
 from ggshield.core.config.utils import (
-    get_global_path,
+    find_global_config_path,
+    find_local_config_path,
     load_yaml_dict,
     remove_common_dict_items,
     replace_in_keys,
     save_yaml_dict,
     update_from_other_instance,
 )
-from ggshield.core.constants import (
-    DEFAULT_LOCAL_CONFIG_PATH,
-    GLOBAL_CONFIG_FILENAMES,
-    LOCAL_CONFIG_PATHS,
-)
+from ggshield.core.constants import DEFAULT_LOCAL_CONFIG_PATH
 from ggshield.core.errors import ParseError, UnexpectedError, format_validation_error
 from ggshield.core.types import FilteredConfig, IgnoredMatch
 from ggshield.core.utils import api_to_dashboard_url
@@ -134,21 +130,18 @@ class UserConfig(FilteredConfig):
             user_config._update_from_file(config_path)
             return user_config, config_path
 
-        for global_config_filename in GLOBAL_CONFIG_FILENAMES:
-            global_config_path = get_global_path(global_config_filename)
-            if os.path.exists(global_config_path):
-                user_config._update_from_file(global_config_path)
-                logger.debug("Loaded global config from %s", global_config_path)
-                break
+        global_config_path = find_global_config_path()
+        if global_config_path:
+            user_config._update_from_file(global_config_path)
+            logger.debug("Loaded global config from %s", global_config_path)
         else:
             logger.debug("No global config")
 
-        for local_config_path in LOCAL_CONFIG_PATHS:
-            if os.path.exists(local_config_path):
-                user_config._update_from_file(local_config_path)
-                config_path = local_config_path
-                logger.debug("Loaded local config from %s", local_config_path)
-                break
+        local_config_path = find_local_config_path()
+        if local_config_path:
+            user_config._update_from_file(local_config_path)
+            config_path = local_config_path
+            logger.debug("Loaded local config from %s", local_config_path)
         else:
             logger.debug("No local config")
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -8,7 +8,7 @@ import yaml.parser
 import yaml.scanner
 
 from ggshield.core.constants import AUTH_CONFIG_FILENAME, USER_CONFIG_FILENAMES
-from ggshield.core.dirs import get_config_dir
+from ggshield.core.dirs import get_config_dir, get_user_home_dir
 from ggshield.core.errors import UnexpectedError
 
 
@@ -58,7 +58,7 @@ def get_auth_config_filepath() -> str:
 
 
 def get_global_path(filename: str) -> str:
-    return os.path.join(os.path.expanduser("~"), filename)
+    return os.path.join(get_user_home_dir(), filename)
 
 
 def find_global_config_path() -> Optional[str]:

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -1,13 +1,28 @@
 import os
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 import yaml
 import yaml.parser
 import yaml.scanner
 
-from ggshield.core.constants import AUTH_CONFIG_FILENAME, USER_CONFIG_FILENAMES
+from ggshield.core.constants import (
+    AUTH_CONFIG_FILENAME,
+    DEFAULT_CONFIG_FILENAME,
+    USER_CONFIG_FILENAMES,
+)
 from ggshield.core.dirs import get_config_dir, get_user_home_dir
 from ggshield.core.errors import UnexpectedError
 
@@ -61,12 +76,31 @@ def get_global_path(filename: str) -> str:
     return os.path.join(get_user_home_dir(), filename)
 
 
-def find_global_config_path() -> Optional[str]:
+@overload
+def find_global_config_path(*, to_write: Literal[False] = False) -> Optional[str]:
+    ...
+
+
+@overload
+def find_global_config_path(*, to_write: Literal[True]) -> str:
+    ...
+
+
+def find_global_config_path(*, to_write: bool = False) -> Optional[str]:
+    """
+    Returns the path to the user global config file (the file in the user home
+    directory).
+    If there is no such file:
+    - If `to_write` is False, returns None.
+    - If `to_write` is True, returns the path to the default file.
+
+    This means the function never returns None if `to_write` is True.
+    """
     for filename in USER_CONFIG_FILENAMES:
         path = get_global_path(filename)
         if os.path.exists(path):
             return path
-    return None
+    return get_global_path(DEFAULT_CONFIG_FILENAME) if to_write else None
 
 
 def find_local_config_path() -> Optional[str]:

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -7,7 +7,7 @@ import yaml
 import yaml.parser
 import yaml.scanner
 
-from ggshield.core.constants import AUTH_CONFIG_FILENAME
+from ggshield.core.constants import AUTH_CONFIG_FILENAME, USER_CONFIG_FILENAMES
 from ggshield.core.dirs import get_config_dir
 from ggshield.core.errors import UnexpectedError
 
@@ -59,6 +59,21 @@ def get_auth_config_filepath() -> str:
 
 def get_global_path(filename: str) -> str:
     return os.path.join(os.path.expanduser("~"), filename)
+
+
+def find_global_config_path() -> Optional[str]:
+    for filename in USER_CONFIG_FILENAMES:
+        path = get_global_path(filename)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def find_local_config_path() -> Optional[str]:
+    for filename in USER_CONFIG_FILENAMES:
+        if os.path.exists(filename):
+            return filename
+    return None
 
 
 def update_from_other_instance(dst: Any, src: Any) -> None:

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -11,8 +11,7 @@ def _get_max_workers() -> int:
 
 MAX_WORKERS = min(CPU_COUNT, _get_max_workers())
 CACHE_FILENAME = "./.cache_ggshield"
-GLOBAL_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", ".gitguardian.yaml"]
-LOCAL_CONFIG_PATHS = ["./.gitguardian", "./.gitguardian.yml", "./.gitguardian.yaml"]
+USER_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", ".gitguardian.yaml"]
 DEFAULT_LOCAL_CONFIG_PATH = "./.gitguardian.yaml"
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 DEFAULT_HMSL_URL = "https://api.hasmysecretleaked.com"

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -11,8 +11,9 @@ def _get_max_workers() -> int:
 
 MAX_WORKERS = min(CPU_COUNT, _get_max_workers())
 CACHE_FILENAME = "./.cache_ggshield"
-USER_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", ".gitguardian.yaml"]
-DEFAULT_LOCAL_CONFIG_PATH = "./.gitguardian.yaml"
+DEFAULT_CONFIG_FILENAME = ".gitguardian.yaml"
+USER_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", DEFAULT_CONFIG_FILENAME]
+DEFAULT_LOCAL_CONFIG_PATH = os.path.join(".", DEFAULT_CONFIG_FILENAME)
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 DEFAULT_HMSL_URL = "https://api.hasmysecretleaked.com"
 AUTH_CONFIG_FILENAME = "auth_config.yaml"

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -7,6 +7,14 @@ APPNAME = "ggshield"
 APPAUTHOR = "GitGuardian"
 
 
+def get_user_home_dir() -> str:
+    try:
+        # See tests/conftest.py for details
+        return str(os.environ["GG_USER_HOME_DIR"])
+    except KeyError:
+        return os.path.expanduser("~")
+
+
 def get_config_dir() -> str:
     try:
         # See tests/conftest.py for details

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,20 +65,17 @@ resource "aws_network_acl_rule" "bad_example" {
 
 
 @pytest.fixture(autouse=True)
-def do_not_use_real_config_dir(monkeypatch, tmp_path):
+def do_not_use_real_user_dirs(monkeypatch, tmp_path):
     """
-    This fixture ensures we do not use the real configuration directory, where
-    `ggshield auth` stores credentials.
+    This fixture ensures we do not use real user directories.
+    Overridden directories are:
+    - the auth configuration directory, where `ggshield auth` stores credentials.
+    - the cache directory
+    - the home directory
     """
-    monkeypatch.setenv("GG_CONFIG_DIR", str(tmp_path))
-
-
-@pytest.fixture(autouse=True)
-def do_not_use_real_cache_dir(monkeypatch, tmp_path):
-    """
-    This fixture ensures we do not use the real cache directory.
-    """
-    monkeypatch.setenv("GG_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("GG_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("GG_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("GG_USER_HOME_DIR", str(tmp_path / "home"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -38,13 +38,6 @@ expiry: not set
 """
 
 
-@pytest.fixture(autouse=True)
-def tmp_config(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "ggshield.core.config.utils.get_config_dir", lambda: str(tmp_path)
-    )
-
-
 class TestAuthConfigList:
     def test_valid_list(self, cli_fs_runner):
         """

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -38,12 +38,12 @@ expiry: not set
 """
 
 
-class TestAuthConfigList:
+class TestConfigList:
     def test_valid_list(self, cli_fs_runner):
         """
-        GIVEN several auth config saved
-        WHEN calling ggshield auth config list command
-        THEN all config should be listed with the correct format
+        GIVEN several config saved
+        WHEN calling `ggshield config list` command
+        THEN all configs should be listed with the correct format
         """
 
         # May 4th
@@ -73,13 +73,13 @@ class TestAuthConfigList:
         return result.exit_code, result.output
 
 
-class TestAuthConfigSet:
+class TestConfigSet:
     @pytest.mark.parametrize("value", [0, 365])
     def test_set_lifetime_default_config_value(self, value, cli_fs_runner):
         """
         GIVEN a saved protected config
         WHEN running the set command with a valid param and no instance specified
-        THEN the default config speficied field value be saved
+        THEN the default config specified field value be saved
         AND other instance configs must not be affected
         """
         unchanged_value = 42
@@ -102,7 +102,7 @@ class TestAuthConfigSet:
         """
         GIVEN a saved protected config
         WHEN running the set command with a valid param and the instance specified
-        THEN the instance's speficied field value be saved
+        THEN the instance's specified field value be saved
         AND other configs must not be affected
         """
         unchanged_value = 4
@@ -143,15 +143,7 @@ class TestAuthConfigSet:
         default_value = Config().auth_config.default_token_lifetime
 
         exit_code, output = self.run_cmd(cli_fs_runner, 0, param="invalid_field_name")
-
         assert exit_code == ExitCode.USAGE_ERROR, output
-        expected_output = (
-            "Usage: cli config set [OPTIONS] {default_token_lifetime} VALUE\n"
-            "Try 'cli config set -h' for help.\n\n"
-            "Error: Invalid value for '{default_token_lifetime}': 'invalid_field_name' "
-            "is not 'default_token_lifetime'.\n"
-        )
-        assert output == expected_output
 
         config = Config()
         assert (
@@ -209,12 +201,12 @@ class TestAuthConfigSet:
         return result.exit_code, result.output
 
 
-class TestAuthConfigUnset:
+class TestConfigUnset:
     def test_unset_lifetime_instance_config_value(self, cli_fs_runner):
         """
         GIVEN a saved protected config
         WHEN running the unset command with the instance specified
-        THEN the speficied field value must be erased from this config
+        THEN the specified field value must be erased from this config
         AND other configs must not be affected
         """
         unchanged_value = 42
@@ -250,7 +242,7 @@ class TestAuthConfigUnset:
         """
         GIVEN a saved protected config
         WHEN running the unset command with no instance specified
-        THEN the speficied field value must be erased from the default config
+        THEN the specified field value must be erased from the default config
         AND other configs must not be affected
         """
         unchanged_value = 42
@@ -271,7 +263,7 @@ class TestAuthConfigUnset:
         """
         GIVEN saved protected configs
         WHEN running the unset command with --all option
-        THEN the speficied field value must be erased from all configs
+        THEN the specified field value must be erased from all configs
         (per instance and default)
         """
         second_instance = "https://some-gg-instance.com"
@@ -298,7 +290,7 @@ class TestAuthConfigUnset:
         """
         GIVEN -
         WHEN running the unset command with an unknown instance
-        THEN the command shoud exit with and error
+        THEN the command should exit with and error
         AND no config must ne affected
         """
         instance_url = "https://some-invalid-gg-instance.com"
@@ -328,7 +320,7 @@ class TestAuthConfigUnset:
         return result.exit_code, result.output
 
 
-class TestAuthConfigGet:
+class TestConfigGet:
     @pytest.mark.parametrize(
         ["default_value", "instance_value", "expected_value"],
         [
@@ -405,7 +397,7 @@ class TestAuthConfigGet:
         """
         GIVEN -
         WHEN running the get command with an unknown instance
-        THEN the command shoud exit with and error
+        THEN the command should exit with and error
         """
         instance_url = "https://some-invalid-gg-instance.com"
         exit_code, output = self.run_cmd(cli_fs_runner, instance_url=instance_url)
@@ -413,21 +405,14 @@ class TestAuthConfigGet:
         assert exit_code == ExitCode.AUTHENTICATION_ERROR, output
         assert output == f"Error: Unknown instance: '{instance_url}'\n"
 
-    def test_set_invalid_field_name(self, cli_fs_runner):
+    def test_get_invalid_field_name(self, cli_fs_runner):
         """
         GIVEN _
-        WHEN running the set command with an invalid field name
+        WHEN running the get command with an invalid field name
         THEN the command should exit with an error
         """
         exit_code, output = self.run_cmd(cli_fs_runner, param="invalid_field_name")
         assert exit_code == ExitCode.USAGE_ERROR, output
-        expected_output = (
-            "Usage: cli config get [OPTIONS] {default_token_lifetime}\n"
-            "Try 'cli config get -h' for help.\n\n"
-            "Error: Invalid value for '{default_token_lifetime}': 'invalid_field_name' "
-            "is not 'default_token_lifetime'.\n"
-        )
-        assert output == expected_output
 
     @staticmethod
     def run_cmd(cli_fs_runner, param="default_token_lifetime", instance_url=None):

--- a/tests/unit/core/config/conftest.py
+++ b/tests/unit/core/config/conftest.py
@@ -40,7 +40,7 @@ TEST_AUTH_CONFIG = {
 
 @pytest.fixture
 def local_config_path():
-    yield "./.gitguardian"
+    yield ".gitguardian"
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Description

This PR makes it possible to set the default instance of GitGuardian to use with `ggshield config set instance <THE_INSTANCE_URL>`.

What the command does is setting the `instance` field of the user global configuration file (~/.gitguardian.yaml, ~/.gitguardian.yml or ~/.gitguardian). If no such file exists, it creates the ~/.gitguardian.yaml file.

The next PR completes this by allowing the default instance to be read with `ggshield config get instance`, unset with `ggshield config unset instance` and listed in `ggshield config list`.

## What has been done

The first 3 commits make some cleanups.

Then the next two rework the way we find the user config file to make it possible to implement and test `ggshield config set instance`.

The final commit really implements the feature.

## Related issue

This should make bug #359 a bit less annoying.