### PR TITLE
Isolate functional tests from user Git config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all:
 test: unittest functest
 
 unittest:
-	GIT_CONFIG_GLOBAL=''  GIT_CONFIG_SYSTEM='' pipenv run pytest --disable-pytest-warnings -vvv tests/unit
+	pipenv run pytest --disable-pytest-warnings -vvv tests/unit
 
 functest:
 	scripts/run-functional-tests

--- a/scripts/run-functional-tests
+++ b/scripts/run-functional-tests
@@ -42,10 +42,10 @@ install_packages() {
 
 run_tests() {
     log_progress "Running tests"
-    pytest --disable-pytest-warnings -vvv tests/functional "${@}"
+    pytest --disable-pytest-warnings -vvv tests/functional "$@"
 }
 
 build_wheel
 create_venv
 install_packages
-run_tests "${@}"
+run_tests "$@"

--- a/scripts/run-functional-tests
+++ b/scripts/run-functional-tests
@@ -42,10 +42,10 @@ install_packages() {
 
 run_tests() {
     log_progress "Running tests"
-    pytest --disable-pytest-warnings -vvv tests/functional
+    pytest --disable-pytest-warnings -vvv tests/functional "${@}"
 }
 
 build_wheel
 create_venv
 install_packages
-run_tests
+run_tests "${@}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,18 @@ resource "aws_network_acl_rule" "bad_example" {
 """
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolated_git():
+    """
+    Don't use any of the existing Git config
+
+    NOTE: As the fixture is scoped to the session we don't have to restore the
+        original values.
+    """
+    os.environ["GIT_CONFIG_GLOBAL"] = ""
+    os.environ["GIT_CONFIG_SYSTEM"] = ""
+
+
 @pytest.fixture(autouse=True)
 def do_not_use_real_user_dirs(monkeypatch, tmp_path):
     """


### PR DESCRIPTION
Some users could have hooks defined in their Git template directory. The content of this directory is copied every time a repository is cloned or created. We have to isolate our functional tests to avoid the user Git config interferes with our tests.
