### PR TITLE
Add support for creating a token with extra scopes

### DIFF
--- a/changelog.d/20231006_173320_aurelien.gateau_oauth_scopes.md
+++ b/changelog.d/20231006_173320_aurelien.gateau_oauth_scopes.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield auth login` learned to create tokens with extra scopes using the `--scopes` option. Using `ggshield auth login --scopes honeytokens:write` would create a token suitable for the `ggshield honeytokens` commands.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -128,13 +128,17 @@ def login_cmd(
 
     The default authentication method is `web`.
     ggshield launches a web browser to authenticate you to your GitGuardian instance,
-    then automatically generates a token on your behalf.
+    then automatically generates a token on your behalf. By default, the token will have
+    the `scan` scope. Use the `--scopes` option to grant the token extra scopes. You can
+    find the list of available scopes in [GitGuardian API documentation][1].
 
     Alternatively, you can use `--method token` to authenticate using an already existing token.
     The minimum required scope for the token is `scan`.
 
     If a valid personal access token is already configured, this command simply displays
     a success message indicating that ggshield is already ready to use.
+
+    [1]: https://docs.gitguardian.com/api-docs/introduction#scopes
     """
     config: Config = ctx.obj["config"]
 

--- a/ggshield/cmd/honeytoken/create.py
+++ b/ggshield/cmd/honeytoken/create.py
@@ -72,8 +72,10 @@ def create_cmd(
     Command to create a honeytoken.
 
     The prerequisites to use this command are the following:
+
     - you have the necessary permissions as a user (for now, Honeytoken is restricted to users with a manager role),
-    - the personal access token used by ggshield has the required scopes. (`honeytoken:read` and `honeytoken:write`).
+
+    - the personal access token used by ggshield has the `honeytokens:write` scope.
     """
     # if name is not given, generate a random one
     if not name:
@@ -89,7 +91,7 @@ def create_cmd(
 
 - the honeytoken module is enabled for your GitGuardian workspace,
 - you have the necessary permissions as a user,
-- the personal access token used by ggshield has the required scopes (honeytoken:write).
+- the personal access token used by ggshield has the `honeytokens:write` scope.
 
 To learn more, visit https://docs.gitguardian.com/honeytoken/getting-started."""
         )

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -423,32 +423,32 @@ class RequestHandlerWrapper:
                 """
                 callback_url: str = self_.path
                 parsed_url = urlparse.urlparse(callback_url)
-                if parsed_url.path == "/":
-                    error_string = get_error_param(parsed_url)
-                    if error_string is not None:
-                        self_._end_request(200)
-                        self.error_message = self.oauth_client.get_server_error_message(
-                            error_string
-                        )
-                    else:
-                        try:
-                            self.oauth_client.process_callback(callback_url)
-                        except OAuthError as error:
-                            self_._end_request(400)
-                            # attach error message to the handler wrapper instance
-                            self.error_message = error.message
-                        else:
-                            self_._end_request(
-                                301,
-                                urljoin(
-                                    self.oauth_client.dashboard_url, "authenticated"
-                                ),
-                            )
-
-                    # indicate to the server to stop
-                    self.complete = True
-                else:
+                if parsed_url.path != "/":
                     self_._end_request(404)
+                    return
+
+                error_string = get_error_param(parsed_url)
+                if error_string is not None:
+                    self_._end_request(200)
+                    self.error_message = self.oauth_client.get_server_error_message(
+                        error_string
+                    )
+                    return
+
+                try:
+                    self.oauth_client.process_callback(callback_url)
+                except OAuthError as error:
+                    self_._end_request(400)
+                    # attach error message to the handler wrapper instance
+                    self.error_message = error.message
+                else:
+                    self_._end_request(
+                        301,
+                        urljoin(self.oauth_client.dashboard_url, "authenticated"),
+                    )
+
+                # indicate to the server to stop
+                self.complete = True
 
             def _end_request(
                 self_,  # type:ignore

--- a/tests/unit/request_mock.py
+++ b/tests/unit/request_mock.py
@@ -19,6 +19,19 @@ def create_json_response(json_data: Dict[str, Any], status_code: int = 200) -> R
     return response
 
 
+def create_html_response(html: str, status_code: int = 200) -> Response:
+    """Helper function to create a Response returned by the requests package containing
+    HTML. This is required because `requests.Response` does not provide an easy
+    way to build a response manually.
+
+    Can be used on its own or with RequestMock."""
+    response = Response()
+    response.headers = {"content-type": "text/html"}
+    response.status_code = status_code
+    response._content = html.encode("utf-8")
+    return response
+
+
 # See ExpectedRequest.data_checker
 DataChecker = Callable[[Any], None]
 JSONChecker = Callable[[Union[List[str], Dict[str, Any]]], None]

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -45,6 +45,10 @@ def test_get_error_url_param(url, expected_error):
             "The given SSO URL is invalid.",
         ),
         (
+            "invalid_scope",
+            "The requested scopes are invalid.",
+        ),
+        (
             "invalid_error_code",
             "An unknown server error has occurred (error code: invalid_error_code).",
         ),


### PR DESCRIPTION
This PR makes it possible to create a GitGuardian token with extra scopes in addition to the `scan` scope.