### PR TITLE
Remove the Files class

### DIFF
--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -11,7 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.core.config import Config
 from ggshield.core.errors import UnexpectedError
-from ggshield.core.scan import Files, ScanContext, ScanMode
+from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
 from ggshield.utils.click import RealPath
 from ggshield.verticals.secret import (
@@ -44,7 +44,7 @@ def archive_cmd(
 
         config: Config = ctx.obj["config"]
         verbose = config.user_config.verbose
-        files: Files = get_files_from_paths(
+        files = get_files_from_paths(
             paths=[temp_path],
             exclusion_regexes=ctx.obj["exclusion_regexes"],
             recursive=True,
@@ -54,7 +54,7 @@ def archive_cmd(
             ignore_git=True,
         )
 
-        with RichSecretScannerUI(len(files.files), dataset_type="Archive") as ui:
+        with RichSecretScannerUI(len(files), dataset_type="Archive") as ui:
             scan_context = ScanContext(
                 scan_mode=ScanMode.ARCHIVE,
                 command_path=ctx.command_path,
@@ -67,7 +67,7 @@ def archive_cmd(
                 ignored_matches=config.user_config.secret.ignored_matches,
                 ignored_detectors=config.user_config.secret.ignored_detectors,
             )
-            results = scanner.scan(files.files, scanner_ui=ui)
+            results = scanner.scan(files, scanner_ui=ui)
 
         scan = SecretScanCollection(id=path, type="archive_scan", results=results)
 

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -57,7 +57,7 @@ def path_cmd(
         ignore_git=True,
     )
 
-    with RichSecretScannerUI(len(files.files), dataset_type="Path") as ui:
+    with RichSecretScannerUI(len(files), dataset_type="Path") as ui:
         scan_context = ScanContext(
             scan_mode=ScanMode.PATH,
             command_path=ctx.command_path,
@@ -70,7 +70,7 @@ def path_cmd(
             scan_context=scan_context,
             ignored_detectors=config.user_config.secret.ignored_detectors,
         )
-        results = scanner.scan(files.files, scanner_ui=ui)
+        results = scanner.scan(files, scanner_ui=ui)
     scan = SecretScanCollection(
         id=" ".join(str(x) for x in paths), type="path_scan", results=results
     )

--- a/ggshield/core/scan/__init__.py
+++ b/ggshield/core/scan/__init__.py
@@ -2,7 +2,7 @@ from .commit import Commit
 from .file import File, get_files_from_paths
 from .scan_context import ScanContext
 from .scan_mode import ScanMode
-from .scannable import DecodeError, Files, Scannable, StringScannable
+from .scannable import DecodeError, Scannable, StringScannable
 
 
 __all__ = [
@@ -10,7 +10,6 @@ __all__ = [
     "Commit",
     "DecodeError",
     "File",
-    "Files",
     "ScanContext",
     "ScanMode",
     "Scannable",

--- a/ggshield/core/scan/commit.py
+++ b/ggshield/core/scan/commit.py
@@ -5,7 +5,7 @@ from ggshield.core.text_utils import STYLE, format_text
 from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import Filemode, git
 
-from .scannable import Files, Scannable, StringScannable
+from .scannable import Scannable, StringScannable
 
 
 _RX_HEADER_LINE_SEPARATOR = re.compile("[\n\0]:", re.MULTILINE)
@@ -82,7 +82,7 @@ class CommitInformation(NamedTuple):
     date: str
 
 
-class Commit(Files):
+class Commit:
     """
     Commit represents a commit which is a list of commit files.
     """
@@ -92,8 +92,8 @@ class Commit(Files):
         sha: Optional[str] = None,
         exclusion_regexes: Optional[Set[re.Pattern]] = None,
     ):
-        super().__init__([])
         self.sha = sha
+        self._files: List[Scannable] = []
         self._patch: Optional[str] = None
         self.exclusion_regexes: Set[re.Pattern] = exclusion_regexes or set()
         self._info: Optional[CommitInformation] = None

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -6,7 +6,7 @@ import click
 
 from ggshield.utils.files import UnexpectedDirectoryError, get_filepaths, is_path_binary
 
-from .scannable import Files, Scannable
+from .scannable import Scannable
 
 
 class File(Scannable):
@@ -61,7 +61,7 @@ def get_files_from_paths(
     display_scanned_files: bool,
     display_binary_files: bool,
     ignore_git: bool = False,
-) -> Files:
+) -> List[Scannable]:
     """
     Create a scan object from files content.
 
@@ -97,7 +97,7 @@ def get_files_from_paths(
             err=True,
         )
 
-    return Files(files)
+    return files
 
 
 def generate_files_from_paths(

--- a/ggshield/core/scan/scannable.py
+++ b/ggshield/core/scan/scannable.py
@@ -4,7 +4,7 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from io import SEEK_END, SEEK_SET
 from pathlib import Path
-from typing import BinaryIO, Callable, List, Optional, Tuple
+from typing import BinaryIO, Optional, Tuple
 
 import charset_normalizer
 from charset_normalizer import CharsetMatch
@@ -188,32 +188,3 @@ class StringScannable(Scannable):
     @property
     def content(self) -> str:
         return self._content
-
-
-class Files:
-    """
-    Files is a list of files. Useful for directory scanning.
-
-    TODO: Rename to something like ScannableCollection: this class is no longer limited
-    to holding File instances.
-    """
-
-    def __init__(self, files: List[Scannable]):
-        self._files = files
-
-    @property
-    def files(self) -> List[Scannable]:
-        """The list of files owned by this instance. The same filename can appear twice,
-        in case of a merge commit."""
-        return self._files
-
-    @property
-    def paths(self) -> List[Path]:
-        """Convenience property to list paths in the same order as files"""
-        return [x.path for x in self.files]
-
-    def __repr__(self) -> str:
-        return f"<Files files={self.files}>"
-
-    def apply_filter(self, filter_func: Callable[[Scannable], bool]) -> "Files":
-        return Files([file for file in self.files if filter_func(file)])

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -2,7 +2,6 @@ import re
 from pathlib import Path
 from typing import List, Set
 
-from ggshield.core.scan import Scannable
 from ggshield.core.scan.file import get_files_from_paths
 
 
@@ -32,17 +31,21 @@ def get_iac_files_from_path(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
-    files = get_files_from_paths(
-        paths=[path],
-        exclusion_regexes=exclusion_regexes,
-        recursive=True,
-        yes=True,
-        display_binary_files=verbose,
-        display_scanned_files=False,  # If True, this displays all files in the directory but we only want IaC files
-        ignore_git=ignore_git,
-    ).apply_filter(is_iac_file)
+    paths = [
+        x.path
+        for x in get_files_from_paths(
+            paths=[path],
+            exclusion_regexes=exclusion_regexes,
+            recursive=True,
+            yes=True,
+            display_binary_files=verbose,
+            display_scanned_files=False,  # If True, this displays all files in the directory but we only want IaC files
+            ignore_git=ignore_git,
+        )
+        if is_iac_file_path(x.path)
+    ]
 
-    return [str(x.relative_to(path)) for x in files.paths]
+    return [str(x.relative_to(path)) for x in paths]
 
 
 def is_iac_file_path(path: Path) -> bool:
@@ -52,7 +55,3 @@ def is_iac_file_path(path: Path) -> bool:
         return True
     name = path.name.lower()
     return any(keyword in name for keyword in IAC_FILENAME_KEYWORDS)
-
-
-def is_iac_file(scannable: Scannable) -> bool:
-    return is_iac_file_path(scannable.path)

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -47,17 +47,21 @@ def get_all_files_from_sca_paths(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files tracked by git are scanned
     """
-    files = get_files_from_paths(
-        paths=[path],
-        exclusion_regexes=exclusion_regexes,
-        recursive=True,
-        yes=True,
-        display_binary_files=verbose,
-        display_scanned_files=False,  # If True, this displays all files in the directory but we only want SCA files
-        ignore_git=ignore_git,
-    ).apply_filter(is_not_excluded_from_sca)
+    paths = [
+        x.path
+        for x in get_files_from_paths(
+            paths=[path],
+            exclusion_regexes=exclusion_regexes,
+            recursive=True,
+            yes=True,
+            display_binary_files=verbose,
+            display_scanned_files=False,  # If True, this displays all files in the directory but we only want SCA files
+            ignore_git=ignore_git,
+        )
+        if is_not_excluded_from_sca(x)
+    ]
 
-    return [str(x.relative_to(path)) for x in files.paths]
+    return [str(x.relative_to(path)) for x in paths]
 
 
 def is_not_excluded_from_sca(scannable: Scannable) -> bool:

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -7,7 +7,7 @@ import pytest
 
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
-from ggshield.core.scan import Files, StringScannable
+from ggshield.core.scan import StringScannable
 from ggshield.verticals.secret import SecretScanCollection
 from ggshield.verticals.secret.docker import DockerImage, LayerInfo, _validate_filepath
 from tests.unit.conftest import (
@@ -123,7 +123,7 @@ class TestDockerCMD:
             scannable = StringScannable(
                 content=UNCHECKED_SECRET_PATCH, url="file_secret"
             )
-            docker_image.get_layer.return_value = Files([scannable])
+            docker_image.get_layer_scannables.return_value = [scannable]
 
             return docker_image
 
@@ -147,7 +147,7 @@ class TestDockerCMD:
             )
             assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
             docker_image_open_mock.assert_called_once_with(image_path)
-            docker_image.get_layer.assert_called_once_with(layer_info)
+            docker_image.get_layer_scannables.assert_called_once_with(layer_info)
 
             if json_output:
                 output = json.loads(result.output)

--- a/tests/unit/core/scan/test_scannable.py
+++ b/tests/unit/core/scan/test_scannable.py
@@ -2,17 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ggshield.core.scan import Files, StringScannable
-
-
-def test_apply_filter():
-    file1 = StringScannable(content="", url="file1")
-    file2 = StringScannable(content="", url="file2")
-    files = Files([file1, file2])
-
-    filtered_files = files.apply_filter(lambda file: file.filename == "file1")
-    assert len(filtered_files.files) == 1
-    assert file1 in filtered_files.files
+from ggshield.core.scan import StringScannable
 
 
 def test_string_scannable_path():

--- a/tests/unit/core/test_match_indices.py
+++ b/tests/unit/core/test_match_indices.py
@@ -6,7 +6,7 @@ from pygitguardian import GGClient
 from ggshield.core.cache import Cache
 from ggshield.core.lines import get_lines_from_content
 from ggshield.core.match_indices import MatchIndices, find_match_indices
-from ggshield.core.scan import Commit, Files, ScanContext, ScanMode, StringScannable
+from ggshield.core.scan import Commit, ScanContext, ScanMode, StringScannable
 from ggshield.verticals.secret import SecretScanner
 from tests.unit.conftest import (
     _PATCH_WITH_NONEWLINE_BEFORE_SECRET,
@@ -67,10 +67,11 @@ def test_make_indices_patch(
     expected_indices_list: List[MatchIndices],
 ):
     if is_patch:
-        o = Commit()
-        o._patch = content
+        commit = Commit()
+        commit._patch = content
+        files = commit.files
     else:
-        o = Files([StringScannable(content=content, url="test_file")])
+        files = [StringScannable(content=content, url="test_file")]
     with my_vcr.use_cassette(name):
         scanner = SecretScanner(
             client=client,
@@ -80,7 +81,7 @@ def test_make_indices_patch(
                 command_path="external",
             ),
         )
-        results = scanner.scan(o.files)
+        results = scanner.scan(files)
         result = results.results[0]
 
     lines = get_lines_from_content(


### PR DESCRIPTION
This PR removes the `Files` class, either inlining its features (like the filtering) or merging it into its only descendant class: `Commit`. The rationale for this removal is to prepare for the refactoring of the scanning classes to scan patches as we parse them instead of all at the end.