### PR TITLE
fix: unbreak perfbench step

### DIFF
--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python --version
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pipenv
+          python -m pip install pipenv==2022.10.4
           pipenv install --system --skip-lock
 
       - name: Setup benchmark


### PR DESCRIPTION
Pin pipenv to a version which still supports the --skip-lock option, like we do in the ci.yml workflow.

This fixes https://github.com/GitGuardian/ggshield/actions/runs/5924686760/job/16062675817?pr=700

```
Successfully installed certifi-2023.7.22 distlib-0.3.7 filelock-3.12.2 pipenv-2023.8.20 platformdirs-3.10.0 setuptools-68.1.2 virtualenv-20.24.3
The flag --skip-lock has been functionally removed.  Without running the lock 
resolver it is not possible to manage multiple package indexes.  Additionally it
bypassed the build consistency guarantees provided by maintaining a lock file.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.12/x64/bin/pipenv", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/cli/options.py", line 58, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 1655, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 920, in make_context
    self.parse_args(ctx, args)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 1378, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 2360, in handle_parse_result
    value = self.process_value(ctx, value)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/vendor/click/core.py", line 2322, in process_value
    value = self.callback(ctx, self, value)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pipenv/cli/options.py", line 497, in callback
    raise ValueError("The flag --skip-lock flag has been removed.")
ValueError: The flag --skip-lock flag has been removed.
Error: Process completed with exit code 1.
```