### PR TITLE
Unhide hmsl command group

### DIFF
--- a/changelog.d/20230811_135805_aurelien.gateau_unhide_hmsl.md
+++ b/changelog.d/20230811_135805_aurelien.gateau_unhide_hmsl.md
@@ -1,0 +1,3 @@
+### Added
+
+- ggshield gained a new group of commands: `hmsl`, short for "Has My Secret Leaked". These commands make it possible to securely check if secrets have been leaked in a public repository.

--- a/ggshield/cmd/hmsl/__init__.py
+++ b/ggshield/cmd/hmsl/__init__.py
@@ -20,7 +20,6 @@ from ggshield.cmd.hmsl.quota import quota_cmd
         "quota": quota_cmd,
         "api-status": status_cmd,
     },
-    hidden=True,
 )
 @add_common_options()
 def hmsl_group(**kwargs: Any) -> None:


### PR DESCRIPTION
This PR makes the `hmsl` command group visible, so that it can be discovered in the upcoming release.