### PR TITLE
jgriffe/expl 201/add hmsl url fallback values

### DIFF
--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -17,6 +17,7 @@ USER_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", DEFAULT_CONFIG_FILE
 DEFAULT_LOCAL_CONFIG_PATH = os.path.join(".", DEFAULT_CONFIG_FILENAME)
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 DEFAULT_HMSL_URL = "https://api.hasmysecretleaked.com"
+DEFAULT_API_URL = "https://api.gitguardian.com"
 AUTH_CONFIG_FILENAME = "auth_config.yaml"
 ON_PREMISE_API_URL_PATH_PREFIX = "/exposed"
 


### PR DESCRIPTION
Issue: EXPL-201

This MR makes hmsl url fall back to the values of GITGUARDIAN_SAAS_URL and then GITGUARDIAN_API_URL, and then the default value to find the hmsl url.
If the GITGUARDIAN_API_URL is an on-prem URL, it raises an error since HMSL is not available on-prem.