### PR TITLE
Migrate more code to use Path

### DIFF
--- a/ggshield/cmd/honeytoken/create.py
+++ b/ggshield/cmd/honeytoken/create.py
@@ -10,6 +10,7 @@ from pygitguardian.models import Detail, HoneytokenResponse
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
+from ggshield.utils.click import RealPath
 
 
 def _generate_random_honeytoken_name() -> str:
@@ -52,9 +53,7 @@ def _dict_to_string(data: Dict, space: bool = False) -> str:
     "-o",
     "--output",
     "output_file",
-    type=click.Path(
-        path_type=Path, file_okay=True, dir_okay=False, readable=True, writable=True
-    ),
+    type=RealPath(file_okay=True, dir_okay=False, readable=True, writable=True),
     required=False,
     help="Specify a filename to append your honeytoken directly to the content of this file. \
 If the file does not exist, it will be created.",
@@ -108,7 +107,7 @@ To learn more, visit https://docs.gitguardian.com/honeytoken/getting-started."""
         )
 
         # special output for piped or redirect
-        with open(output_file, "a") as opened_output_file:
+        with output_file.open("a") as opened_output_file:
             opened_output_file.write(f"{_dict_to_string(token_to_display)}\n")
 
     else:

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -13,6 +13,7 @@ from ggshield.core.config import Config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import Files, ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.utils.click import RealPath
 from ggshield.verticals.secret import (
     RichSecretScannerUI,
     SecretScanCollection,
@@ -22,27 +23,28 @@ from ggshield.verticals.secret import (
 
 @click.command()
 @click.argument(
-    "path", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
+    "path", nargs=1, type=RealPath(exists=True, resolve_path=True), required=True
 )
 @add_secret_scan_common_options()
 @click.pass_context
 def archive_cmd(
     ctx: click.Context,
-    path: str,
+    path: Path,
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
     scan archive <PATH>.
     """
     with tempfile.TemporaryDirectory(suffix="ggshield") as temp_dir:
+        temp_path = Path(temp_dir)
         try:
-            shutil.unpack_archive(path, extract_dir=Path(temp_dir))
+            shutil.unpack_archive(path, extract_dir=temp_path)
         except Exception as exn:
             raise UnexpectedError(f'Failed to unpack "{path}" archive: {exn}')
 
         config: Config = ctx.obj["config"]
         files: Files = get_files_from_paths(
-            paths=[temp_dir],
+            paths=[temp_path],
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             recursive=True,
             yes=True,

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -10,12 +10,13 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.core.config import Config
 from ggshield.core.scan import ScanContext, ScanMode
+from ggshield.utils.click import RealPath
 from ggshield.verticals.secret.docker import docker_scan_archive
 
 
 @click.command(hidden=True)
 @click.argument(
-    "archive", nargs=1, type=click.Path(exists=True, resolve_path=True), required=True
+    "archive", nargs=1, type=RealPath(exists=True, resolve_path=True), required=True
 )
 @add_secret_scan_common_options()
 @click.pass_context

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, List
 
 import click
@@ -10,6 +11,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.core.config import Config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.utils.click import RealPath
 from ggshield.verticals.secret import (
     RichSecretScannerUI,
     SecretScanCollection,
@@ -19,7 +21,7 @@ from ggshield.verticals.secret import (
 
 @click.command()
 @click.argument(
-    "paths", nargs=-1, type=click.Path(exists=True, resolve_path=True), required=True
+    "paths", nargs=-1, type=RealPath(exists=True, resolve_path=True), required=True
 )
 @click.option("--recursive", "-r", is_flag=True, help="Scan directory recursively.")
 @click.option("--yes", "-y", is_flag=True, help="Confirm recursive scan.")
@@ -28,7 +30,7 @@ from ggshield.verticals.secret import (
 @exception_wrapper
 def path_cmd(
     ctx: click.Context,
-    paths: List[str],
+    paths: List[Path],
     recursive: bool,
     yes: bool,
     **kwargs: Any,
@@ -62,6 +64,8 @@ def path_cmd(
             ignored_detectors=config.user_config.secret.ignored_detectors,
         )
         results = scanner.scan(files.files, scanner_ui=ui)
-    scan = SecretScanCollection(id=" ".join(paths), type="path_scan", results=results)
+    scan = SecretScanCollection(
+        id=" ".join(str(x) for x in paths), type="path_scan", results=results
+    )
 
     return output_handler.process_scan(scan)

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -26,13 +26,13 @@ from ggshield.verticals.secret import (
 PYPI_DOWNLOAD_TIMEOUT = 30
 
 
-def save_package_to_tmp(temp_dir: str, package_name: str) -> None:
+def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     command: List[str] = [
         "pip",
         "download",
         package_name,
         "--dest",
-        temp_dir,
+        str(temp_dir),
         "--no-deps",
     ]
 
@@ -55,21 +55,18 @@ def save_package_to_tmp(temp_dir: str, package_name: str) -> None:
 
 
 def get_files_from_package(
-    archive_dir: str,
+    archive_dir: Path,
     package_name: str,
     exclusion_regexes: Set[re.Pattern],
     verbose: bool,
 ) -> Files:
-    archive_dir_path = Path(archive_dir)
-    archive: Path = next(archive_dir_path.iterdir())
+    archive: Path = next(archive_dir.iterdir())
     unpack_kwargs: Dict[str, str] = (
         {"format": "zip"} if archive.suffix == ".whl" else {}
     )
 
     try:
-        shutil.unpack_archive(
-            str(archive), extract_dir=archive_dir_path, **unpack_kwargs
-        )
+        shutil.unpack_archive(str(archive), extract_dir=archive_dir, **unpack_kwargs)
     except Exception as exn:
         raise UnexpectedError(f'Failed to unpack package "{package_name}": {exn}.')
 
@@ -101,10 +98,11 @@ def pypi_cmd(
     output_handler = create_output_handler(ctx)
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temp_dir:
-        save_package_to_tmp(temp_dir=temp_dir, package_name=package_name)
+        temp_path = Path(temp_dir)
+        save_package_to_tmp(temp_dir=temp_path, package_name=package_name)
 
         files: Files = get_files_from_package(
-            archive_dir=temp_dir,
+            archive_dir=temp_path,
             package_name=package_name,
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             verbose=config.user_config.verbose,

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -1,4 +1,5 @@
-from typing import Callable, List, Optional
+from pathlib import Path
+from typing import Callable, List, Optional, Union
 
 import click
 
@@ -15,6 +16,7 @@ from ggshield.cmd.utils.common_options import (
 from ggshield.core.config import Config
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.filter import init_exclusion_regexes
+from ggshield.utils.click import RealPath
 from ggshield.verticals.secret.output import (
     SecretJSONOutputHandler,
     SecretOutputHandler,
@@ -47,7 +49,7 @@ def _get_secret_config(ctx: click.Context) -> SecretConfig:
 _output_option = click.option(
     "--output",
     "-o",
-    type=click.Path(exists=False, resolve_path=True),
+    type=RealPath(exists=False, resolve_path=True),
     default=None,
     help="Route ggshield output to file.",
     callback=create_ctx_callback("output"),
@@ -78,7 +80,6 @@ def _exclude_callback(
 _exclude_option = click.option(
     "--exclude",
     default=None,
-    type=click.Path(),
     help="""
     Do not scan paths that match the specified glob-like patterns.
     """,
@@ -138,7 +139,7 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
         SecretJSONOutputHandler if use_json(ctx) else SecretTextOutputHandler
     )
     config: Config = ctx.obj["config"]
-    output = ctx.obj.get("output")
+    output: Union[Path, None] = ctx.obj.get("output")
     return output_handler_cls(
         show_secrets=config.user_config.secret.show_secrets,
         verbose=config.user_config.verbose,

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -164,7 +164,6 @@ ignore_path_option = click.option(
     "--ipa",
     "ignore_paths",
     default=None,
-    type=click.Path(),
     multiple=True,
     help="Do not scan paths that match the specified glob-like patterns.",
 )

--- a/ggshield/core/check_updates.py
+++ b/ggshield/core/check_updates.py
@@ -1,6 +1,6 @@
 import logging
-import os.path
 import time
+from pathlib import Path
 from typing import Optional, Tuple
 
 import requests
@@ -12,10 +12,7 @@ from .config.utils import load_yaml_dict, save_yaml_dict
 
 
 logger = logging.getLogger(__name__)
-CACHE_FILE = os.path.join(
-    get_cache_dir(),
-    "update_check.yaml",
-)
+CACHE_FILE = Path(get_cache_dir(), "update_check.yaml")
 
 CHECK_AT_KEY = "check-at"
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -29,11 +29,12 @@ def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> No
             replace_in_keys(element, old_char=old_char, new_char=new_char)
 
 
-def load_yaml_dict(path: str) -> Optional[Dict[str, Any]]:
-    if not os.path.isfile(path):
+def load_yaml_dict(path: Union[str, Path]) -> Optional[Dict[str, Any]]:
+    path = Path(path)
+    if not path.exists():
         return None
 
-    with open(path) as f:
+    with path.open() as f:
         try:
             data = yaml.safe_load(f) or {}
         except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
@@ -46,7 +47,7 @@ def load_yaml_dict(path: str) -> Optional[Dict[str, Any]]:
     return data
 
 
-def save_yaml_dict(data: Dict[str, Any], path: str) -> None:
+def save_yaml_dict(data: Dict[str, Any], path: Union[str, Path]) -> None:
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     with p.open("w") as f:

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -55,7 +55,7 @@ class File(Scannable):
 
 
 def get_files_from_paths(
-    paths: List[str],
+    paths: List[Path],
     exclusion_regexes: Set[re.Pattern],
     recursive: bool,
     yes: bool,
@@ -73,7 +73,7 @@ def get_files_from_paths(
     """
     try:
         filepaths = get_filepaths(
-            paths, exclusion_regexes, recursive, ignore_git=ignore_git
+            [str(x) for x in paths], exclusion_regexes, recursive, ignore_git=ignore_git
         )
     except UnexpectedDirectoryError as error:
         raise click.UsageError(

--- a/ggshield/utils/click/__init__.py
+++ b/ggshield/utils/click/__init__.py
@@ -1,5 +1,10 @@
 from .default_command_group import DefaultCommandGroup
 from .natural_order_group import NaturalOrderGroup
+from .real_path import RealPath
 
 
-__all__ = ["DefaultCommandGroup", "NaturalOrderGroup"]
+__all__ = [
+    "DefaultCommandGroup",
+    "NaturalOrderGroup",
+    "RealPath",
+]

--- a/ggshield/utils/click/real_path.py
+++ b/ggshield/utils/click/real_path.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from typing import Any
+
+import click
+
+
+class RealPath(click.Path):
+    """
+    A click.Path which uses real Path objects
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, path_type=Path, **kwargs)

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path, PurePosixPath
-from typing import List, Set, Union
+from typing import List, Set
 
 from ggshield.utils._binary_extensions import BINARY_EXTENSIONS
 from ggshield.utils.git_shell import git_ls, is_git_dir
@@ -19,7 +19,7 @@ def is_filepath_excluded(filepath: str, exclusion_regexes: Set[re.Pattern]) -> b
 
 
 def get_filepaths(
-    paths: Union[List, str],
+    paths: List[str],
     exclusion_regexes: Set[re.Pattern],
     recursive: bool,
     ignore_git: bool,

--- a/ggshield/verticals/hmsl/utils.py
+++ b/ggshield/verticals/hmsl/utils.py
@@ -1,7 +1,7 @@
 import logging
-import os
 import re
 import time
+from pathlib import Path
 from typing import Optional
 
 import jwt
@@ -21,7 +21,7 @@ from ggshield.verticals.hmsl.client import HMSLClient
 logger = logging.getLogger(__name__)
 
 
-TOKEN_PATH = f"{get_cache_dir()}/hmsl_token"
+TOKEN_PATH = Path(get_cache_dir(), "hmsl_token")
 
 # Tools for parsing env files
 ENV_LINE_REGEX = re.compile(r'(\S+)(?: *?)=(?: *?)((?:".*?[^\\]")|\S+)')
@@ -121,7 +121,7 @@ def is_token_valid(token: Optional[str], audience: str) -> bool:
 
 def load_token_from_disk() -> Optional[str]:
     try:
-        return open(TOKEN_PATH).read()
+        return TOKEN_PATH.read_text()
     except FileNotFoundError:
         return None
     except Exception as e:
@@ -131,14 +131,14 @@ def load_token_from_disk() -> Optional[str]:
 
 def save_token(token: str) -> None:
     try:
-        open(TOKEN_PATH, "w").write(token)
+        TOKEN_PATH.write_text(token)
     except Exception as e:
         logger.warning(f"Error while saving token: {e}")
 
 
 def remove_token_from_disk() -> None:
     try:
-        os.remove(TOKEN_PATH)
+        TOKEN_PATH.unlink(missing_ok=True)
     except OSError:
         pass
     except Exception as e:

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -33,7 +33,7 @@ def get_iac_files_from_path(
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
     files = get_files_from_paths(
-        paths=[str(path)],
+        paths=[path],
         exclusion_regexes=exclusion_regexes,
         recursive=True,
         yes=True,

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -46,7 +46,7 @@ def get_all_files_from_sca_paths(
     :param ignore_git: Ignore that the folder is a git repository. If False, only files tracked by git are scanned
     """
     files = get_files_from_paths(
-        paths=[str(path)],
+        paths=[path],
         exclusion_regexes=exclusion_regexes,
         recursive=True,
         yes=True,

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -1,11 +1,11 @@
 import json
-import os.path
 import re
 import subprocess
 import tarfile
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Generator, Iterable, List, Optional, Set
 
 from click import UsageError
 from pygitguardian import GGClient
@@ -144,12 +144,19 @@ class DockerImage:
 
     layer_infos: List[LayerInfo]
 
-    def __init__(self, tar_file: tarfile.TarFile):
+    @staticmethod
+    @contextmanager
+    def open(archive_path: Path) -> Generator["DockerImage", None, None]:
+        """ContextManager to create a DockerImage instance."""
+        with tarfile.open(archive_path) as tar_file:
+            yield DockerImage(archive_path, tar_file)
+
+    def __init__(self, archive_path: Path, tar_file: tarfile.TarFile):
+        """Creates a DockerImage instance. Internal. Prefer using DockerImage.open()."""
+        self.archive_path = archive_path
         self.tar_file = tar_file
         self._load_manifest()
-
         self._load_image()
-
         self.config_scannable = StringScannable(
             "Dockerfile or build-args", json.dumps(self.image, indent=2)
         )
@@ -232,7 +239,7 @@ class DockerImage:
         """
         layer_filename = layer_info.filename
         layer_archive = tarfile.TarFile(
-            name=os.path.join(self.tar_file.name, layer_filename),  # type: ignore
+            name=self.archive_path / layer_filename,
             fileobj=self.tar_file.extractfile(layer_filename),
         )
 
@@ -342,8 +349,7 @@ def docker_scan_archive(
     assert secrets_engine_version is not None
     layer_id_cache = _get_layer_id_cache(secrets_engine_version)
 
-    with tarfile.open(archive_path) as archive:
-        docker_image = DockerImage(archive)
+    with DockerImage.open(archive_path) as docker_image:
 
         display_heading("Scanning Docker config")
         with RichSecretScannerUI(1) as ui:
@@ -367,5 +373,5 @@ def docker_scan_archive(
                 results.extend(layer_results)
 
     return SecretScanCollection(
-        id=str(archive), type="scan_docker_archive", results=results
+        id=str(archive_path), type="scan_docker_archive", results=results
     )

--- a/ggshield/verticals/secret/output/secret_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_output_handler.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional
 
 import click
@@ -10,14 +11,14 @@ from ggshield.verticals.secret import SecretScanCollection
 class SecretOutputHandler(ABC):
     show_secrets: bool = False
     verbose: bool = False
-    output: Optional[str] = None
+    output: Optional[Path] = None
     use_stderr: bool = False
 
     def __init__(
         self,
         show_secrets: bool,
         verbose: bool,
-        output: Optional[str] = None,
+        output: Optional[Path] = None,
         ignore_known_secrets: bool = False,
     ):
         self.show_secrets = show_secrets
@@ -33,8 +34,7 @@ class SecretOutputHandler(ABC):
         """
         text = self._process_scan_impl(scan)
         if self.output:
-            with open(self.output, "w+") as f:
-                f.write(text)
+            self.output.write_text(text)
         else:
             click.echo(text, err=self.use_stderr)
         return self._get_exit_code(scan)

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
+from os import PathLike
+from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 from pygitguardian.models import ScanResult
 
@@ -81,14 +82,14 @@ class SecretScanCollection:
 
     def __init__(
         self,
-        id: str,
+        id: Union[str, PathLike],
         type: str,
         results: Optional[Results] = None,
         scans: Optional[List["SecretScanCollection"]] = None,
         optional_header: Optional[str] = None,
         extra_info: Optional[Dict[str, str]] = None,
     ):
-        self.id = id
+        self.id = str(id)
         self.type = type
         self.results = results
         self.scans = scans

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -17,11 +17,10 @@ from ggshield.core.errors import UnexpectedError
 
 class TestPipDownload:
     package_name: str = "what-ever-non-existing"
-    tmp_dir: str = "/tmp/iam-temporary"
 
-    def test_pip_download_success(self):
+    def test_pip_download_success(self, tmp_path):
         with patch("subprocess.run") as call:
-            save_package_to_tmp(temp_dir=self.tmp_dir, package_name=self.package_name)
+            save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
             call.assert_called_once_with(
                 [
@@ -29,7 +28,7 @@ class TestPipDownload:
                     "download",
                     self.package_name,
                     "--dest",
-                    self.tmp_dir,
+                    str(tmp_path),
                     "--no-deps",
                 ],
                 check=True,
@@ -38,7 +37,7 @@ class TestPipDownload:
                 timeout=PYPI_DOWNLOAD_TIMEOUT,
             )
 
-    def test_pip_download_nonexistent_package(self):
+    def test_pip_download_nonexistent_package(self, tmp_path):
         with patch(
             "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=None)
         ):
@@ -46,11 +45,9 @@ class TestPipDownload:
                 UnexpectedError,
                 match=f'Failed to download "{self.package_name}"',
             ):
-                save_package_to_tmp(
-                    temp_dir=self.tmp_dir, package_name=self.package_name
-                )
+                save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
-    def test_pip_download_timeout(self):
+    def test_pip_download_timeout(self, tmp_path):
         with patch(
             "subprocess.run",
             side_effect=subprocess.TimeoutExpired(
@@ -61,17 +58,14 @@ class TestPipDownload:
                 UnexpectedError,
                 match=(
                     f'Command "pip download {self.package_name} '
-                    f'--dest {self.tmp_dir} --no-deps" timed out'
+                    f'--dest {re.escape(str(tmp_path))} --no-deps" timed out'
                 ),
             ):
-                save_package_to_tmp(
-                    temp_dir=self.tmp_dir, package_name=self.package_name
-                )
+                save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
 
 class TestListPackageFiles:
     package_name: str = "what-ever-non-existing"
-    tmp_dir: str = "/tmp/iam-temporary"
     exclusion_regexes: Set[re.Pattern] = {re.compile("i am a regex")}
 
     @pytest.mark.parametrize(
@@ -90,12 +84,13 @@ class TestListPackageFiles:
         get_files_from_paths_mock: Mock,
         extension: str,
         verbose: bool,
+        tmp_path,
     ):
-        archive_path: str = Path(f"{self.tmp_dir}/{self.package_name}.{extension}")
+        archive_path = tmp_path / f"{self.package_name}.{extension}"
 
         with patch.object(Path, "iterdir", return_value=iter([archive_path])):
             get_files_from_package(
-                archive_dir=self.tmp_dir,
+                archive_dir=tmp_path,
                 package_name=self.package_name,
                 exclusion_regexes=self.exclusion_regexes,
                 verbose=verbose,
@@ -104,7 +99,7 @@ class TestListPackageFiles:
             unpack_kwargs = {"format": "zip"} if extension == "whl" else {}
             unpack_archive_mock.assert_called_once_with(
                 str(archive_path),
-                extract_dir=Path(self.tmp_dir),
+                extract_dir=tmp_path,
                 **unpack_kwargs,
             )
 
@@ -114,7 +109,7 @@ class TestListPackageFiles:
             )
 
             get_files_from_paths_mock.assert_called_once_with(
-                paths=[self.tmp_dir],
+                paths=[tmp_path],
                 exclusion_regexes=expected_exclusion_regexes,
                 recursive=True,
                 yes=True,

--- a/tests/unit/verticals/secret/test_scan_docker.py
+++ b/tests/unit/verticals/secret/test_scan_docker.py
@@ -1,6 +1,5 @@
 import re
 import subprocess
-import tarfile
 from pathlib import Path
 from typing import Dict
 from unittest.mock import patch
@@ -80,14 +79,13 @@ class TestDockerScan:
     def test_get_config(self, members, match):
         tarfile = TarMock(members)
         with pytest.raises(InvalidDockerArchiveException, match=match):
-            DockerImage(tarfile)
+            DockerImage(Path("dummy"), tarfile)
 
     @pytest.mark.parametrize(
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
     def test_docker_archive(self, image_path: Path):
-        with tarfile.open(image_path) as archive:
-            image = DockerImage(archive)
+        with DockerImage.open(image_path) as image:
 
             # List of (LayerInfo, Files)
             # The filter is here to remove layers with no scannables


### PR DESCRIPTION
## Context 

This PR makes more code use Path instead of os.path.

Part of #464

## What has been done

- Added a RealPath helper to utils.click
- Migrated all of cmd.secret to Path
- Some fixes on the type of arguments accepting wildcards: they should not be defined as path, since they are not paths
- Minor changes in honeytoken code to make it use Path to read/write files
- Rework of DockerImage to use Path, this required a slightly-more-involved-than-expected refactor
- Make core.check_updates() use Path

Best reviewed commit by commit.

This does not solve #464 completely, but it moves in the right direction. I prefer merging this work early to avoid a giant, hard to merge, PR.