### PR TITLE
feat(hmsl,vault): use the full path of the secret as hint in results

### DIFF
--- a/changelog.d/20231005_164337_henri.hubert_improve_vault_secret_name.md
+++ b/changelog.d/20231005_164337_henri.hubert_improve_vault_secret_name.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- command `hmsl check-secret-manager hashicorp-vault` with a "key" naming strategy will display the variable's full path instead of the variable name
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/verticals/hmsl/collection.py
+++ b/ggshield/verticals/hmsl/collection.py
@@ -62,7 +62,10 @@ def collect_list(input: List[Tuple[str, str]]) -> Iterator[SecretWithKey]:
         # filter our excluded keys and values
         if not key or not value:
             continue
-        if key.upper() in EXCLUDED_KEYS or value.lower() in EXCLUDED_VALUES:
+        if (
+            key.split("/")[-1].upper() in EXCLUDED_KEYS  # Only use the variable name
+            or value.lower() in EXCLUDED_VALUES
+        ):
             continue
         yield SecretWithKey(key=key, value=value)
 

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
@@ -127,7 +127,8 @@ class VaultAPIClient:
 
         data = api_res["data"]["data"] if mount.version == "2" else api_res["data"]
         return [
-            (secret_name, secret_value) for secret_name, secret_value in data.items()
+            (f"{path}/{secret_name}", secret_value)
+            for secret_name, secret_value in data.items()
         ]
 
     def _get_secrets_or_empty(

--- a/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py
+++ b/tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py
@@ -162,12 +162,15 @@ def test_list_kv_items_v2(vault_api_client, vault_path, expected_results):
 @pytest.mark.parametrize(
     "vault_path, expected_results",
     [
-        ("b2b/web_app/prod/config.env", [("PROD_STUFF", "test")]),
+        (
+            "b2b/web_app/prod/config.env",
+            [("b2b/web_app/prod/config.env/PROD_STUFF", "test")],
+        ),
         (
             "b2b/worker/config.env",
             [
-                ("ANOTHER_PASSWORD", "my_secret_key"),
-                ("SECRET", "super_secret"),
+                ("b2b/worker/config.env/ANOTHER_PASSWORD", "my_secret_key"),
+                ("b2b/worker/config.env/SECRET", "super_secret"),
             ],
         ),
     ],
@@ -192,12 +195,15 @@ def test_get_kv_secrets_v1(vault_api_client, vault_path, expected_results):
 @pytest.mark.parametrize(
     "vault_path, expected_results",
     [
-        ("b2b/web_app/prod/config.env", [("PROD_STUFF", "test")]),
+        (
+            "b2b/web_app/prod/config.env",
+            [("b2b/web_app/prod/config.env/PROD_STUFF", "test")],
+        ),
         (
             "b2b/worker/config.env",
             [
-                ("ANOTHER_PASSWORD", "my_secret_key"),
-                ("SECRET", "super_secret"),
+                ("b2b/worker/config.env/ANOTHER_PASSWORD", "my_secret_key"),
+                ("b2b/worker/config.env/SECRET", "super_secret"),
             ],
         ),
     ],


### PR DESCRIPTION
We now return the full path of the secret when the naming strategy of the hint is the key