### PR TITLE
Fix typo in git command to mark a directory as safe

### DIFF
--- a/changelog.d/20230818_111845_aurelien.gateau_fix_typo.md
+++ b/changelog.d/20230818_111845_aurelien.gateau_fix_typo.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a typo in the command suggested to tell git a directory is safe.

--- a/ggshield/core/git_shell.py
+++ b/ggshield/core/git_shell.py
@@ -142,7 +142,7 @@ def git(
                 "Git command failed because of a dubious ownership in repository.\n"
                 "If you still want to run ggshield, make sure you mark "
                 "the current repository as safe for git with:\n"
-                "   git config --global --add safe.repository <YOUR_REPO>"
+                "   git config --global --add safe.directory <YOUR_REPO>"
             )
         raise e
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
Found this while testing ggshield from inside a Docker container.