### PR TITLE
feat(core): try to extract repository url from ci env variables

### DIFF
--- a/ggshield/core/git_hooks/ci/__init__.py
+++ b/ggshield/core/git_hooks/ci/__init__.py
@@ -1,6 +1,7 @@
 from .commit_range import collect_commit_range_from_ci_env
 from .current_and_previous_state import get_current_and_previous_state_from_ci_env
 from .previous_commit import get_previous_commit_from_ci_env
+from .repository import get_repository_url_from_ci
 from .supported_ci import SupportedCI
 
 
@@ -9,4 +10,5 @@ __all__ = [
     "collect_commit_range_from_ci_env",
     "get_previous_commit_from_ci_env",
     "get_current_and_previous_state_from_ci_env",
+    "get_repository_url_from_ci",
 ]

--- a/ggshield/core/git_hooks/ci/repository.py
+++ b/ggshield/core/git_hooks/ci/repository.py
@@ -1,0 +1,31 @@
+import os
+from typing import Optional
+
+from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
+from ggshield.utils.git_shell import simplify_git_url
+
+
+def get_repository_url_from_ci() -> Optional[str]:
+    supported_ci = SupportedCI.from_ci_env()
+    if supported_ci == SupportedCI.AZURE:
+        repository_url = os.getenv("BUILD_REPOSITORY_URI")
+    elif supported_ci == SupportedCI.DRONE:
+        repository_url = os.getenv("DRONE_REPO_LINK")
+    elif supported_ci == SupportedCI.GITHUB:
+        domain = os.getenv("GITHUB_SERVER_URL")
+        slug = os.getenv("GITHUB_REPOSITORY")
+        repository_url = f"{domain}/{slug}" if domain and slug else None
+    elif supported_ci == SupportedCI.GITLAB:
+        repository_url = os.getenv("CI_REPOSITORY_URL")
+    elif supported_ci == SupportedCI.CIRCLECI:
+        repository_url = os.getenv("CIRCLE_REPOSITORY_URL")
+    elif supported_ci == SupportedCI.BITBUCKET:
+        repository_url = os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+    # TRAVIS_REPO_SLUG does not provide the domain name
+    # JENKINS provides nothing
+    else:
+        repository_url = None
+
+    if not repository_url:
+        return None
+    return simplify_git_url(repository_url)

--- a/ggshield/core/scan/scan_context.py
+++ b/ggshield/core/scan/scan_context.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 from ggshield import __version__
+from ggshield.core.git_hooks.ci.repository import get_repository_url_from_ci
 from ggshield.utils.git_shell import get_repository_url_from_path
 from ggshield.utils.os import get_os_info
 
@@ -23,6 +24,16 @@ class ScanContext:
         self.os_name, self.os_version = get_os_info()
         self.python_version = platform.python_version()
 
