### PR TITLE
feat(iac): #IAC-211 add exception wrapper in commands

### DIFF
--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -15,6 +15,7 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
     handle_scan_error,
 )
 from ggshield.core.config import Config
+from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import display_info
 from ggshield.iac.collection.iac_path_scan_collection import IaCPathScanCollection
 from ggshield.iac.filter import get_iac_files_from_path
@@ -38,12 +39,17 @@ def scan_all_cmd(
     """
     Scan a directory for all IaC vulnerabilities in the current state.
     """
-    if directory is None:
-        directory = Path().resolve()
-    update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
+    try:
+        if directory is None:
+            directory = Path().resolve()
+        update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    result = iac_scan_all(ctx, directory)
-    return display_iac_scan_all_result(ctx, directory, result)
+        result = iac_scan_all(ctx, directory)
+        return display_iac_scan_all_result(ctx, directory, result)
+
+    except Exception as error:
+        config: Config = ctx.obj["config"]
+        return handle_exception(error, config.user_config.verbose)
 
 
 def iac_scan_all(

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -37,6 +37,7 @@ def scan_ci_cmd(
     display_warning(
         "This feature is still in beta, its behavior may change in future versions."
     )
+    config: Config = ctx.obj["config"]
     try:
         if directory is None:
             directory = Path().resolve()
@@ -44,8 +45,6 @@ def scan_ci_cmd(
         if scan_all:
             result = iac_scan_all(ctx, directory)
             return display_iac_scan_all_result(ctx, directory, result)
-
-        config: Config = ctx.obj["config"]
 
         current_commit, previous_commit = get_current_and_previous_state_from_ci_env(
             config.user_config.verbose
@@ -61,5 +60,4 @@ def scan_ci_cmd(
         return display_iac_scan_diff_result(ctx, directory, result)
 
     except Exception as error:
-        config: Config = ctx.obj["config"]
         return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -22,6 +22,7 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
     handle_scan_error,
 )
 from ggshield.core.config import Config
+from ggshield.core.errors import handle_exception
 from ggshield.core.file_utils import get_empty_tar
 from ggshield.core.filter import is_filepath_excluded
 from ggshield.core.git_shell import (
@@ -59,13 +60,16 @@ def scan_diff_cmd(
     display_warning(
         "This feature is still in beta, its behavior may change in future versions."
     )
+    try:
+        if directory is None:
+            directory = Path().resolve()
+        update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    if directory is None:
-        directory = Path().resolve()
-    update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
-
-    result = iac_scan_diff(ctx, directory, ref, staged)
-    return display_iac_scan_diff_result(ctx, directory, result)
+        result = iac_scan_diff(ctx, directory, ref, staged)
+        return display_iac_scan_diff_result(ctx, directory, result)
+    except Exception as error:
+        config: Config = ctx.obj["config"]
+        return handle_exception(error, config.user_config.verbose)
 
 
 def iac_scan_diff(

--- a/ggshield/cmd/iac/scan/precommit.py
+++ b/ggshield/cmd/iac/scan/precommit.py
@@ -10,6 +10,8 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.core.config import Config
+from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import display_warning
 
 
@@ -34,11 +36,15 @@ def scan_pre_commit_cmd(
     display_warning(
         "This feature is still in beta, its behavior may change in future versions."
     )
-    if directory is None:
-        directory = Path().resolve()
-    update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
-    if scan_all:
-        result = iac_scan_all(ctx, directory)
-        return display_iac_scan_all_result(ctx, directory, result)
-    result = iac_scan_diff(ctx, directory, "HEAD", include_staged=True)
-    return display_iac_scan_diff_result(ctx, directory, result)
+    try:
+        if directory is None:
+            directory = Path().resolve()
+        update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
+        if scan_all:
+            result = iac_scan_all(ctx, directory)
+            return display_iac_scan_all_result(ctx, directory, result)
+        result = iac_scan_diff(ctx, directory, "HEAD", include_staged=True)
+        return display_iac_scan_diff_result(ctx, directory, result)
+    except Exception as error:
+        config: Config = ctx.obj["config"]
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -10,6 +10,8 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.core.config import Config
+from ggshield.core.errors import handle_exception
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.text_utils import display_warning
 from ggshield.core.utils import EMPTY_SHA
@@ -37,18 +39,22 @@ def scan_pre_push_cmd(
         "This feature is still in beta, its behavior may change in future versions."
     )
 
-    directory = Path().resolve()
-    update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
+    try:
+        directory = Path().resolve()
+        update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
-    _, remote_commit = collect_commits_refs(prepush_args)
-    # Will happen if this is the first push on the branch
-    has_no_remote_commit = (
-        remote_commit is None or "~1" in remote_commit or remote_commit == EMPTY_SHA
-    )
+        _, remote_commit = collect_commits_refs(prepush_args)
+        # Will happen if this is the first push on the branch
+        has_no_remote_commit = (
+            remote_commit is None or "~1" in remote_commit or remote_commit == EMPTY_SHA
+        )
 
-    if scan_all or has_no_remote_commit:
-        result = iac_scan_all(ctx, directory)
-        return display_iac_scan_all_result(ctx, directory, result)
-    else:
-        result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
-        return display_iac_scan_diff_result(ctx, directory, result)
+        if scan_all or has_no_remote_commit:
+            result = iac_scan_all(ctx, directory)
+            return display_iac_scan_all_result(ctx, directory, result)
+        else:
+            result = iac_scan_diff(ctx, directory, remote_commit, include_staged=False)
+            return display_iac_scan_diff_result(ctx, directory, result)
+    except Exception as error:
+        config: Config = ctx.obj["config"]
+        return handle_exception(error, config.user_config.verbose)

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -60,6 +60,15 @@ class ParseError(_ExitError):
         super().__init__(ExitCode.UNEXPECTED_ERROR, message)
 
 
+class InvalidGitRefError(_ExitError):
+    """
+    Raised when the git reference does not exist
+    """
+
+    def __init__(self, ref: str):
+        super().__init__(ExitCode.USAGE_ERROR, f"Not a git reference: {ref}.")
+
+
 class AuthError(_ExitError):
     """
     Base exception for Auth-related configuration error

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -14,7 +14,7 @@ from click import UsageError
 from pygitguardian import ContentTooLarge
 from pygitguardian.client import MAX_TAR_CONTENT_SIZE
 
-from ggshield.core.errors import UnexpectedError
+from ggshield.core.errors import InvalidGitRefError, UnexpectedError
 
 
 COMMAND_TIMEOUT = 45
@@ -179,7 +179,7 @@ def check_git_ref(ref: str, wd: Optional[str] = None) -> None:
     check_git_dir(wd)
 
     if not is_valid_git_commit_ref(ref=ref, wd=wd):
-        raise UsageError(f"Not a git reference: {ref}.")
+        raise InvalidGitRefError(ref)
 
 
 def get_list_commit_SHA(


### PR DESCRIPTION
### Add exception wrappers in IaC commands.

### Add a specific error raise for invalid git reference.
We used to call UsageError raising an exception which was not of type _ExitError. However, we are using the function handle_exception from this same file ggshield/core/errors.py, which tests if the exception raised is from type _ExitError else return an UNEXPECTED_ERROR. So with the old way and after adding the exception wrapper, we always ended up having this exit code whereas we wanted a USAGE_ERROR one.