### PR TITLE
More type checks

### DIFF
--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -46,7 +46,7 @@ def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
                 else "never"
             )
         else:
-            workspace_id = token = token_name = expiry = "not set"  # type: ignore
+            workspace_id = token = token_name = expiry = "not set"
 
         _default_token_lifetime = (
             instance.default_token_lifetime

--- a/ggshield/cmd/sca/scan/__init__.py
+++ b/ggshield/cmd/sca/scan/__init__.py
@@ -21,5 +21,5 @@ from ggshield.cmd.sca.scan.prereceive import scan_pre_receive_cmd
     }
 )
 @click.pass_context
-def scan_group(*args, **kwargs: Any) -> None:
+def scan_group(*args: Any, **kwargs: Any) -> None:
     """Perform a SCA scan."""

--- a/ggshield/cmd/utils/common_decorators.py
+++ b/ggshield/cmd/utils/common_decorators.py
@@ -1,15 +1,21 @@
 from functools import wraps
+from typing import Callable, TypeVar
 
 import click
+from typing_extensions import ParamSpec
 
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import display_warning
 
 
-def exception_wrapper(func):
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def exception_wrapper(func: Callable[P, int]) -> Callable[P, int]:
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> int:
         try:
             return func(*args, **kwargs)
         except Exception as error:
@@ -20,13 +26,13 @@ def exception_wrapper(func):
     return wrapper
 
 
-def display_beta_warning(func):
+def display_beta_warning(func: Callable[P, T]) -> Callable[P, T]:
     """
     Displays warning about new verticals' commands being in beta.
     """
 
     @wraps(func)
-    def func_with_beta_warning(*args, **kwargs):
+    def func_with_beta_warning(*args: P.args, **kwargs: P.kwargs) -> T:
         display_warning(
             "This feature is still in beta, its behavior may change in future versions."
         )

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import marshmallow_dataclass
 from marshmallow import ValidationError, post_load, pre_load
@@ -75,7 +75,7 @@ class ConfigIgnoredElement(FilteredConfig):
 
     # Accept date yyyy-mm-dd instead of a full datetime
     @pre_load
-    def parse_date(self, data, **kwargs):
+    def parse_date(self, data: Dict[str, Any], **kwargs: Any):
         if not (isinstance(data, dict)) or data.get("until") is None:
             return data
         try:
@@ -85,7 +85,7 @@ class ConfigIgnoredElement(FilteredConfig):
             return data
 
     @post_load
-    def datetime_to_utc(self, data, **kwargs):
+    def datetime_to_utc(self, data: Dict[str, Any], **kwargs: Any):
         if data["until"] is not None:
             data["until"] = data["until"].astimezone(timezone.utc)
         return data
@@ -117,7 +117,14 @@ def report_expired_elements(expired_lst: List[ConfigIgnoredElement]) -> None:
 class IaCConfigIgnoredPath(ConfigIgnoredElement):
     path: str
 
