### PR TITLE
feat(hmsl): scan hashicorp vault

### DIFF
--- a/changelog.d/20230823_121314_corentin.garcia_hmsl_hashicorp_vault_scan.md
+++ b/changelog.d/20230823_121314_corentin.garcia_hmsl_hashicorp_vault_scan.md
@@ -1,0 +1,5 @@
+### Added
+
+#### HMSL
+
+- Added new `ggshield hmsl check-secret-manager hashicorp-vault` command to scan secrets of an [HashiCorp Vault](https://www.hashicorp.com/products/vault) instance.

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -47,6 +47,8 @@ This is checked at each release: ggshield release process starts with removing a
 
 If your test cannot run without a cassette, then you have to mock the network calls.
 
+For tests interacting with Hashicorp Vault instances in `hmsl` commands, see [the corresponding doc](./hmsl/hashicorp-vault.md).
+
 ### Verifying code coverage
 
 Run `make coverage`. This runs the unit tests through [coverage](https://pypi.org/project/coverage/) and generates an HTML report in `htmlcov/index.html`.

--- a/doc/dev/hmsl/hashicorp-vault.md
+++ b/doc/dev/hmsl/hashicorp-vault.md
@@ -1,0 +1,48 @@
+# Hashicorp Vault
+
+The `ggshield check-secret-manager hashicorp-vault` command interacts with Hashicorp Vault instances.
+
+## Tests using cassettes
+
+Like other tests, a lot of the tests for ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client
+are using cassettes recorded using [VCR.py](https://github.com/kevin1024/vcrpy) to replay network interactions.
+
+To generate these cassettes, a local Hashicorp Vault instance in dev mode is used by running the official Vault docker image.
+The server is populated with test data:
+
+- a `secret_v1` kv mount (version 1)
+- a `secret` kv mount (version 2)
+  These two mounts are populated with some file and directories (same data for both)
+
+The server has two tokens:
+
+- `my_vault_token` is a root token with all rights
+- `restricted_token` is a token with the `default` policy.
+  It cannot read the kv mounts (if you want to test error handling for example).
+
+These vault tokens do not use the `hvs.<random_characters>` pattern on purpose to avoid
+triggering ggshield.
+
+### Running the server
+
+The script handling the server is `scripts/hmsl/hashicorp_vault.py`:
+
+- to start the server: `python scripts/hmsl/hashicorp_vault.py start`.
+- to stop the server: `python scripts/hmsl/hashicorp_vault.py stop`
+
+The server runs on the default Vault port (8200).
+
+You can then use the tokens above to interact with the server API.
+
+The web UI is enabled and can be reached on http://127.0.0.1:8200.
+
+If you want to use the CLI, it's available directly in the container:
+
+- Run `docker exec -it hashicorp-vault-ggshield sh` to get a shell inside the container
+- Call the vault CLI as normal (no need to login). For example `vault token lookup`.
+
+### Using the server in tests
+
+The server can be used in tests like in `tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py`.
+
+The stable test data mean that the cassettes can be deleted and recreated without issues.

--- a/ggshield/cmd/hmsl/check.py
+++ b/ggshield/cmd/hmsl/check.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Any, List, Optional, TextIO, cast
+from typing import Any, TextIO, cast
 
 import click
-from requests import HTTPError
 
 from ggshield.cmd.hmsl.hmsl_common_options import (
     full_hashes_option,
@@ -10,18 +9,15 @@ from ggshield.cmd.hmsl.hmsl_common_options import (
     input_type_option,
     naming_strategy_option,
 )
+from ggshield.cmd.hmsl.hmsl_utils import check_secrets
 from ggshield.cmd.utils.common_options import add_common_options, json_option
-from ggshield.core.config import Config
-from ggshield.core.errors import UnexpectedError
-from ggshield.core.text_utils import display_info, pluralize
-from ggshield.verticals.hmsl import Secret, get_client
+from ggshield.core.text_utils import display_info
 from ggshield.verticals.hmsl.collection import (
     InputType,
     NamingStrategy,
     collect,
     prepare,
 )
-from ggshield.verticals.hmsl.output import show_results
 
 
 logger = logging.getLogger(__name__)
@@ -59,24 +55,11 @@ def check_cmd(
     prepared_data = prepare(secrets, naming_strategy, full_hashes=True)
     display_info(f"Collected {len(prepared_data.payload)} secrets.")
 
-    # Query the API
-    display_info("Querying HasMySecretLeaked...")
-    config: Config = ctx.obj["config"]
-    client = get_client(config)
-    found: List[Secret] = []
-    error: Optional[Exception] = None
-    try:
-        for secret in client.check(prepared_data.payload, full_hashes=full_hashes):
-            found.append(secret)
-    except (ValueError, HTTPError) as exception:
-        error = exception
-    display_info(
-        f"{client.quota.remaining} {pluralize('credit', client.quota.remaining)} left for today."
+    check_secrets(
+        ctx=ctx,
+        prepared_secrets=prepared_data,
+        json_output=json_output,
+        full_hashes=full_hashes,
     )
-
-    # Display results and error
-    show_results(found, prepared_data.mapping, json_output, error=error)
-    if error:
-        raise UnexpectedError(str(error))
 
     return 0

--- a/ggshield/cmd/hmsl/check_secret_manager/__init__.py
+++ b/ggshield/cmd/hmsl/check_secret_manager/__init__.py
@@ -12,7 +12,6 @@ from ggshield.cmd.utils.common_options import add_common_options
     commands={
         "hashicorp-vault": check_hashicorp_vault_cmd,
     },
-    hidden=True,
 )
 @add_common_options()
 def check_secret_manager_group(**kwargs: Any) -> None:

--- a/ggshield/cmd/hmsl/hmsl_utils.py
+++ b/ggshield/cmd/hmsl/hmsl_utils.py
@@ -1,0 +1,40 @@
+from typing import Iterable, Optional
+
+import click
+from requests import HTTPError
+
+from ggshield.core.config import Config
+from ggshield.core.errors import UnexpectedError
+from ggshield.core.text_utils import display_info, pluralize
+from ggshield.verticals.hmsl import Secret, get_client
+from ggshield.verticals.hmsl.collection import PreparedSecrets
+from ggshield.verticals.hmsl.output import show_results
+
+
+def check_secrets(
+    ctx: click.Context,
+    prepared_secrets: PreparedSecrets,
+    json_output: bool,
+    full_hashes: bool,
+):
+    """
+    Common code to check secrets and display results for check commands.
+    """
+    # Query the API
+    display_info("Querying HasMySecretLeaked...")
+    config: Config = ctx.obj["config"]
+    client = get_client(config)
+    found: Iterable[Secret] = []
+    error: Optional[Exception] = None
+    try:
+        found = list(client.check(prepared_secrets.payload, full_hashes=full_hashes))
+    except (ValueError, HTTPError) as exception:
+        error = exception
+    display_info(
+        f"{client.quota.remaining} {pluralize('credit', client.quota.remaining)} left for today."
+    )
+
+    # Display results and error
+    show_results(found, prepared_secrets.mapping, json_output, error)
+    if error:
+        raise UnexpectedError(str(error))

--- a/ggshield/verticals/hmsl/collection.py
+++ b/ggshield/verticals/hmsl/collection.py
@@ -1,6 +1,16 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, Iterable, Iterator, Optional, Set, TextIO
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    TextIO,
+    Tuple,
+)
 
 from dotenv import dotenv_values
 
@@ -41,11 +51,27 @@ NAMING_STRATEGIES: Dict[str, NamingStrategy] = {
 }
 
 
+def collect_list(input: List[Tuple[str, str]]) -> Iterator[SecretWithKey]:
+    """
+    Collect the secrets to pass to prepare.
+
+    Input should be a list of tuple with the first item of the tuple being the secret
+    key and the second the secret value.
+    """
+    for key, value in input:
+        # filter our excluded keys and values
+        if not key or not value:
+            continue
+        if key.upper() in EXCLUDED_KEYS or value.lower() in EXCLUDED_VALUES:
+            continue
+        yield SecretWithKey(key=key, value=value)
+
+
 def collect(
     input: TextIO, input_type: InputType = InputType.FILE
 ) -> Iterator[SecretWithKey]:
     """
-    Collect the secrets
+    Collect the secrets to pass to prepare.
     """
     if input_type == InputType.ENV:
         config = dotenv_values(stream=input)

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
@@ -1,0 +1,202 @@
+import logging
+from typing import Dict, Generator, List, Tuple
+from urllib.parse import urlparse
+
+import requests
+
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.exceptions import (
+    VaultForbiddenItemError,
+    VaultInvalidUrlError,
+    VaultNotFoundItemError,
+    VaultPathIsNotADirectoryError,
+)
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.models import (
+    VaultKvMount,
+    VaultSecrets,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class VaultAPIClient:
+    """Client to interact with Vault API."""
+
+    def __init__(self, vault_url: str, api_token: str) -> None:
+        self.session = requests.Session()
+        self.session.headers["X-Vault-Token"] = api_token
+
+        if not vault_url.startswith("http://") and not vault_url.startswith("https://"):
+            vault_url = f"https://{vault_url}"
+        try:
+            self.vault_url = urlparse(vault_url).geturl()
+        except ValueError:
+            raise VaultInvalidUrlError(
+                f"cannot parse the Vault URL '{vault_url}'. Are you sure it is valid?"
+            )
+
+    def _make_request(
+        self, endpoint: str, method: str = "GET", api_version: str = "v1"
+    ) -> Dict:
+        """ "
+        Make request to the API.
+        """
+        api_res = self.session.request(
+            method, f"{self.vault_url}/{api_version}/{endpoint}"
+        )
+        api_res.raise_for_status()
+
+        return api_res.json()
+
+    def get_kv_mounts(self) -> Generator[VaultKvMount, None, None]:
+        """
+        Get all kv mounts for the Vault instance.
+
+        Will try the /sys/mounts endpoint first, and if there is a forbidden error
+        fallback to the /sys/internal/ui internal endpoint.
+        """
+
+        try:
+            api_res = self._make_request("sys/mounts")["data"]
+        except requests.HTTPError:
+            api_res = self._make_request("sys/internal/ui/mounts")["data"]["secret"]
+
+        for key, value in api_res.items():
+            if value["type"] != "kv":
+                continue
+
+            yield VaultKvMount(
+                name=key.rstrip("/"),  # remove trailing slash
+                version=value["options"]["version"],
+            )
+
+    def list_kv_items(self, mount: VaultKvMount, path: str):
+        logger.debug(f"Listing kv items for mount {mount.name} at {path}")
+
+        api_endpoint = (
+            f"{mount.name}/metadata/{path}"
+            if mount.version == "2"
+            else f"{mount.name}/{path}"
+        )
+
+        try:
+            api_res = self._make_request(api_endpoint, method="LIST")
+        except requests.HTTPError as exc:
+            if exc.response.status_code == 403:
+                raise VaultForbiddenItemError(
+                    f"cannot access item on mount {mount.name} at path {path}"
+                )
+
+            # The API return 404 when trying to list items when the path is a file
+            # and not a directory
+            if exc.response.status_code == 404:
+                raise VaultPathIsNotADirectoryError()
+
+            raise exc
+
+        return [item.rstrip("/") for item in api_res["data"]["keys"]]
+
+    def get_kv_secrets(self, mount: VaultKvMount, path: str) -> List[Tuple[str, str]]:
+        """
+        Get secrets from the specified mount at the specified path.
+
+        Returns a list of tuples containing secret key and secret value
+        """
+
+        logger.debug(f"Getting secrets at {path}")
+        api_endpoint = (
+            f"{mount.name}/data/{path}"
+            if mount.version == "2"
+            else f"{mount.name}/{path}"
+        )
+        try:
+            api_res = self._make_request(api_endpoint)
+        except requests.HTTPError as exc:
+            if exc.response.status_code == 403:
+                raise VaultForbiddenItemError(
+                    f"cannot access item on mount {mount.name} at path {path}"
+                )
+
+            if exc.response.status_code == 404:
+                raise VaultNotFoundItemError(
+                    f"{path} was not found: it's either not a file, "
+                    "was deleted or cannot be accessed with the current token"
+                )
+
+            raise exc
+
+        data = api_res["data"]["data"] if mount.version == "2" else api_res["data"]
+        return [
+            (secret_name, secret_value) for secret_name, secret_value in data.items()
+        ]
+
+    def _get_secrets_or_empty(
+        self, mount: VaultKvMount, folder_path: str
+    ) -> VaultSecrets:
+        """
+        Call get_kv_secrets on the given mount and folder path.
+
+        Return the secrets or an empty list if VaultNotFoundItemError was raised.
+        """
+        try:
+            return VaultSecrets(
+                secrets=self.get_kv_secrets(mount, folder_path),
+                not_fetched_paths=[],
+            )
+        except VaultNotFoundItemError as exc:
+            logger.debug(f"Not found error: {exc}")
+            return VaultSecrets(secrets=[], not_fetched_paths=[folder_path])
+        except VaultForbiddenItemError as exc:
+            logger.debug(f"Forbidden error: {exc}")
+            return VaultSecrets(secrets=[], not_fetched_paths=[folder_path])
+
+    def _get_secrets_from_path(
+        self, mount: VaultKvMount, folder_path: str, recursive: bool
+    ) -> VaultSecrets:
+        """
+        Get the secrets on the given mount and folder path.
+        If recursive is True, iterate recursively on subfolders.
+
+        Return the secrets or an empty list if errors were raised.
+        """
+        # Get current directory secret
+        try:
+            subfolders = self.list_kv_items(mount, folder_path)
+        except VaultPathIsNotADirectoryError:
+            return self._get_secrets_or_empty(mount, folder_path)
+        except VaultForbiddenItemError as exc:
+            logger.debug(f"Forbidden error: {exc}")
+            return VaultSecrets(secrets=[], not_fetched_paths=[folder_path])
+
+        if not recursive:
+            return VaultSecrets(secrets=[], not_fetched_paths=[])
+
+        result = VaultSecrets(secrets=[], not_fetched_paths=[])
+        for subfolder in subfolders:
+            subfolder_result = self._get_secrets_from_path(
+                mount, f"{folder_path}/{subfolder}", True
+            )
+            result.secrets += subfolder_result.secrets
+            result.not_fetched_paths += subfolder_result.not_fetched_paths
+
+        return result
+
+    def get_secrets(
+        self, mount: VaultKvMount, path: str, recursive: bool
+    ) -> VaultSecrets:
+        # Check first if it's a directory
+        try:
+            keys = self.list_kv_items(mount, path)
+        except VaultPathIsNotADirectoryError:
+            # If it's a file, return directly
+            return self._get_secrets_or_empty(mount, path)
+
+        # If it's a folder, get secrets of the folder
+        result = VaultSecrets(secrets=[], not_fetched_paths=[])
+        for folder in keys:
+            folder_path = f"{path}/{folder}".strip("/")
+            folder_result = self._get_secrets_from_path(mount, folder_path, recursive)
+            result.secrets += folder_result.secrets
+            result.not_fetched_paths += folder_result.not_fetched_paths
+
+        return result

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/cli.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/cli.py
@@ -1,15 +1,9 @@
 import json
-import logging
 import subprocess
 
-
-logger = logging.getLogger(__name__)
-
-
-class VaultCliTokenFetchingError(Exception):
-    """Raised when the token used by Vault CLI cannot be fetched."""
-
-    pass
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.exceptions import (
+    VaultCliTokenFetchingError,
+)
 
 
 def get_vault_cli_token() -> str:

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/exceptions.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/exceptions.py
@@ -1,0 +1,28 @@
+class VaultCliTokenFetchingError(Exception):
+    """Raised when the token used by Vault CLI cannot be fetched."""
+
+    pass
+
+
+class VaultInvalidUrlError(Exception):
+    """Raised when the Vault instance URL cannot be parsed."""
+
+    pass
+
+
+class VaultPathIsNotADirectoryError(Exception):
+    """Raised when list_kv_items was called on a file and not a directory."""
+
+    pass
+
+
+class VaultNotFoundItemError(Exception):
+    """Raised when list_kv_items was called on a directory and not a file."""
+
+    pass
+
+
+class VaultForbiddenItemError(Exception):
+    """Raised when a 403 forbidden error was returned for an item."""
+
+    pass

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/models.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/models.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class VaultMount:
+    """
+    Model to represent a Vault mount.
+    """
+
+    name: str
+
+
+@dataclass
+class VaultKvMount(VaultMount):
+    """
+    Model to represent a Vault KV mount.
+    """
+
+    version: str
+
+
+@dataclass
+class VaultSecrets:
+    """
+    Model to hold secrets fetched from the vault.
+
+    The aim is to include the secrets themselves and the not_fetched_paths
+    list to communicate the paths that could not be fetched
+    (permission denied, errors etc.).
+    """
+
+    secrets: List[Tuple[str, str]]
+    not_fetched_paths: List[str]

--- a/scripts/hmsl/hashicorp_vault.py
+++ b/scripts/hmsl/hashicorp_vault.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Start an Hashicorp Vault server and get the root token associated with it
+"""
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+
+
+CONTAINER_NAME = "hashicorp-vault-ggshield"
+ROOT_TOKEN = "my_vault_token"
+RESTRICTED_TOKEN = "restricted_token"
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.getLevelName(os.environ.get("LOG_LEVEL", "WARN").upper()),
+)
+
+
+def wait_for_server_to_be_ready() -> None:
+    """
+    Will block (with a timeout) while waiting for the server to be ready.
+
+    If timeout elapsed, a RuntimeError is raised.
+    """
+    tries = 0
+    while tries < 10:
+        check_cmd_ret = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"name={CONTAINER_NAME}",
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+        )
+        json_status = json.loads(check_cmd_ret.stdout)
+
+        if "(healthy)" in json_status["Status"]:
+            logger.debug("Server is healthy")
+            return True
+
+        logger.debug("Server not healthy yet, waiting...")
+        time.sleep(0.500)
+        tries += 1
+
+    raise RuntimeError("Hashicorp Vault server is not ready")
+
+
+def stop_hashicorp_vault_server():
+    """Stop the Hashicorp Vault server instance."""
+    stop_cmd_ret = subprocess.run(
+        ["docker", "stop", CONTAINER_NAME], capture_output=True
+    )
+    stop_cmd_ret.check_returncode()
+
+
+def execute_container_command(cmd: str):
+    """
+    Execute the given command in the container.
+    """
+    cmd_ret = subprocess.run(
+        ["docker", "exec", CONTAINER_NAME] + cmd.split(" "),
+        capture_output=True,
+    )
+    cmd_ret.check_returncode()
+
+
+def populate_server():
+    """
+    Populate the server with a known state.
+    """
+
+    # Add a v1 kv at path secret_v1
+    execute_container_command("vault secrets enable -version=1 -path=secret_v1 kv")
+
+    # Add same secrets for both paths
+    data: dict[str, dict[str, str]] = {
+        "b2c/worker/config.env": {
+            "WORKER_KEY": "my_secret_key",
+            "DB_PASSWORD": "my_password",
+        },
+        "b2c/web_app/config.env": {
+            "SECRET_KEY": "another_secret",
+            "DB_PASSWORD": "test_test",
+        },
+        "b2c/web_app/prod/config.env": {
+            "PROD_STUFF": "test",
+        },
+        "b2b/worker/config.env": {
+            "ANOTHER_PASSWORD": "my_secret_key",
+            "SECRET": "super_secret",
+        },
+        "b2b/web_app/config.env": {
+            "TESTING": "true",
+            "TIMEOUT": "15",
+        },
+        "b2b/web_app/prod/config.env": {
+            "PROD_STUFF": "test",
+        },
+    }
+    for mount in ["secret", "secret_v1"]:
+        for secret_path, secrets in data.items():
+            execute_container_command(
+                f"vault kv put -mount={mount} {secret_path} "
+                + " ".join(
+                    (
+                        f"{secret_name}={secret_value}"
+                        for secret_name, secret_value in secrets.items()
+                    )
+                )
+            )
+
+    # Add another token without any rights on the secret and secret_v1 mounts
+    execute_container_command(
+        f"vault token create -policy=default -id {RESTRICTED_TOKEN}"
+    )
+
+
+def start_hashicorp_vault_server():
+    """Start the Hashicorp Vault server"""
+    logger.debug("Starting server...")
+
+    docker_run_ret = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--cap-add=IPC_LOCK",
+            "--rm",
+            "-d",
+            f"--name={CONTAINER_NAME}",
+            "--env",
+            f"VAULT_DEV_ROOT_TOKEN_ID={ROOT_TOKEN}",
+            "--env",
+            "VAULT_ADDR=http://127.0.0.1:8200",
+            "-p",
+            "8200:8200",
+            "--health-cmd=wget -q -O - http://127.0.0.1:8200/v1/sys/health",
+            "--health-start-period=1s",
+            "--health-interval=2s",
+            "hashicorp/vault",
+        ],
+    )
+    if docker_run_ret.returncode == 125:
+        logger.error("it seems the server is running already.")
+        sys.exit(1)
+
+    docker_run_ret.check_returncode()
+
+    try:
+        wait_for_server_to_be_ready()
+    except RuntimeError:
+        stop_hashicorp_vault_server()
+        raise
+
+    execute_container_command(f"vault login {ROOT_TOKEN}")
+    populate_server()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Dev Hashicorp Vault Server")
+
+    parser.add_argument(
+        "command", type=str, help="the command to run", choices=["start", "stop"]
+    )
+    args = parser.parse_args()
+
+    if args.command == "start":
+        start_hashicorp_vault_server()
+    elif args.command == "stop":
+        stop_hashicorp_vault_server()
+    else:
+        raise RuntimeError("Unknown command")

--- a/scripts/release
+++ b/scripts/release
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Any, List, Union
 
 import click
+from hmsl.hashicorp_vault import (
+    start_hashicorp_vault_server,
+    stop_hashicorp_vault_server,
+)
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -197,6 +201,9 @@ def run_tests() -> None:
     shutil.rmtree(CASSETTES_DIR)
     CASSETTES_DIR.mkdir()
 
+    # Start the hashicorp Vault server for HMSL tests
+    start_hashicorp_vault_server()
+
     log_progress("Running unit tests")
     check_run(["pytest", "tests/unit"], cwd=ROOT_DIR)
 
@@ -205,6 +212,8 @@ def run_tests() -> None:
 
     log_progress("Restoring cassettes")
     check_run(["git", "restore", CASSETTES_DIR], cwd=ROOT_DIR)
+
+    stop_hashicorp_vault_server()
 
 
 def replace_once_in_file(path: Path, src: str, dst: str, flags: int = 0) -> None:

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_mounts_api_endpoint.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_mounts_api_endpoint.yaml
@@ -1,0 +1,45 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/sys/mounts
+    response:
+      body:
+        string:
+          '{"identity/":{"accessor":"identity_f2adbd10","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0,"passthrough_request_headers":["Authorization"]},"description":"identity
+          store","external_entropy_access":false,"local":false,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":false,"type":"identity","uuid":"8e3d7d44-e6ff-fca5-7123-d13f93e9b54d"},"cubbyhole/":{"accessor":"cubbyhole_7ca06224","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"per-token
+          private secret storage","external_entropy_access":false,"local":true,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":false,"type":"cubbyhole","uuid":"c5490e6e-53b7-0569-7bfb-dff6434549ef"},"secret/":{"accessor":"kv_fd093876","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"deprecation_status":"supported","description":"key/value
+          secret storage","external_entropy_access":false,"local":false,"options":{"version":"2"},"plugin_version":"","running_plugin_version":"v0.15.0+builtin","running_sha256":"","seal_wrap":false,"type":"kv","uuid":"220684e5-6170-6766-9f9e-90cc817d81f7"},"secret_v1/":{"accessor":"kv_affc2db1","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"deprecation_status":"supported","description":"","external_entropy_access":false,"local":false,"options":{"version":"1"},"plugin_version":"","running_plugin_version":"v0.15.0+builtin","running_sha256":"","seal_wrap":false,"type":"kv","uuid":"ca971480-d8d4-7fc6-0b77-6ce843bd118d"},"sys/":{"accessor":"system_1087c6e6","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0,"passthrough_request_headers":["Accept"]},"description":"system
+          endpoints used for control, policy and debugging","external_entropy_access":false,"local":false,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":true,"type":"system","uuid":"78668b1c-b5c5-a64f-093b-cc93bdf53050"},"request_id":"1278b272-83b8-6af0-7068-0d2c05492fb7","lease_id":"","renewable":false,"lease_duration":0,"data":{"cubbyhole/":{"accessor":"cubbyhole_7ca06224","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"description":"per-token
+          private secret storage","external_entropy_access":false,"local":true,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":false,"type":"cubbyhole","uuid":"c5490e6e-53b7-0569-7bfb-dff6434549ef"},"identity/":{"accessor":"identity_f2adbd10","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0,"passthrough_request_headers":["Authorization"]},"description":"identity
+          store","external_entropy_access":false,"local":false,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":false,"type":"identity","uuid":"8e3d7d44-e6ff-fca5-7123-d13f93e9b54d"},"secret/":{"accessor":"kv_fd093876","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"deprecation_status":"supported","description":"key/value
+          secret storage","external_entropy_access":false,"local":false,"options":{"version":"2"},"plugin_version":"","running_plugin_version":"v0.15.0+builtin","running_sha256":"","seal_wrap":false,"type":"kv","uuid":"220684e5-6170-6766-9f9e-90cc817d81f7"},"secret_v1/":{"accessor":"kv_affc2db1","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0},"deprecation_status":"supported","description":"","external_entropy_access":false,"local":false,"options":{"version":"1"},"plugin_version":"","running_plugin_version":"v0.15.0+builtin","running_sha256":"","seal_wrap":false,"type":"kv","uuid":"ca971480-d8d4-7fc6-0b77-6ce843bd118d"},"sys/":{"accessor":"system_1087c6e6","config":{"default_lease_ttl":0,"force_no_cache":false,"max_lease_ttl":0,"passthrough_request_headers":["Accept"]},"description":"system
+          endpoints used for control, policy and debugging","external_entropy_access":false,"local":false,"options":null,"plugin_version":"","running_plugin_version":"v1.14.2+builtin.vault","running_sha256":"","seal_wrap":true,"type":"system","uuid":"78668b1c-b5c5-a64f-093b-cc93bdf53050"}},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_forbidden.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_forbidden.yaml
@@ -1,0 +1,36 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - restricted_token
+      method: GET
+      uri: http://localhost:8200/v1/secret/data/b2c/web_app/config.env
+    response:
+      body:
+        string: '{"errors":["1 error occurred:\n\t* permission denied\n\n"]}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '60'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 403
+        message: Forbidden
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_not_found.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_not_found.yaml
@@ -1,0 +1,36 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/secret/data/these_are_not_the_secrets_you_are_looking_for.env
+    response:
+      body:
+        string: '{"errors":[]}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '14'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 404
+        message: Not Found
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v1_b2b_web_app_prod_config.env.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v1_b2b_web_app_prod_config.env.yaml
@@ -1,0 +1,37 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/secret_v1/b2b/web_app/prod/config.env
+    response:
+      body:
+        string:
+          '{"request_id":"3ef588ad-c719-31d1-faf2-7f98f8ad7d4f","lease_id":"","renewable":false,"lease_duration":2764800,"data":{"PROD_STUFF":"test"},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '185'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v1_b2b_worker_config.env.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v1_b2b_worker_config.env.yaml
@@ -1,0 +1,37 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/secret_v1/b2b/worker/config.env
+    response:
+      body:
+        string:
+          '{"request_id":"23048aa8-0727-b7e7-63e9-88a88288351a","lease_id":"","renewable":false,"lease_duration":2764800,"data":{"ANOTHER_PASSWORD":"my_secret_key","SECRET":"super_secret"},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '224'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v2_b2b_web_app_prod_config.env.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v2_b2b_web_app_prod_config.env.yaml
@@ -1,0 +1,37 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/secret/data/b2b/web_app/prod/config.env
+    response:
+      body:
+        string:
+          '{"request_id":"a303c545-d018-3c56-5793-2db567dd59db","lease_id":"","renewable":false,"lease_duration":0,"data":{"data":{"PROD_STUFF":"test"},"metadata":{"created_time":"2023-09-21T13:08:50.689212457Z","custom_metadata":null,"deletion_time":"","destroyed":false,"version":1}},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '321'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v2_b2b_worker_config.env.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v2_b2b_worker_config.env.yaml
@@ -1,0 +1,37 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: GET
+      uri: http://localhost:8200/v1/secret/data/b2b/worker/config.env
+    response:
+      body:
+        string:
+          '{"request_id":"0ed38eb7-5137-f783-1214-608ecb0f8994","lease_id":"","renewable":false,"lease_duration":0,"data":{"data":{"ANOTHER_PASSWORD":"my_secret_key","SECRET":"super_secret"},"metadata":{"created_time":"2023-09-21T13:08:50.394627804Z","custom_metadata":null,"deletion_time":"","destroyed":false,"version":1}},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '360'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_forbidden.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_forbidden.yaml
@@ -1,0 +1,38 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - restricted_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/
+    response:
+      body:
+        string: '{"errors":["1 error occurred:\n\t* permission denied\n\n"]}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '60'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 403
+        message: Forbidden
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_not_a_directory.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_not_a_directory.yaml
@@ -1,0 +1,38 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c/worker/config.env
+    response:
+      body:
+        string: '{"errors":[]}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '14'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 404
+        message: Not Found
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/
+    response:
+      body:
+        string:
+          '{"request_id":"35ca965a-ee98-d3e3-8e31-a124cd6f0461","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["b2b/","b2c/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '182'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2b
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Location:
+          - /v1/secret_v1/b2b
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b
+    response:
+      body:
+        string:
+          '{"request_id":"6ba7042a-111d-1283-b1d9-6f208a064738","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b_web_app.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2b/web_app
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Location:
+          - /v1/secret_v1/b2b/web_app
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"22777ef7-5359-9ea2-9416-0526dadd1271","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2b_worker.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2b/worker
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Location:
+          - /v1/secret_v1/b2b/worker
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b/worker
+    response:
+      body:
+        string:
+          '{"request_id":"72535b21-fee1-732b-c336-319d7783cd23","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2c
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret_v1/b2c
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c
+    response:
+      body:
+        string:
+          '{"request_id":"63962874-01b6-f506-4261-153b3af78ab4","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c_web_app.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2c/web_app
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret_v1/b2c/web_app
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"3af719f8-1d8f-c2ec-93e8-7d2600e5d808","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1__b2c_worker.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1//b2c/worker
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret_v1/b2c/worker
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c/worker
+    response:
+      body:
+        string:
+          '{"request_id":"afc33cba-7d69-2b7d-516e-b7a7155dbbbd","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b
+    response:
+      body:
+        string:
+          '{"request_id":"797c3eb4-2a1e-9580-32a0-b3963db094c2","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b_web_app.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"045bf1c6-24d7-de15-5d20-07794daef3d9","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2b_worker.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2b/worker
+    response:
+      body:
+        string:
+          '{"request_id":"deceb1fb-f7cf-6493-af70-b2aa38af27de","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c
+    response:
+      body:
+        string:
+          '{"request_id":"381d7c9f-3aef-d875-373f-38aee079ae4b","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c_web_app.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"0c95dfdd-2f09-9d01-51b8-59ba75d10e9a","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_b2c_worker.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret_v1/b2c/worker
+    response:
+      body:
+        string:
+          '{"request_id":"bfbe1c5a-fc8b-d3ac-a9b5-d52707698181","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:55 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/
+    response:
+      body:
+        string:
+          '{"request_id":"c746b5c2-7aa2-b538-c810-632b5a35e188","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["b2b/","b2c/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '182'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2b
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2b
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b
+    response:
+      body:
+        string:
+          '{"request_id":"d7ddabdc-a9d8-493e-ca84-ca9cd921c5e3","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b_web_app.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2b/web_app
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2b/web_app
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"28d0ca85-f9b2-f07a-1711-4988c67ef941","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2b_worker.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2b/worker
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2b/worker
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b/worker
+    response:
+      body:
+        string:
+          '{"request_id":"1d708b0d-959d-95ca-23d6-f0c261e5a483","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2c
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2c
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c
+    response:
+      body:
+        string:
+          '{"request_id":"ffe90eb2-5bcc-0305-851f-9e048fb0d3c0","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c_web_app.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2c/web_app
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2c/web_app
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"900083cc-2d84-5678-58de-46adde89a3a8","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2__b2c_worker.yaml
@@ -1,0 +1,71 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata//b2c/worker
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '0'
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Location:
+          - /v1/secret/metadata/b2c/worker
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 301
+        message: Moved Permanently
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c/worker
+    response:
+      body:
+        string:
+          '{"request_id":"7b0600de-c87e-d305-d322-e882e963e17c","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b
+    response:
+      body:
+        string:
+          '{"request_id":"136da9a5-753a-5d72-24c5-ca690c28e959","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b_web_app.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"b78ab884-174d-2cdf-9060-e9ddfa6421c0","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2b_worker.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2b/worker
+    response:
+      body:
+        string:
+          '{"request_id":"11de8057-c424-ebdf-1419-856f826e44fe","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c
+    response:
+      body:
+        string:
+          '{"request_id":"ca553808-39ab-2476-732c-77924a9fc17b","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["web_app/","worker/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c_web_app.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c_web_app.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c/web_app
+    response:
+      body:
+        string:
+          '{"request_id":"c6610fa3-2eed-3e19-a7f0-2597ef7e17a6","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env","prod/"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '189'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c_worker.yaml
+++ b/tests/unit/cassettes/test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_b2c_worker.yaml
@@ -1,0 +1,39 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        User-Agent:
+          - python-requests/2.31.0
+        X-Vault-Token:
+          - my_vault_token
+      method: LIST
+      uri: http://localhost:8200/v1/secret/metadata/b2c/worker
+    response:
+      body:
+        string:
+          '{"request_id":"fb03bd1d-4994-7764-61b3-f98b0b8d1c7e","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["config.env"]},"wrap_info":null,"warnings":null,"auth":null}
+
+          '
+      headers:
+        Cache-Control:
+          - no-store
+        Content-Length:
+          - '181'
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 21 Sep 2023 13:08:56 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/hmsl/check_secret_manager/test_hashicorp_vault.py
+++ b/tests/unit/cmd/hmsl/check_secret_manager/test_hashicorp_vault.py
@@ -1,6 +1,21 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault import _get_vault_token
+import pytest
+
+from ggshield.__main__ import cli
+from ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault import (
+    _get_vault_token,
+    _split_vault_mount_and_path,
+)
+from ggshield.verticals.hmsl.collection import (
+    NAMING_STRATEGIES,
+    PreparedSecrets,
+    SecretWithKey,
+)
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.models import (
+    VaultKvMount,
+    VaultSecrets,
+)
 
 
 def test_get_vault_token_from_vault_cli(monkeypatch):
@@ -18,7 +33,6 @@ def test_get_vault_token_from_vault_cli(monkeypatch):
         "ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.get_vault_cli_token",
         return_value=token_from_cli,
     ) as get_vault_cli_token_mock:
-
         returned_token = _get_vault_token(use_vault_cli_token=True)
 
         assert returned_token == token_from_cli
@@ -38,8 +52,143 @@ def test_get_vault_token_from_env(monkeypatch):
         "ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.get_vault_cli_token",
         return_value="should_not_use_token_from_cli",
     ) as get_vault_cli_token_mock:
-
         returned_token = _get_vault_token(use_vault_cli_token=False)
 
         assert returned_token == token_from_env
         get_vault_cli_token_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "input_str,expected_output",
+    [
+        ("dev/b2b", ("dev", "b2b")),
+        ("/dev/b2b/", ("dev", "b2b")),
+        ("/dev/b2c", ("dev", "b2c")),
+        ("dev/b2c/", ("dev", "b2c")),
+        ("prod/web/app/2", ("prod", "web/app/2")),
+        ("/prod/web/app/2/", ("prod", "web/app/2")),
+        ("/prod/web/app/2", ("prod", "web/app/2")),
+        ("prod/web/app/2/", ("prod", "web/app/2")),
+    ],
+)
+def test_split_vault_mount_and_path(input_str, expected_output):
+    """
+    GIVEN a path combining mount and path
+    WHEN calling _split_vault_mount_and_path
+    THEN the mount and path are splitted correctly
+    """
+
+    assert _split_vault_mount_and_path(input_str) == expected_output
+
+
+@patch("ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.check_secrets")
+@patch(
+    "ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.prepare",
+)
+@patch("ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.collect_list")
+@patch(
+    "ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault._get_vault_token",
+    return_value="vault_token",
+)
+@patch(
+    "ggshield.cmd.hmsl.check_secret_manager.hashicorp_vault.VaultAPIClient",
+)
+@pytest.mark.parametrize("use_cli_token", [True, False])
+@pytest.mark.parametrize("recursive", [True, False])
+@pytest.mark.parametrize("mount_not_found", [True, False])
+@pytest.mark.parametrize("verbose", [True, False])
+def test_check_hashicorp_vault_cmd(
+    vault_api_client_cls_mock,
+    get_vault_token_mock,
+    collect_mock,
+    prepare_mock,
+    check_secrets_mock,
+    cli_fs_runner,
+    recursive,
+    use_cli_token,
+    mount_not_found,
+    verbose,
+):
+    """
+    GIVEN the hmsl check-secret-manager hashicorp-vault command
+    WHEN calling the command with different arguments
+    THEN the expected vertical calls are made to compute the result
+    """
+    args = [
+        "hmsl",
+        "check-secret-manager",
+        "hashicorp-vault",
+        "--url",
+        "http://127.0.0.1:6789",
+        "secret",
+    ]
+    if recursive:
+        args.append("--recursive")
+    if use_cli_token:
+        args.append("--use-cli-token")
+    if verbose:
+        args.append("--verbose")
+
+    vault_api_client_mock = Mock()
+    vault_api_client_cls_mock.return_value = vault_api_client_mock
+    vault_api_client_mock.get_kv_mounts.return_value = (
+        [] if mount_not_found else [VaultKvMount(name="secret", version="2")]
+    )
+    returned_api_secrets = [
+        ("DATABASE_PASSWORD", "postgres_password"),
+        ("SECRET_KEY", "my_secret_key"),
+    ]
+    collect_mock.return_value = [
+        SecretWithKey(key=key, value=value) for key, value in returned_api_secrets
+    ]
+    prepare_mock.return_value = PreparedSecrets(
+        payload=set([key for key, _ in returned_api_secrets]),
+        mapping={key: f"hash_{value}" for key, value in returned_api_secrets},
+    )
+    vault_api_client_mock.get_secrets.return_value = VaultSecrets(
+        secrets=returned_api_secrets,
+        not_fetched_paths=["super_secret_path", "prod_credentials"],
+    )
+
+    cmd_ret = cli_fs_runner.invoke(cli, args)
+
+    # get_vault_token is called and the API client is initialized
+    get_vault_token_mock.assert_called_once_with(use_cli_token)
+    vault_api_client_cls_mock.assert_called_once_with(
+        "http://127.0.0.1:6789", "vault_token"
+    )
+
+    # Get the KV mounts and return an error if not found, else continue
+    vault_api_client_mock.get_kv_mounts.assert_called_once()
+    if mount_not_found:
+        assert cmd_ret.exit_code == 128
+        assert (
+            cmd_ret.output
+            == "Error: mount secret not found. Make sure it exists and that your token has access to it.\n"
+        )
+        return
+
+    # Secrets are fetched
+    vault_api_client_mock.get_secrets.assert_called_once_with(
+        VaultKvMount(name="secret", version="2"), "", recursive
+    )
+
+    # Collect, prepare and common check are called
+    collect_mock.assert_called_once_with(returned_api_secrets)
+    prepare_mock.assert_called_once_with(
+        collect_mock.return_value, NAMING_STRATEGIES["key"], full_hashes=True
+    )
+    check_secrets_mock.assert_called_once()
+
+    assert cmd_ret.exit_code == 0
+    assert "Fetching secrets from Vault...\n" in cmd_ret.output
+    assert (
+        "Could not fetch 2 paths. Make sure your token has access to all the secrets in your vault.\n"
+        in cmd_ret.output
+    )
+    assert "Got 2 secrets.\n" in cmd_ret.output
+    if verbose:
+        assert (
+            "> The following paths could not be fetched:\n- super_secret_path\n- prod_credentials"
+            in cmd_ret.output
+        )

--- a/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py
+++ b/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py
@@ -1,0 +1,485 @@
+from unittest.mock import patch
+
+import pytest
+
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client import (
+    VaultAPIClient,
+)
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.exceptions import (
+    VaultForbiddenItemError,
+    VaultNotFoundItemError,
+    VaultPathIsNotADirectoryError,
+)
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.models import (
+    VaultKvMount,
+    VaultSecrets,
+)
+from tests.unit.conftest import my_vcr
+
+
+@pytest.fixture(scope="module")
+def vault_api_client():
+    """
+    Get a Vault API client with all rights.
+    """
+    return VaultAPIClient(
+        vault_url="http://localhost:8200",
+        api_token="my_vault_token",  # as defined in scripts/hmsl/hashicorp_vault.py
+    )
+
+
+@pytest.fixture(scope="module")
+def restricted_vault_api_client():
+    """
+    Get a Vault API client with restricted permissions
+    """
+    return VaultAPIClient(
+        vault_url="http://localhost:8200",
+        api_token="restricted_token",  # as defined in scripts/hmsl/hashicorp_vault.py
+    )
+
+
+@my_vcr.use_cassette(
+    "test_hmsl_secret_manager_hashicorp_vault_get_kv_mounts_api_endpoint.yaml",
+    ignore_localhost=False,
+)
+def test_get_kv_mounts_api_endpoint(vault_api_client):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling get_kv_mounts
+    THEN I get all the kv mounts of this instance
+    """
+    kv_mounts = list(vault_api_client.get_kv_mounts())
+
+    assert kv_mounts == [
+        VaultKvMount(name="secret", version="2"),
+        VaultKvMount(name="secret_v1", version="1"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "vault_path, expected_results",
+    [
+        ("", ["b2b", "b2c"]),
+        ("b2b", ["web_app", "worker"]),
+        ("b2b/worker", ["config.env"]),
+        ("b2b/web_app", ["config.env", "prod"]),
+        ("b2c", ["web_app", "worker"]),
+        ("b2c/worker", ["config.env"]),
+        ("b2c/web_app", ["config.env", "prod"]),
+        ("/b2b", ["web_app", "worker"]),
+        ("/b2b/worker", ["config.env"]),
+        ("/b2b/web_app", ["config.env", "prod"]),
+        ("/b2c", ["web_app", "worker"]),
+        ("/b2c/worker", ["config.env"]),
+        ("/b2c/web_app", ["config.env", "prod"]),
+    ],
+)
+def test_list_kv_items_v1(vault_api_client, vault_path, expected_results):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling list_kv_items on a v1 mount
+    THEN I get all the items
+    """
+    kv_mount = VaultKvMount(name="secret_v1", version="1")
+
+    with my_vcr.use_cassette(
+        f"test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v1_{vault_path.replace('/', '_')}.yaml",
+        ignore_localhost=False,
+    ):
+        kv_items = list(vault_api_client.list_kv_items(kv_mount, vault_path))
+
+    assert kv_items == expected_results
+
+
+@my_vcr.use_cassette(
+    "test_hmsl_secret_manager_hashicorp_vault_list_kv_items_not_a_directory.yaml",
+    ignore_localhost=False,
+)
+def test_list_kv_items_not_a_directory(vault_api_client):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling list_kv_items with a path that is actually a file
+    THEN VaultPathIsNotADirectoryError is raised
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with pytest.raises(VaultPathIsNotADirectoryError):
+        vault_api_client.list_kv_items(kv_mount, "b2c/worker/config.env")
+
+
+@my_vcr.use_cassette(
+    "test_hmsl_secret_manager_hashicorp_vault_list_kv_items_forbidden.yaml",
+    ignore_localhost=False,
+)
+def test_list_kv_items_forbidden(restricted_vault_api_client):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling list_kv_items on a path you don't have access to
+    THEN VaultForbiddenItemError is raised
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with pytest.raises(VaultForbiddenItemError):
+        restricted_vault_api_client.list_kv_items(kv_mount, "")
+
+
+@pytest.mark.parametrize(
+    "vault_path, expected_results",
+    [
+        ("", ["b2b", "b2c"]),
+        ("b2b", ["web_app", "worker"]),
+        ("b2b/worker", ["config.env"]),
+        ("b2b/web_app", ["config.env", "prod"]),
+        ("b2c", ["web_app", "worker"]),
+        ("b2c/worker", ["config.env"]),
+        ("b2c/web_app", ["config.env", "prod"]),
+        ("/b2b", ["web_app", "worker"]),
+        ("/b2b/worker", ["config.env"]),
+        ("/b2b/web_app", ["config.env", "prod"]),
+        ("/b2c", ["web_app", "worker"]),
+        ("/b2c/worker", ["config.env"]),
+        ("/b2c/web_app", ["config.env", "prod"]),
+    ],
+)
+def test_list_kv_items_v2(vault_api_client, vault_path, expected_results):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling list_kv_items on a v2 mount
+    THEN I get all the items
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with my_vcr.use_cassette(
+        f"test_hmsl_secret_manager_hashicorp_vault_list_kv_items_v2_{vault_path.replace('/', '_')}.yaml",
+        ignore_localhost=False,
+    ):
+        kv_items = list(vault_api_client.list_kv_items(kv_mount, vault_path))
+
+    assert kv_items == expected_results
+
+
+@pytest.mark.parametrize(
+    "vault_path, expected_results",
+    [
+        ("b2b/web_app/prod/config.env", [("PROD_STUFF", "test")]),
+        (
+            "b2b/worker/config.env",
+            [
+                ("ANOTHER_PASSWORD", "my_secret_key"),
+                ("SECRET", "super_secret"),
+            ],
+        ),
+    ],
+)
+def test_get_kv_secrets_v1(vault_api_client, vault_path, expected_results):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling get_kv_secrets on a v1 mount
+    THEN I get all the expected secrets
+    """
+    kv_mount = VaultKvMount(name="secret_v1", version="1")
+
+    with my_vcr.use_cassette(
+        f"test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v1_{vault_path.replace('/', '_')}.yaml",
+        ignore_localhost=False,
+    ):
+        secrets = vault_api_client.get_kv_secrets(kv_mount, vault_path)
+
+    assert secrets == expected_results
+
+
+@pytest.mark.parametrize(
+    "vault_path, expected_results",
+    [
+        ("b2b/web_app/prod/config.env", [("PROD_STUFF", "test")]),
+        (
+            "b2b/worker/config.env",
+            [
+                ("ANOTHER_PASSWORD", "my_secret_key"),
+                ("SECRET", "super_secret"),
+            ],
+        ),
+    ],
+)
+def test_get_kv_secrets_v2(vault_api_client, vault_path, expected_results):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling get_kv_secrets on a v2 mount
+    THEN I get all the expected secrets
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with my_vcr.use_cassette(
+        f"test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_v2_{vault_path.replace('/', '_')}.yaml",
+        ignore_localhost=False,
+    ):
+        secrets = vault_api_client.get_kv_secrets(kv_mount, vault_path)
+
+    assert secrets == expected_results
+
+
+@my_vcr.use_cassette(
+    "test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_not_found.yaml",
+    ignore_localhost=False,
+)
+def test_get_kv_secrets_not_found(vault_api_client):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling get_kv_secrets with a path that doesn't exist
+    THEN VaultNotFoundItemError is raised
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with pytest.raises(VaultNotFoundItemError):
+        vault_api_client.get_kv_secrets(
+            kv_mount, "these_are_not_the_secrets_you_are_looking_for.env"
+        )
+
+
+@my_vcr.use_cassette(
+    "test_hmsl_secret_manager_hashicorp_vault_get_kv_secrets_forbidden.yaml",
+    ignore_localhost=False,
+)
+def test_get_kv_secrets_forbidden(restricted_vault_api_client):
+    """
+    GIVEN a Vault instance and an API client
+    WHEN calling get_kv_secrets on a path you don't have access to
+    THEN VaultForbiddenItemError is raised
+    """
+    kv_mount = VaultKvMount(name="secret", version="2")
+
+    with pytest.raises(VaultForbiddenItemError):
+        restricted_vault_api_client.get_kv_secrets(kv_mount, "b2c/web_app/config.env")
+
+
+def test_get_secrets_or_empty_success():
+    """
+    GIVEN a valid mount and path
+    WHEN calling _get_secrets_or_empty
+    THEN the secrets are returned
+    """
+
+    secrets = [("PASSWORD", "my_password"), ("SECRET_KEY", "my_secret_key")]
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.get_kv_secrets",
+        return_value=secrets,
+    ):
+        api_client = VaultAPIClient("vault_url", "vault_token")
+        ret = api_client._get_secrets_or_empty(
+            VaultKvMount(name="mount_name", version="2"), "my_path"
+        )
+
+        assert ret.secrets == secrets
+        assert ret.not_fetched_paths == []
+
+
+def test_get_secrets_or_empty_vault_not_found_item_error():
+    """
+    GIVEN a valid mount with a path that doesn't exist
+    WHEN calling _get_secrets_or_empty
+    THEN the inner exception is catched and no secrets are returned
+    """
+
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.get_kv_secrets",
+        side_effect=VaultNotFoundItemError,
+    ):
+        api_client = VaultAPIClient("vault_url", "vault_token")
+        ret = api_client._get_secrets_or_empty(
+            VaultKvMount(name="mount_name", version="2"), "my_path"
+        )
+
+        assert ret.secrets == []
+        assert ret.not_fetched_paths == ["my_path"]
+
+
+def test_get_secrets_or_empty_vault_forbidden_item_error():
+    """
+    GIVEN a valid mount with a forbidden path
+    WHEN calling _get_secrets_or_empty
+    THEN the inner exception is catched and no secrets are returned
+    """
+
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.get_kv_secrets",
+        side_effect=VaultForbiddenItemError,
+    ):
+        api_client = VaultAPIClient("vault_url", "vault_token")
+        ret = api_client._get_secrets_or_empty(
+            VaultKvMount(name="mount_name", version="2"), "my_path"
+        )
+
+        assert ret.secrets == []
+        assert ret.not_fetched_paths == ["my_path"]
+
+
+@pytest.mark.parametrize("recursive", [True, False])
+def test_get_secrets_from_path_on_directory(recursive):
+    """
+    GIVEN a valid mount and path of a directory
+    WHEN calling _get_secrets_from_path
+    THEN the expected results are returned depending on if recursive was set
+    """
+
+    directories_res = ["prod", "dev"]
+    api_client = VaultAPIClient("vault_url", "vault_token")
+    mount = VaultKvMount(name="mount_name", version="2")
+
+    # It's a recursive function, so copy the non-mocked function
+    # first for the initial call
+    api_client._get_secrets_from_path_not_mocked = api_client._get_secrets_from_path
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient._get_secrets_from_path",
+    ):
+        with patch(
+            "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+            "VaultAPIClient.list_kv_items",
+            return_value=directories_res,
+        ):
+            ret = api_client._get_secrets_from_path_not_mocked(
+                mount, "my_path", recursive
+            )
+
+            if not recursive:
+                assert ret == VaultSecrets(secrets=[], not_fetched_paths=[])
+            else:
+                api_client.list_kv_items.assert_called_once_with(mount, "my_path")
+                assert api_client._get_secrets_from_path.call_count == 2
+                assert api_client._get_secrets_from_path.call_args_list[0][0] == (
+                    mount,
+                    "my_path/prod",
+                    True,
+                )
+                assert api_client._get_secrets_from_path.call_args_list[1][0] == (
+                    VaultKvMount(name="mount_name", version="2"),
+                    "my_path/dev",
+                    True,
+                )
+
+
+@pytest.mark.parametrize("recursive", [True, False])
+def test_get_secrets_from_path_on_file(recursive):
+    """
+    GIVEN a valid mount and path of a file
+    WHEN calling _get_secrets_from_path
+    THEN the expected results are returned and recursive parameter has no effect
+    """
+
+    secrets_res = VaultSecrets(secrets=[("PASSWORD", "test")], not_fetched_paths=[])
+    api_client = VaultAPIClient("vault_url", "vault_token")
+    mount = VaultKvMount(name="mount_name", version="2")
+    vault_path = "my_path"
+
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.list_kv_items",
+        side_effect=VaultPathIsNotADirectoryError,
+    ):
+        with patch(
+            "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+            "VaultAPIClient._get_secrets_or_empty",
+            return_value=secrets_res,
+        ):
+            returned_secrets = api_client._get_secrets_from_path(
+                mount, vault_path, recursive
+            )
+
+            api_client.list_kv_items.assert_called_once_with(mount, vault_path)
+            api_client._get_secrets_or_empty.assert_called_once_with(mount, vault_path)
+            assert returned_secrets == secrets_res
+
+
+@pytest.mark.parametrize("recursive", [True, False])
+def test_get_secrets_on_file(recursive):
+    """
+    GIVEN a valid mount and path of a file
+    WHEN calling get_secrets
+    THEN we directly return with the secrets of the file and recursive parameter has no effect
+    """
+
+    secrets = [
+        ("DATABASE_PASSWORD", "my_password"),
+        ("ADMIN_PASSWORD", "another_password"),
+    ]
+    mount = VaultKvMount(name="test", version="2")
+    api_client = VaultAPIClient("my_vault_url", "my_vault_token")
+    vault_path = "dev/env"
+
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.list_kv_items",
+        side_effect=VaultPathIsNotADirectoryError,
+    ):
+        with patch(
+            "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+            "VaultAPIClient._get_secrets_or_empty",
+            return_value=VaultSecrets(secrets=secrets, not_fetched_paths=[]),
+        ):
+            returned_secrets = api_client.get_secrets(mount, vault_path, recursive)
+            api_client._get_secrets_or_empty.assert_called_once_with(mount, vault_path)
+
+            assert returned_secrets.secrets == secrets
+            assert returned_secrets.not_fetched_paths == []
+
+
+@pytest.mark.parametrize("recursive", [True, False])
+def test_get_secrets_on_directory(recursive):
+    """
+    GIVEN a valid mount and path of a directory
+    WHEN calling get_secrets
+    THEN _get_secrets_from_path is called with the correct parameters
+    """
+
+    directories = ["dev", "prod", "sandbox"]
+    mount = VaultKvMount(name="test", version="2")
+    api_client = VaultAPIClient("my_vault_url", "my_vault_token")
+    vault_path = ""
+
+    with patch(
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+        "VaultAPIClient.list_kv_items",
+        return_value=directories,
+    ):
+        with patch(
+            "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.api_client."
+            "VaultAPIClient._get_secrets_from_path",
+            side_effect=lambda _, called_path, __: VaultSecrets(
+                secrets=[
+                    (
+                        f"PASSWORD_{called_path}",
+                        "my_password",
+                    )
+                ],
+                not_fetched_paths=[],
+            ),
+        ):
+            returned_secrets = api_client.get_secrets(mount, vault_path, recursive)
+
+            api_client.list_kv_items.assert_called_once_with(mount, vault_path)
+            assert api_client._get_secrets_from_path.call_count == 3
+
+            assert api_client._get_secrets_from_path.call_args_list[0][0] == (
+                mount,
+                "dev",
+                recursive,
+            )
+            assert api_client._get_secrets_from_path.call_args_list[1][0] == (
+                mount,
+                "prod",
+                recursive,
+            )
+            assert api_client._get_secrets_from_path.call_args_list[2][0] == (
+                mount,
+                "sandbox",
+                recursive,
+            )
+            assert returned_secrets.secrets == [
+                ("PASSWORD_dev", "my_password"),
+                ("PASSWORD_prod", "my_password"),
+                ("PASSWORD_sandbox", "my_password"),
+            ]

--- a/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_cli.py
+++ b/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_cli.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from ggshield.verticals.hmsl.secret_manager.hashicorp_vault import (
-    VaultCliTokenFetchingError,
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.cli import (
     get_vault_cli_token,
+)
+from ggshield.verticals.hmsl.secret_manager.hashicorp_vault.exceptions import (
+    VaultCliTokenFetchingError,
 )
 
 
@@ -50,7 +52,7 @@ def test_get_vault_cli_token_vault_cli_parsing_error(successful_vault_cli_call):
     """
 
     with patch(
-        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.json.loads",
+        "ggshield.verticals.hmsl.secret_manager.hashicorp_vault.cli.json.loads",
         side_effect=RuntimeError(),
     ):
         with pytest.raises(


### PR DESCRIPTION
Following #707, add the code to perform the scan itself:
- Organized the code in `hmsl/secret_manager/hashicorp_vault` in multiple files for models, cli logic and api client
- Add a function for the common check code between the `check-secret-manager` and `check` command
- Refactor `collect` method so that it can be used directly with a list of tuples for input instead of a TextIO object
- Add missing common check options to the `check-secret-manager hashicorp-vault` function
- Add unit tests for new functionality, functional tests are possible but will come in a later PR