### PR TITLE
refactor: Move ggshield.core.file_utils to ggshield.utils.files

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -12,9 +12,10 @@ layers =
 	ggshield.cmd.auth | ggshield.cmd.config | ggshield.cmd.hmsl | ggshield.cmd.honeytoken | ggshield.cmd.iac | ggshield.cmd.install | ggshield.cmd.quota | ggshield.cmd.sca | ggshield.cmd.secret | ggshield.cmd.status | ggshield.cmd.utils
 	ggshield.verticals.auth | ggshield.verticals.hmsl | ggshield.verticals.iac | ggshield.verticals.sca | ggshield.verticals.secret
 	ggshield.core
-	ggshield.utils | pygitguardian
+	click | ggshield.utils | pygitguardian
 ignore_imports = 
 	ggshield.cmd.** -> ggshield.cmd.utils.*
+	ggshield.utils.click.** -> click
 unmatched_ignore_imports_alerting = warn
 
 [importlinter:contract:verticals-cmd-transversals]

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -23,10 +23,10 @@ from ggshield.cmd.utils.common_options import (
 )
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
-from ggshield.core.file_utils import is_filepath_excluded
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.tar_utils import INDEX_REF, get_empty_tar
 from ggshield.core.text_utils import display_info, display_warning
+from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import (
     Filemode,
     get_diff_files_status,

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -10,9 +10,9 @@ from pygitguardian.models import Detail
 from ggshield.cmd.utils.common_options import use_json
 from ggshield.core.config import Config
 from ggshield.core.errors import APIKeyCheckError
-from ggshield.core.file_utils import is_filepath_excluded
 from ggshield.core.tar_utils import INDEX_REF, tar_from_ref_and_filepaths
 from ggshield.core.text_utils import display_error
+from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import get_filepaths_from_ref, get_staged_filepaths
 from ggshield.verticals.iac.filter import is_iac_file_path
 from ggshield.verticals.iac.output import (

--- a/ggshield/core/scan/commit.py
+++ b/ggshield/core/scan/commit.py
@@ -1,9 +1,9 @@
 import re
 from typing import Iterable, List, NamedTuple, Optional, Set, Tuple
 
-from ggshield.core.file_utils import is_filepath_excluded
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.core.utils import REGEX_HEADER_INFO
+from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import Filemode, git
 
 from .scannable import Files, Scannable, StringScannable

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -5,7 +5,7 @@ from typing import Iterable, Iterator, List, Optional, Set
 
 import click
 
-from ggshield.core.file_utils import get_filepaths, is_path_binary
+from ggshield.utils.files import UnexpectedDirectoryError, get_filepaths, is_path_binary
 
 from .scannable import Files, Scannable
 
@@ -71,9 +71,16 @@ def get_files_from_paths(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository
     """
-    filepaths = get_filepaths(
-        paths, exclusion_regexes, recursive, ignore_git=ignore_git
-    )
+    try:
+        filepaths = get_filepaths(
+            paths, exclusion_regexes, recursive, ignore_git=ignore_git
+        )
+    except UnexpectedDirectoryError as error:
+        raise click.UsageError(
+            f"{click.format_filename(error.path)} is a directory."
+            " Use --recursive to scan directories."
+        )
+
     files = list(generate_files_from_paths(filepaths, verbose))
 
     if verbose:

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -3,10 +3,15 @@ import re
 from pathlib import Path, PurePosixPath
 from typing import List, Set, Union
 
-import click
-
 from ggshield.utils._binary_extensions import BINARY_EXTENSIONS
 from ggshield.utils.git_shell import git_ls, is_git_dir
+
+
+class UnexpectedDirectoryError(ValueError):
+    """Raise when a directory is used where it is not excepted"""
+
+    def __init__(self, path: str):
+        self.path = path
 
 
 def is_filepath_excluded(filepath: str, exclusion_regexes: Set[re.Pattern]) -> bool:
@@ -25,7 +30,7 @@ def get_filepaths(
     :param paths: List of file/dir paths from the command
     :param recursive: Recursive option
     :param ignore_git: Ignore that the folder is a git repository
-    :raise: click.UsageError if directory is given without --recursive option
+    :raise: UnexceptedDirectoryError if directory is given without --recursive option
     """
     targets = set()
     for path in paths:
@@ -33,9 +38,7 @@ def get_filepaths(
             targets.add(path)
         elif os.path.isdir(path):
             if not recursive:
-                raise click.UsageError(
-                    f"{click.format_filename(path)} is a directory. Use --recursive to scan directories."
-                )
+                raise UnexpectedDirectoryError(path)
             top_dir = Path(path)
 
             if not ignore_git and is_git_dir(path):

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -5,10 +5,10 @@ from typing import List, Optional, Set
 from pygitguardian.models import Detail
 
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
-from ggshield.core.file_utils import is_filepath_excluded
 from ggshield.core.scan import Scannable
 from ggshield.core.scan.file import get_files_from_paths
 from ggshield.core.tar_utils import INDEX_REF
+from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import get_filepaths_from_ref, get_staged_filepaths
 from ggshield.verticals.sca.client import SCAClient
 

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -13,11 +13,11 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.dirs import get_cache_dir
 from ggshield.core.errors import UnexpectedError
-from ggshield.core.file_utils import is_path_binary
 from ggshield.core.scan import Files, ScanContext, Scannable, StringScannable
 from ggshield.core.scan.id_cache import IDCache
 from ggshield.core.text_utils import display_heading, display_info
 from ggshield.core.types import IgnoredMatch
+from ggshield.utils.files import is_path_binary
 
 from .rich_secret_scanner_ui import RichSecretScannerUI
 from .secret_scan_collection import SecretScanCollection

--- a/scripts/generate-import-linter-config.py
+++ b/scripts/generate-import-linter-config.py
@@ -43,10 +43,11 @@ STATIC_CONFIG = {
                 "ggshield.cmd|%",
                 "ggshield.verticals|%",
                 "ggshield.core",
-                "ggshield.utils | pygitguardian",
+                "click | ggshield.utils | pygitguardian",
             ],
             "ignore_imports": [
                 "ggshield.cmd.** -> ggshield.cmd.utils.*",
+                "ggshield.utils.click.** -> click",
             ],
             "unmatched_ignore_imports_alerting": "warn",
         },

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -7,8 +7,8 @@ from typing import Set, Union
 
 import pytest
 
-from ggshield.core.file_utils import is_filepath_excluded
 from ggshield.core.tar_utils import get_empty_tar
+from ggshield.utils.files import is_filepath_excluded
 
 
 def test_get_empty_tar():


### PR DESCRIPTION
The functions inside the module are not ggshield specific and should be in the ggshield.utils module according to the architecture described in #521.

refs #521