### PR TITLE
fix(config): ignore config regexes when needed

### DIFF
--- a/ggshield/cmd/sca/scan/all.py
+++ b/ggshield/cmd/sca/scan/all.py
@@ -9,7 +9,10 @@ from ggshield.cmd.sca.scan.scan_common_options import (
     update_context,
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
-from ggshield.cmd.utils.common_options import directory_argument
+from ggshield.cmd.utils.common_options import (
+    check_directory_in_ignored_path,
+    directory_argument,
+)
 from ggshield.verticals.sca.collection.collection import (
     SCAScanAllVulnerabilityCollection,
 )
@@ -41,6 +44,9 @@ def scan_all_cmd(
 
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+
+    # If directory is in the ignored paths, ignore config and proceed with scan
+    check_directory_in_ignored_path(ctx, directory)
 
     result = sca_scan_all(ctx, directory)
     scan = SCAScanAllVulnerabilityCollection(id=str(directory), result=result)

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -15,7 +15,11 @@ from ggshield.cmd.sca.scan.scan_common_options import (
     update_context,
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
-from ggshield.cmd.utils.common_options import all_option, directory_argument
+from ggshield.cmd.utils.common_options import (
+    all_option,
+    check_directory_in_ignored_path,
+    directory_argument,
+)
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_hooks.ci import get_current_and_previous_state_from_ci_env
@@ -55,6 +59,9 @@ def scan_ci_cmd(
 
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+
+    # If directory is in the ignored paths, ignore config and proceed with scan
+    check_directory_in_ignored_path(ctx, directory)
 
     config: Config = ctx.obj["config"]
     try:

--- a/ggshield/cmd/sca/scan/diff.py
+++ b/ggshield/cmd/sca/scan/diff.py
@@ -10,6 +10,7 @@ from ggshield.cmd.sca.scan.scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import (
+    check_directory_in_ignored_path,
     directory_argument,
     reference_option,
     staged_option,
@@ -54,6 +55,9 @@ def scan_diff_cmd(
 
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+
+    # If directory is in the ignored paths, ignore config and proceed with scan
+    check_directory_in_ignored_path(ctx, directory)
 
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/sca/scan/precommit.py
+++ b/ggshield/cmd/sca/scan/precommit.py
@@ -13,7 +13,11 @@ from ggshield.cmd.sca.scan.scan_common_options import (
     update_context,
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
-from ggshield.cmd.utils.common_options import all_option, directory_argument
+from ggshield.cmd.utils.common_options import (
+    all_option,
+    check_directory_in_ignored_path,
+    directory_argument,
+)
 from ggshield.core.scan.scan_mode import ScanMode
 from ggshield.verticals.sca.collection.collection import (
     SCAScanAllVulnerabilityCollection,
@@ -52,6 +56,9 @@ def scan_pre_commit_cmd(
 
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+
+    # If directory is in the ignored paths, ignore config and proceed with scan
+    check_directory_in_ignored_path(ctx, directory)
 
     if scan_all:
         result = sca_scan_all(ctx, directory)

--- a/ggshield/cmd/sca/scan/prepush.py
+++ b/ggshield/cmd/sca/scan/prepush.py
@@ -13,7 +13,10 @@ from ggshield.cmd.sca.scan.scan_common_options import (
     update_context,
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
-from ggshield.cmd.utils.common_options import all_option
+from ggshield.cmd.utils.common_options import (
+    all_option,
+    check_directory_in_ignored_path,
+)
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.scan.scan_mode import ScanMode
 from ggshield.utils.git_shell import EMPTY_SHA
@@ -53,6 +56,9 @@ def scan_pre_push_cmd(
 
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+
+    # If directory is in the ignored paths, ignore config and proceed with scan
+    check_directory_in_ignored_path(ctx, directory)
 
     _, remote_commit = collect_commits_refs(prepush_args)
     # Will happen if this is the first push on the branch

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -17,6 +17,8 @@ import click
 
 from ggshield.cmd.utils.debug_logs import setup_debug_logs
 from ggshield.core.config.user_config import UserConfig
+from ggshield.core.text_utils import display_warning
+from ggshield.utils.files import is_filepath_excluded
 
 
 AnyFunction = Callable[..., Any]
@@ -34,6 +36,15 @@ ClickCallback = Callable[
 def get_config_from_context(ctx: click.Context) -> UserConfig:
     """Returns the UserConfig object stored in Click context"""
     return cast(UserConfig, ctx.obj["config"].user_config)
+
+
+def check_directory_in_ignored_path(ctx: click.Context, directory: Path) -> None:
+    """Check if the directory is in the ignored paths in the config."""
+    if is_filepath_excluded(next(directory.rglob("*")), ctx.obj["exclusion_regexes"]):
+        display_warning(
+            "Directory to scan is in the ignored paths in the config, ignoring config and proceeding with scan."  # noqa: E501
+        )
+        ctx.obj["exclusion_regexes"] = set()
 
 
 def create_ctx_callback(name: str) -> ClickCallback:


### PR DESCRIPTION
When we explicitly ask to scan a path that is in a configuration file, then we should ignore the config file and scan the path after displaying a warning.