### PR TITLE
Add support for "instance" to "ggshield config get", "unset", and "list"

### DIFF
--- a/changelog.d/20230807_180315_aurelien.gateau_config_set_instance.md
+++ b/changelog.d/20230807_180315_aurelien.gateau_config_set_instance.md
@@ -1,3 +1,3 @@
 ### Added
 
-- It is now possible to define the default instance using `ggshield config set instance <THE_INSTANCE_URL>`.
+- It is now possible to manipulate the default instance using `ggshield config`: `ggshield config set instance <THE_INSTANCE_URL>` defines the default instance, `ggshield config unset instance` removes the previously defined instance. The default instance can be printed with `ggshield config get instance` and `ggshield config list`.

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -5,7 +5,7 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
-from .constants import DATETIME_FORMAT
+from .constants import DATETIME_FORMAT, FIELDS
 
 
 @click.command()
@@ -24,6 +24,14 @@ def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
         for key, value in entries:
             message_lines.append(f"{key}: {value}")
 
+    # List global values
+    for field in FIELDS.values():
+        config_obj = config.auth_config if field.auth_config else config.user_config
+        value = getattr(config_obj, field.name)
+        add_entries((field.name, value))
+    message_lines.append("")
+
+    # List instance values
     for instance in config.auth_config.instances:
         instance_name = instance.name or instance.url
 

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 
 import click
 
@@ -18,7 +18,12 @@ def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
     config: Config = ctx.obj["config"]
     default_token_lifetime = config.auth_config.default_token_lifetime
 
-    message = ""
+    message_lines = []
+
+    def add_entries(*entries: Tuple[str, Any]):
+        for key, value in entries:
+            message_lines.append(f"{key}: {value}")
+
     for instance in config.auth_config.instances:
         instance_name = instance.name or instance.url
 
@@ -41,16 +46,16 @@ def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
             else default_token_lifetime
         )
 
-        message_lines = [
-            f"[{instance_name}]",
-            f"default_token_lifetime: {_default_token_lifetime}",
-            f"workspace_id: {workspace_id}",
-            f"url: {instance.url}",
-            f"token: {token}",
-            f"token_name: {token_name}",
-            f"expiry: {expiry}",
-        ]
-        message += ("\n".join(message_lines)) + "\n\n"
+        message_lines.append(f"[{instance_name}]")
+        add_entries(
+            ("default_token_lifetime", _default_token_lifetime),
+            ("workspace_id", workspace_id),
+            ("url", instance.url),
+            ("token", token),
+            ("token_name", token_name),
+            ("expiry", expiry),
+        )
+        message_lines.append("")
 
-    click.echo(message[:-2])
+    click.echo("\n".join(message_lines).strip())
     return 0

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -8,7 +8,14 @@ from ggshield.core.config import Config
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import find_global_config_path
 
-from .constants import FIELD_NAMES, FIELDS
+from .constants import FIELD_NAMES, FIELDS, ConfigField
+
+
+def set_user_config_field(field: ConfigField, value: Any) -> None:
+    config_path = find_global_config_path(to_write=True)
+    user_config, _ = UserConfig.load(config_path)
+    setattr(user_config, field.name, value)
+    user_config.save(config_path)
 
 
 @click.command()
@@ -55,8 +62,5 @@ def config_set_cmd(
         setattr(config.auth_config, field.name, value)
         config.auth_config.save()
     else:
-        config_path = find_global_config_path(to_write=True)
-        user_config, _ = UserConfig.load(config_path)
-        setattr(user_config, field.name, value)
-        user_config.save(config_path)
+        set_user_config_field(field, value)
     return 0

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -5,7 +5,8 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.config import Config
 
-from .constants import FIELD_NAMES
+from .config_set import set_user_config_field
+from .constants import FIELD_NAMES, FIELDS
 
 
 @click.command()
@@ -33,18 +34,22 @@ def config_unset_cmd(
     If --all is passed, it iterates over all instances.
     """
     config: Config = ctx.obj["config"]
+    field = FIELDS[field_name]
 
-    if all_:
-        setattr(config.auth_config, field_name, None)
-        for instance in config.auth_config.instances:
+    if field.auth_config:
+        if all_:
+            setattr(config.auth_config, field_name, None)
+            for instance in config.auth_config.instances:
+                setattr(instance, field_name, None)
+
+        elif instance_url is None:
+            setattr(config.auth_config, field_name, None)
+
+        else:
+            instance = config.auth_config.get_instance(instance_url)
             setattr(instance, field_name, None)
 
-    elif instance_url is None:
-        setattr(config.auth_config, field_name, None)
-
+        config.auth_config.save()
     else:
-        instance = config.auth_config.get_instance(instance_url)
-        setattr(instance, field_name, None)
-
-    config.auth_config.save()
+        set_user_config_field(field, None)
     return 0

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -345,6 +345,27 @@ class TestConfigUnset:
             config.auth_config.default_token_lifetime == default_value
         ), "The instance config should remain unchanged"
 
+    def test_unset_instance(self, cli_fs_runner):
+        """
+        GIVEN a default instance previously set
+        WHEN running `ggshield config unset instance`
+        THEN the default instance is removed
+        """
+        # update global user config
+        assert find_global_config_path() is None
+        config_path = find_global_config_path(to_write=True)
+        config = UserConfig()
+        config.instance = "https://example.com"
+        config.save(config_path)
+
+        exit_code, output = self.run_cmd(cli_fs_runner, param="instance")
+
+        assert exit_code == ExitCode.SUCCESS, output
+        assert output == ""
+
+        config, _ = UserConfig.load(config_path)
+        assert config.instance is None
+
     @staticmethod
     def run_cmd(
         cli_fs_runner, param="default_token_lifetime", instance_url=None, all_=False

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -452,6 +452,34 @@ class TestConfigGet:
         exit_code, output = self.run_cmd(cli_fs_runner, param="invalid_field_name")
         assert exit_code == ExitCode.USAGE_ERROR, output
 
+    @pytest.mark.parametrize(
+        ["default_value", "expected_value"],
+        [
+            (None, "not set"),
+            ("https://example.com", "https://example.com"),
+        ],
+    )
+    def test_get_instance(self, default_value, expected_value, cli_fs_runner):
+        """
+        GIVEN a default instance previously set
+        WHEN running `config get instance`
+        THEN it should display the value for this specific config
+        OR display "not set" if no value is found
+        """
+
+        # update global user config
+        assert find_global_config_path() is None
+        if default_value:
+            config_path = find_global_config_path(to_write=True)
+            config = UserConfig()
+            config.instance = default_value
+            config.save(config_path)
+
+        exit_code, output = self.run_cmd(cli_fs_runner, param="instance")
+
+        assert output == f"instance: {expected_value}\n"
+        assert exit_code == ExitCode.SUCCESS
+
     @staticmethod
     def run_cmd(cli_fs_runner, param="default_token_lifetime", instance_url=None):
         cmd = ["config", "get", param]

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -15,7 +15,10 @@ from .utils import add_instance_config
 
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 
-EXPECTED_OUTPUT = """[https://dashboard.gitguardian.com]
+EXPECTED_OUTPUT = """instance: None
+default_token_lifetime: None
+
+[https://dashboard.gitguardian.com]
 default_token_lifetime: None
 workspace_id: 1
 url: https://dashboard.gitguardian.com


### PR DESCRIPTION
This PR is the continuation of #670. #670 added support for `ggshield config set instance <NAME>`. This PR adds support for `ggshield config get instance`, `ggshield config unset instance` and make `ggshield config list` show the instance.