### PR TITLE
chore(sca): show error in case of HTTP 501

### DIFF
--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -99,6 +99,8 @@ def sca_files_from_git_repo(
     if isinstance(sca_files_result, Detail):
         if sca_files_result.status_code == 401:
             raise APIKeyCheckError(client.base_uri, "Invalid API key.")
+        elif sca_files_result.status_code == 501:
+            raise UnexpectedError(sca_files_result.detail)
         raise UnexpectedError("Failed to select SCA files")
 
     sca_files = sca_files_result.sca_files


### PR DESCRIPTION
See https://linear.app/gitguardian/issue/SCA-1147/deactivate-correctly-in-on-prem

Note that the other API calls already display the associate error message.