### PR TITLE
HMSL Auth uses GITGUARDIAN_API_KEY if GITGUARDIAN_SAAS_API_KEY is not set

### DIFF
--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -143,6 +143,7 @@ class Config:
             default_value = self.hmsl_url.replace("hasmysecretleaked", "gitguardian")
         else:  # case https://hasmysecretleaked.[...]
             default_value = self.hmsl_url.replace("hasmysecretleaked", "api")
+
         return os.environ.get(
             "GITGUARDIAN_SAAS_URL",
             default_value,
@@ -162,9 +163,8 @@ class Config:
             pass
         else:
             return key
-        logger.debug("Using API key for SaaS instancefrom config")
-        dashboard_url = api_to_dashboard_url(self.saas_api_url)
-        return self.auth_config.get_instance_token(dashboard_url)
+        logger.debug("Using API key for SaaS instance from config")
+        return self.api_key
 
     # Properties for HasMySecretLeaked
     # We can't rely on the instance selected by the user,

--- a/tests/unit/cmd/hmsl/test_api_status.py
+++ b/tests/unit/cmd/hmsl/test_api_status.py
@@ -13,6 +13,7 @@ def use_staging_env(monkeypatch):
     monkeypatch.setenv(
         "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.staging.gitguardian.tech"
     )
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
 
 
 @my_vcr.use_cassette

--- a/tests/unit/cmd/hmsl/test_check.py
+++ b/tests/unit/cmd/hmsl/test_check.py
@@ -14,6 +14,7 @@ def use_staging_env(monkeypatch):
     monkeypatch.setenv(
         "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.staging.gitguardian.tech"
     )
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
 
 
 @my_vcr.use_cassette

--- a/tests/unit/cmd/hmsl/test_query.py
+++ b/tests/unit/cmd/hmsl/test_query.py
@@ -13,6 +13,7 @@ def use_staging_env(monkeypatch):
     monkeypatch.setenv(
         "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.staging.gitguardian.tech"
     )
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
 
 
 @my_vcr.use_cassette

--- a/tests/unit/cmd/hmsl/test_quota.py
+++ b/tests/unit/cmd/hmsl/test_quota.py
@@ -13,6 +13,7 @@ def use_staging_env(monkeypatch):
     monkeypatch.setenv(
         "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.staging.gitguardian.tech"
     )
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
 
 
 @my_vcr.use_cassette

--- a/tests/unit/hmsl/test_hmsl_utils.py
+++ b/tests/unit/hmsl/test_hmsl_utils.py
@@ -16,6 +16,7 @@ from ggshield.hmsl.utils import (
 
 @pytest.fixture
 def hmsl_no_env_vars(monkeypatch):
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
     monkeypatch.delenv("GITGUARDIAN_SAAS_URL", raising=False)
     monkeypatch.delenv("GITGUARDIAN_SAAS_API_KEY", raising=False)
     monkeypatch.delenv("GITGUARDIAN_HMSL_URL", raising=False)


### PR DESCRIPTION
Fixes EXPL-201
When GITGUARDIAN_SAAS_API_KEY is not set and GITGUARDIAN_API_KEY is set, the auth will use the later. 