### PR TITLE
chore(wording): # Reword credits to quotas for clarity

### DIFF
--- a/ggshield/cmd/hmsl/quota.py
+++ b/ggshield/cmd/hmsl/quota.py
@@ -20,7 +20,7 @@ def quota_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Get the number of remaining credits for today.
+    Get the remaining quotas for today.
     """
 
     # Get our client

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -17,7 +17,7 @@ from ggshield.core.errors import UnexpectedError
 @click.pass_context
 def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
-    Show the remaining quota of API calls available for the entire workspace.
+    Show the remaining quotas of API calls available for the entire workspace.
     """
     client: GGClient = create_client_from_config(ctx.obj["config"])
     response: Union[Detail, QuotaResponse] = client.quota_overview()

--- a/ggshield/verticals/hmsl/client.py
+++ b/ggshield/verticals/hmsl/client.py
@@ -87,7 +87,7 @@ class HMSLClient:
 
     @property
     def quota(self) -> Quota:
-        """Return the remaining credits."""
+        """Return the remaining quotas for the day."""
         if self._quota is None:
             # Use the side effect of the call to set the remaining credits
             self.check_prefixes([])

--- a/ggshield/verticals/hmsl/output.py
+++ b/ggshield/verticals/hmsl/output.py
@@ -95,10 +95,10 @@ def show_results(
 
 def show_error_during_scan(error: Exception):
     if isinstance(error, HTTPError) and error.response.status_code == 429:
-        error_message = "These are partial results: Quota exceeded"
+        error_message = "These are partial results: quota exceeded"
         if error.response.headers.get("RateLimit-Query") is not None:
             error_message += (
-                f" required {error.response.headers.get('RateLimit-Query')} credits."
+                f" required {error.response.headers.get('RateLimit-Query')} quotas."
             )
         else:
             error_message += "."


### PR DESCRIPTION
Avoid mixing credits and quota.  
Credits are one prefix call, on the landing page for instance.  
A quota is one quota as counted by the API.