### PR TITLE
Send the scanned repository's origin url as an extra header

### DIFF
--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -99,6 +99,7 @@ def iac_scan_all(
             command_path=ctx.command_path,
             scan_mode=scan_mode if ci_mode is None else f"{scan_mode}/{ci_mode.value}",
             extra_headers={"Ci-Mode": str(ci_mode)} if ci_mode else None,
+            target_path=directory,
         ).get_http_headers(),
     )
 

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -186,6 +186,7 @@ def iac_scan_diff(
             command_path=ctx.command_path,
             scan_mode=scan_mode if ci_mode is None else f"{scan_mode}/{ci_mode.value}",
             extra_headers={"Ci-Mode": str(ci_mode)} if ci_mode else None,
+            target_path=directory,
         ).get_http_headers(),
     )
 

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -86,6 +86,7 @@ def sca_scan_all(
         ScanContext(
             command_path=ctx.command_path,
             scan_mode=scan_mode,
+            target_path=directory,
         ).get_http_headers(),
     )
 
@@ -233,6 +234,7 @@ def sca_scan_diff(
         extra_headers=ScanContext(
             command_path=ctx.command_path,
             scan_mode=scan_mode,
+            target_path=directory,
             extra_headers={"Ci-Mode": ci_mode} if ci_mode else None,
         ).get_http_headers(),
     )

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any
 
 import click
@@ -39,6 +40,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     scan_context = ScanContext(
         scan_mode=mode_header,
         command_path=ctx.command_path,
+        target_path=Path.cwd(),
         extra_headers={"Ci-Mode": ci_mode.name},
     )
 

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -57,10 +57,13 @@ def path_cmd(
         ignore_git=True,
     )
 
