### PR TITLE
Xblanchot/sca 942/fix commit range in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,6 @@ jobs:
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
-          GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
@@ -204,6 +203,7 @@ jobs:
         with:
           args: .
         env:
+          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
 
@@ -222,6 +222,7 @@ jobs:
         with:
           args: .
         env:
+          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
 

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -11,7 +11,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     update_context,
 )
 from ggshield.core.config import Config
-from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
+from ggshield.core.git_hooks.ci import get_current_and_previous_state_from_ci_env
 from ggshield.core.text_utils import display_warning
 
 
@@ -44,14 +44,12 @@ def scan_ci_cmd(
         return display_iac_scan_all_result(ctx, directory, result)
 
     config: Config = ctx.obj["config"]
-    commit_list, _ = collect_commit_range_from_ci_env(config.user_config.verbose)
-    reference, current_ref = commit_list[0], commit_list[-1]
 
-    # If we failed to fetch a current reference, we set it to HEAD
-    if len(commit_list) < 2 or not current_ref:
-        current_ref = "HEAD"
+    current_commit, previous_commit = get_current_and_previous_state_from_ci_env(
+        config.user_config.verbose
+    )
 
     result = iac_scan_diff(
-        ctx, directory, reference, current_ref=current_ref, include_staged=True
+        ctx, directory, previous_commit, current_ref=current_commit, include_staged=True
     )
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -18,8 +18,7 @@ from ggshield.cmd.sca.scan.scan_common_options import (
 )
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
-from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
-from ggshield.core.git_shell import check_git_dir
+from ggshield.core.git_hooks.ci import get_current_and_previous_state_from_ci_env
 from ggshield.sca.collection.collection import (
     SCAScanAllVulnerabilityCollection,
     SCAScanDiffVulnerabilityCollection,
@@ -63,16 +62,15 @@ def scan_ci_cmd(
             scan = SCAScanAllVulnerabilityCollection(id=str(directory), result=result)
             return output_handler.process_scan_all_result(scan)
 
-        check_git_dir()
-        commit_count = len(
-            collect_commit_range_from_ci_env(config.user_config.verbose)[0]
+        current_commit, previous_commit = get_current_and_previous_state_from_ci_env(
+            config.user_config.verbose
         )
-        if config.user_config.verbose:
-            click.echo(f"Commits to scan: {commit_count}", err=True)
+
         result = sca_scan_diff(
             ctx=ctx,
             directory=directory,
-            previous_ref=f"HEAD~{commit_count}" if commit_count > 0 else "HEAD",
+            previous_ref=previous_commit,
+            current_ref=current_commit,
         )
         scan = SCAScanDiffVulnerabilityCollection(id=str(directory), result=result)
         return output_handler.process_scan_diff_result(scan)

--- a/ggshield/core/git_hooks/ci/__init__.py
+++ b/ggshield/core/git_hooks/ci/__init__.py
@@ -1,0 +1,12 @@
+from .commit_range import collect_commit_range_from_ci_env
+from .current_and_previous_state import get_current_and_previous_state_from_ci_env
+from .previous_commit import get_previous_commit_from_ci_env
+from .supported_ci import SupportedCI
+
+
+__all__ = [
+    "SupportedCI",
+    "collect_commit_range_from_ci_env",
+    "get_previous_commit_from_ci_env",
+    "get_current_and_previous_state_from_ci_env",
+]

--- a/ggshield/core/git_hooks/ci/current_and_previous_state.py
+++ b/ggshield/core/git_hooks/ci/current_and_previous_state.py
@@ -1,0 +1,35 @@
+import click
+
+from ggshield.core.git_shell import check_git_dir
+
+from .commit_range import collect_commit_range_from_ci_env
+from .previous_commit import get_previous_commit_from_ci_env
+
+
+def get_current_and_previous_state_from_ci_env(verbose: bool):
+    """
+    Returns the current commit sha and the previous commit sha of the targeted
+    branch in a CI env
+    """
+    check_git_dir()
+
+    new_commits, _ = collect_commit_range_from_ci_env(verbose)
+    previous_commit = get_previous_commit_from_ci_env(verbose)
+
+    if not new_commits:
+        current_commit = "HEAD"
+    else:
+        current_commit = new_commits[-1]
+
+    if verbose:
+        if new_commits:
+            click.echo("List of new commits: ", err=True)
+            for commit in new_commits:
+                click.echo(f"- {commit}", err=True)
+
+        click.echo(
+            f"Comparing commit {current_commit} to commit {previous_commit}",
+            err=True,
+        )
+
+    return current_commit, previous_commit

--- a/ggshield/core/git_hooks/ci/previous_commit.py
+++ b/ggshield/core/git_hooks/ci/previous_commit.py
@@ -1,0 +1,155 @@
+import os
+from typing import Optional
+
+import click
+
+from ggshield.core.errors import UnexpectedError
+from ggshield.core.git_shell import get_last_commit_sha_of_branch
+from ggshield.core.utils import EMPTY_SHA
+
+from .supported_ci import SupportedCI
+
+
+def get_previous_commit_from_ci_env(
+    verbose: bool,
+) -> Optional[str]:
+    """
+    Returns the previous HEAD sha of the targeted branch.
+    Returns None if there was no commit before.
+    """
+    supported_ci = SupportedCI.from_ci_env()
+    try:
+        fcn = PREVIOUS_COMMIT_SHA_FUNCTIONS[supported_ci]
+    except KeyError:
+        raise UnexpectedError(f"Not implemented for {supported_ci.value}")
+
+    return fcn(verbose)
+
+    # if os.getenv("GITLAB_CI"):
+    #     commit_sha = gitlab_previous_commit_sha(verbose)
+
+    # elif os.getenv("GITHUB_ACTIONS"):
+    #     commit_sha = github_previous_commit_sha(verbose)
+
+    # elif os.getenv("TRAVIS"):
+    #     raise NotImplementedError("Not implemented for Travis.")
+
+    # elif os.getenv("JENKINS_HOME") or os.getenv("JENKINS_URL"):
+    #     raise NotImplementedError("Not implemented for Jenkins.")
+
+    # elif os.getenv("CIRCLECI"):
+    #     raise NotImplementedError("Not implemented for CircleCI.")
+
+    # elif os.getenv("BITBUCKET_COMMIT"):
+    #     raise NotImplementedError("Not implemented for BitBucket.")
+
+    # elif os.getenv("DRONE"):
+    #     raise NotImplementedError("Not implemented for Drone.")
+
+    # elif os.getenv("BUILD_BUILDID"):
+    #     raise NotImplementedError("Not implemented for Azure.")
+
+    # else:
+    #     raise UnexpectedError(
+    #         f"Current CI is not detected or supported."
+    #         f" Supported CIs: {', '.join([ci.value for ci in SupportedCI])}."
+    #     )
+    # return commit_sha
+
+
+def github_previous_commit_sha(verbose: bool) -> Optional[str]:
+    push_before_sha = github_push_previous_commit_sha()
+    pull_req_base_sha = github_pull_request_previous_commit_sha()
+
+    if verbose:
+        click.echo(
+            f"github_push_before_sha: {push_before_sha}\n"
+            f"github_pull_base_sha: {pull_req_base_sha}\n",
+            err=True,
+        )
+
+    # The PR base sha has to be checked before the push_before_sha
+    # because the first one is only populated in case of PR
+    # whereas push_before_sha can be populated in PR in case of
+    # push force event in a PR
+    if pull_req_base_sha:
+        return pull_req_base_sha
+
+    if push_before_sha:
+        return push_before_sha
+
+    raise UnexpectedError(
+        "Unable to get previous commit. Please submit an issue with the following info:\n"
+        "  Repository URL: <Fill if public>\n"
+        f"github_push_before_sha: {push_before_sha}\n"
+        f"github_pull_base_sha: {pull_req_base_sha}\n"
+    )
+
+
+def github_push_previous_commit_sha() -> Optional[str]:
+    push_before_sha = os.getenv("GITHUB_PUSH_BEFORE_SHA")
+
+    if not push_before_sha:
+        return None
+
+    return push_before_sha
+
+
+def github_pull_request_previous_commit_sha() -> Optional[str]:
+    targeted_branch = os.getenv("GITHUB_BASE_REF")
+
+    # Not in a pull request workflow
+    if targeted_branch is None:
+        return None
+
+    return get_last_commit_sha_of_branch(f"remotes/origin/{targeted_branch}")
+
+
+def gitlab_previous_commit_sha(verbose: bool) -> Optional[str]:
+    push_before_sha = gitlab_push_previous_commit_sha()
+    merge_req_base_sha = gitlab_merge_request_previous_commit_sha()
+
+    if verbose:
+        click.echo(
+            f"gitlab_push_before_sha: {push_before_sha}\n"
+            f"gitlab_merge_base_sha: {merge_req_base_sha}\n",
+            err=True,
+        )
+
+    # push_before_sha is always EMPTY_SHA in MR pipeline according with
+    # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    if push_before_sha == EMPTY_SHA and merge_req_base_sha:
+        # Targeted branch is empty
+        if merge_req_base_sha == EMPTY_SHA:
+            return None
+        return merge_req_base_sha
+
+    if push_before_sha and push_before_sha != EMPTY_SHA:
+        return push_before_sha
+
+    raise UnexpectedError(
+        "Unable to get previous commit. Please submit an issue with the following info:\n"
+        "  Repository URL: <Fill if public>\n"
+        f"gitlab_push_before_sha: {push_before_sha}\n"
+        f"gitlab_pull_base_sha: {merge_req_base_sha}\n"
+    )
+
+
+def gitlab_push_previous_commit_sha() -> Optional[str]:
+    return os.getenv("CI_COMMIT_BEFORE_SHA")
+
+
+def gitlab_merge_request_previous_commit_sha() -> Optional[str]:
+    targeted_branch = os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
+
+    # Not in a pull request workflow
+    if targeted_branch is None:
+        return None
+
+    return get_last_commit_sha_of_branch(f"remotes/origin/{targeted_branch}")
+
+
+PREVIOUS_COMMIT_SHA_FUNCTIONS = {
+    SupportedCI.GITLAB: gitlab_previous_commit_sha,
+    SupportedCI.GITHUB: github_previous_commit_sha,
+}

--- a/ggshield/core/git_hooks/ci/supported_ci.py
+++ b/ggshield/core/git_hooks/ci/supported_ci.py
@@ -1,0 +1,39 @@
+import os
+from enum import Enum
+
+from ggshield.core.errors import UnexpectedError
+
+
+class SupportedCI(Enum):
+    GITLAB = "GITLAB"
+    TRAVIS = "TRAVIS"
+    CIRCLECI = "CIRCLECI"
+    JENKINS = "JENKINS HOME"
+    GITHUB = "GITHUB ACTIONS"
+    BITBUCKET = "BITBUCKET PIPELINES"
+    DRONE = "DRONE"
+    AZURE = "AZURE PIPELINES"
+
+    @staticmethod
+    def from_ci_env() -> "SupportedCI":
+        if os.getenv("GITLAB_CI"):
+            return SupportedCI.GITLAB
+        if os.getenv("GITHUB_ACTIONS"):
+            return SupportedCI.GITHUB
+        if os.getenv("TRAVIS"):
+            return SupportedCI.TRAVIS
+        if os.getenv("JENKINS_HOME") or os.getenv("JENKINS_URL"):
+            return SupportedCI.JENKINS
+        if os.getenv("CIRCLECI"):
+            return SupportedCI.CIRCLECI
+        if os.getenv("BITBUCKET_COMMIT"):
+            return SupportedCI.BITBUCKET
+        if os.getenv("DRONE"):
+            return SupportedCI.DRONE
+        if os.getenv("BUILD_BUILDID"):
+            return SupportedCI.AZURE
+
+        raise UnexpectedError(
+            f"Current CI is not detected or supported."
+            f" Supported CIs: {', '.join([ci.value for ci in SupportedCI])}."
+        )

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -220,6 +220,23 @@ def get_list_commit_SHA(
     return commit_list
 
 
+def get_last_commit_sha_of_branch(branch_name: str) -> Optional[str]:
+    """
+    Returns the last commit sha of the given branch, or None
+    if no commit could be found
+    """
+    # The branch is not directly available in CI env
+    # We need to get commits through remotes
+    last_target_commit = get_list_commit_SHA(branch_name, max_count=1)
+
+    # Unable to find a commit on this branch
+    # Consider it empty
+    if not last_target_commit:
+        return None
+
+    return last_target_commit[0]
+
+
 def get_filepaths_from_ref(ref: str, wd: Optional[str] = None) -> List[Path]:
     """
     Fetches a list of all file paths indexed at a given reference in a git repository.

--- a/tests/functional/sca/test_sca_scan_ci.py
+++ b/tests/functional/sca/test_sca_scan_ci.py
@@ -9,7 +9,7 @@ def test_scan_ci_diff(tmp_path: Path, monkeypatch, pipfile_lock_with_vuln) -> No
     GIVEN a repository with a commit containing a vuln,
     two clean commits on top of it, and a CI env
     WHEN scanning the last two commits, it's OK
-    WHEN scanning the commit containing the vuln
+    WHEN scanning the last three commits, including the vuln
     THEN the vuln is found
     """
     repo = Repository.create(tmp_path)
@@ -26,10 +26,10 @@ def test_scan_ci_diff(tmp_path: Path, monkeypatch, pipfile_lock_with_vuln) -> No
     for key, value in env.items():
         monkeypatch.setenv(key, value)
 
-    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", "HEAD~1")
+    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", "HEAD~2")
     run_ggshield_sca_scan("ci", expected_code=0, cwd=repo.path)
 
-    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", "HEAD~2")
+    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", "HEAD~3")
     proc = run_ggshield_sca_scan("ci", expected_code=1, cwd=repo.path)
     assert "> Pipfile.lock: 1 incident detected" in proc.stdout
     assert (

--- a/tests/unit/cmd/sca/test_ci.py
+++ b/tests/unit/cmd/sca/test_ci.py
@@ -7,22 +7,55 @@ from ggshield.core.errors import ExitCode
 
 
 @patch("ggshield.sca.client.SCAClient.scan_diff")
-@patch("ggshield.cmd.sca.scan.ci.collect_commit_range_from_ci_env")
-@patch("ggshield.cmd.sca.scan.ci.check_git_dir")
+@patch(
+    "ggshield.cmd.sca.scan.sca_scan_utils.sca_files_from_git_repo", return_value=set()
+)
+@patch("ggshield.cmd.sca.scan.ci.get_current_and_previous_state_from_ci_env")
 def test_sca_scan_ci_no_commit(
-    check_dir_mock: Mock,
-    collect_commit_range_from_ci_env_mock: Mock,
+    get_current_and_previous_state_from_ci_env_mock: Mock,
+    sca_files_from_git_repo_mock: Mock,
     scan_diff_mock: Mock,
     cli_fs_runner: click.testing.CliRunner,
     monkeypatch,
 ):
     """
-    GIVEN there are no commits
+    GIVEN a repository with no commits
+    WHEN `secret scan ci` is called without --all
+    THEN no scan has been triggered and the scan is successful
+    """
+
+    monkeypatch.setenv("CI", "1")
+    get_current_and_previous_state_from_ci_env_mock.return_value = (
+        "HEAD",
+        None,
+    )
+
+    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
+
+    scan_diff_mock.assert_not_called()
+    assert result.exit_code == ExitCode.SUCCESS
+    assert "No file to scan." in result.stdout
+    assert "No SCA vulnerability has been added." in result.stdout
+
+
+@patch("ggshield.sca.client.SCAClient.scan_diff")
+@patch("ggshield.cmd.sca.scan.ci.get_current_and_previous_state_from_ci_env")
+def test_sca_scan_ci_same_commit(
+    get_current_and_previous_state_from_ci_env_mock: Mock,
+    scan_diff_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN the same commits in the two states in CI
     WHEN `secret scan ci` is called without --all
     THEN no scan has been triggered and the scan is successful
     """
     monkeypatch.setenv("CI", "1")
-    collect_commit_range_from_ci_env_mock.return_value = ([], "")
+    get_current_and_previous_state_from_ci_env_mock.return_value = (
+        "abcdefg",
+        "abcdefg",
+    )
 
     result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
 

--- a/tests/unit/cmd/scan/test_ci.py
+++ b/tests/unit/cmd/scan/test_ci.py
@@ -6,7 +6,7 @@ import pytest
 
 from ggshield.cmd.main import cli
 from ggshield.core.errors import ExitCode
-from ggshield.core.git_hooks.ci import gitlab_ci_range
+from ggshield.core.git_hooks.ci.commit_range import gitlab_ci_range
 from ggshield.core.utils import EMPTY_SHA
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
@@ -19,7 +19,7 @@ def clear_current_ci_envs(monkeypatch):
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
 
 
-@patch("ggshield.core.git_hooks.ci.get_list_commit_SHA")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
 @patch("ggshield.cmd.secret.scan.ci.check_git_dir")
 @pytest.mark.parametrize(
     "env,expected_parameter",
@@ -90,7 +90,7 @@ def test_gitlab_ci_range(
 
 
 @patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
-@patch("ggshield.core.git_hooks.ci.get_list_commit_SHA")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
 @patch("ggshield.cmd.secret.scan.ci.check_git_dir")
 @pytest.mark.parametrize(
     ("env", "expected_mode"),


### PR DESCRIPTION
This MR adds a util to get the previous state of the targeted branch in CI for github, and use it in sca scan ci.
It also removes the need of defining a custom env variable for PR in github CI. A custom env variable is still required for push event on github.
For now, SCA and IaC CI scans work only with github and gitlab CIs. 
All other CIs will come in a next PR.