### PR TITLE
chore(hmsl): handle missing urls

### DIFF
--- a/changelog.d/20231016_140309_pierrelalanne_improve_hmsl_output.md
+++ b/changelog.d/20231016_140309_pierrelalanne_improve_hmsl_output.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Support no location URL in HMSL response.
+- Change wording for HMSL output: do not mention occurrences as it can be misleading.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/verticals/hmsl/output.py
+++ b/ggshield/verticals/hmsl/output.py
@@ -19,6 +19,9 @@ TEMPLATE = """
 Secret name: "{name}"
 Secret hash: "{hash}"
 Distinct locations: {count}
+"""
+
+URL_DISPLAY_TEMPLATE = """
 First occurrence:
     URL: "{url}"
 """
@@ -75,7 +78,12 @@ def show_results(
         click.echo(json.dumps(data))
     else:
         for i, secret in enumerate(data["leaks"]):
-            click.echo(TEMPLATE.format(number=i + 1, **secret))
+            # Don't show empty URL
+            template = TEMPLATE
+            if secret.get("url"):
+                template = template.rstrip() + URL_DISPLAY_TEMPLATE
+
+            click.echo(template.format(number=i + 1, **secret))
             if secret["count"] >= TOO_MANY_SECRETS_THRESHOLD:
                 display_warning(
                     "Given the number of occurrences, your secret might be a template value."

--- a/ggshield/verticals/hmsl/output.py
+++ b/ggshield/verticals/hmsl/output.py
@@ -22,7 +22,7 @@ Distinct locations: {count}
 """
 
 URL_DISPLAY_TEMPLATE = """
-First occurrence:
+First location:
     URL: "{url}"
 """
 

--- a/tests/unit/cmd/hmsl/test_check.py
+++ b/tests/unit/cmd/hmsl/test_check.py
@@ -36,9 +36,9 @@ def test_hmsl_check_random_secret(cli_fs_runner: CliRunner, tmp_path: Path) -> N
 @my_vcr.use_cassette
 def test_hmsl_check_common_secret(cli_fs_runner: CliRunner, tmp_path: Path) -> None:
     """
-    GIVEN a random secret
+    GIVEN a common secret
     WHEN running the check command on it
-    THEN we should not find a match
+    THEN we do find matches
     """
     secrets_path = tmp_path / "secrets.txt"
     secrets_path.write_text("password")
@@ -55,9 +55,9 @@ def test_hmsl_check_common_secret(cli_fs_runner: CliRunner, tmp_path: Path) -> N
 @my_vcr.use_cassette
 def test_hmsl_check_full_hash(cli_fs_runner: CliRunner, tmp_path: Path) -> None:
     """
-    GIVEN a random
-    WHEN running the check command on it
-    THEN we should not find a match
+    GIVEN a common secret
+    WHEN running the check command on it with full hash option
+    THEN we do find matches
     """
     secrets_path = tmp_path / "secrets.txt"
     secrets_path.write_text("password")
@@ -65,7 +65,6 @@ def test_hmsl_check_full_hash(cli_fs_runner: CliRunner, tmp_path: Path) -> None:
     result = cli_fs_runner.invoke(
         cli, ["hmsl", "check", "-f", "-n", "cleartext", str(secrets_path)]
     )
-
     assert "Found 1 leaked secret" in result.output
     assert "password" in result.output
     assert_invoke_ok(result)


### PR DESCRIPTION
This MR improve the model for Secret as well as the output to handle the cases where there is no url.

Please note that I choose to always keep a field "url" in the json output but it is nullable.