### PR TITLE
test(iac): remove old policy documentation url from tests

### DIFF
--- a/tests/unit/verticals/iac/output/test_iac_text_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_text_output.py
@@ -126,11 +126,7 @@ def assert_no_failures_displayed(result: Result):
 
 
 def assert_documentation_url_displayed(result: Result):
-    # TODO IAC-424: remove `iac-scanning` from regex
-    # base_doc_url = "https://docs.gitguardian.com/iac-security/policies/"
-    base_doc_url = (
-        r"https://docs.gitguardian.com/(iac\-security|iac\-scanning)/policies/"
-    )
+    base_doc_url = "https://docs.gitguardian.com/iac-security/policies/"
     regex = r"\((GG_IAC_\d{4})\).+" + base_doc_url.replace(".", r"\.") + r"\1"
     assert re.search(
         regex,


### PR DESCRIPTION
In #767 we updated policy documentation url references in tests, but left one for compatibility reasons. This PR cleans the last reference.