### PR TITLE
chore: add headers to HMSL commands

### DIFF
--- a/ggshield/cmd/hmsl/api_status.py
+++ b/ggshield/cmd/hmsl/api_status.py
@@ -25,7 +25,7 @@ def status_cmd(
 
     # Get our client
     config: Config = ctx.obj["config"]
-    client = get_client(config)
+    client = get_client(config, ctx.command_path)
 
     click.echo(
         f"{format_text('API URL:', STYLE['key'])} {client.url}\n"

--- a/ggshield/cmd/hmsl/hmsl_utils.py
+++ b/ggshield/cmd/hmsl/hmsl_utils.py
@@ -23,7 +23,7 @@ def check_secrets(
     # Query the API
     display_info("Querying HasMySecretLeaked...")
     config: Config = ctx.obj["config"]
-    client = get_client(config)
+    client = get_client(config, hmsl_command_path=ctx.command_path)
     found: Iterable[Secret] = []
     error: Optional[Exception] = None
     try:

--- a/ggshield/cmd/hmsl/query.py
+++ b/ggshield/cmd/hmsl/query.py
@@ -40,7 +40,7 @@ def query_cmd(
 
     # Get our client
     config: Config = ctx.obj["config"]
-    client = get_client(config)
+    client = get_client(config, ctx.command_path)
 
     # Send the hashes to the API
     try:

--- a/ggshield/cmd/hmsl/quota.py
+++ b/ggshield/cmd/hmsl/quota.py
@@ -25,7 +25,7 @@ def quota_cmd(
 
     # Get our client
     config: Config = ctx.obj["config"]
-    client = get_client(config)
+    client = get_client(config, ctx.command_path)
 
     click.echo(
         f"Quota limit: {client.quota.limit}\n"

--- a/ggshield/verticals/hmsl/utils.py
+++ b/ggshield/verticals/hmsl/utils.py
@@ -50,9 +50,15 @@ EXCLUDED_VALUES = {
 }
 
 
-def get_client(config: Config) -> HMSLClient:
+def get_client(config: Config, hmsl_command_path: str) -> HMSLClient:
+    """
+    Get an instance of HMSLClient according to your current CLI config and the
+    current CLI command.
+    """
     token = get_token(config)
-    return HMSLClient(config.hmsl_url, token)
+    return HMSLClient(
+        url=config.hmsl_url, hmsl_command_path=hmsl_command_path, jwt=token
+    )
 
 
 def get_token(config: Config) -> Optional[str]:


### PR DESCRIPTION
- Add User-Agent header to HMSLClient
- Add a `GGShield-HMSL-Command-Name`, similar to `GGShield-Command-Path` in the secret module but which takes an enum value of possible HMSL command