### PR TITLE
Update documentation

### DIFF
--- a/actions/iac/action.yml
+++ b/actions/iac/action.yml
@@ -5,16 +5,9 @@ author: GitGuardian <support@gitguardian.com>
 inputs:
   args:
     description: |
-      Arguments to be passed to ggshield iac scan
-      Options:
-        --exit-zero                     Always return a 0 (non-error) status code, even if issues
-                                        are found. The env var GITGUARDIAN_EXIT_ZERO can also be used
-                                        to set this option.
-        --minimum-severity              [LOW|MEDIUM|HIGH|CRITICAL]
-                                        Minimum severity of the policies
-        --ignore-policy, --ipo TEXT     Policies to exclude from the results.
-        --ignore-path, --ipa PATH       Do not scan the specified paths.
-        --json                          JSON output.
+      Arguments to pass to `ggshield iac scan ci`.
+
+      [`ggshield iac scan ci` reference](https://docs.gitguardian.com/ggshield-docs/reference/iac/scan/ci).
     required: false
 branding:
   icon: 'shield'

--- a/actions/sca/action.yml
+++ b/actions/sca/action.yml
@@ -5,14 +5,9 @@ author: GitGuardian <support@gitguardian.com>
 inputs:
   args:
     description: |
-      Arguments to be passed to ggshield sca scan
-      Options:
-        --exit-zero                     Always return a 0 (non-error) status code, even if issues
-                                        are found. The env var GITGUARDIAN_EXIT_ZERO can also be used
-                                        to set this option.
-        --minimum-severity              [LOW|MEDIUM|HIGH|CRITICAL]
-                                        Minimum severity of the policies
-        --ignore-path, --ipa PATH       Do not scan the specified paths.
+      Arguments to pass to `ggshield sca scan ci`.
+
+      [`ggshield iac sca ci` reference](https://docs.gitguardian.com/ggshield-docs/reference/sca/scan/ci).
     required: false
 branding:
   icon: 'shield'

--- a/actions/secret/action.yml
+++ b/actions/secret/action.yml
@@ -9,14 +9,9 @@ branding:
 inputs:
   args:
     description: |
-      Arguments to be passed to ggshield secret scan
-      Options:        
-        --json                        Output results in JSON format  [default: False]
-        --show-secrets                Show secrets in plaintext instead of hiding them.
-        --all-policies                Present fails of all policies (Filenames, FileExtensions,
-                                      Secret Detection). By default, only Secret Detection is shown.
-        --exit-zero                   Always return a 0 (non-error) status code, even if incidents are found.
-        -b, --banlist-detector TEXT   Exclude results from a detector.
+      Arguments to pass to `ggshield secret scan ci`.
+
+      [`ggshield secret scan ci` reference](https://docs.gitguardian.com/ggshield-docs/reference/secret/scan/ci).
     required: false
 
 runs:

--- a/changelog.d/20230913_171100_aurelien.gateau_update_action_doc.md
+++ b/changelog.d/20230913_171100_aurelien.gateau_update_action_doc.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Help messages have been improved and are now kept in sync with [ggshield online reference documentation](https://docs.gitguardian.com/ggshield-docs/reference/overview).

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -75,12 +75,14 @@ def print_default_instance_message(config: Config) -> None:
     required=False,
     type=str,
     help="URL of the instance to authenticate against.",
+    metavar="URL",
 )
 @click.option(
     "--sso-url",
     required=False,
     type=str,
     help="URL of your SSO login page to force the authentication flow through your workspace SSO.",
+    metavar="URL",
 )
 @click.option(
     "--token-name",
@@ -94,6 +96,7 @@ def print_default_instance_message(config: Config) -> None:
     type=click.IntRange(0),
     default=None,
     help="Number of days before the token expires. 0 means the token never expires.",
+    metavar="DAYS",
 )
 @add_common_options()
 @click.pass_context
@@ -107,16 +110,20 @@ def login_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Authenticate with a GitGuardian workspace.
+    Authenticate with a GitGuardian instance.
+
     A successful authentication results in a personal access token.
     This token is stored in your configuration and used to authenticate your future requests.
 
-    The default authentication method is "web".
-    ggshield launches a web browser to authenticate you to your GitGuardian workspace,
+    The default authentication method is `web`.
+    ggshield launches a web browser to authenticate you to your GitGuardian instance,
     then automatically generates a token on your behalf.
 
     Alternatively, you can use `--method token` to authenticate using an already existing token.
     The minimum required scope for the token is `scan`.
+
+    If a valid personal access token is already configured, this command simply displays
+    a success message indicating that ggshield is already ready to use.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -23,6 +23,7 @@ CONNECTION_ERROR_MESSAGE = (
     required=False,
     type=str,
     help="URL of the instance to logout from.",
+    metavar="URL",
 )
 @click.option(
     "--revoke/--no-revoke",
@@ -30,7 +31,12 @@ CONNECTION_ERROR_MESSAGE = (
     default=True,
     help="Whether the token should be revoked on logout before being removed from the configuration.",
 )
-@click.option("--all", "all_", is_flag=True, help="Iterate over every saved tokens.")
+@click.option(
+    "--all",
+    "all_",
+    is_flag=True,
+    help="Remove authentication for all instances.",
+)
 @add_common_options()
 @click.pass_context
 def logout_cmd(
@@ -81,7 +87,6 @@ def check_account_config_exists(config: Config, instance_url: str) -> None:
 
 
 def revoke_token(config: Config, instance_url: str) -> None:
-
     instance = config.auth_config.get_instance(instance_url)
 
     assert instance.account is not None

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -2,14 +2,26 @@ from typing import Any, Optional
 
 import click
 
-from ggshield.cmd.config.constants import FIELD_NAMES, FIELDS
+from ggshield.cmd.config.constants import FIELD_NAMES, FIELD_NAMES_DOC, FIELDS
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core.config import Config
 from ggshield.core.errors import UnknownInstanceError
 
 
-@click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
+@click.command(
+    help=f"""
+Print the value of the given configuration key.
+If `--instance` is passed, retrieve the value for this specific instance.
+
+{FIELD_NAMES_DOC}"""
+)
+@click.argument(
+    "field_name",
+    nargs=1,
+    type=click.Choice(FIELD_NAMES),
+    required=True,
+    metavar="KEY",
+)
 @click.option(
     "--instance",
     "instance_url",
@@ -23,10 +35,6 @@ from ggshield.core.errors import UnknownInstanceError
 def config_get_cmd(
     ctx: click.Context, field_name: str, instance_url: Optional[str], **kwargs: Any
 ) -> int:
-    """
-    Print the value of the given configuration key.
-    If --instance is passed, retrieve the value for this specific instance.
-    """
     config: Config = ctx.obj["config"]
     field = FIELDS[field_name]
 

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -8,7 +8,7 @@ from ggshield.core.config import Config
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import find_global_config_path
 
-from .constants import FIELD_NAMES, FIELDS, ConfigField
+from .constants import FIELD_NAMES, FIELD_NAMES_DOC, FIELDS, ConfigField
 
 
 def set_user_config_field(field: ConfigField, value: Any) -> None:
@@ -18,8 +18,19 @@ def set_user_config_field(field: ConfigField, value: Any) -> None:
     user_config.save(config_path)
 
 
-@click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
+@click.command(
+    help=f"""Update the value of the given configuration key.
+
+{FIELD_NAMES_DOC}
+"""
+)
+@click.argument(
+    "field_name",
+    nargs=1,
+    type=click.Choice(FIELD_NAMES),
+    required=True,
+    metavar="KEY",
+)
 @click.argument("value", nargs=1, type=click.STRING, required=True)
 @click.option(
     "--instance",
@@ -37,9 +48,6 @@ def config_set_cmd(
     instance: Optional[str],
     **kwargs: Any,
 ) -> int:
-    """
-    Update the value of the given configuration key.
-    """
     config: Config = ctx.obj["config"]
 
     field = FIELDS[field_name]

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -6,11 +6,24 @@ from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core.config import Config
 
 from .config_set import set_user_config_field
-from .constants import FIELD_NAMES, FIELDS
+from .constants import FIELD_NAMES, FIELD_NAMES_DOC, FIELDS
 
 
-@click.command()
-@click.argument("field_name", nargs=1, type=click.Choice(FIELD_NAMES), required=True)
+@click.command(
+    help=f"""Remove the value of the given configuration key.
+
+If `--all` is passed, iterates over all instances.
+
+{FIELD_NAMES_DOC}
+"""
+)
+@click.argument(
+    "field_name",
+    nargs=1,
+    type=click.Choice(FIELD_NAMES),
+    required=True,
+    metavar="KEY",
+)
 @click.option(
     "--instance",
     "instance_url",
@@ -19,7 +32,7 @@ from .constants import FIELD_NAMES, FIELDS
     metavar="URL",
     help="Set per instance configuration.",
 )
-@click.option("--all", "all_", is_flag=True, help="Iterate over every instances.")
+@click.option("--all", "all_", is_flag=True, help="Iterate over all instances.")
 @add_common_options()
 @click.pass_context
 def config_unset_cmd(
@@ -29,10 +42,6 @@ def config_unset_cmd(
     all_: bool,
     **kwargs: Any,
 ) -> int:
-    """
-    Remove the value of the given configuration key.
-    If --all is passed, it iterates over all instances.
-    """
     config: Config = ctx.obj["config"]
     field = FIELDS[field_name]
 

--- a/ggshield/cmd/config/constants.py
+++ b/ggshield/cmd/config/constants.py
@@ -37,3 +37,5 @@ _FIELDS = (
 FIELDS = {x.name: x for x in _FIELDS}
 
 FIELD_NAMES = sorted(FIELDS.keys())
+
+FIELD_NAMES_DOC = "Supported keys:\n" + "\n".join(f"- `{x}`" for x in FIELD_NAMES)

--- a/ggshield/cmd/hmsl/check.py
+++ b/ggshield/cmd/hmsl/check.py
@@ -45,7 +45,9 @@ def check_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Check if secrets have leaked in one command.
+    Check if secrets have leaked.
+
+    Note: Secrets can be read from stdin using `ggshield hmsl check -`.
     """
 
     # Collect secrets

--- a/ggshield/cmd/hmsl/fingerprint.py
+++ b/ggshield/cmd/hmsl/fingerprint.py
@@ -31,8 +31,9 @@ def validate_prefix(prefix: str) -> str:
     "--prefix",
     "-p",
     default="",
-    help="Prefix for output file names.",
+    help="Prefix for output file names. For instance `-p foo` produces `foo-payload.txt` and `foo-mapping.txt`.",
     callback=lambda _, __, value: validate_prefix(value),
+    metavar="PREFIX",
 )
 @full_hashes_option
 @naming_strategy_option
@@ -50,6 +51,8 @@ def fingerprint_cmd(
     Collect secrets and compute fingerprints.
 
     Fingerprints are to be used later by the `decrypt` command.
+
+    Note: Secrets can be read from stdin using `ggshield hmsl fingerprint -`.
     """
     # Opens the file or stdin
     input = cast(TextIO, click.open_file(path, "r"))

--- a/ggshield/cmd/hmsl/hmsl_common_options.py
+++ b/ggshield/cmd/hmsl/hmsl_common_options.py
@@ -20,10 +20,12 @@ naming_strategy_option = click.option(
     default="key",
     show_default=True,
     help="""Strategy to generate the hints in the output.
-            With "censored", only the first and last characters are displayed.
-            With "cleartext", the full secret is used as a hint (Not recommended!).
-            With "none", no hint is generated.
-            With "key", the key name is selected if available (e.g. in .env files), otherwise censored is used.""",
+
+            \b
+            - `censored`: only the first and last characters are displayed.
+            - `cleartext`: the full secret is used as a hint (Not recommended!).
+            - `none`: no hint is generated.
+            - `key`: the key name is selected if available (e.g. in .env files), otherwise censored is used.""",
     callback=lambda _, __, value: NAMING_STRATEGIES[value],
 )
 input_type_option = click.option(
@@ -34,8 +36,10 @@ input_type_option = click.option(
     default="file",
     show_default=True,
     help="""Type of input to process.
-            With "file", the input is a simple file containing secrets.
-            With "env", the input is a file containing environment variables.""",
+
+            \b
+            - `file`: the input is a simple file containing secrets.
+            - `env`: the input is a file containing environment variables.""",
     callback=lambda _, __, value: InputType[value.upper()],
 )
 full_hashes_option = click.option(
@@ -43,5 +47,9 @@ full_hashes_option = click.option(
     "--full-hashes",
     is_flag=True,
     default=False,
-    help="Send full hashes to the API instead of prefixes.",
+    help=(
+        "Put the full hashes into the payload instead of the prefixes. This is useful"
+        " for partners that trust GitGuardian because it allows to send more hashes"
+        " per batch, and consumes less credits, but leaks more data to GitGuardian."
+    ),
 )

--- a/ggshield/cmd/hmsl/query.py
+++ b/ggshield/cmd/hmsl/query.py
@@ -27,7 +27,11 @@ def query_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Query HasMySecretLeaked using outputs of `fingerprint` command.
+    Query HasMySecretLeaked using outputs from the `fingerprint` command.
+
+    Note: If you used the `-f` option during stage one, the results will not be
+    encrypted. It is still useful to pass them through `decrypt` to properly format the
+    output.
     """
 
     # Opens the file or stdin

--- a/ggshield/cmd/honeytoken/create.py
+++ b/ggshield/cmd/honeytoken/create.py
@@ -33,14 +33,14 @@ def _dict_to_string(data: Dict, space: bool = False) -> str:
     required=False,
     type=str,
     help="Specify a name for your honeytoken. If this option is not provided, a unique name will be generated with a \
-'ggshield-' prefix.",
+`ggshield-` prefix.",
 )
 @click.option(
     "--type",
     "type_",
     required=True,
     type=click.Choice(("AWS",)),
-    help="Specify the type of honeytoken that you want to create. (For now only AWS honeytokens are supported!)",
+    help="Specify the type of honeytoken that you want to create. (For now only AWS honeytokens are supported)",
 )
 @click.option(
     "--description",
@@ -70,8 +70,10 @@ def create_cmd(
 ) -> int:
     """
     Command to create a honeytoken.
-    This action is restricted to authorized users only. To learn more, visit
-    <https://docs.gitguardian.com/honeytoken/getting-started>
+
+    The prerequisites to use this command are the following:
+    - you have the necessary permissions as a user (for now, Honeytoken is restricted to users with a manager role),
+    - the personal access token used by ggshield has the required scopes. (`honeytoken:read` and `honeytoken:write`).
     """
     # if name is not given, generate a random one
     if not name:

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -41,6 +41,8 @@ def scan_all_cmd(
 ) -> int:
     """
     Scan a directory for all IaC vulnerabilities in the current state.
+
+    The scan is successful if no IaC vulnerability (known or new) was found.
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -34,6 +34,9 @@ def scan_ci_cmd(
 ) -> int:
     """
     Scan in CI for IaC vulnerabilities. By default, it will return vulnerabilities added in the new commits.
+
+    The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
+    in which case the scan is only successful if no IaC vulnerability (old and new) was found.
     """
     config: Config = ctx.obj["config"]
     if directory is None:

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -58,7 +58,14 @@ def scan_diff_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan all changes made since the provided Git ref for IaC vulnerabilities.
+    Scan a Git repository for changes in IaC vulnerabilities between two states.
+
+    The scan is successful if no *new* IaC vulnerability was found.
+
+    By default, the output will show:
+    - The number of known IaC vulnerabilities resolved by the changes
+    - The number of known IaC vulnerabilities left untouched
+    - The number and the list of new IaC vulnerabilities introduced by the changes
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/iac/scan/precommit.py
+++ b/ggshield/cmd/iac/scan/precommit.py
@@ -31,7 +31,15 @@ def scan_pre_commit_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan as pre-commit for IaC vulnerabilities. By default, it will return vulnerabilities added in the commit.
+    Scan a Git repository for changes in IaC vulnerabilities between HEAD and current staged changes.
+
+    The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
+    in which case the scan is only successful if no IaC vulnerability (old and new) was found.
+
+    By default, the output will show:
+    - The number of known IaC vulnerabilities resolved by the changes
+    - The number of known IaC vulnerabilities left untouched
+    - The number and the list of new IaC vulnerabilities introduced by the changes
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -33,7 +33,16 @@ def scan_pre_push_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan as pre-push for IaC vulnerabilities. By default, it will return vulnerabilities added in the pushed commits.
+    Scan a Git repository for changes in IaC vulnerabilities in the pushed commits.
+    This is intended to be used as a pre-push hook.
+
+    The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
+    in which case the scan is only successful if no IaC vulnerability (old and new) was found.
+
+    By default, the output will show:
+    - The number of known IaC vulnerabilities resolved by the changes
+    - The number of known IaC vulnerabilities left untouched
+    - The number and the list of new IaC vulnerabilities introduced by the changes
     """
     directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)

--- a/ggshield/cmd/iac/scan/prereceive.py
+++ b/ggshield/cmd/iac/scan/prereceive.py
@@ -48,7 +48,20 @@ def scan_pre_receive_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    scan as a pre-receive git hook.
+    Scan a Git repository for changes in IaC vulnerabilities in the received pushed commits.
+    This is intended to be used as a pre-receive hook.
+
+    The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
+    in which case the scan is only successful if no IaC vulnerability (old and new) was found.
+
+    By default, the output will show:
+    - The number of known IaC vulnerabilities resolved by the changes
+    - The number of known IaC vulnerabilities left untouched
+    - The number and the list of new IaC vulnerabilities introduced by the changes
+
+    It is the remote equivalent of the `iac scan pre-push` command.
+
+    Note that it is not currently possible to scan a specific sub-directory of the repo.
     """
     if get_breakglass_option():
         return 0

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -41,13 +41,18 @@ fi
     help="Type of hook to install.",
     default="pre-commit",
 )
-@click.option("--force", "-f", is_flag=True, help="Force override.")
+@click.option("--force", "-f", is_flag=True, help="Overwrite any existing hook script.")
 @click.option("--append", "-a", is_flag=True, help="Append to existing script.")
 @add_common_options()
 def install_cmd(
     mode: str, hook_type: str, force: bool, append: bool, **kwargs: Any
 ) -> int:
-    """Install a pre-commit or pre-push git hook (local or global)."""
+    """
+    Installs ggshield as a pre-commit or pre-push hook.
+
+    The `install` command installs ggshield as a git pre-commit or pre-push hook, either
+    for the current repository (locally) or for all repositories (globally).
+    """
     return_code = (
         install_global(hook_type=hook_type, force=force, append=append)
         if mode == "global"

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -16,7 +16,9 @@ from ggshield.core.errors import UnexpectedError
 @add_common_options()
 @click.pass_context
 def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:
-    """Show quotas overview."""
+    """
+    Show the remaining quota of API calls available for the entire workspace.
+    """
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()
 

--- a/ggshield/cmd/sca/scan/all.py
+++ b/ggshield/cmd/sca/scan/all.py
@@ -30,7 +30,11 @@ def scan_all_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan a directory for SCA vulnerabilities.
+    Scans a directory for existing vulnerabilities in open-source dependencies.
+
+    Scanning a repository with this command will not trigger any incident on your dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -44,7 +44,11 @@ def scan_ci_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    scan in a CI environment.
+    Evaluates if a CI event introduces SCA vulnerabilities.
+
+    Scanning a repository with this command will not trigger any incident on your dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/sca/scan/diff.py
+++ b/ggshield/cmd/sca/scan/diff.py
@@ -39,7 +39,15 @@ def scan_diff_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan all changes made since the provided Git ref for SCA vulnerabilities.
+    Scans if the current revision of a git repository introduces SCA vulnerabilities.
+
+    This command checks if the current revision introduces new vulnerabilities compared
+    to the revision from GIT_REF.
+
+    Scanning a repository with this command will not trigger any incident on your
+    dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/sca/scan/precommit.py
+++ b/ggshield/cmd/sca/scan/precommit.py
@@ -38,7 +38,14 @@ def scan_pre_commit_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Find SCA vulnerabilities in a git working directory, compared to HEAD.
+    Scans if the currently staged files introduce SCA vulnerabilities.
+
+    This command checks if the currently staged files introduce SCA vulnerabilities
+    compared to the current state of the repository.
+
+    Scanning a repository with this command will not trigger any incident on your dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     if directory is None:
         directory = Path().resolve()

--- a/ggshield/cmd/sca/scan/prepush.py
+++ b/ggshield/cmd/sca/scan/prepush.py
@@ -40,8 +40,14 @@ def scan_pre_push_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan as pre-push for SCA vulnerabilities.
-    By default, it will return vulnerabilities added in the pushed commits.
+    Scans if the local HEAD of a git repository introduces new SCA vulnerabilities.
+
+    This command checks if the current HEAD of a git repository introduces new SCA
+    vulnerabilities compared to the remote HEAD of the branch in a pre-push hook.
+
+    Scanning a repository with this command will not trigger any incident on your dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     directory = Path().resolve()
 

--- a/ggshield/cmd/sca/scan/prereceive.py
+++ b/ggshield/cmd/sca/scan/prereceive.py
@@ -42,7 +42,14 @@ def scan_pre_receive_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Scan as a pre-receive git hook.
+    Scans if the received HEAD of a git repository introduces new SCA vulnerabilities.
+
+    This command checks if the current HEAD of a git repository introduces new SCA
+    vulnerabilities compared to the remote HEAD of the branch in a pre-receive hook.
+
+    Scanning a repository with this command will not trigger any incident on your dashboard.
+
+    Only metadata such as call time, request size and scan mode is stored server-side.
     """
     if get_breakglass_option():
         return 0

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -12,7 +12,7 @@ from ggshield.core.text_utils import pluralize
 @click.option(
     "--last-found",
     is_flag=True,
-    help="Ignore secrets found in the last ggshield secret scan run.",
+    help="Ignore secrets found in the last `ggshield secret scan` run.",
 )
 @add_common_options()
 @click.pass_context
@@ -23,6 +23,14 @@ def ignore_cmd(
 ) -> None:
     """
     Ignore some secrets.
+
+    The `secret ignore` command instructs ggshield to ignore secrets it finds during a scan.
+
+    This command needs to be used with an option to determine which secrets it should ignore.
+    For now, it only handles the `--last-found` option, which ignores all secrets found during the last scan.
+
+    The command adds the ignored secrets to the `secrets.ignored-matches` section of your local
+    configuration file. If no local configuration file is found, a `.gitguardian.yaml` file is created.
     """
     if last_found:
         config: Config = ctx.obj["config"]

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -33,7 +33,7 @@ def archive_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan archive <PATH>.
+    Scan an archive file. Supported archive formats are zip, tar, tar.gz, tar.bz2 and tar.xz.
     """
     with tempfile.TemporaryDirectory(suffix="ggshield") as temp_dir:
         temp_path = Path(temp_dir)

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -23,7 +23,7 @@ from ggshield.verticals.secret.repo import scan_commit_range
 @exception_wrapper
 def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
-    scan in a CI environment.
+    Scan the set of pushed commits that triggered the CI pipeline.
     """
     config: Config = ctx.obj["config"]
     check_git_dir()

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -35,9 +35,9 @@ def docker_name_cmd(
     ctx: click.Context, name: str, docker_timeout: int, **kwargs: Any
 ) -> int:
     """
-    scan a docker image <NAME>.
+    Scan a Docker image after exporting its filesystem and manifest with the `docker save` command.
 
-    ggshield will try to pull the image if it's not available locally.
+    ggshield tries to pull the image if it's not available locally.
     """
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temporary_dir:

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -27,7 +27,7 @@ def docker_archive_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan a docker archive <ARCHIVE> without attempting to save or pull the image.
+    Scan a docker archive <ARCHIVE> without attempting to save or pull the image.
 
     Hidden command `ggshield secret scan docker-archive`
     """

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -60,7 +60,12 @@ def docset_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan docset JSONL files.
+    Scan docset JSONL files.
+
+    The JSONL files must be formatted using the ["Docset" format][1].
+
+    \b
+    [1]: https://docs.gitguardian.com/ggshield-docs/integrations/other-data-sources/other-data-sources
     """
     config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -36,7 +36,7 @@ def path_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan files and directories.
+    Scan files and directories.
     """
     config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -36,7 +36,7 @@ def precommit_cmd(
     ctx: click.Context, precommit_args: List[str], **kwargs: Any
 ) -> int:  # pragma: no cover
     """
-    scan as a pre-commit git hook.
+    Scan as a pre-commit hook all changes that have been staged in a git repository.
     """
     config: Config = ctx.obj["config"]
     output_handler = SecretTextOutputHandler(

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -36,7 +36,7 @@ REMEDIATION_STEPS = """  Since the secret was detected before the push BUT after
 @exception_wrapper
 def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> int:
     """
-    scan as a pre-push git hook.
+    Scan as a pre-push git hook all commits that are about to be pushed.
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -94,7 +94,7 @@ def prereceive_cmd(
     ctx: click.Context, web: bool, prereceive_args: List[str], **kwargs: Any
 ) -> int:
     """
-    scan as a pre-receive git hook.
+    Scan as a pre-receive git hook all commits about to enter the remote git repository.
     """
     config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -93,7 +93,16 @@ def pypi_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan a pypi package <NAME>.
+    Scan a pypi package.
+
+    Under the hood this command uses the `pip download` command to download the python
+    package.
+
+    You can use pip environment variables or configuration files to set `pip download`
+    parameters as explained in [pip documentation][1].  For example, you can set pip
+    `--index-url` parameter with the `PIP_INDEX_URL` environment variable.
+
+    [1]: https://pip.pypa.io/en/stable/topics/configuration/
     """
     config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -25,10 +25,11 @@ def range_cmd(
     **kwargs: Any,
 ) -> int:  # pragma: no cover
     """
-    scan a defined COMMIT_RANGE in git.
+    Scan each commit in the given commit range.
 
-    git rev-list COMMIT_RANGE to list several commits to scan.
-    example: ggshield secret scan commit-range HEAD~1...
+    Any git compatible commit range can be provided as an input.
+
+    Example: `ggshield secret scan commit-range HEAD~1...`
     """
     config: Config = ctx.obj["config"]
     commit_list = get_list_commit_SHA(commit_range)

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -33,14 +33,9 @@ def repo_cmd(
     ctx: click.Context, repository: str, **kwargs: Any
 ) -> int:  # pragma: no cover
     """
-    scan a REPOSITORY's commits at a given URL or path.
+    Scan a REPOSITORY's commits at the given URL or path.
 
-    REPOSITORY is the clone URI or the path of the repository to scan.
-    Examples:
-
-    ggshield secret scan repo git@github.com:GitGuardian/ggshield.git
-
-    ggshield secret scan repo /repositories/ggshield
+    REPOSITORY is the clone URL or the path of the repository to scan.
     """
     config: Config = ctx.obj["config"]
     cache: Cache = ctx.obj["cache"]

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -51,7 +51,7 @@ _output_option = click.option(
     "-o",
     type=RealPath(exists=False, resolve_path=True),
     default=None,
-    help="Route ggshield output to file.",
+    help="Redirect ggshield output to PATH.",
     callback=create_ctx_callback("output"),
 )
 
@@ -85,6 +85,7 @@ _exclude_option = click.option(
     """,
     multiple=True,
     callback=_exclude_callback,
+    metavar="PATTERNS",
 )
 
 
@@ -114,6 +115,7 @@ _banlist_detectors_option = click.option(
     help="Exclude results from a detector.",
     multiple=True,
     callback=_banlist_detectors_callback,
+    metavar="DETECTOR",
 )
 
 

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -16,7 +16,7 @@ from ggshield.core.text_utils import STYLE, format_text
 @add_common_options()
 @click.pass_context
 def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
-    """Show API status."""
+    """Show API status and version."""
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: HealthCheckResponse = client.health_check()
 

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -146,8 +146,11 @@ exit_zero_option = click.option(
     is_flag=True,
     default=None,
     envvar="GITGUARDIAN_EXIT_ZERO",
-    help="Always return a 0 (non-error) status code, even if incidents are found."
-    "The env var GITGUARDIAN_EXIT_ZERO can also be used to set this option.",
+    help=(
+        "Always return a 0 (non-error) status code, even if incidents are found."
+        " This option can also be set with the `GITGUARDIAN_EXIT_ZERO` environment"
+        " variable."
+    ),
     callback=create_config_callback("exit_zero"),
 )
 
@@ -166,6 +169,7 @@ ignore_path_option = click.option(
     default=None,
     multiple=True,
     help="Do not scan paths that match the specified glob-like patterns.",
+    metavar="PATTERN",
 )
 
 
@@ -215,10 +219,11 @@ reference_option = click.option(
     "--ref",
     required=True,
     type=click.STRING,
-    help="A git reference.",
+    help="A Git reference, such as a commit ID, a reference relative to HEAD or a remote.",
+    metavar="GIT_REF",
 )
 staged_option = click.option(
     "--staged",
     is_flag=True,
-    help="Whether staged changes should be included into the scan.",
+    help="Include staged changes in the scan.",
 )


### PR DESCRIPTION
## Description

This PR does two things:

- Replace the documentation of ggshield arguments in our GitHub action files with links to docs.gitguardian.com
- Update the CLI help messages following a synchronization between docs.gitguardian.com and the CLI help messages
