### PR TITLE
chore(env): # Use py-gitguardian 1.11.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -273,8 +273,11 @@
             "version": "==2.21"
         },
         "pygitguardian": {
-            "git": "git+https://github.com/GitGuardian/py-gitguardian.git@cfa919cff68cc4d3ca40bf2bb8a6f24bc5fca786",
-            "ref": "cfa919cff68cc4d3ca40bf2bb8a6f24bc5fca786"
+            "hashes": [
+                "sha256:6f1b9c1e9628032ef620d7c8440ee5a3cfd7f00f79bce02d9c609dcac6abd776",
+                "sha256:f8ecdb6550610c0638d5c6ebb4f1ee626742171bd0bba1251aa4595f6cbdba1d"
+            ],
+            "version": "==1.11.0"
         },
         "pygments": {
             "hashes": [
@@ -699,74 +702,74 @@
         },
         "grimp": {
             "hashes": [
-                "sha256:0451d4c63dd9119becd3dcced87c34c37537ea547aeec9e684694365c198e7ae",
-                "sha256:061d93d60ae30f45b00d0fc2ded7734909ab77aa9584d7331e5c4d2dbe195fff",
-                "sha256:08c399ad8c4ac3bdc439042f7b332e9f77bff3e6edc9b80c88833a83204277d0",
-                "sha256:09552f1de09def35d3178eb5aef806f95e2ee29afec5514393db8c9491565b86",
-                "sha256:101ef2d103e92b327195dd4f76238d3f3c33b4e6dd5c91ede15e8ddc672d99bc",
-                "sha256:15890a999adac1c6bb008d7c428eb47175b62aa41d10950f07605d685bed8af4",
-                "sha256:20127058bc850608a34d3faf1542d7e05b1510669bd6a0213a838e8d7b3b16bb",
-                "sha256:23e64d66b28f46f441441ad63fdb8e2aebe9057ab1541d3b8a88e2b2e5d7ed80",
-                "sha256:24104e0209ef75f5c634f9d019cf24a87f21f91d3ce2ee065c70584a70a6fd6b",
-                "sha256:26537fd65989f47cbcb2b6e8acc0b020d3a085a260f3def9662d50469df1cdbc",
-                "sha256:282bb232f6a6fd08155f39f5cdb3b7167271f735a466a6ee562eb379ea42eb93",
-                "sha256:2beb69a6bc24bc86be0c0eb8740077031707dd00eed910de3b2fb71bdbb8c03a",
-                "sha256:2cbbcc7e7bb222ed21ac72fb906051a7d9d25e78e2bc48f2f3cee46cc449149f",
-                "sha256:3538ee0c9ba66d4eba64944b73f1eaf3d46a397ef76fa9c178baea8ddd810f3f",
-                "sha256:37ef60c3a193d8d3a1c545ecdcfbcaa4692d710f0173a6764d6fc18e6ad2bb99",
-                "sha256:380d6d70b5ba08f8528bb2d44916a48881e0f6881eda41fc40afc93814a31daf",
-                "sha256:3b3269db8001eafda8cf62fbb660b7b2dffc1c78042861d69d6c1c4e2cba5ff2",
-                "sha256:40d3d599afd1e1665a93660d4384944db08e9655943858919b7c8acdd9536ea3",
-                "sha256:4574d203a2b91456be665212159ab00ce5ff3c606ccadb25a1d2ea184032ea5e",
-                "sha256:468e3d76862f9d0ba7208e2fb50099482a293847a5a7d4f541206fb9bf9931ad",
-                "sha256:497b875a0efe74295935207efaf4824b200aa6aecd1761eff5a04d64a5d402c9",
-                "sha256:4ed12f1c22d170d5ccd343119014e8b456e06567a2431e09fe6c24754c2496bb",
-                "sha256:54d44d14df6894c74ccbf074fe373991ab65added1700386d9f992e2233533dc",
-                "sha256:5785b39f1614ca70214b5555e723697ebc9dae50f4254ec54857d0e7de0bceb2",
-                "sha256:591ff820a309f5c61907a4d2e8b33f8e04335288f3123de64e611bbfd362e941",
-                "sha256:5e4d464a5506bcb2df3bd17f1d1441c1871263075efbaf8511a1c64991a10012",
-                "sha256:612297bce26f892aa760a997a2e2789dfeb010b384fd812c0e28653add70bccf",
-                "sha256:64bd93e2cac4aed359d3e2bca727ae0787e4ca80504a4ac5211f546543cbc6ed",
-                "sha256:6528f84124bf56d967e34cff68bb59090bf2d58c82fcb318ee137776be9eb634",
-                "sha256:6e2f5a874d4fde5ce2a873e493bac5f985679af5294fa841b92094416354f434",
-                "sha256:7213d818f4f616144c751610e60e64e876076b45bb473f0c158f4803a1bc1e95",
-                "sha256:77fb4ce411b555a1cd28a0879db5b938b399a37236b5013e2e9d075e35a81525",
-                "sha256:78e3a6af921cc4b76abd94edf889979c8055acdd1ba0a793920a9b8706b14a53",
-                "sha256:829b12cd8b82b358bf5e2ebbb871a4aef2ffdf480a6833476aebd1b22dbc447e",
-                "sha256:835486c3eedbaad65c3a8e099f515eaa6856e45e4960df6f8cc5bc81a5f2a286",
-                "sha256:882b4cb15aa623a75921dfc6e47d2d2dd6eb5765ccef6c85fb6715d303883cf4",
-                "sha256:88fcd857c59026e3f5b3facc2258f73b637e6e819ab8e469ce59b55f1e009728",
-                "sha256:931bd00db01693422300faa5ab690d21f6a3b68d52dbe82201d9e67e32af17fc",
-                "sha256:939d4366c079039fb5e0a91141536b6037606f1fd8bed0a3daddd3e2c5b29cf7",
-                "sha256:96202031b1da4ddb04b52b26c3be108e063e2f08a4106c2c3bc2315d8e662989",
-                "sha256:98405a62f0ae88a02026f404529aea26e60e1bef92282c58bbcb8769b1541a7d",
-                "sha256:9916600072601ebfc1f32da41b98daeecac05051d20de08eaab218f5bdc79f76",
-                "sha256:a0188bd6babda18a069d258e2f39f267b4e157d804170f5eb9fe6b034f66d20d",
-                "sha256:a03ea36e910ac9199abea8a6ee8f18c13ff807af1c1ff5ce7e12572701a6e5c5",
-                "sha256:a04166e56022a7f92b723223ed6a19765838d0e2e59bbc7346d3a686228b3943",
-                "sha256:a53a1b97d3ca4e8b6100fc83df52b1d8f2fa08b8a4fb4ec8bbbbd47b01fc4740",
-                "sha256:a614a6e52f20a97e68af902c7a5b6904904b0acace1659fcd235dfd2d5f62504",
-                "sha256:a7b990a8b4264211978521fe7359fcb60574e78af699964f30a741529cdf4d4b",
-                "sha256:aaf2d1c8db5e31fca8978f6879c0eaff2c71191812e60c16f54d3fb6b0a261bd",
-                "sha256:addcce240f02c97e95a87ec4086bc66984b68ea737a43351225e92fc6f514c29",
-                "sha256:b409594a71d2a746688d2b506fa53dc128005f4acbd07e1363f09aa4f6b13425",
-                "sha256:b73a4e89c9a449af9c816d234a8d21a4760fd442871a4ee363dbe8e3ba379fff",
-                "sha256:bd65467347ef8dd9b83587769a0cef191028cb306175472270e1bb62debc466c",
-                "sha256:c335597ca6a92b29d03a2d39c47e6156ca867ee1c85336c8afd1a50ec7c98d93",
-                "sha256:cd6871dca0c87c2c36010065c98bc06cde2dbb1132b81ebfbd03cba7588e7a8c",
-                "sha256:d334808de8218ffc28395a70d3e391d1137a32e56ee277421f945c4f9154a9d8",
-                "sha256:d4e8a960de4debfd7894805907daa233ccd85df9bdf00c783fb3f7b593264761",
-                "sha256:e13243e68ed77ede0d74395d6b3dab74f9adff58f24fbb085462e4c75fb82835",
-                "sha256:e31b452a155d999401efc5b02622a5a810a1142031f411b8c5499900b9f7bfba",
-                "sha256:e5c9d57fe54ad8f831b0688334eeec0ab31cdd853ce12c45f806f2d53b59eef1",
-                "sha256:f51cfd2601ca89893f262da1423be5c739c7b34ab45d03f0f287fc2d4c3f1fd7",
-                "sha256:f5869fc957d2f276b4708182a8dcb72b7c508a357d33ad8bf0cc4d35f7127ee2",
-                "sha256:fcfe0bf60b81642348d1be3c0e079277c64effa3acce7f12248e30a2f1957905",
-                "sha256:fe5b9ae10101c2406097e8e43ca5bd92ac323904e935abf66489642afbf6d3b8",
-                "sha256:ff888898ae14395b558c88ec315728ba648cd81913b41d4f1d873fdcd29c5517"
+                "sha256:017bd8f43fe27eccd7ff3bf5a5e2edf6607e60a297f157dcc570cdde8a70d22f",
+                "sha256:01af11b494d2b2f724580595eca36a796f7ad1a273909235cc0e563519a73f71",
+                "sha256:09dd84bd0e48a02b8f5fd4311f46b76460afdb07572419f87648f5f6983d21c3",
+                "sha256:0cf8b9d002be37c1e1352b89972d59f65029a4cd412a94446ca6c7b022a407de",
+                "sha256:0d8d53548c11139626a4440a99d54b3dde1c6abb69e3f6a8334a77089dcce688",
+                "sha256:0fb4f9ddf1570496b3a4f33452180f849cffbc06c41afdacbaa140fb8ebaa523",
+                "sha256:2161406d33ac06be8965ab898c4ec86b5a3b8a84e32a9c01db99db6d82da2d46",
+                "sha256:24ba7a19bce334386951d62fee2565586fb42913d773021748ae2d993acab8e7",
+                "sha256:2947327f25ffa3930db0b29a67002a24f06a5d9ba222e3404b58537bf526df10",
+                "sha256:2ad2ab8d3c63b9236f3be3774b05c63b1d2c126921847c03d34007b6e4f6fcbd",
+                "sha256:318ec85ddc1bad843308be4112e63edcbcb1628a03a1998a5d9c9091370c3bd0",
+                "sha256:3372c24794e00196c5f24080d76f6bacb3732be267f8207fc2e5052659c75d28",
+                "sha256:385eef6322bffeb65455d3d8661c8d34fd05a545aac1981d0c9a7e13fd62705d",
+                "sha256:3d92acf3cce5234cf0583f8376aac6d0d2121cbc06a1415fe8b6a05429c3f644",
+                "sha256:3dc13375782af4faddc8d7959742b2a290f515e63b9f59df3d1f47f764279178",
+                "sha256:3df0e373b1f34b1ae3249771646eadedd18a824916baa86dcba0f176c235129e",
+                "sha256:3ee0ddcdbcb195620aeed1783d1199ca9506a67da69eaef28f9f6a4c08343675",
+                "sha256:41dce762bdb81f6a6d60fdc04e9cdc9b690f1b8127b27f45366735d294d63867",
+                "sha256:453900cf18a67acfe07e72788752255673c5ad482c65220c44d567889b4b4778",
+                "sha256:4c50bc683bf48554cbfc8b59cfdde0d5c7a789e7b0c039784f9d1f493bc9d843",
+                "sha256:507eebe6b23bdc4d11d0fd30f6d3565bf02d2b2d20ea597ddba8ee8dee8b734e",
+                "sha256:536cf8899afa13255e117ea2c242867b0e19cc7b0f4fcd7bd4a44c36433e37c4",
+                "sha256:53f863b75a54620407a45a030fb2bc1b5ebc688f280ae581048a5340db3c0a65",
+                "sha256:587e983aeea0df05763adae2dcc6dfe2d4c174d5ec21d6ac201b3591918afbfd",
+                "sha256:5baa7e7531f6d278696adfc18923b038eb16bc02e4ac52d253b68391c0cfdc19",
+                "sha256:5d157e2aeec26938ebc95c8e3cc3c2a218c4ed5bc6e85b764b2b758039f24d7d",
+                "sha256:62e73a72a034085173f3956f82b88ff4c0a34497497a16571fac01c39c6628d4",
+                "sha256:657f7ec3215ad7dc9edbaa1cbba13dcfd7f8fb606419c20dfaa546a3a89690e7",
+                "sha256:66efc5df7e6a7276c381a9cde73ff774cbc101324abc96fcb8bff667e636c22a",
+                "sha256:68cd040f0aa3563fc179f557471d7aa1f5f430c55ff37098f24333185c4ad23a",
+                "sha256:6efef6d5d2ade3e82e440f52cd10b96eb7a2e78e0e859dc5ac7784f6b2167ca0",
+                "sha256:7ae92df551850d7498e3408807816ede206924f3c3ea8504e1c1413898c80303",
+                "sha256:7c33cb6403a48c0fd57467dacd69beb2f87b7af727785657d9beef13bb18f8f7",
+                "sha256:84869db5ca1f40c6106822def5abea68b304a3c9f2646105dc60a1299b00fa25",
+                "sha256:8a35921a7e240b7a18dbb6e9bca2bfe7c952e654711c17959b94e2cd7853ab73",
+                "sha256:904c2719d2fdf5b27ddb434a8078eb1b327f66494fbc18f8008944e96d3133ae",
+                "sha256:95bca44e9aaa3531cee5772641571c0caf2f61868593624b2d0960d1d8d433eb",
+                "sha256:95e7594b7d8041f4cc4fac4f087a789ae3035d53a8a5aee5530680a856df8eb7",
+                "sha256:96b7342e08dad2a5521be9f222e24bc601f2c727deed69f5e9d999bca6b5d956",
+                "sha256:9a21230f450c63615d7c4bceec72ec5dade15e8308203cb9a537c8867ece47f0",
+                "sha256:a34d0b5be1556ffd398014f44b0032091bebbb2637c4d90958269010103ab54f",
+                "sha256:a5258b651829a5b6844340a22d1d9430224d70dae128e68c3a65b742ab1cb795",
+                "sha256:a85ad736a70eb75902b8befbfa44269091f477d5ce5770980c10f7249e9d7546",
+                "sha256:ac7a530c59efe06843b3196254bfffe7b5ebac4b3f60579181d41b1b711f0288",
+                "sha256:b1e6539d24e5c54b83c1078d1af865523ae9c7750fd19e4e824580ac4aca8c46",
+                "sha256:b3ba23623671990676a16fd8736f607bb2d6ceefbafbd1beb73904941ef77fbf",
+                "sha256:bc2c4b5e7bf3c9ed7ef936c8934996fd684a15b7993929379af33769ec2cdaef",
+                "sha256:c0b4f2968066410a339142354c23e259d5df33a9b9853f4ff085fd0029fd5b1f",
+                "sha256:c1d1c1eae7b611fbe152d2cd0dc3af54540287559e5511b9d28009aebd336b54",
+                "sha256:c53125bbce0584d48a619251f66778025a30dcf3538e6b08e75356e6d0dfde74",
+                "sha256:d34e0221e0a349e84aaa23d671abd46fe8213c36daf41ad94f0e5bfa954117a5",
+                "sha256:dc80a437c0a7748f712cc31ec1dad940ff0d1310a25309fb9082a6d2b5c0e2db",
+                "sha256:dda912f9afb0930603040afaecf1a241675858fb031c2e9fe5786127dbe7fccb",
+                "sha256:e60e941f4928f117517c0e9a84dbf53315af7cc272345f115245e7768afa7a38",
+                "sha256:e758e36de652987393342aa317e20e8a014b138ce6395e522dd645a4ce4c4640",
+                "sha256:e77027f9ce17656c9266c7cbdfea6ba5f6657c2c122cd0f408e5d8f8dc6d51a8",
+                "sha256:e850e4acd5e71f98be582cc9ef072680dc4d65037f9abda00b2a5b9c1b8c8ff5",
+                "sha256:f318d58c0143b5b3659595fadfef93838195b85d1068e67d1c91a432e1d172a6",
+                "sha256:f4b00edb2ebcbe2c938b9b4fdbc3c01071b1160b3a67d071f6bb1ed51d8d0eaf",
+                "sha256:f53b262e7dc8ef282cfeb8249b95f52c44ed65f6c5e854180e2ae3a33726bade",
+                "sha256:f6aa3bc2325ffed18789706915d0f789ffb22f5039ea4f625e773ca7320691ef",
+                "sha256:f7ab55e976465e81e3c9896badba749f14539655794c4ecc20bd337f724d00c8",
+                "sha256:f837792892f2467818cdbefa1e1c1d5bade1a47b16ffc67b15c8ca8dea922ec6",
+                "sha256:f842b796a69f89a438d1dc1d30499f77e7f9c478bc3edb0c236cec838f95a1d0",
+                "sha256:fbc322a9f937545c04e906f8bf51daa9c69c452088573f86efd9fea1ac2275e2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0"
+            "version": "==3.1"
         },
         "identify": {
             "hashes": [
@@ -1077,12 +1080,12 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:6bbd5129a64cad4c0dfaeeb12cd8f7ea7e15b77028d985341478c8af3c759522",
-                "sha256:96d529a951f8b677f730a7212442027e8ba53f9b04d217c4c67dc56c393ad945"
+                "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32",
+                "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.4.0"
+            "version": "==3.5.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -1108,20 +1111,20 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0",
-                "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"
+                "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f",
+                "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.0"
+            "version": "==2.11.1"
         },
         "pyfakefs": {
             "hashes": [
-                "sha256:3e040f3792086086a0dc2191b05fe709438e168aafe2e94fcdbef8e3859208d8",
-                "sha256:8eb95f1dd1c4b8bdce30448fe169875e3a4451c32d3f9c37799157bd4eb7b789"
+                "sha256:33c1f891078c727beec465e75cb314120635e2298456493cc2cc0539e2130cbb",
+                "sha256:e3e35f65ce55ee8ecc5e243d55cfdbb5d0aa24938f6e04e19f0fab062f255020"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==5.2.4"
+            "version": "==5.3.0"
         },
         "pyflakes": {
             "hashes": [
@@ -1182,13 +1185,6 @@
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
-        },
-        "python-version": {
-            "hashes": [
-                "sha256:2c7429f3375cee19873892e5db4d10d2b42172d8851a8bb5111729e028470580",
-                "sha256:5c16de57c7f2d614621cf468e8f5a20bb6b3cec665c9c7f5e9f9f000bf04fe67"
-            ],
-            "version": "==0.0.2"
         },
         "pyyaml": {
             "hashes": [
@@ -1259,10 +1255,10 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:4df597ee0a7b3dcc0d5315d7649df091efcb1b3ff08f0b51a698340727d17118",
-                "sha256:9137e343f98dd65b8ba3dda286739cb21b0b04fa1fc4a25ef4a8342556686f6b"
+                "sha256:6592f06b53e3fe7be9d68e58df31633496a4fa4d1c09def97c4100aebf09411e",
+                "sha256:bdd1ad7491a4694cc7d89a31b85b1f339ecea1d9716c41ee2e5f358222949fa5"
             ],
-            "version": "==1.3.1"
+            "version": "==1.4.0"
         },
         "seed-isort-config": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,7 @@ install_requires =
     marshmallow>=3.18.0,<3.19.0
     marshmallow-dataclass>=8.5.8,<8.6.0
     oauthlib>=3.2.1,<3.3.0
-    # TODO: replace this with a real version number as soon as a new version of
-    # py-gitguardian is out
-    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@cfa919cff68cc4d3ca40bf2bb8a6f24bc5fca786
+    pygitguardian>=1.11.0,<1.12.0
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1


### PR DESCRIPTION
Update lock for `py-gitguardian`.