### PR TITLE
Remove magic access to user_config and auth_config

### DIFF
--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -44,7 +44,7 @@ def logout_cmd(
     If not specified, ggshield will logout from the default instance.
     The `--all` option can be used if you want to logout from all your GitGuardian instances.
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
 
     if all_:
         for _instance in config.auth_config.instances:
@@ -90,7 +90,7 @@ def revoke_token(config: Config, instance_url: str) -> None:
     client = create_client(
         token,
         dashboard_to_api_url(instance_url),
-        allow_self_signed=config.allow_self_signed,
+        allow_self_signed=config.user_config.allow_self_signed,
     )
     try:
         response = client.post(endpoint="token/revoke")

--- a/ggshield/cmd/config/config_migrate.py
+++ b/ggshield/cmd/config/config_migrate.py
@@ -4,6 +4,7 @@ from typing import Any
 import click
 
 from ggshield.cmd.common_options import add_common_options
+from ggshield.core.config import Config
 
 
 @click.command()
@@ -13,7 +14,7 @@ def config_migrate_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Migrate configuration file to the latest version
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
 
     # Clear all deprecation messages, so that they do not show up when we quit
     config.user_config.deprecation_messages = []

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -10,6 +10,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.core.config import Config
 from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
 from ggshield.core.text_utils import display_warning
 
@@ -42,8 +43,8 @@ def scan_ci_cmd(
         result = iac_scan_all(ctx, directory)
         return display_iac_scan_all_result(ctx, directory, result)
 
-    config = ctx.obj["config"]
-    commit_list, _ = collect_commit_range_from_ci_env(config.verbose)
+    config: Config = ctx.obj["config"]
+    commit_list, _ = collect_commit_range_from_ci_env(config.user_config.verbose)
     reference, current_ref = commit_list[0], commit_list[-1]
 
     # If we failed to fetch a current reference, we set it to HEAD

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -21,6 +21,7 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
     get_iac_tar,
     handle_scan_error,
 )
+from ggshield.core.config import Config
 from ggshield.core.file_utils import get_empty_tar
 from ggshield.core.filter import is_filepath_excluded
 from ggshield.core.git_shell import (
@@ -90,7 +91,7 @@ def iac_scan_diff(
     :return: IacDiffScanResult if the scan was performed; IaCSkipScanResult if the scan
     was skipped (i.e. no IaC files were detected or changed between the two references)
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     client = ctx.obj["client"]
     exclusion_regexes = ctx.obj["exclusion_regexes"]
 
@@ -157,7 +158,8 @@ def iac_scan_diff(
     current_tar = get_iac_tar(directory, current_ref, exclusion_regexes)
 
     scan_parameters = IaCScanParameters(
-        config.user_config.iac.ignored_policies, config.user_config.iac.minimum_severity
+        list(config.user_config.iac.ignored_policies),
+        config.user_config.iac.minimum_severity,
     )
 
     scan = client.iac_diff_scan(

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -44,7 +44,10 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> int:
     exit_code guarantees that the return value of a scan is 0
     when exit_zero is enabled
     """
-    if exit_code == ExitCode.SCAN_FOUND_PROBLEMS and ctx.obj["config"].exit_zero:
+    if (
+        exit_code == ExitCode.SCAN_FOUND_PROBLEMS
+        and ctx.obj["config"].user_config.exit_zero
+    ):
         logger.debug("scan exit_code forced to 0")
         sys.exit(ExitCode.SUCCESS)
 
@@ -101,11 +104,11 @@ def cli(
 ) -> None:
     load_dot_env()
 
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
 
     _set_color(ctx)
 
-    if config.debug:
+    if config.user_config.debug:
         # if `debug` is set in the configuration file, then setup logs now.
         setup_debug_logs(filename=None)
 

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -16,6 +16,7 @@ from ggshield.cmd.sca.scan.scan_common_options import (
     add_sca_scan_common_options,
     update_context,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
 from ggshield.core.git_shell import check_git_dir
@@ -49,7 +50,7 @@ def scan_ci_cmd(
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
 
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     try:
         if not (
             os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")
@@ -63,8 +64,10 @@ def scan_ci_cmd(
             return output_handler.process_scan_all_result(scan)
 
         check_git_dir()
-        commit_count = len(collect_commit_range_from_ci_env(config.verbose)[0])
-        if config.verbose:
+        commit_count = len(
+            collect_commit_range_from_ci_env(config.user_config.verbose)[0]
+        )
+        if config.user_config.verbose:
             click.echo(f"Commits to scan: {commit_count}", err=True)
         result = sca_scan_diff(
             ctx=ctx,
@@ -75,4 +78,4 @@ def scan_ci_cmd(
         return output_handler.process_scan_diff_result(scan)
 
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -6,7 +6,7 @@ import click
 from pygitguardian.client import _create_tar
 
 from ggshield.cmd.common_options import use_json
-from ggshield.core.config.config import Config
+from ggshield.core.config import Config
 from ggshield.core.config.user_config import SCAConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
 from ggshield.core.file_utils import get_empty_tar
@@ -58,13 +58,13 @@ def sca_scan_all(ctx: click.Context, directory: Path) -> SCAScanAllOutput:
     - Create a tar archive with the required files contents
     - Launches the scan with a call to SCA public API
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     client = SCAClient(ctx.obj["client"])
 
     sca_filepaths, sca_filter_status_code = get_sca_scan_all_filepaths(
         directory=directory,
         exclusion_regexes=ctx.obj["exclusion_regexes"],
-        verbose=ctx.obj["config"].verbose,
+        verbose=config.user_config.verbose,
         client=client,
     )
 
@@ -174,7 +174,7 @@ def sca_scan_diff(
     When set to None, the current state is the indexed files currently on disk.
     :return: SCAScanDiffOutput object.
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     client = SCAClient(ctx.obj["client"])
     exclusion_regexes = ctx.obj["exclusion_regexes"]
 

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -25,7 +25,7 @@ def ignore_cmd(
     Ignore some secrets.
     """
     if last_found:
-        config = ctx.obj["config"]
+        config: Config = ctx.obj["config"]
         cache = ctx.obj["cache"]
         nb = ignore_last_found(config, cache)
         path = config.config_path

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -74,7 +74,7 @@ def scan_group_impl(ctx: click.Context) -> int:
 
     max_commits = get_max_commits_for_hook()
     if max_commits:
-        config.max_commits_for_hook = max_commits
+        config.user_config.max_commits_for_hook = max_commits
 
     return return_code
 

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -42,7 +42,7 @@ def archive_cmd(
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             recursive=True,
             yes=True,
-            verbose=config.verbose,
+            verbose=config.user_config.verbose,
             ignore_git=True,
         )
 
@@ -56,8 +56,8 @@ def archive_cmd(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 scan_context=scan_context,
-                ignored_matches=config.secret.ignored_matches,
-                ignored_detectors=config.secret.ignored_detectors,
+                ignored_matches=config.user_config.secret.ignored_matches,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
             results = scanner.scan(files.files, scanner_ui=ui)
 

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -8,6 +8,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.secret.docker import docker_save_to_tmp, docker_scan_archive
@@ -39,7 +40,7 @@ def docker_name_cmd(
     """
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temporary_dir:
-        config = ctx.obj["config"]
+        config: Config = ctx.obj["config"]
         output_handler = create_output_handler(ctx)
 
         try:
@@ -56,10 +57,10 @@ def docker_name_cmd(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
                 scan_context=scan_context,
-                matches_ignore=config.secret.ignored_matches,
-                ignored_detectors=config.secret.ignored_detectors,
+                matches_ignore=config.user_config.secret.ignored_matches,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
 
             return output_handler.process_scan(scan)
         except Exception as error:
-            return handle_exception(error, config.verbose)
+            return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -7,6 +7,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.secret.docker import docker_scan_archive
@@ -28,7 +29,7 @@ def docker_archive_cmd(
 
     Hidden command `ggshield secret scan docker-archive`
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)
 
     scan_context = ScanContext(
@@ -41,11 +42,11 @@ def docker_archive_cmd(
             archive_path=archive,
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
-            matches_ignore=config.secret.ignored_matches,
+            matches_ignore=config.user_config.secret.ignored_matches,
             scan_context=scan_context,
-            ignored_detectors=config.secret.ignored_detectors,
+            ignored_detectors=config.user_config.secret.ignored_detectors,
         )
 
         return output_handler.process_scan(scan)
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -8,6 +8,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.scan import ScanContext, ScanMode, Scannable, StringScannable
@@ -60,7 +61,7 @@ def docset_cmd(
     """
     scan docset JSONL files.
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)
     try:
         with create_progress_bar(doc_type="files") as progress:
@@ -72,9 +73,9 @@ def docset_cmd(
             scanner = SecretScanner(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
-                ignored_matches=config.secret.ignored_matches,
+                ignored_matches=config.user_config.secret.ignored_matches,
                 scan_context=scan_context,
-                ignored_detectors=config.secret.ignored_detectors,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
             task_scan = progress.add_task(
                 "[green]Scanning content...", total=len(files)
@@ -82,7 +83,7 @@ def docset_cmd(
             scans = create_scans_from_docset_files(
                 scanner=scanner,
                 input_files=files,
-                verbose=config.verbose,
+                verbose=config.user_config.verbose,
                 progress_callback=partial(progress.update, task_scan),
             )
 
@@ -90,4 +91,4 @@ def docset_cmd(
             SecretScanCollection(id=scan_context.command_id, type="docset", scans=scans)
         )
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -6,6 +6,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.scan import ScanContext, ScanMode
 from ggshield.scan.file import get_files_from_paths
@@ -30,7 +31,7 @@ def path_cmd(
     """
     scan files and directories.
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)
     try:
         files = get_files_from_paths(
@@ -38,7 +39,7 @@ def path_cmd(
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             recursive=recursive,
             yes=yes,
-            verbose=config.verbose,
+            verbose=config.user_config.verbose,
             # when scanning a path explicitly we should not care if it is a git repository or not
             ignore_git=True,
         )
@@ -52,9 +53,9 @@ def path_cmd(
             scanner = SecretScanner(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
-                ignored_matches=config.secret.ignored_matches,
+                ignored_matches=config.user_config.secret.ignored_matches,
                 scan_context=scan_context,
-                ignored_detectors=config.secret.ignored_detectors,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
             results = scanner.scan(files.files, scanner_ui=ui)
         scan = SecretScanCollection(
@@ -63,4 +64,4 @@ def path_cmd(
 
         return output_handler.process_scan(scan)
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -5,6 +5,7 @@ import click
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import check_git_dir
 from ggshield.scan import Commit, ScanContext, ScanMode
@@ -36,12 +37,12 @@ def precommit_cmd(
     """
     scan as a pre-commit git hook.
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     output_handler = SecretTextOutputHandler(
-        show_secrets=config.secret.show_secrets,
-        verbose=config.verbose,
+        show_secrets=config.user_config.secret.show_secrets,
+        verbose=config.user_config.verbose,
         output=None,
-        ignore_known_secrets=config.secret.ignore_known_secrets,
+        ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
     )
     try:
         check_git_dir()
@@ -56,8 +57,8 @@ def precommit_cmd(
             client=ctx.obj["client"],
             cache=ctx.obj["cache"],
             scan_context=scan_context,
-            ignored_matches=config.secret.ignored_matches,
-            ignored_detectors=config.secret.ignored_detectors,
+            ignored_matches=config.user_config.secret.ignored_matches,
+            ignored_detectors=config.user_config.secret.ignored_detectors,
         )
         results = scanner.scan(commit.files)
 
@@ -75,4 +76,4 @@ def precommit_cmd(
             )
         return return_code
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -103,7 +103,7 @@ def pypi_cmd(
             archive_dir=temp_dir,
             package_name=package_name,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
-            verbose=config.verbose,
+            verbose=config.user_config.verbose,
         )
 
         with RichSecretScannerUI(len(files.files), dataset_type="PyPI Package") as ui:
@@ -115,9 +115,9 @@ def pypi_cmd(
             scanner = SecretScanner(
                 client=ctx.obj["client"],
                 cache=ctx.obj["cache"],
-                ignored_matches=config.secret.ignored_matches,
+                ignored_matches=config.user_config.secret.ignored_matches,
                 scan_context=scan_context,
-                ignored_detectors=config.secret.ignored_detectors,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
             results = scanner.scan(files.files, scanner_ui=ui)
         scan = SecretScanCollection(id=package_name, type="path_scan", results=results)

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -7,6 +7,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_shell import get_list_commit_SHA
 from ggshield.scan import ScanContext, ScanMode
@@ -28,12 +29,12 @@ def range_cmd(
     git rev-list COMMIT_RANGE to list several commits to scan.
     example: ggshield secret scan commit-range HEAD~1...
     """
-    config = ctx.obj["config"]
+    config: Config = ctx.obj["config"]
     try:
         commit_list = get_list_commit_SHA(commit_range)
         if not commit_list:
             raise UsageError("invalid commit range")
-        if config.verbose:
+        if config.user_config.verbose:
             click.echo(f"Commits to scan: {len(commit_list)}", err=True)
 
         scan_context = ScanContext(
@@ -47,9 +48,9 @@ def range_cmd(
             commit_list=commit_list,
             output_handler=create_output_handler(ctx),
             exclusion_regexes=ctx.obj["exclusion_regexes"],
-            matches_ignore=config.secret.ignored_matches,
+            matches_ignore=config.user_config.secret.ignored_matches,
             scan_context=scan_context,
-            ignored_detectors=config.secret.ignored_detectors,
+            ignored_detectors=config.user_config.secret.ignored_detectors,
         )
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -12,6 +12,7 @@ from ggshield.cmd.common_options import (
     json_option,
     use_json,
 )
+from ggshield.core.config import Config
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.utils import IGNORED_DEFAULT_WILDCARDS
@@ -119,11 +120,11 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     output_handler_cls = (
         SecretJSONOutputHandler if use_json(ctx) else SecretTextOutputHandler
     )
-    config = ctx.obj["config"].user_config
+    config: Config = ctx.obj["config"]
     output = ctx.obj.get("output")
     return output_handler_cls(
-        show_secrets=config.secret.show_secrets,
-        verbose=config.verbose,
+        show_secrets=config.user_config.secret.show_secrets,
+        verbose=config.user_config.verbose,
         output=output,
-        ignore_known_secrets=config.secret.ignore_known_secrets,
+        ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
     )

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -35,7 +35,9 @@ https://docs.gitguardian.com/ggshield-docs/reference/auth/login""",
         else:
             raise
 
-    return create_client(api_key, api_url, allow_self_signed=config.allow_self_signed)
+    return create_client(
+        api_key, api_url, allow_self_signed=config.user_config.allow_self_signed
+    )
 
 
 def create_client(

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -1,18 +1,7 @@
 import os
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    overload,
-)
+from typing import Any, Dict, List, Literal, Optional, Union, overload
 
 import yaml
 import yaml.parser
@@ -133,20 +122,6 @@ def update_from_other_instance(dst: Any, src: Any) -> None:
 
 def ensure_path_exists(dir_path: str) -> None:
     Path(dir_path).mkdir(parents=True, exist_ok=True)
-
-
-def get_attr_mapping(classes: Iterable[Tuple[Type[Any], str]]) -> Dict[str, str]:
-    """
-    Return a mapping from a field name to the correct class
-    raise an AssertionError if there is a field name collision
-    """
-    mapping = {}
-    for klass, attr_name in classes:
-        assert is_dataclass(klass)
-        for field_ in fields(klass):
-            assert field_.name not in mapping, f"Conflict with field '{field_.name}'"
-            mapping[field_.name] = attr_name
-    return mapping
 
 
 def remove_common_dict_items(dct: Dict, reference_dct: Dict) -> Dict:

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -238,7 +238,7 @@ class OAuthClient:
             body=urlparse.urlencode(request_params),
         )
 
-        session = create_session(self.config.allow_self_signed)
+        session = create_session(self.config.user_config.allow_self_signed)
         response = session.post(
             urljoin(self.api_url, "/v1/oauth/token"),
             request_body,
@@ -273,7 +273,7 @@ class OAuthClient:
         response = create_client(
             self._access_token,
             self.api_url,
-            allow_self_signed=self.config.allow_self_signed,
+            allow_self_signed=self.config.user_config.allow_self_signed,
         ).get(endpoint="token")
         if not response.ok:
             raise OAuthError("The created token is invalid.")

--- a/ggshield/hmsl/utils.py
+++ b/ggshield/hmsl/utils.py
@@ -47,7 +47,7 @@ def get_token(config: Config) -> Optional[str]:
         client = create_client(
             api_url=config.saas_api_url,
             api_key=config.saas_api_key,
-            allow_self_signed=config.allow_self_signed,
+            allow_self_signed=config.user_config.allow_self_signed,
         )
         audience = config.hmsl_audience
     except (MissingTokenError, AuthExpiredError):

--- a/ggshield/secret/repo.py
+++ b/ggshield/secret/repo.py
@@ -57,12 +57,12 @@ def scan_repo_path(
                 commit_list=get_list_commit_SHA("--all"),
                 output_handler=output_handler,
                 exclusion_regexes=set(),
-                matches_ignore=config.secret.ignored_matches,
+                matches_ignore=config.user_config.secret.ignored_matches,
                 scan_context=scan_context,
-                ignored_detectors=config.secret.ignored_detectors,
+                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
     except Exception as error:
-        return handle_exception(error, config.verbose)
+        return handle_exception(error, config.user_config.verbose)
 
 
 def scan_commits_content(

--- a/tests/unit/cmd/sca/test_ci.py
+++ b/tests/unit/cmd/sca/test_ci.py
@@ -24,7 +24,7 @@ def test_sca_scan_ci_no_commit(
     monkeypatch.setenv("CI", "1")
     collect_commit_range_from_ci_env_mock.return_value = ([], "")
 
-    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"])
+    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
 
     scan_diff_mock.assert_not_called()
     assert result.exit_code == ExitCode.SUCCESS

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -26,7 +26,7 @@ def get_valid_ctx(client: GGClient) -> click.Context:
     Returns a valid click.Context to run sca scan all
     """
     config = Config()
-    config.verbose = False
+    config.user_config.verbose = False
     ctx = click.Context(
         click.Command("sca scan all"),
         obj={"client": client, "exclusion_regexes": [], "config": config},

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -32,8 +32,8 @@ class TestAuthConfig:
 
         config = Config()
 
-        assert config.instances[0].account.token_name == "my_token"
-        assert config.instances[0].default_token_lifetime == 1
+        assert config.auth_config.instances[0].account.token_name == "my_token"
+        assert config.auth_config.instances[0].default_token_lifetime == 1
         assert config.auth_config.default_token_lifetime == 2
 
         config_data = config.auth_config.to_dict()
@@ -89,7 +89,7 @@ class TestAuthConfig:
 
         config = Config()
 
-        assert config.instances[0].account.expire_at is None
+        assert config.auth_config.instances[0].account.expire_at is None
 
     def test_update(self):
         """
@@ -98,13 +98,13 @@ class TestAuthConfig:
         THEN it's not persisted until .save() is called
         """
         config = Config()
-        config.instance = "custom"
+        config.user_config.instance = "custom"
 
-        assert Config().instance != "custom"
+        assert Config().user_config.instance != "custom"
 
         config.save()
 
-        assert Config().instance == "custom"
+        assert Config().user_config.instance == "custom"
 
     def test_load_file_not_existing(self):
         """
@@ -115,7 +115,7 @@ class TestAuthConfig:
         config = Config()
 
         assert config.instance_name == "https://dashboard.gitguardian.com"
-        assert config.instances == []
+        assert config.auth_config.instances == []
 
     def test_save_file_not_existing(self):
         """
@@ -129,11 +129,11 @@ class TestAuthConfig:
         except FileNotFoundError:
             pass
 
-        config.instance = "custom"
+        config.user_config.instance = "custom"
         config.save()
         updated_config = Config()
 
-        assert updated_config.instance == "custom"
+        assert updated_config.user_config.instance == "custom"
 
     def test_timezone_aware_expired(self):
         """
@@ -143,7 +143,7 @@ class TestAuthConfig:
         """
         write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
         config = Config()
-        assert config.instances[0].account.expire_at.tzinfo is not None
+        assert config.auth_config.instances[0].account.expire_at.tzinfo is not None
 
     def test_init_instance_config_with_expiration_date(self):
         token_data = {

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -110,7 +110,7 @@ class TestConfig:
         THEN it raises
         """
         config = Config()
-        config.instance = "toto"
+        config.user_config.instance = "toto"
 
         with pytest.raises(UnknownInstanceError, match="Unknown instance: 'toto'"):
             config.api_key

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -25,8 +25,8 @@ class TestUserConfig:
         write_yaml(local_config_path, {"verbose": True, "show_secrets": True})
 
         config = Config()
-        assert config.verbose is True
-        assert config.secret.show_secrets is True
+        assert config.user_config.verbose is True
+        assert config.user_config.secret.show_secrets is True
 
     def test_unknown_option(self, local_config_path):
         write_yaml(local_config_path, {"verbosity": True})
@@ -53,15 +53,15 @@ class TestUserConfig:
         )
 
         config = Config()
-        assert config.verbose is True
-        assert config.secret.show_secrets is False
+        assert config.user_config.verbose is True
+        assert config.user_config.secret.show_secrets is False
         assert config.api_url == "https://api.gitguardian.com"
 
     def test_exclude_regex(self, local_config_path):
         write_yaml(local_config_path, {"paths-ignore": ["/tests/"]})
 
         config = Config()
-        assert r"/tests/" in config.secret.ignored_paths
+        assert r"/tests/" in config.user_config.secret.ignored_paths
 
     def test_accumulation_matches(self, local_config_path, global_config_path):
         write_yaml(
@@ -78,7 +78,7 @@ class TestUserConfig:
             {"matches_ignore": [{"name": "", "match": "three"}]},
         )
         config = Config()
-        assert config.secret.ignored_matches == [
+        assert config.user_config.secret.ignored_matches == [
             IgnoredMatch(match="three", name=""),
             IgnoredMatch(match="one", name=""),
             IgnoredMatch(match="two", name=""),
@@ -175,10 +175,11 @@ class TestUserConfig:
             },
         )
         config = Config()
-        assert isinstance(config.iac, IaCConfig)
-        assert config.iac.ignored_paths == {"mypath"}
-        assert config.iac.ignored_policies == {"GG_IAC_0001"}
-        assert config.iac.minimum_severity == "myseverity"
+        iac_config = config.user_config.iac
+        assert isinstance(iac_config, IaCConfig)
+        assert iac_config.ignored_paths == {"mypath"}
+        assert iac_config.ignored_policies == {"GG_IAC_0001"}
+        assert iac_config.minimum_severity == "myseverity"
 
     def test_iac_config_bad_policy_id(self, local_config_path):
         write_yaml(
@@ -221,10 +222,11 @@ class TestUserConfig:
             },
         )
         config = Config()
-        assert isinstance(config.iac, IaCConfig)
-        assert config.iac.ignored_paths == {"myglobalpath", "mypath"}
-        assert config.iac.ignored_policies == {"GG_IAC_0001", "GG_IAC_0002"}
-        assert config.iac.minimum_severity == "myseverity"
+        iac_config = config.user_config.iac
+        assert isinstance(iac_config, IaCConfig)
+        assert iac_config.ignored_paths == {"myglobalpath", "mypath"}
+        assert iac_config.ignored_policies == {"GG_IAC_0001", "GG_IAC_0002"}
+        assert iac_config.minimum_severity == "myseverity"
 
     def test_sca_config(self, local_config_path):
         """
@@ -250,11 +252,12 @@ class TestUserConfig:
             },
         )
         config = Config()
-        assert isinstance(config.sca, SCAConfig)
-        assert config.sca.ignored_paths == {"mypath"}
-        assert config.sca.minimum_severity == "myseverity"
-        assert len(config.sca.ignored_vulnerabilities) == 1
-        assert config.sca.ignored_vulnerabilities[0] == SCAIgnoredVulnerability(
+        sca_config = config.user_config.sca
+        assert isinstance(sca_config, SCAConfig)
+        assert sca_config.ignored_paths == {"mypath"}
+        assert sca_config.minimum_severity == "myseverity"
+        assert len(sca_config.ignored_vulnerabilities) == 1
+        assert sca_config.ignored_vulnerabilities[0] == SCAIgnoredVulnerability(
             identifier="GHSA-aaaa-bbbb-cccc",
             path="Pipfile",
             comment="Not my prob",
@@ -284,8 +287,9 @@ class TestUserConfig:
             },
         )
         config = Config()
-        assert isinstance(config.sca, SCAConfig)
-        assert len(config.sca.ignored_vulnerabilities) == 0
+        sca_config = config.user_config.sca
+        assert isinstance(sca_config, SCAConfig)
+        assert len(sca_config.ignored_vulnerabilities) == 0
 
     def test_sca_config_options_inheritance(
         self, local_config_path, global_config_path
@@ -316,9 +320,10 @@ class TestUserConfig:
             },
         )
         config = Config()
-        assert isinstance(config.sca, SCAConfig)
-        assert config.sca.ignored_paths == {"myglobalpath", "mypath"}
-        assert config.sca.minimum_severity == "myseverity"
+        sca_config = config.user_config.sca
+        assert isinstance(sca_config, SCAConfig)
+        assert sca_config.ignored_paths == {"myglobalpath", "mypath"}
+        assert sca_config.minimum_severity == "myseverity"
 
     def test_sca_config_invalid_identifier(self, local_config_path, capsys):
         """

--- a/tests/unit/core/test_cache.py
+++ b/tests/unit/core/test_cache.py
@@ -85,4 +85,4 @@ class TestCache:
             file.write(yaml.dump({"max-commits-for-hook": 75}))
 
         config = Config()
-        assert config.max_commits_for_hook == 75
+        assert config.user_config.max_commits_for_hook == 75


### PR DESCRIPTION
## Context

While working on `ggshield config` I had the need to turn the `Config.set_cmdline_instance_name()` method into a `Config.cmdline_instance_name` property, but the magic in the Config class (the code automatically dispatching attribute access to either `user_config` or `auth_config`) interfered with defining the property setter.

I am not fond of that magic because it confuses developers, IDE and type-hinters, so I decided to remove it.

## What has been done

Code using `UserConfig` or `AuthConfig` attributes now explicitly uses the intermediate `user_config` and `auth_config` objects:

`config.verbose` becomes `config.user_config.verbose`

Code extracting the Config instance from Click context object now explicitly sets the type of the Config instance, making it possible for pyright to check attribute access.