### PR TITLE
Hide --scopes for now

### DIFF
--- a/changelog.d/20231006_173320_aurelien.gateau_oauth_scopes.md
+++ b/changelog.d/20231006_173320_aurelien.gateau_oauth_scopes.md
@@ -1,3 +1,0 @@
-### Added
-
-- `ggshield auth login` learned to create tokens with extra scopes using the `--scopes` option. Using `ggshield auth login --scopes honeytokens:write` would create a token suitable for the `ggshield honeytokens` commands.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -79,6 +79,7 @@ def print_default_instance_message(config: Config) -> None:
 )
 @click.option(
     "--scopes",
+    hidden=True,
     required=False,
     type=str,
     help=(


### PR DESCRIPTION
Server-side is not fully ready for `--scopes`, so hide the option for now.