+    target = paths[0] if len(paths) == 1 else Path.cwd()
+    target_path = target if target.is_dir() else target.parent
     with RichSecretScannerUI(len(files), dataset_type="Path") as ui:
         scan_context = ScanContext(
             scan_mode=ScanMode.PATH,
             command_path=ctx.command_path,
+            target_path=target_path,
         )
 
         scanner = SecretScanner(

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, List
 
 import click
@@ -50,6 +51,7 @@ def precommit_cmd(
     scan_context = ScanContext(
         scan_mode=ScanMode.PRE_COMMIT,
         command_path=ctx.command_path,
+        target_path=Path.cwd(),
     )
 
     commit = Commit(exclusion_regexes=ctx.obj["exclusion_regexes"])

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Any, List
 
 import click
@@ -89,6 +90,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
     scan_context = ScanContext(
         scan_mode=ScanMode.PRE_PUSH,
         command_path=ctx.command_path,
+        target_path=Path.cwd(),
     )
 
     return_code = scan_commit_range(

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import re
 import sys
+from pathlib import Path
 from typing import Any, List, Set
 
 import click
@@ -53,6 +54,7 @@ def _execute_prereceive(
         scan_context = ScanContext(
             scan_mode=ScanMode.PRE_RECEIVE,
             command_path=command_path,
+            target_path=Path.cwd(),
         )
 
         return_code = scan_commit_range(

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import click
@@ -41,6 +42,7 @@ def range_cmd(
     scan_context = ScanContext(
         scan_mode=ScanMode.COMMIT_RANGE,
         command_path=ctx.command_path,
+        target_path=Path.cwd(),
     )
 
     return scan_commit_range(

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -48,6 +48,7 @@ def repo_cmd(
 
     path = Path(repository)
     if path.is_dir():
+        scan_context.target_path = path
         return scan_repo_path(
             client=client,
             cache=cache,
@@ -60,6 +61,7 @@ def repo_cmd(
     if REGEX_GIT_URL.match(repository):
         with tempfile.TemporaryDirectory() as tmpdirname:
             git(["clone", repository, tmpdirname])
+            scan_context.target_path = Path(tmpdirname)
             return scan_repo_path(
                 client=client,
                 cache=cache,

--- a/ggshield/core/scan/scan_context.py
+++ b/ggshield/core/scan/scan_context.py
@@ -1,9 +1,11 @@
 import platform
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 from ggshield import __version__
+from ggshield.utils.git_shell import get_repository_url_from_path
 from ggshield.utils.os import get_os_info
 
 from .scan_mode import ScanMode
@@ -14,6 +16,7 @@ class ScanContext:
     scan_mode: Union[ScanMode, str]
     command_path: str
     extra_headers: Optional[Dict[str, str]] = None
+    target_path: Optional[Path] = None
 
     def __post_init__(self) -> None:
         self.command_id = str(uuid.uuid4())
@@ -34,6 +37,10 @@ class ScanContext:
             "OS-Version": self.os_version,
             "Python-Version": self.python_version,
         }
+        if self.target_path is not None:
+            repo_url = get_repository_url_from_path(self.target_path)
+            if repo_url is not None:
+                headers["Repository-URL"] = repo_url
         if self.extra_headers:
             headers = {**headers, **self.extra_headers}
 

--- a/tests/unit/cassettes/test_sca_scan_context_repository.yaml
+++ b/tests/unit/cassettes/test_sca_scan_context_repository.yaml
@@ -1,0 +1,64 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '27'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.10.0 (Linux;py3.10.4) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 25 Oct 2023 13:35:42 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.41.5
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '13'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.18.1
+        x-sca-last-vuln-fetch:
+          - '2023-10-17T16:26:51.058422+00:00'
+        x-secrets-engine-version:
+          - 2.98.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_sca_scan_diff_context_repository.yaml
+++ b/tests/unit/cassettes/test_sca_scan_diff_context_repository.yaml
@@ -1,0 +1,64 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '27'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.10.0 (Linux;py3.10.4) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 25 Oct 2023 13:35:16 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.41.5
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '15'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.18.1
+        x-sca-last-vuln-fetch:
+          - '2023-10-17T16:26:51.058422+00:00'
+        x-secrets-engine-version:
+          - 2.98.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_scan_context_repository.yaml
+++ b/tests/unit/cassettes/test_scan_context_repository.yaml
@@ -1,0 +1,60 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.10.0 (Linux;py3.10.4) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/metadata
+    response:
+      body:
+        string: '{"version":"v2.41.5","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"onboarding__segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '392'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 25 Oct 2023 13:36:10 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.41.5
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '21'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.18.1
+        x-sca-last-vuln-fetch:
+          - '2023-10-17T16:26:51.058422+00:00'
+        x-secrets-engine-version:
+          - 2.98.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/iac/test_scan_diff.py
+++ b/tests/unit/cmd/iac/test_scan_diff.py
@@ -191,3 +191,36 @@ def test_iac_scan_diff_ignored_directory(
     assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
     assert "An ignored file or directory cannot be scanned." in result.stdout
     iac_diff_scan_mock.assert_not_called()
+
+
+@patch("pygitguardian.GGClient.iac_diff_scan")
+def test_iac_scan_diff_context_repository(
+    scan_mock: Mock,
+    tmp_path: Path,
+    cli_fs_runner: CliRunner,
+) -> None:
+    """
+    GIVEN a repository with a remote url
+    WHEN executing a scan diff
+    THEN repository url is sent
+    """
+    local_repo = Repository.create(tmp_path)
+    remote_url = "https://github.com/owner/repository.git"
+    local_repo.git("remote", "add", "origin", remote_url)
+    local_repo.create_commit()
+
+    tracked_file = local_repo.path / "iac_file_single_vulnerability.tf"
+    tracked_file.write_text(_IAC_SINGLE_VULNERABILITY)
+    local_repo.add(tracked_file)
+
+    cli_fs_runner.invoke(
+        cli,
+        ["iac", "scan", "diff", "--ref", "HEAD", "--staged", str(local_repo.path)],
+    )
+
+    scan_mock.assert_called_once()
+    assert any(
+        isinstance(arg, dict)
+        and arg.get("GGShield-Repository-URL") == "github.com/owner/repository"
+        for arg in scan_mock.call_args[0]
+    )

--- a/tests/unit/cmd/sca/test_diff.py
+++ b/tests/unit/cmd/sca/test_diff.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
 import pytest
+from click.testing import CliRunner
 
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
 from ggshield.utils.os import cd
+from tests.repository import Repository
 from tests.unit.conftest import my_vcr
 
 
@@ -50,3 +55,42 @@ def test_scan_diff(
             # THEN we get a vulnerability when a commit contains any
             assert result.exit_code == exit_code, result
             assert output_message in result.stdout
+
+
+@patch("pygitguardian.GGClient.scan_diff")
+@my_vcr.use_cassette("test_sca_scan_diff_context_repository.yaml")
+def test_sca_scan_diff_context_repository(
+    scan_mock: Mock, tmp_path: Path, cli_fs_runner: CliRunner, pipfile_lock_with_vuln
+) -> None:
+    """
+    GIVEN a repository with a remote url
+    WHEN executing a scan diff
+    THEN repository url is sent
+    """
+    local_repo = Repository.create(tmp_path)
+    remote_url = "https://github.com/owner/repository.git"
+    local_repo.git("remote", "add", "origin", remote_url)
+    local_repo.create_commit()
+
+    file = local_repo.path / "Pipfile.lock"
+    file.write_text(pipfile_lock_with_vuln)
+    local_repo.add(file)
+
+    cli_fs_runner.invoke(
+        cli,
+        [
+            "sca",
+            "scan",
+            "diff",
+            "--ref",
+            "HEAD",
+            "--staged",
+            str(local_repo.path),
+        ],
+    )
+
+    scan_mock.assert_called_once()
+    assert (
+        scan_mock.call_args[1].get("extra_headers").get("GGShield-Repository-URL")
+        == "github.com/owner/repository"
+    )

--- a/tests/unit/cmd/scan/test_prepush.py
+++ b/tests/unit/cmd/scan/test_prepush.py
@@ -167,6 +167,7 @@ class TestPrepush:
             scan_context=ScanContext(
                 scan_mode=ScanMode.PRE_PUSH,
                 command_path="cli secret scan pre-push",
+                target_path=local_repo.path,
             ),
             ignored_detectors=set(),
         )

--- a/tests/unit/core/scan/test_scan_context.py
+++ b/tests/unit/core/scan/test_scan_context.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import Union
+
+from ggshield.core.scan.scan_context import ScanContext
+from ggshield.core.scan.scan_mode import ScanMode
+from tests.repository import Repository
+
+
+class TestScanContextRepositoryURL:
+    def _assert_repo_url_in_headers(
+        self, context: ScanContext, expected_url: Union[Path, str]
+    ):
+        assert context.get_http_headers().get("GGShield-Repository-URL") == str(
+            expected_url
+        )
+
+    def _assert_no_repo_url_in_headers(self, context: ScanContext):
+        assert context.get_http_headers().get("GGShield-Repository-URL") is None
+
+    def test_scan_context_no_repo(
+        self,
+        tmp_path: Path,
+    ):
+        """
+        GIVEN a directory which is not a git repo
+        WHEN passing the local path to the scan context
+        THEN there is no GGShield-Repository-URL in the headers
+        """
+        context = ScanContext(
+            scan_mode=ScanMode.PATH,
+            command_path="ggshield secret scan path",
+            target_path=tmp_path,
+        )
+        self._assert_no_repo_url_in_headers(context)
+
+    def test_scan_context_repository_url_parsed(self, tmp_path: Path):
+        """
+        GIVEN a repository with a remote (url)
+        WHEN passing the local path to the scan context
+        THEN the remote url is found and simplified
+        """
+        local_repo = Repository.create(tmp_path)
+        remote_url = "https://user:password@github.com:84/owner/repository.git"
+        expected_url = "github.com/owner/repository"
+        local_repo.git("remote", "add", "origin", remote_url)
+
+        context = ScanContext(
+            scan_mode=ScanMode.PATH,
+            command_path="ggshield secret scan path",
+            target_path=local_repo.path,
+        )
+        self._assert_repo_url_in_headers(context, expected_url)


### PR DESCRIPTION
Compute the repository remote url. Pick one at random if several are found. This will allow a better connection between ggshield and GIM's database.
This will appear in the request headers: `'GGShield-Repository-URL': 'https://github.com/bridgecrewio/terragoat.git'`

All verticals will send this header. For IAC/SCA, the repository found is based on the provided path in the command.
For Secrets:

- No repository are sent for subcommands `archive`, `docker`, `docker-archive`, `docset`, `pypi`.
- Current working directory is sent for subcommands `ci`, `pre-commit`, `pre-push`, `pre-receive`, `range`. This is the directory that is checked by `check_git_dir`.
- For `path` subcommand, if the `paths` argument has exactly one element, it is sent. Otherwise cwd is sent.
- For `repo` subcommand, the `repository` argument or the local clone path is sent, depending on the type of the provided argument.