### PR TITLE
Add comment and until date to iac config file

### DIFF
--- a/.gitguardian.example.yml
+++ b/.gitguardian.example.yml
@@ -43,11 +43,21 @@ iac:
     - '**/README.md'
     - 'doc/*'
     - 'LICENSE'
+    - path: 'tests/*'
+      comment: 'Ignore vulnerabilities in tests'
+    - path: 'dev/*'
+      comment: 'Ignore vulnerabilities in dev sandbox'
+      until: '2030-06-24T00:00:01Z'
 
   # IaC vulnerabilities to ignore
   ignored-policies:
     - GG_IAC_0000
     - GG_IAC_0005
+    - policy: 'GG_IAC_0003'
+      until: '2030-06-24T00:00:01Z'
+    - policy: 'GG_IAC_0012'
+      comment: 'We will handle this later'
+      until: '2030-06-24T00:00:01Z'
 
   # Minimum severity of the policies
   minimum-severity: HIGH

--- a/changelog.d/20231019_095052_paul.beslin.ext_accept_comment_until_iac_config.md
+++ b/changelog.d/20231019_095052_paul.beslin.ext_accept_comment_until_iac_config.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support for new options in gitguardian config file. IaC `ignored-paths` and `ignored_policies` can now be defined as objects with `comment` and `until` properties. If an `until` date is provided, the path/policy is only ignored up until this date. The old format is still supported. Check `.gitguardian.example.yaml` for a sample.

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -85,7 +85,7 @@ def iac_scan_all(
     client = ctx.obj["client"]
 
     scan_parameters = IaCScanParameters(
-        list(config.user_config.iac.ignored_policies),
+        list({ignored.policy for ignored in config.user_config.iac.ignored_policies}),
         config.user_config.iac.minimum_severity,
     )
     # If paths are not sorted, the tar bytes order will be different when calling the function twice

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -174,7 +174,7 @@ def iac_scan_diff(
     current_tar = get_iac_tar(directory, current_ref, exclusion_regexes)
 
     scan_parameters = IaCScanParameters(
-        list(config.user_config.iac.ignored_policies),
+        list({ignored.policy for ignored in config.user_config.iac.ignored_policies}),
         config.user_config.iac.minimum_severity,
     )
 

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -23,7 +23,12 @@ from ggshield.cmd.utils.common_options import (
 )
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config.config import Config
-from ggshield.core.config.user_config import POLICY_ID_PATTERN, validate_policy_id
+from ggshield.core.config.user_config import (
+    POLICY_ID_PATTERN,
+    IaCConfigIgnoredPath,
+    IaCConfigIgnoredPolicy,
+    validate_policy_id,
+)
 from ggshield.core.filter import init_exclusion_regexes
 
 
@@ -72,14 +77,18 @@ def update_context(
     ctx.obj["client"] = create_client_from_config(config)
 
     if ignore_paths is not None:
-        config.user_config.iac.ignored_paths.update(ignore_paths)
+        config.user_config.iac.ignored_paths.extend(
+            (IaCConfigIgnoredPath(path=path) for path in ignore_paths)
+        )
 
     ctx.obj["exclusion_regexes"] = init_exclusion_regexes(
-        config.user_config.iac.ignored_paths
+        {ignored.path for ignored in config.user_config.iac.ignored_paths}
     )
 
     if ignore_policies is not None:
-        config.user_config.iac.ignored_policies.update(ignore_policies)
+        config.user_config.iac.ignored_policies.extend(
+            (IaCConfigIgnoredPolicy(policy=policy) for policy in ignore_policies)
+        )
 
     if exit_zero is not None:
         config.user_config.exit_zero = exit_zero


### PR DESCRIPTION
For both `ignored_policies` and `ignored_paths` in IAC config file, the expected data was changed.
Format before (still handled):
```
iac:
    ignored-policies:
        - "GG_IAC_0001"
```
New format handled:
```
iac:
    ignored-policies:
        - policy: "GG_IAC_0001"
              comment: "This policy isn't vulnerable for this repo."
              until: "2024-01-01T00:00:01Z"
```

Mixed formats are supported too.

Ignored policies and paths are only applied if no until date is provided, or if the date is in the future