### PR TITLE
chore(pre-commit): run ggshield-local on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,6 @@ repos:
         name: GitGuardian Shield
         entry: pipenv run ggshield secret scan pre-commit
         language: system
-        types: [python]
         stages: [commit]
 
   - repo: local
@@ -78,7 +77,6 @@ repos:
         entry: pipenv run ggshield secret scan pre-push
         language: system
         pass_filenames: false
-        types: [python]
         stages: [push]
 
   - repo: https://github.com/gitguardian/ggshield


### PR DESCRIPTION
Remove filter on Python files

For an unknown reason, this filter was added. According to [the documentation](https://pre-commit.com/#config-types), it acts as a filter (logical AND) and will not trigger a scan for non python files.

To test the behavior before the change:
- modify the `.prettierignore`
- commit
- the `GitGuardian Shield` job is skipped