### PR TITLE
Suggest using `ggshield config set instance` at login

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -125,7 +125,7 @@ def login_cmd(
 
 def token_login(config: Config, instance: Optional[str]) -> None:
     if instance:
-        config.set_cmdline_instance_name(instance)
+        config.cmdline_instance_name = instance
     instance = config.instance_name
     # Override instance to make sure we get a normalized instance name
     instance_config = config.auth_config.get_or_create_instance(instance_name=instance)
@@ -167,7 +167,7 @@ def web_login(
 ) -> None:
     instance, login_path = validate_login_path(instance=instance, sso_url=sso_url)
     if instance:
-        config.set_cmdline_instance_name(instance)
+        config.cmdline_instance_name = instance
     defined_instance = config.instance_name
     # Override instance to make sure we get a normalized instance name
     config.auth_config.get_or_create_instance(instance_name=defined_instance)

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -6,6 +6,7 @@ import click
 from ggshield.cmd.common_options import add_common_options
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
+from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.oauth import OAuthClient
 from ggshield.core.utils import clean_url
@@ -47,6 +48,18 @@ def validate_login_path(
     ):
         raise UnexpectedError("instance and SSO URL params do not match")
     return instance, sso_login_path
+
+
+def print_default_instance_message(config: Config) -> None:
+    """If the instance used is not defined as the default instance, show a message
+    explaining how to make it the default instance."""
+    cli_instance = config.cmdline_instance_name
+    if not cli_instance or cli_instance == DEFAULT_INSTANCE_URL:
+        return
+    click.echo(
+        "\nTo make ggshield always use this instance,"
+        f' run "ggshield config set instance {cli_instance}".'
+    )
 
 
 @click.command()
@@ -156,6 +169,7 @@ def token_login(config: Config, instance: Optional[str]) -> None:
     instance_config.init_account(token, api_token_data)
     config.auth_config.save()
     click.echo("Authentication was successful.")
+    print_default_instance_message(config)
 
 
 def web_login(
@@ -172,6 +186,13 @@ def web_login(
     # Override instance to make sure we get a normalized instance name
     config.auth_config.get_or_create_instance(instance_name=defined_instance)
 
-    OAuthClient(config, defined_instance).oauth_process(
+    client = OAuthClient(config, defined_instance)
+
+    if client.check_existing_token():
+        # skip the process if a valid token is already saved
+        return
+
+    client.oauth_process(
         token_name=token_name, lifetime=lifetime, login_path=login_path
     )
+    print_default_instance_message(config)

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -48,7 +48,7 @@ class Config:
         """
         The instance name (defaulting to URL) of the selected instance
         priority order is:
-        - set from the command line (with set_cmdline_instance_name)
+        - set from the command line (by setting cmdline_instance_name)
         - env var (in auth_config.current_instance)
         - in local user config (in user_config.dashboard_url)
         - in global user config (in user_config.dashboard_url)
@@ -78,7 +78,12 @@ class Config:
 
         return DEFAULT_INSTANCE_URL
 
-    def set_cmdline_instance_name(self, name: str) -> None:
+    @property
+    def cmdline_instance_name(self) -> Optional[str]:
+        return self._cmdline_instance_name
+
+    @cmdline_instance_name.setter
+    def cmdline_instance_name(self, name: str) -> None:
         """
         Override the current instance name. To be called by commands supporting the
         `--instance` option.

--- a/ggshield/core/oauth.py
+++ b/ggshield/core/oauth.py
@@ -93,10 +93,6 @@ class OAuthClient:
         - opening the user's webbrowser to GitGuardian login page
         - open a server and wait for the callback processing
         """
-        if self._check_existing_token():
-            # skip the process if a valid token is already saved
-            return
-
         # enable redirection to http://localhost
         os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = str(True)
 
@@ -321,7 +317,7 @@ class OAuthClient:
             )
         return self._state
 
-    def _check_existing_token(self) -> bool:
+    def check_existing_token(self) -> bool:
         """
         Check if the config already has a non expired token.
         If one could be found, outputs a message including the expiry date

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -96,7 +96,7 @@ class TestConfig:
         )
         config = Config()
         if priority >= InstanceNamePriority.CMDLINE:
-            config.set_cmdline_instance_name(INSTANCES[InstanceNamePriority.CMDLINE])
+            config.cmdline_instance_name = INSTANCES[InstanceNamePriority.CMDLINE]
 
         expected_instance = INSTANCES[priority]
         assert config.instance_name == expected_instance
@@ -181,7 +181,7 @@ class TestConfig:
 
         config = Config()
         if cmdline_instance:
-            config.set_cmdline_instance_name(cmdline_instance)
+            config.cmdline_instance_name = cmdline_instance
         if not env_var_instance:
             config.user_config.instance = user_config_instance
 

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -172,7 +172,7 @@ def test_retrieve_client_unknown_custom_dashboard_url(isolated_fs):
     ):
         with patch.dict(os.environ, clear=True):
             config = Config()
-            config.set_cmdline_instance_name("https://example.com")
+            config.cmdline_instance_name = "https://example.com"
             create_client_from_config(config)
 
 


### PR DESCRIPTION
## Context

To login on an instance other than the default instance, users pass the `--instance INSTANCE_URL` option to `ggshield auth login`. This does not make INSTANCE_URL the default instance though, leading to confusion.

This PR makes `ggshield auth login` print a message suggesting to use `ggshield config set instance INSTANCE_URL` when `auth login` is called with `--instance`.

## What has been done

- Turn `Config.set_cmdline_instance()` into a `cmdline_instance` property
- Add the message

## Demo

Logging in on the default instance, no message:

```
$ ggshield auth login --method token
Enter your GitGuardian API token: 
Authentication was successful.
```

Logging in on a custom instance, suggestion message is printed:

```
$ ggshield auth login --method token --instance https://example.com
Enter your GitGuardian API token: 
Authentication was successful.

To make ggshield always use this instance, run "ggshield config set instance https://example.com".
```