### PR TITLE
Create the auth "vertical"

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -9,7 +9,7 @@ from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.utils import clean_url
-from ggshield.verticals.auth.oauth import OAuthClient
+from ggshield.verticals.auth import OAuthClient
 
 
 def validate_login_path(

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -8,8 +8,8 @@ from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import UnexpectedError
-from ggshield.core.oauth import OAuthClient
 from ggshield.core.utils import clean_url
+from ggshield.verticals.auth.oauth import OAuthClient
 
 
 def validate_login_path(

--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -269,9 +269,7 @@ def file_diff_info(
 
 def get_pretty_date(dt: datetime) -> str:
     """
-    convert the given datetime to the format September 1st 2022
+    convert the given datetime to the format September 1, 2022
     """
-    month_suffix = {1: "st", 2: "nd", 3: "rd"}.get(
-        dt.day if dt.day < 20 else dt.day % 10, "th"
-    )
-    return dt.strftime(f"%B {dt.day}{month_suffix} %Y")
+    # Don't use %d for the day because it adds a leading 0
+    return dt.strftime(f"%B {dt.day}, %Y")

--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
@@ -264,3 +265,13 @@ def file_diff_info(
         format_text(filename, STYLE["filename"]),
         ", ".join(incidents_count),
     )
+
+
+def get_pretty_date(dt: datetime) -> str:
+    """
+    convert the given datetime to the format September 1st 2022
+    """
+    month_suffix = {1: "st", 2: "nd", 3: "rd"}.get(
+        dt.day if dt.day < 20 else dt.day % 10, "th"
+    )
+    return dt.strftime(f"%B {dt.day}{month_suffix} %Y")

--- a/ggshield/verticals/auth/__init__.py
+++ b/ggshield/verticals/auth/__init__.py
@@ -1,0 +1,7 @@
+from .oauth import OAuthClient, OAuthError
+
+
+__all__ = [
+    "OAuthClient",
+    "OAuthError",
+]

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -12,16 +12,15 @@ from typing import Any, Dict, Optional, Type, no_type_check
 import click
 from oauthlib.oauth2 import OAuth2Error, WebApplicationClient
 
-from ggshield.core.utils import urljoin
-
-from .client import (
+from ggshield.core.client import (
     check_client_api_key,
     create_client,
     create_client_from_config,
     create_session,
 )
-from .config import Config, InstanceConfig
-from .errors import APIKeyCheckError, UnexpectedError
+from ggshield.core.config import Config, InstanceConfig
+from ggshield.core.errors import APIKeyCheckError, UnexpectedError
+from ggshield.core.utils import urljoin
 
 
 CLIENT_ID = "ggshield_oauth"

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -7,7 +7,7 @@ from base64 import urlsafe_b64encode
 from datetime import datetime
 from hashlib import sha256
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Dict, Optional, Type, no_type_check
+from typing import Any, Dict, Optional, Type
 
 import click
 from oauthlib.oauth2 import OAuth2Error, WebApplicationClient
@@ -20,6 +20,7 @@ from ggshield.core.client import (
 )
 from ggshield.core.config import Config, InstanceConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
+from ggshield.core.text_utils import get_pretty_date
 from ggshield.core.utils import urljoin
 
 
@@ -33,17 +34,6 @@ SCOPE = "scan"
 USABLE_PORT_RANGE = (29170, 29998)
 
 logger = logging.getLogger(__name__)
-
-
-@no_type_check
-def get_pretty_date(dt: datetime) -> str:
-    """
-    convert the given datetime to the format September 1st 2022
-    """
-    month_suffix = {1: "st", 2: "nd", 3: "rd"}.get(
-        dt.day if dt.day < 20 else dt.day % 10, "th"
-    )
-    return dt.strftime(f"%B {dt.day}{month_suffix} %Y")
 
 
 def get_error_param(parsed_url: urlparse.ParseResult) -> Optional[str]:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -11,7 +11,8 @@ from ggshield.cmd.main import cli
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
-from ggshield.verticals.auth.oauth import OAuthClient, OAuthError, get_pretty_date
+from ggshield.core.text_utils import get_pretty_date
+from ggshield.verticals.auth import OAuthClient, OAuthError
 from tests.unit.conftest import assert_invoke_ok
 from tests.unit.request_mock import RequestMock, create_json_response
 

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -329,11 +329,11 @@ class TestAuthLoginWeb:
     @pytest.mark.parametrize(
         ["month", "day", "str_date"],
         [
-            ("01", "31", "January 31st"),
-            ("02", "22", "February 22nd"),
-            ("03", "13", "March 13th"),
-            ("04", "03", "April 3rd"),
-            ("05", "04", "May 4th"),
+            ("01", "31", "January 31"),
+            ("02", "22", "February 22"),
+            ("03", "13", "March 13"),
+            ("04", "03", "April 3"),
+            ("05", "04", "May 4"),
         ],
     )
     def test_existing_non_expired_token(
@@ -352,7 +352,7 @@ class TestAuthLoginWeb:
         self._request_mock.assert_all_requests_happened()
 
         self._assert_last_print(
-            output, f"ggshield is already authenticated until {str_date} 2100"
+            output, f"ggshield is already authenticated until {str_date}, 2100"
         )
 
     def test_auth_login_recreates_token_if_deleted_server_side(

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -11,12 +11,7 @@ from ggshield.cmd.main import cli
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
-from ggshield.core.oauth import (
-    OAuthClient,
-    OAuthError,
-    get_error_param,
-    get_pretty_date,
-)
+from ggshield.verticals.auth.oauth import OAuthClient, OAuthError, get_pretty_date
 from tests.unit.conftest import assert_invoke_ok
 from tests.unit.request_mock import RequestMock, create_json_response
 
@@ -287,13 +282,14 @@ class TestAuthLoginWeb:
         # open browser for the user to login
         self._webbrowser_open_mock = Mock()
         monkeypatch.setattr(
-            "ggshield.core.oauth.webbrowser.open_new_tab", self._webbrowser_open_mock
+            "ggshield.verticals.auth.oauth.webbrowser.open_new_tab",
+            self._webbrowser_open_mock,
         )
 
         # Ensure that original wait_for_callback method is not called
         self._wait_for_callback_mock = Mock()
         monkeypatch.setattr(
-            "ggshield.core.oauth.OAuthClient._wait_for_callback",
+            "ggshield.verticals.auth.oauth.OAuthClient._wait_for_callback",
             self._wait_for_callback_mock,
         )
 
@@ -597,7 +593,9 @@ class TestAuthLoginWeb:
         mock_server_class = Mock(
             side_effect=self._get_oserror_side_effect(used_port_count)
         )
-        monkeypatch.setattr("ggshield.core.oauth.HTTPServer", mock_server_class)
+        monkeypatch.setattr(
+            "ggshield.verticals.auth.oauth.HTTPServer", mock_server_class
+        )
 
         if login_result < LoginResult.EXCHANGE_FAILED:
             return
@@ -856,57 +854,3 @@ class TestAuthLoginWeb:
         assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_called()
         self._assert_open_url(host=expected_web_host)
-
-
-class TestLoginUtils:
-    @pytest.mark.parametrize(
-        ["url", "expected_error"],
-        [
-            ("http://localhost:3455", None),
-            ("http://localhost:3455?", None),
-            ("http://localhost:3455?auth=ggshield", None),
-            ("http://localhost:3455?error=some+error", "some error"),
-            ("http://localhost/?error=some+error", "some error"),
-            ("http://localhost:3455/?auth=ggshield&error=some+error", "some error"),
-        ],
-    )
-    def test_get_error_url_param(self, url, expected_error):
-        """
-        GIVEN a url
-        WHEN calling get_error_param
-        THEN it returns the value of the 'error' parameter if it exists else None
-        """
-        error = get_error_param(urlparse.urlparse(url))
-        assert error == expected_error
-
-    @pytest.mark.parametrize(
-        ["error_code", "expected_message"],
-        [
-            (
-                "too_many_tokens",
-                (
-                    "Maximum number of personal access tokens reached. "
-                    "Could not provision a new personal access token.\n"
-                    "Go to your workspace to manage your tokens: "
-                    "https://dashboard.gitguardian.com/api/personal-access-tokens"
-                ),
-            ),
-            (
-                "invalid_saml",
-                "The given SSO URL is invalid.",
-            ),
-            (
-                "invalid_error_code",
-                "An unknown server error has occurred (error code: invalid_error_code).",
-            ),
-        ],
-    )
-    def test_get_error_message(self, error_code, expected_message):
-        """
-        GIVEN an OAuthClient instance and an error code
-        WHEN calling OAuthClient.get_server_error with the error code
-        THEN it should return the corresponding human readable message with formated urls
-        """
-        oauth_client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
-        error_message = oauth_client.get_server_error_message(error_code)
-        assert error_message == expected_message

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -3,7 +3,8 @@ from urllib import parse as urlparse
 import pytest
 
 from ggshield.core.config import Config
-from ggshield.verticals.auth.oauth import OAuthClient, get_error_param
+from ggshield.verticals.auth import OAuthClient
+from ggshield.verticals.auth.oauth import get_error_param
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -1,0 +1,60 @@
+from urllib import parse as urlparse
+
+import pytest
+
+from ggshield.core.config import Config
+from ggshield.verticals.auth.oauth import OAuthClient, get_error_param
+
+
+@pytest.mark.parametrize(
+    ["url", "expected_error"],
+    [
+        ("http://localhost:3455", None),
+        ("http://localhost:3455?", None),
+        ("http://localhost:3455?auth=ggshield", None),
+        ("http://localhost:3455?error=some+error", "some error"),
+        ("http://localhost/?error=some+error", "some error"),
+        ("http://localhost:3455/?auth=ggshield&error=some+error", "some error"),
+    ],
+)
+def test_get_error_url_param(url, expected_error):
+    """
+    GIVEN a url
+    WHEN calling get_error_param
+    THEN it returns the value of the 'error' parameter if it exists else None
+    """
+    error = get_error_param(urlparse.urlparse(url))
+    assert error == expected_error
+
+
+@pytest.mark.parametrize(
+    ["error_code", "expected_message"],
+    [
+        (
+            "too_many_tokens",
+            (
+                "Maximum number of personal access tokens reached. "
+                "Could not provision a new personal access token.\n"
+                "Go to your workspace to manage your tokens: "
+                "https://dashboard.gitguardian.com/api/personal-access-tokens"
+            ),
+        ),
+        (
+            "invalid_saml",
+            "The given SSO URL is invalid.",
+        ),
+        (
+            "invalid_error_code",
+            "An unknown server error has occurred (error code: invalid_error_code).",
+        ),
+    ],
+)
+def test_get_error_message(error_code, expected_message):
+    """
+    GIVEN an OAuthClient instance and an error code
+    WHEN calling OAuthClient.get_server_error with the error code
+    THEN it should return the corresponding human readable message with formated urls
+    """
+    oauth_client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
+    error_message = oauth_client.get_server_error_message(error_code)
+    assert error_message == expected_message


### PR DESCRIPTION
## Intro

This PR introduces an `auth` "vertical". It's not a real vertical but it provides the same support as other `ggshield.verticals` packages to the `ggshield.cmd` packages.

## What has been done

I initially considered moving part of cmd.login and cmd.logout there but it would require more refactoring to make the code less tied to the CLI parsing and output. It is not worth the move without these refactoring IMHO and I do not want to spend time on it for now.

Instead I just moved OAuthClient and its related code there, and moved an helper date formatting function to core.textutils.

While I was at it, I simplified said helper date and made it output a more correctly formatted string.

## Ref

Part of #521.