### PR TITLE
refactor(iac): change iac diff scan json output format

### DIFF
--- a/changelog.d/20231103_145927_paul.beslin.ext_change_diff_scan_json_output.md
+++ b/changelog.d/20231103_145927_paul.beslin.ext_change_diff_scan_json_output.md
@@ -1,0 +1,70 @@
+### Changed
+
+- `ggshield iac scan diff --json` output was changed. `added_vulns`, `persisting_vulns` and `removed_vulns` were renamed as `new`, `unchanged` and `deleted`. They also were moved into a `entities_with_incidents` similarly to the scan all JSON output.
+<details>
+  <summary>Sample IaC diff JSON output</summary>
+  
+    ```json
+    {
+        "id": "fb0e9a92-de34-43f9-b779-17d25e99ab35",
+        "iac_engine_version": "1.15.0",
+        "type": "diff_scan",
+        "entities_with_incidents": {
+            "unchanged": [
+                {
+                    "filename": "s3.tf",
+                    "incidents": [
+                        {
+                            "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
+                            "policy_id": "GG_IAC_0055",
+                            "line_end": 118,
+                            "line_start": 96,
+                            "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
+                            "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
+                            "component": "aws_s3_bucket.operations",
+                            "severity": "HIGH"
+                        }
+                    ],
+                    "total_incidents": 1
+                }
+            ],
+            "deleted": [
+            {
+                "filename": "s3.tf",
+                    "incidents": [
+                        {
+                            "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
+                            "policy_id": "GG_IAC_0055",
+                            "line_end": 118,
+                            "line_start": 96,
+                            "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
+                            "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
+                            "component": "aws_s3_bucket.operations",
+                            "severity": "HIGH",
+                        }
+                    ],
+                    "total_incidents": 1
+                }
+            ],
+            "new": [
+            {
+                "filename": "s3.tf",
+                    "incidents": [
+                        {
+                            "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
+                            "policy_id": "GG_IAC_0055",
+                            "line_end": 118,
+                            "line_start": 96,
+                            "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
+                            "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
+                            "component": "aws_s3_bucket.operations",
+                            "severity": "HIGH"
+                        }
+                    ],
+                    "total_incidents": 1
+                }
+            ]
+        }
+    }
+    ```
+</details>

--- a/ggshield/verticals/iac/output/schemas.py
+++ b/ggshield/verticals/iac/output/schemas.py
@@ -1,5 +1,21 @@
+from dataclasses import dataclass, field
+from typing import List, Type, cast
+
+import marshmallow_dataclass
 from marshmallow import fields
-from pygitguardian.iac_models import IaCFileResultSchema, IaCScanResultSchema
+from pygitguardian.iac_models import (
+    IaCDiffScanEntities,
+    IaCDiffScanResult,
+    IaCFileResult,
+    IaCFileResultSchema,
+    IaCScanResultSchema,
+)
+from pygitguardian.models import BaseSchema
+
+
+@dataclass
+class IaCJSONFileResult(IaCFileResult):
+    total_incidents: int
 
 
 class IaCJSONFileResultSchema(IaCFileResultSchema):
@@ -11,7 +27,22 @@ class IaCJSONScanResultSchema(IaCScanResultSchema):
     total_incidents = fields.Integer(dump_default=0)
 
 
-class IaCJSONScanDiffResultSchema(IaCFileResultSchema):
-    added_vulns = fields.List(fields.Nested(IaCJSONFileResultSchema))
-    persisting_vulns = fields.List(fields.Nested(IaCJSONFileResultSchema))
-    removed_vulns = fields.List(fields.Nested(IaCJSONFileResultSchema))
+@dataclass
+class IaCJSONScanDiffEntities(IaCDiffScanEntities):
+    unchanged: List[IaCJSONFileResult] = field(default_factory=list)
+    new: List[IaCJSONFileResult] = field(default_factory=list)
+    deleted: List[IaCJSONFileResult] = field(default_factory=list)
+
+
+@dataclass
+class IaCJSONScanDiffResult(IaCDiffScanResult):
+    entities_with_incidents: IaCJSONScanDiffEntities = field(
+        default_factory=IaCJSONScanDiffEntities
+    )
+
+
+IaCJSONScanDiffResultSchema = cast(
+    Type[BaseSchema],
+    marshmallow_dataclass.class_schema(IaCJSONScanDiffResult, BaseSchema),
+)
+IaCJSONScanDiffResult.SCHEMA = IaCJSONScanDiffResultSchema()

