### PR TITLE
test(iac): update tests with the new policy documentation url

### DIFF
--- a/tests/unit/cassettes/test_iac_scan_all_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_all_exit_zero.yaml
@@ -45,7 +45,7 @@ interactions:
         string:
           '{"id":"88ec59ba-5b30-4225-8c0e-ba0bc81cb1b2","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"file.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_diff_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_diff_exit_zero.yaml
@@ -44,7 +44,7 @@ interactions:
         string:
           '{"id":"2bb3badd-82f5-46d9-acd9-64aa92d0c714","iac_engine_version":"1.8.0","type":"diff_scan","entities_with_incidents":{"unchanged":[],"deleted":[],"new":[{"filename":"file.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_exit_zero.yaml
+++ b/tests/unit/cassettes/test_iac_scan_exit_zero.yaml
@@ -45,7 +45,7 @@ interactions:
         string:
           '{"id":"b5d256d9-5cbe-4efa-8bf9-f9bf7d2a48e3","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"file.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_files.yaml
@@ -46,15 +46,15 @@ interactions:
         string:
           '{"id":"402bc71d-07a1-47aa-8723-ea96c0cf922c","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
           egress traffic might lead to remote code execution","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
-          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0002"},{"policy":"Unrestricted
+          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0002"},{"policy":"Unrestricted
           ingress traffic leaves assets exposed to remote attacks","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
           security group has open ingress from all IPs, and on all ports. This means
           that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
           no port range is specified. This\nmeans that some applications running on
           assets of this security group may be reached by\nexternal traffic, while they
-          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0003"}]},{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
+          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0003"}]},{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
+++ b/tests/unit/cassettes/test_iac_scan_multiple_vulnerabilities.yaml
@@ -44,13 +44,13 @@ interactions:
         string:
           '{"id":"60c5188f-16b9-4124-b88a-1a19c01f6022","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"iac_file_multiple_vulnerabilities.tf","incidents":[{"policy":"Unrestricted
           egress traffic might lead to remote code execution","policy_id":"GG_IAC_0002","severity":"HIGH","component":"aws_security_group.bad_example","line_end":4,"line_start":4,"description":"Open
-          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0002"},{"policy":"Unrestricted
+          egress means that the asset can download data from the whole web.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0002"},{"policy":"Unrestricted
           ingress traffic leaves assets exposed to remote attacks","policy_id":"GG_IAC_0003","severity":"HIGH","component":"aws_security_group_rule.bad_example","line_end":10,"line_start":10,"description":"A
           security group has open ingress from all IPs, and on all ports. This means
           that the\nassets in this security group are exposed to the whole web.\n\nFurthermore,
           no port range is specified. This\nmeans that some applications running on
           assets of this security group may be reached by\nexternal traffic, while they
-          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0003"}]}]}'
+          are not expected to do so.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0003"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_prepush_output_all.yaml
+++ b/tests/unit/cassettes/test_iac_scan_prepush_output_all.yaml
@@ -45,7 +45,7 @@ interactions:
         string:
           '{"id":"df40575d-b1e6-4f3d-ad75-34a487ad43be","iac_engine_version":"1.10.2","type":"path_scan","entities_with_incidents":[{"filename":"vuln.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_prepush_output_diff.yaml
+++ b/tests/unit/cassettes/test_iac_scan_prepush_output_diff.yaml
@@ -46,7 +46,7 @@ interactions:
         string:
           '{"id":"1c35cf53-d150-43d0-936b-a587e56b2332","iac_engine_version":"1.10.2","type":"diff_scan","entities_with_incidents":{"unchanged":[],"deleted":[],"new":[{"filename":"vuln.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
+++ b/tests/unit/cassettes/test_iac_scan_single_vulnerability.yaml
@@ -43,7 +43,7 @@ interactions:
         string:
           '{"id":"73f973b2-8d76-45ff-9c95-4a01c0da973e","iac_engine_version":"1.8.0","type":"path_scan","entities_with_incidents":[{"filename":"iac_file_single_vulnerability.tf","incidents":[{"policy":"Plain
           HTTP is used","policy_id":"GG_IAC_0001","severity":"HIGH","component":"aws_alb_listener.bad_example","line_end":3,"line_start":3,"description":"Plain
-          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0001"}]}]}'
+          HTTP should not be used, it is unencrypted. HTTPS should be used instead.","documentation_url":"https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001"}]}]}'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
+++ b/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
@@ -55,7 +55,7 @@ def _generate_file_result_with_vulnerability() -> IaCFileResult:
                 line_end=35,
                 line_start=1,
                 description="The API server of an AKS cluster [...]",
-                documentation_url="https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0024",
+                documentation_url="https://docs.gitguardian.com/iac-security/policies/GG_IAC_0024",
                 component="azurerm_kubernetes_cluster.k8s_cluster",
                 severity="HIGH",
             )

--- a/tests/unit/verticals/iac/output/test_iac_diff_text_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_diff_text_output.py
@@ -15,7 +15,7 @@ from ggshield.verticals.iac.collection.iac_diff_scan_collection import (
 from ggshield.verticals.iac.output.iac_text_output_handler import IaCTextOutputHandler
 
 
-POLICY_DOC_URL = "https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0021"
+POLICY_DOC_URL = "https://docs.gitguardian.com/iac-security/policies/GG_IAC_0021"
 
 
 def _generate_iac_file_result() -> IaCFileResult:

--- a/tests/unit/verticals/iac/output/test_iac_text_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_text_output.py
@@ -126,7 +126,11 @@ def assert_no_failures_displayed(result: Result):
 
 
 def assert_documentation_url_displayed(result: Result):
-    base_doc_url = "https://docs.gitguardian.com/iac-scanning/policies/"
+    # TODO IAC-424: remove `iac-scanning` from regex
+    # base_doc_url = "https://docs.gitguardian.com/iac-security/policies/"
+    base_doc_url = (
+        r"https://docs.gitguardian.com/(iac\-security|iac\-scanning)/policies/"
+    )
     regex = r"\((GG_IAC_\d{4})\).+" + base_doc_url.replace(".", r"\.") + r"\1"
     assert re.search(
         regex,


### PR DESCRIPTION
https://linear.app/gitguardian/issue/IAC-400/change-urls-returned-in-ggshield

Public documentation URLs were changed from `iac-scanning` to `iac-security`. Here we change all occurrences in tests and cassettes.
Note that one test still allows both URLs. This will be changed later in https://linear.app/gitguardian/issue/IAC-424/change-urls-returned-in-ggshield-cleanup 