### PR TITLE
Convert more code to use Path

### DIFF
--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -11,14 +11,18 @@ def _get_max_workers() -> int:
 
 
 MAX_WORKERS = min(CPU_COUNT, _get_max_workers())
-CACHE_FILENAME = "./.cache_ggshield"
+
 DEFAULT_CONFIG_FILENAME = ".gitguardian.yaml"
 USER_CONFIG_FILENAMES = [".gitguardian", ".gitguardian.yml", DEFAULT_CONFIG_FILENAME]
-DEFAULT_LOCAL_CONFIG_PATH = os.path.join(".", DEFAULT_CONFIG_FILENAME)
 DEFAULT_INSTANCE_URL = "https://dashboard.gitguardian.com"
 DEFAULT_HMSL_URL = "https://api.hasmysecretleaked.com"
 AUTH_CONFIG_FILENAME = "auth_config.yaml"
 ON_PREMISE_API_URL_PATH_PREFIX = "/exposed"
+
+# These do not use pathlib.Path because of issues with pyfakefs. See:
+# https://github.com/pytest-dev/pyfakefs/discussions/657
+CACHE_PATH = os.path.join(".", ".cache_ggshield")
+DEFAULT_LOCAL_CONFIG_PATH = os.path.join(".", DEFAULT_CONFIG_FILENAME)
 
 
 class IncidentStatus(str, Enum):


### PR DESCRIPTION
This PR makes `Cache` use Path and simplifies `Cache.load_cache()`.

I tried to update the constants in `core.constants` to use Path too but that caused issues in test (see the comment I added about this).

I think at this point we can consider #464 to be done.
