### PR TITLE
GHA: run ci only on 'main' branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
   push:
     branches:
-      - '*'
+      - 'main'
     tags-ignore:
       - '*'
     paths-ignore:


### PR DESCRIPTION
two avoid CI running twice, once on branch push and another time on pull requests.