### PR TITLE
Add a way to override the default git timeout

### DIFF
--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -27,6 +27,7 @@ from ggshield.core.env_utils import load_dot_env
 from ggshield.core.errors import ExitCode
 from ggshield.core.text_utils import display_warning
 from ggshield.utils.click import RealPath
+from ggshield.utils.os import getenv_bool
 
 
 logger = logging.getLogger(__name__)
@@ -168,7 +169,7 @@ def main(args: Optional[List[str]] = None) -> Any:
     `args` is only used by unit-tests.
     """
     disable_logs()
-    show_crash_log = os.getenv("GITGUARDIAN_CRASH_LOG", "False").lower() == "true"
+    show_crash_log = getenv_bool("GITGUARDIAN_CRASH_LOG")
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)
 
 

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -1,13 +1,15 @@
 import os
 from enum import Enum
 
+from ggshield.utils.os import getenv_int
+
 
 CPU_COUNT = os.cpu_count() or 1
 
 
 def _get_max_workers() -> int:
     # We add a max value to avoid silently consuming all threads on powerful machines
-    return int(os.getenv("GG_MAX_WORKERS", "32"))
+    return getenv_int("GG_MAX_WORKERS", 32)
 
 
 MAX_WORKERS = min(CPU_COUNT, _get_max_workers())

--- a/ggshield/core/env_utils.py
+++ b/ggshield/core/env_utils.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 
 from ggshield.core.text_utils import display_error
 from ggshield.utils.git_shell import get_git_root, is_git_dir
+from ggshield.utils.os import getenv_bool
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ def _find_dot_env() -> Optional[Path]:
 
 def load_dot_env() -> None:
     """Loads .env file into os.environ."""
-    dont_load_env = os.getenv("GITGUARDIAN_DONT_LOAD_ENV", False)
+    dont_load_env = getenv_bool("GITGUARDIAN_DONT_LOAD_ENV")
     if dont_load_env:
         logger.debug("Not loading .env, GITGUARDIAN_DONT_LOAD_ENV is set")
         return

--- a/ggshield/core/git_hooks/prereceive.py
+++ b/ggshield/core/git_hooks/prereceive.py
@@ -8,6 +8,7 @@ import click
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import display_error
 from ggshield.utils.git_shell import EMPTY_SHA, git
+from ggshield.utils.os import getenv_float, getenv_int
 
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ BYPASS_MESSAGE = """\n     git push -o breakglass"""
 
 def get_prereceive_timeout() -> float:
     try:
-        return float(os.getenv("GITGUARDIAN_TIMEOUT", PRERECEIVE_TIMEOUT))
+        return getenv_float("GITGUARDIAN_TIMEOUT", PRERECEIVE_TIMEOUT)
     except BaseException as e:
         display_error(f"Unable to parse GITGUARDIAN_TIMEOUT: {str(e)}")
         return PRERECEIVE_TIMEOUT
@@ -31,9 +32,8 @@ def get_prereceive_timeout() -> float:
 
 def get_breakglass_option() -> bool:
     """Test all options passed to git for `breakglass`"""
-    raw_option_count = os.getenv("GIT_PUSH_OPTION_COUNT", None)
-    if raw_option_count is not None:
-        option_count = int(raw_option_count)
+    option_count = getenv_int("GIT_PUSH_OPTION_COUNT")
+    if option_count is not None:
         for option in range(option_count):
             if os.getenv(f"GIT_PUSH_OPTION_{option}", "") == "breakglass":
                 click.echo(

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from shutil import which
 from typing import Dict, List, Optional, Union
 
+from ggshield.utils.os import getenv_int
+
 
 EMPTY_SHA = "0000000000000000000000000000000000000000"
 EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-COMMAND_TIMEOUT = 45
+COMMAND_TIMEOUT = getenv_int("GG_GIT_TIMEOUT", 45)
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +148,7 @@ def git(
         cwd = Path.cwd()
 
     try:
-        logger.debug("command=%s", command)
+        logger.debug("command=%s timeout=%d", command, timeout)
         result = subprocess.run(
             [_get_git_path()] + command,
             check=check,

--- a/ggshield/utils/os.py
+++ b/ggshield/utils/os.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
-from typing import Iterator, Tuple, Union
+from typing import Iterator, Optional, Tuple, Union, overload
 
 
 logger = logging.getLogger(__name__)
@@ -64,3 +64,54 @@ def cd(newdir: Union[str, Path]) -> Iterator[None]:
         yield
     finally:
         os.chdir(prevdir)
+
+
+@overload
+def getenv_int(key: str, default: None = None) -> Optional[int]:
+    ...
+
+
+@overload
+def getenv_int(key: str, default: int) -> int:
+    ...
+
+
+def getenv_int(key: str, default: Optional[int] = None) -> Optional[int]:
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return int(value)
+
+
+@overload
+def getenv_float(key: str, default: None = None) -> Optional[float]:
+    ...
+
+
+@overload
+def getenv_float(key: str, default: float) -> float:
+    ...
+
+
+def getenv_float(key: str, default: Optional[float] = None) -> Optional[float]:
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return float(value)
+
+
+@overload
+def getenv_bool(key: str, default: None = None) -> Optional[bool]:
+    ...
+
+
+@overload
+def getenv_bool(key: str, default: bool) -> bool:
+    ...
+
+
+def getenv_bool(key: str, default: Optional[bool] = None) -> Optional[bool]:
+    value = os.getenv(key)
+    if value is None:
+        return default
+    return value.lower() not in {"false", "0"}

--- a/tests/unit/utils/test_os.py
+++ b/tests/unit/utils/test_os.py
@@ -3,7 +3,7 @@ from typing import AnyStr, Tuple
 
 import pytest
 
-from ggshield.utils.os import parse_os_release
+from ggshield.utils.os import getenv_bool, getenv_float, getenv_int, parse_os_release
 
 
 @pytest.mark.skipif(
@@ -29,3 +29,62 @@ def test_parse_os_release(
     file.write_text(file_contents)
     file.chmod(file_permissions)
     assert parse_os_release(file) == expected_tuple
+
+
+@pytest.mark.parametrize(
+    ("env_value", "default", "expected"),
+    (
+        ("12", 5, 12),
+        ("12", None, 12),
+        (None, 5, 5),
+        (None, None, None),
+    ),
+)
+def test_getenv_int(monkeypatch, env_value, default, expected):
+    key = "TEST_GETENV_VAR"
+    if env_value:
+        monkeypatch.setenv(key, env_value)
+    else:
+        monkeypatch.delenv(key, raising=False)
+    assert getenv_int(key, default) == expected
+
+
+@pytest.mark.parametrize(
+    ("env_value", "default", "expected"),
+    (
+        ("12.5", 5.3, 12.5),
+        ("12.5", None, 12.5),
+        (None, 5.5, 5.5),
+        (None, None, None),
+    ),
+)
+def test_getenv_float(monkeypatch, env_value, default, expected):
+    key = "TEST_GETENV_VAR"
+    if env_value:
+        monkeypatch.setenv(key, env_value)
+    else:
+        monkeypatch.delenv(key, raising=False)
+    assert getenv_float(key, default) == expected
+
+
+@pytest.mark.parametrize(
+    ("env_value", "default", "expected"),
+    (
+        ("true", False, True),
+        ("Whatever", False, True),
+        ("1", False, True),
+        (None, True, True),
+        (None, False, False),
+        ("0", True, False),
+        ("false", True, False),
+        ("FaLsE", True, False),
+        (None, None, None),
+    ),
+)
+def test_getenv_bool(monkeypatch, env_value, default, expected):
+    key = "TEST_GETENV_VAR"
+    if env_value:
+        monkeypatch.setenv(key, env_value)
+    else:
+        monkeypatch.delenv(key, raising=False)
+    assert getenv_bool(key, default) == expected


### PR DESCRIPTION
## Description

This PR makes it possible to override the timeout applied to all git commands with the `GG_GIT_TIMEOUT` environment variable.

## What has been done

I got a bit annoyed by the multiple places where we read environment variables and turn them into int, float or boolean, sometimes in different ways (at least for boolean variables) so I went a bit overboard and added new functions to `utils.os` to read int, float or boolean values from the environment. This is the first commit.

the second commit uses the new function to read the timeout, and log it in debug mode.