### PR TITLE
Re-enable HMSL by default

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [packages]
 # Do not add dependencies here, but list them in the setup.py instead
-ggshield = { editable = true, extras = ["all"], path = "." }
+ggshield = { editable = true, path = "." }
 
 [dev-packages]
 black = "==22.3.0"

--- a/ggshield/cmd/main.py
+++ b/ggshield/cmd/main.py
@@ -10,13 +10,7 @@ from ggshield.cmd.auth import auth_group
 from ggshield.cmd.common_options import add_common_options
 from ggshield.cmd.config import config_group
 from ggshield.cmd.debug_logs import disable_logs, setup_debug_logs
-
-
-try:
-    from ggshield.cmd.hmsl import hmsl_group
-except ImportError:
-    hmsl_group = None
-
+from ggshield.cmd.hmsl import hmsl_group
 from ggshield.cmd.honeytoken import honeytoken_group
 from ggshield.cmd.iac import iac_group
 from ggshield.cmd.install import install_cmd
@@ -67,11 +61,6 @@ def config_path_callback(
     return value
 
 
-extra_groups = {}
-if hmsl_group:
-    extra_groups["hmsl"] = hmsl_group
-
-
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]},
     commands={
@@ -84,7 +73,7 @@ if hmsl_group:
         "iac": iac_group,
         "honeytoken": honeytoken_group,
         "sca": sca_group,
-        **extra_groups,
+        "hmsl": hmsl_group,
     },
 )
 @click.option(

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,6 @@ def get_version() -> str:
     return VERSION_RE.search(init).group(1)  # type: ignore
 
 
-extras_require = {
-    "hmsl": [
-        "cryptography>=41.0.3,<42.0.0",
-    ]
-}
-extras_require["all"] = list(
-    {value for values in extras_require.values() for value in values}
-)
-
-
 setup(
     name="ggshield",
     version=get_version(),
@@ -46,6 +36,7 @@ setup(
         "appdirs>=1.4.4,<1.5.0",
         "charset-normalizer>=3.1.0,<3.2.0",
         "click>=8.1,<8.2",
+        "cryptography>=41.0.3,<42.0.0",
         "marshmallow>=3.18.0,<3.19.0",
         "marshmallow-dataclass>=8.5.8,<8.6.0",
         "oauthlib>=3.2.1,<3.3.0",
@@ -56,7 +47,6 @@ setup(
         "requests>=2.31.0,<2.32.0",
         "rich>=12.5.1,<12.6.0",
     ],
-    extras_require=extras_require,
     include_package_data=True,
     zip_safe=True,
     license="MIT",


### PR DESCRIPTION
Now that our [Homebrew formula supports cryptography](https://github.com/GitGuardian/homebrew-tap/pull/4) we can re-enable HMSL.

This PR more-or-less undoes what was done for 1.17.2 in eeca9e30dd05441ba3fca525b268fafcaa7d6814.