+    def _get_repository_url(
+        self,
+    ) -> Optional[str]:
+        repo_url = None
+        if self.scan_mode in [ScanMode.CI, ScanMode.CI_ALL, ScanMode.CI_DIFF]:
+            repo_url = get_repository_url_from_ci()
+        if repo_url is None and self.target_path is not None:
+            repo_url = get_repository_url_from_path(self.target_path)
+        return repo_url
+
     def get_http_headers(self) -> Dict[str, str]:
         """
         Returns the extra headers to send in HTTP requests.
@@ -37,10 +48,9 @@ class ScanContext:
             "OS-Version": self.os_version,
             "Python-Version": self.python_version,
         }
-        if self.target_path is not None:
-            repo_url = get_repository_url_from_path(self.target_path)
-            if repo_url is not None:
-                headers["Repository-URL"] = repo_url
+        repo_url = self._get_repository_url()
+        if repo_url is not None:
+            headers["Repository-URL"] = repo_url
         if self.extra_headers:
             headers = {**headers, **self.extra_headers}
 

--- a/tests/unit/core/scan/test_scan_context.py
+++ b/tests/unit/core/scan/test_scan_context.py
@@ -1,52 +1,123 @@
+import os
 from pathlib import Path
 from typing import Union
+from unittest import mock
+
+import pytest
 
 from ggshield.core.scan.scan_context import ScanContext
 from ggshield.core.scan.scan_mode import ScanMode
 from tests.repository import Repository
 
 
-class TestScanContextRepositoryURL:
-    def _assert_repo_url_in_headers(
-        self, context: ScanContext, expected_url: Union[Path, str]
-    ):
-        assert context.get_http_headers().get("GGShield-Repository-URL") == str(
-            expected_url
+DOMAIN = "https://github.com"
+SLUG = "from-env/repository"
+ENV_REPO_URL = f"{DOMAIN}/{SLUG}"
+EXPECTED_HEADER_ENV = "github.com/from-env/repository"
+
+REMOTE_URL = "https://github.com/from-remote/repository"
+FULL_REMOTE_URL = "https://user:password@github.com:84/from-remote/repository.git"
+EXPECTED_HEADER_REMOTE = "github.com/from-remote/repository"
+
+
+@pytest.fixture(scope="module")
+def fake_url_repo(tmp_path_factory: pytest.TempPathFactory) -> Repository:
+    repo = Repository.create(tmp_path_factory.mktemp("fake_url_repo"))
+    repo.git("remote", "add", "origin", REMOTE_URL)
+    return repo
+
+
+def _assert_repo_url_in_headers(context: ScanContext, expected_url: Union[Path, str]):
+    assert context.get_http_headers().get("GGShield-Repository-URL") == str(
+        expected_url
+    )
+
+
+def _assert_no_repo_url_in_headers(context: ScanContext):
+    assert context.get_http_headers().get("GGShield-Repository-URL") is None
+
+
+def test_scan_context_no_repo(
+    tmp_path: Path,
+):
+    """
+    GIVEN a directory which is not a git repo
+    WHEN passing the local path to the scan context
+    THEN there is no GGShield-Repository-URL in the headers
+    """
+    context = ScanContext(
+        scan_mode=ScanMode.PATH,
+        command_path="ggshield secret scan path",
+        target_path=tmp_path,
+    )
+    _assert_no_repo_url_in_headers(context)
+
+
+def test_scan_context_repository_url_parsed(fake_url_repo: Repository):
+    """
+    GIVEN a repository with a remote (url)
+    WHEN passing the local path to the scan context
+    THEN the remote url is found and simplified
+    """
+    context = ScanContext(
+        scan_mode=ScanMode.PATH,
+        command_path="ggshield secret scan path",
+        target_path=fake_url_repo.path,
+    )
+    _assert_repo_url_in_headers(context, EXPECTED_HEADER_REMOTE)
+
+
+@pytest.mark.parametrize(
+    "env",
+    (
+        {"BUILD_BUILDID": "1", "BUILD_REPOSITORY_URI": ENV_REPO_URL},
+        {"DRONE": "1", "DRONE_REPO_LINK": ENV_REPO_URL},
+        {
+            "GITHUB_ACTIONS": "1",
+            "GITHUB_SERVER_URL": DOMAIN,
+            "GITHUB_REPOSITORY": SLUG,
+        },
+        {"GITLAB_CI": "1", "CI_REPOSITORY_URL": ENV_REPO_URL},
+        {"CIRCLECI": "1", "CIRCLE_REPOSITORY_URL": ENV_REPO_URL},
+        {"BITBUCKET_COMMIT": "1", "BITBUCKET_GIT_HTTP_ORIGIN": ENV_REPO_URL},
+    ),
+)
+def test_ci_repo_found(env, fake_url_repo: Repository) -> None:
+    """
+    GIVEN a repository with a remote url
+    WHEN a repository url is found in the CI environment
+    THEN it is sent instead of the remote url
+    """
+    with mock.patch.dict(os.environ, env, clear=True):
+        context = ScanContext(
+            scan_mode=ScanMode.CI,
+            command_path="ggshield secret scan path",
+            target_path=fake_url_repo.path,
         )
+        _assert_repo_url_in_headers(context, EXPECTED_HEADER_ENV)
 
-    def _assert_no_repo_url_in_headers(self, context: ScanContext):
-        assert context.get_http_headers().get("GGShield-Repository-URL") is None
 
-    def test_scan_context_no_repo(
-        self,
-        tmp_path: Path,
-    ):
-        """
-        GIVEN a directory which is not a git repo
-        WHEN passing the local path to the scan context
-        THEN there is no GGShield-Repository-URL in the headers
-        """
+@pytest.mark.parametrize(
+    "env",
+    (
+        {"BUILD_BUILDID": "1"},
+        {"DRONE": "1"},
+        {"GITHUB_ACTIONS": "1"},
+        {"GITLAB_CI": "1"},
+        {"CIRCLECI": "1"},
+        {"BITBUCKET_COMMIT": "1"},
+    ),
+)
+def test_ci_no_env(env, fake_url_repo: Repository) -> None:
+    """
+    GIVEN a repository with a remote url
+    WHEN there is no repository url in the environment
+    THEN the remote url is sent by default
+    """
+    with mock.patch.dict(os.environ, env, clear=True):
         context = ScanContext(
             scan_mode=ScanMode.PATH,
             command_path="ggshield secret scan path",
-            target_path=tmp_path,
+            target_path=fake_url_repo.path,
         )
-        self._assert_no_repo_url_in_headers(context)
-
-    def test_scan_context_repository_url_parsed(self, tmp_path: Path):
-        """
-        GIVEN a repository with a remote (url)
-        WHEN passing the local path to the scan context
-        THEN the remote url is found and simplified
-        """
-        local_repo = Repository.create(tmp_path)
-        remote_url = "https://user:password@github.com:84/owner/repository.git"
-        expected_url = "github.com/owner/repository"
-        local_repo.git("remote", "add", "origin", remote_url)
-
-        context = ScanContext(
-            scan_mode=ScanMode.PATH,
-            command_path="ggshield secret scan path",
-            target_path=local_repo.path,
-        )
-        self._assert_repo_url_in_headers(context, expected_url)
+        _assert_repo_url_in_headers(context, EXPECTED_HEADER_REMOTE)


### PR DESCRIPTION
Following #747, we want CI commands to gather the current repository URL from the CI environment variables first, falling back on `git remote -v` if variables are not found.