-    def __init__(self, path, comment=None, until=None, *args, **kwargs):
+    def __init__(
+        self,
+        path: str,
+        comment: Optional[str] = None,
+        until: Optional[datetime] = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
         super().__init__(comment, until, *args, **kwargs)
         self.path = path
 
@@ -125,7 +132,7 @@ class IaCConfigIgnoredPath(ConfigIgnoredElement):
         return f"Path {self.path}"
 
     @pre_load
-    def convert_paths(self, in_data, **kwargs):
+    def convert_paths(self, in_data: Union[str, Dict[str, Any]], **kwargs: Any):
         return {"path": in_data} if isinstance(in_data, str) else in_data
 
 
@@ -133,7 +140,14 @@ class IaCConfigIgnoredPath(ConfigIgnoredElement):
 class IaCConfigIgnoredPolicy(ConfigIgnoredElement):
     policy: str = field(metadata={"validate": validate_policy_id})
 
-    def __init__(self, policy, comment=None, until=None, *args, **kwargs):
+    def __init__(
+        self,
+        policy: str,
+        comment: Optional[str] = None,
+        until: Optional[datetime] = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
         super().__init__(comment, until, *args, **kwargs)
         self.policy = policy
 
@@ -141,7 +155,7 @@ class IaCConfigIgnoredPolicy(ConfigIgnoredElement):
         return f"Policy {self.policy}"
 
     @pre_load
-    def convert_policies(self, in_data, **kwargs):
+    def convert_policies(self, in_data: Union[str, Dict[str, Any]], **kwargs: Any):
         return {"policy": in_data} if isinstance(in_data, str) else in_data
 
 
@@ -157,13 +171,13 @@ class IaCConfig(FilteredConfig):
     minimum_severity: str = "LOW"
 
     @post_load
-    def validate_ignored_paths(self, data, **kwargs):
+    def validate_ignored_paths(self, data: Dict[str, Any], **kwargs: Any):
         expired_lst = remove_expired_elements(data["ignored_paths"])
         report_expired_elements(expired_lst)
         return data
 
     @post_load
-    def validate_ignored_policies(self, data, **kwargs):
+    def validate_ignored_policies(self, data: Dict[str, Any], **kwargs: Any):
         expired_lst = remove_expired_elements(data["ignored_policies"])
         report_expired_elements(expired_lst)
         return data
@@ -194,7 +208,15 @@ class SCAConfigIgnoredVulnerability(ConfigIgnoredElement):
     identifier: str = field(metadata={"validate": validate_vuln_identifier})
     path: str
 
-    def __init__(self, identifier, path, comment=None, until=None, *args, **kwargs):
+    def __init__(
+        self,
+        identifier: str,
+        path: str,
+        comment: Optional[str] = None,
+        until: Optional[datetime] = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
         super().__init__(comment, until, *args, **kwargs)
         self.identifier = identifier
         self.path = path
@@ -217,7 +239,7 @@ class SCAConfig(FilteredConfig):
     )
 
     @post_load
-    def validate_ignored_vulns(self, data, **kwargs):
+    def validate_ignored_vulns(self, data: Dict[str, Any], **kwargs: Any):
         expired_lst = remove_expired_elements(data["ignored_vulnerabilities"])
         report_expired_elements(expired_lst)
         return data

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -112,7 +112,7 @@ def leak_dictionary_by_ignore_sha(
     matches that start on said line.
     """
     policy_breaks.sort(
-        key=lambda x: min(  # type: ignore
+        key=lambda x: min(
             match.index_start if match.index_start else -1 for match in x.matches
         )
     )

--- a/ggshield/utils/click/natural_order_group.py
+++ b/ggshield/utils/click/natural_order_group.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import click
 
 
@@ -8,5 +10,5 @@ class NaturalOrderGroup(click.Group):
     This will not work with python < 3.6.
     """
 
-    def list_commands(self, ctx):
-        return self.commands.keys()
+    def list_commands(self, ctx: click.Context) -> List[str]:
+        return list(self.commands.keys())

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -209,7 +209,7 @@ class OAuthClient:
             authorization_code = None
         if authorization_code is None:
             raise OAuthError("Invalid code or state received from the callback.")
-        return authorization_code  # type: ignore
+        return authorization_code
 
     def _claim_token(self, authorization_code: str) -> None:
         """
@@ -266,7 +266,7 @@ class OAuthClient:
         ).get(endpoint="token")
         if not response.ok:
             raise OAuthError("The created token is invalid.")
-        return response.json()  # type: ignore
+        return response.json()
 
     def _save_token(self, api_token_data: Dict[str, Any]) -> None:
         """

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -33,9 +33,7 @@ class Result(NamedTuple):
 
     @property
     def has_policy_breaks(self) -> bool:
-        # Needs a `type: ignore` because py-gitguardian type hints are not complete.
-        # See https://github.com/GitGuardian/py-gitguardian/issues/49
-        return self.scan.has_policy_breaks  # type: ignore
+        return self.scan.has_policy_breaks
 
 
 class Error(NamedTuple):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ omit = [".venv/*"]
 
 [tool.pyright]
 include = ["ggshield"]
+reportMissingParameterType = true
 reportUnnecessaryTypeIgnoreComment = true
 
 [tool.scriv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ omit = [".venv/*"]
 
 [tool.pyright]
 include = ["ggshield"]
+reportUnnecessaryTypeIgnoreComment = true
 
 [tool.scriv]
 version = "literal: ggshield/__init__.py: __version__"


### PR DESCRIPTION
Pyright settings are a bit lax. Tighten them.

This PR enables`reportUnnecessaryTypeIgnoreComment` and `reportMissingParameterType` options. Going to file another PR in the future to enable `reportIncompatibleMethodOverride` and `reportMissingParameterType`.