--- a/tests/unit/verticals/iac/output/test_iac_diff_json_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_diff_json_output.py
@@ -57,28 +57,32 @@ def test_iac_scan_diff_one_new():
         )
     )
     parsed_json = json.loads(raw_json)
-
     assert parsed_json == {
-        "added_vulns": [
-            {
-                "filename": "/path/to/first/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            }
-        ],
-        "persisting_vulns": [],
-        "removed_vulns": [],
+        "id": "id",
+        "type": "type",
+        "iac_engine_version": "",
+        "entities_with_incidents": {
+            "unchanged": [],
+            "new": [
+                {
+                    "filename": "/path/to/first/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                }
+            ],
+            "deleted": [],
+        },
     }
 
 
@@ -111,58 +115,63 @@ def test_iac_scan_diff_several_new():
     parsed_json = json.loads(raw_json)
 
     assert parsed_json == {
-        "added_vulns": [
-            {
-                "filename": "/path/to/first/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            },
-            {
-                "filename": "/path/to/second/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            },
-            {
-                "filename": "/path/to/third/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            },
-        ],
-        "persisting_vulns": [],
-        "removed_vulns": [],
+        "id": "id",
+        "type": "type",
+        "iac_engine_version": "",
+        "entities_with_incidents": {
+            "unchanged": [],
+            "new": [
+                {
+                    "filename": "/path/to/first/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                },
+                {
+                    "filename": "/path/to/second/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                },
+                {
+                    "filename": "/path/to/third/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                },
+            ],
+            "deleted": [],
+        },
     }
 
 
@@ -193,46 +202,51 @@ def test_iac_scan_diff_several_new_on_same_file():
     parsed_json = json.loads(raw_json)
 
     assert parsed_json == {
-        "added_vulns": [
-            {
-                "filename": "/path/to/first/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    },
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    },
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    },
-                ],
-                "total_incidents": 3,
-            },
-        ],
-        "persisting_vulns": [],
-        "removed_vulns": [],
+        "id": "id",
+        "type": "type",
+        "iac_engine_version": "",
+        "entities_with_incidents": {
+            "unchanged": [],
+            "new": [
+                {
+                    "filename": "/path/to/first/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        },
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        },
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        },
+                    ],
+                    "total_incidents": 3,
+                },
+            ],
+            "deleted": [],
+        },
     }
 
 
@@ -263,26 +277,31 @@ def test_iac_scan_diff_one_persisting():
     parsed_json = json.loads(raw_json)
 
     assert parsed_json == {
-        "added_vulns": [],
-        "persisting_vulns": [
-            {
-                "filename": "/path/to/first/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            }
-        ],
-        "removed_vulns": [],
+        "id": "id",
+        "type": "type",
+        "iac_engine_version": "",
+        "entities_with_incidents": {
+            "unchanged": [
+                {
+                    "filename": "/path/to/first/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                }
+            ],
+            "new": [],
+            "deleted": [],
+        },
     }
 
 
@@ -313,24 +332,29 @@ def test_iac_scan_diff_one_removed():
     parsed_json = json.loads(raw_json)
 
     assert parsed_json == {
-        "added_vulns": [],
-        "persisting_vulns": [],
-        "removed_vulns": [
-            {
-                "filename": "/path/to/first/file.tf",
-                "incidents": [
-                    {
-                        "policy": "POLICY",
-                        "policy_id": "POLICY_ID",
-                        "line_end": 0,
-                        "line_start": 0,
-                        "description": "DESCRIPTION",
-                        "documentation_url": "DOCUMENTATION_URL",
-                        "component": "COMPONENT",
-                        "severity": "SEVERITY",
-                    }
-                ],
-                "total_incidents": 1,
-            }
-        ],
+        "id": "id",
+        "type": "type",
+        "iac_engine_version": "",
+        "entities_with_incidents": {
+            "unchanged": [],
+            "new": [],
+            "deleted": [
+                {
+                    "filename": "/path/to/first/file.tf",
+                    "incidents": [
+                        {
+                            "policy": "POLICY",
+                            "policy_id": "POLICY_ID",
+                            "line_end": 0,
+                            "line_start": 0,
+                            "description": "DESCRIPTION",
+                            "documentation_url": "DOCUMENTATION_URL",
+                            "component": "COMPONENT",
+                            "severity": "SEVERITY",
+                        }
+                    ],
+                    "total_incidents": 1,
+                }
+            ],
+        },
     }


### PR DESCRIPTION
Changes the format of the JSON output for an iac diff scan.

<details>
  <summary>Before</summary>

  ```json
{
    "added_vulns": [
        {
            "filename": "terraform/aws/s3.tf",
            "incidents": [
                {
                    "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
                    "policy_id": "GG_IAC_0055",
                    "line_end": 8,
                    "line_start": 1,
                    "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
                    "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
                    "component": "aws_s3_bucket.test",
                    "severity": "HIGH"
                }
            ],
            "total_incidents": 1
        }
    ],
    "persisting_vulns": [
        {
            "filename": "terraform/aws/db-app.tf",
            "incidents": [
                {
                    "policy": "EC2 instances use unencrypted block device",
                    "policy_id": "GG_IAC_0033",
                    "line_end": 413,
                    "line_start": 243,
                    "description": "Amazon EBS provides durable, block-level storage volumes that you can attach\\nto a running instance. They will typically be used to host the filesystem\\nfor an application (except for the boot volume). As such, they will often host\\nconfiguration files, and sometimes the secrets needed by the application to\\naccess external services.\\n\\nEncrypting your volumes ensures that your application runtime data will not be\\ncompromised from raw access to the disks.",
                    "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0033>",
                    "component": "aws_instance.db_app",
                    "severity": "HIGH"
                }
            ],
            "total_incidents": 1
        }
    ],
    "removed_vulns": []
}
  ```
</details>

<details>
  <summary>After</summary>

  ```json
{
    "id": "fb0e9a92-de34-43f9-b779-17d25e99ab35",
    "iac_engine_version": "1.15.0",
    "type": "diff_scan",
    "entities_with_incidents": {
        "unchanged": [
            {
                "filename": "s3.tf",
                "incidents": [
                    {
					    "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
                        "policy_id": "GG_IAC_0055",
                        "line_end": 118,
                        "line_start": 96,
                        "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
                        "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
                        "component": "aws_s3_bucket.operations",
                        "severity": "HIGH"
                    }
                ],
                "total_incidents": 1
            }
        ],
        "deleted": [
          {
            "filename": "s3.tf",
                "incidents": [
                    {
		                "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
                        "policy_id": "GG_IAC_0055",
                        "line_end": 118,
                        "line_start": 96,
                        "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
                        "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
                        "component": "aws_s3_bucket.operations",
                        "severity": "HIGH",
                    }
                ],
                "total_incidents": 1
            }
        ],
        "new": [
          {
            "filename": "s3.tf",
                "incidents": [
                    {
			            "policy": "Allowing public exposure of a S3 bucket can lead to data leakage",
                        "policy_id": "GG_IAC_0055",
                        "line_end": 118,
                        "line_start": 96,
                        "description": "AWS S3 Block Public Access is a feature that allows setting up centralized controls\\nto manage public access to S3 resources.\\n\\nEnforcing the BlockPublicAcls, BlockPublicPolicy and IgnorePublicAcls rule on a bucket\\nallows to make sure that no ACL (Access control list) or policy giving public access\\ncan be associated with the bucket, and that existing ACL giving public access to\\nthe bucket will not be taken into account.",
                        "documentation_url": "<https://docs.gitguardian.com/iac-scanning/policies/GG_IAC_0055>",
                        "component": "aws_s3_bucket.operations",
                        "severity": "HIGH"
                    }
                ],
                "total_incidents": 1
            }
        ]
    }
}
  ```
</details>