### PR TITLE
Implement auto-ignore

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -185,45 +185,44 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0c327cac00f082013c7c9fb6c46b7cc9fa3c288ca702c74773968173bda421bf",
-                "sha256:0d2a6a598847c46e3e321a7aef8af1436f11c27f1254933746304ff014664d84",
-                "sha256:227ec057cd32a41c6651701abc0328135e472ed450f47c2766f23267b792a88e",
-                "sha256:22892cc830d8b2c89ea60148227631bb96a7da0c1b722f2aac8824b1b7c0b6b8",
-                "sha256:392cb88b597247177172e02da6b7a63deeff1937fa6fec3bbf902ebd75d97ec7",
-                "sha256:3be3ca726e1572517d2bef99a818378bbcf7d7799d5372a46c79c29eb8d166c1",
-                "sha256:573eb7128cbca75f9157dcde974781209463ce56b5804983e11a1c462f0f4e88",
-                "sha256:580afc7b7216deeb87a098ef0674d6ee34ab55993140838b14c9b83312b37b86",
-                "sha256:5a70187954ba7292c7876734183e810b728b4f3965fbe571421cb2434d279179",
-                "sha256:73801ac9736741f220e20435f84ecec75ed70eda90f781a148f1bad546963d81",
-                "sha256:7d208c21e47940369accfc9e85f0de7693d9a5d843c2509b3846b2db170dfd20",
-                "sha256:8254962e6ba1f4d2090c44daf50a547cd5f0bf446dc658a8e5f8156cae0d8548",
-                "sha256:88417bff20162f635f24f849ab182b092697922088b477a7abd6664ddd82291d",
-                "sha256:a48e74dad1fb349f3dc1d449ed88e0017d792997a7ad2ec9587ed17405667e6d",
-                "sha256:b948e09fe5fb18517d99994184854ebd50b57248736fd4c720ad540560174ec5",
-                "sha256:c707f7afd813478e2019ae32a7c49cd932dd60ab2d2a93e796f68236b7e1fbf1",
-                "sha256:d38e6031e113b7421db1de0c1b1f7739564a88f1684c6b89234fbf6c11b75147",
-                "sha256:d3977f0e276f6f5bf245c403156673db103283266601405376f075c849a0b936",
-                "sha256:da6a0ff8f1016ccc7477e6339e1d50ce5f59b88905585f77193ebd5068f1e797",
-                "sha256:e270c04f4d9b5671ebcc792b3ba5d4488bf7c42c3c241a3748e2599776f29696",
-                "sha256:e886098619d3815e0ad5790c973afeee2c0e6e04b4da90b88e6bd06e2a0b1b72",
-                "sha256:ec3b055ff8f1dce8e6ef28f626e0972981475173d7973d63f271b29c8a2897da",
-                "sha256:fba1e91467c65fe64a82c689dc6cf58151158993b13eb7a7f3f4b7f395636723"
+                "sha256:079b85658ea2f59c4f43b70f8119a52414cdb7be34da5d019a77bf96d473b960",
+                "sha256:09616eeaef406f99046553b8a40fbf8b1e70795a91885ba4c96a70793de5504a",
+                "sha256:13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc",
+                "sha256:37a138589b12069efb424220bf78eac59ca68b95696fc622b6ccc1c0a197204a",
+                "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf",
+                "sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1",
+                "sha256:48a0476626da912a44cc078f9893f292f0b3e4c739caf289268168d8f4702a39",
+                "sha256:49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406",
+                "sha256:5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a",
+                "sha256:5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a",
+                "sha256:68a2dec79deebc5d26d617bfdf6e8aab065a4f34934b22d3b5010df3ba36612c",
+                "sha256:7a698cb1dac82c35fcf8fe3417a3aaba97de16a01ac914b89a0889d364d2f6be",
+                "sha256:841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15",
+                "sha256:90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2",
+                "sha256:928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d",
+                "sha256:af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157",
+                "sha256:b640981bf64a3e978a56167594a0e97db71c89a479da8e175d8bb5be5178c003",
+                "sha256:c5ca78485a255e03c32b513f8c2bc39fedb7f5c5f8535545bdc223a03b24f248",
+                "sha256:c7f3201ec47d5207841402594f1d7950879ef890c0c495052fa62f58283fde1a",
+                "sha256:d5ec85080cce7b0513cfd233914eb8b7bbd0633f1d1703aa28d1dd5a72f678ec",
+                "sha256:d6c391c021ab1f7a82da5d8d0b3cee2f4b2c455ec86c8aebbc84837a631ff309",
+                "sha256:e3114da6d7f95d2dee7d3f4eec16dacff819740bbab931aff8648cb13c5ff5e7",
+                "sha256:f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==41.0.5"
+            "version": "==41.0.7"
         },
         "ggshield": {
             "editable": true,
-            "markers": "python_version >= '3.8'",
             "path": "."
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
+                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "version": "==3.6"
         },
         "marshmallow": {
             "hashes": [
@@ -273,11 +272,12 @@
             "version": "==2.21"
         },
         "pygitguardian": {
+            "git": "https://github.com/GitGuardian/py-gitguardian.git",
             "hashes": [
                 "sha256:6f1b9c1e9628032ef620d7c8440ee5a3cfd7f00f79bce02d9c609dcac6abd776",
                 "sha256:f8ecdb6550610c0638d5c6ebb4f1ee626742171bd0bba1251aa4595f6cbdba1d"
             ],
-            "version": "==1.11.0"
+            "ref": "675d6d3d363bb766437b1d88f8d927a0d090e575"
         },
         "pygments": {
             "hashes": [
@@ -380,7 +380,7 @@
                 "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
                 "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.7'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.8.0"
         },
         "typing-inspect": {
@@ -450,7 +450,6 @@
                 "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.2'",
             "version": "==22.3.0"
         },
         "certifi": {
@@ -621,7 +620,6 @@
                 "sha256:fe494faa90ce6381770746077243231e0b83ff3f17069d748f645617cefe19d4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==7.3.2"
         },
         "decorator": {
@@ -676,7 +674,6 @@
                 "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.1'",
             "version": "==6.1.0"
         },
         "flake8-isort": {
@@ -685,7 +682,6 @@
                 "sha256:c1f82f3cf06a80c13e1d09bfae460e9666255d5c780b859f19f8318d420370b3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==6.1.1"
         },
         "flake8-quotes": {
@@ -776,11 +772,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
+                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "version": "==3.6"
         },
         "import-linter": {
             "hashes": [
@@ -788,7 +784,6 @@
                 "sha256:92f5ddec77c523bd95c0af88d3fdb354b705a776f7a0e59a7b25b035828a0257"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==1.12.1"
         },
         "iniconfig": {
@@ -805,16 +800,15 @@
                 "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.13"
         },
         "ipython": {
             "hashes": [
-                "sha256:126bb57e1895594bb0d91ea3090bbd39384f6fe87c3d57fd558d0670f50339bb",
-                "sha256:1e4d1d666a023e3c93585ba0d8e962867f7a111af322efff6b9c58062b3e5444"
+                "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27",
+                "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==8.17.2"
+            "version": "==8.18.1"
         },
         "isort": {
             "hashes": [
@@ -846,7 +840,6 @@
                 "sha256:ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==4.20.0"
         },
         "jsonschema-specifications": {
@@ -1077,11 +1070,11 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
-                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+                "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523",
+                "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.8.0"
+            "version": "==4.9.0"
         },
         "platformdirs": {
             "hashes": [
@@ -1105,7 +1098,6 @@
                 "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.5.0"
         },
         "prompt-toolkit": {
@@ -1144,7 +1136,6 @@
                 "sha256:dd1fb374039fadccf35d3f3df7aa5d239482e0650dcd240e053d3b9e78740918"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==5.3.1"
         },
         "pyflakes": {
@@ -1169,7 +1160,6 @@
                 "sha256:95fa963337e2cfd4900601197d0f866d8c51732dea6c0bb12f962f92a79c77e3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.1.313"
         },
         "pytest": {
@@ -1178,7 +1168,6 @@
                 "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==7.2.1"
         },
         "pytest-mock": {
@@ -1187,7 +1176,6 @@
                 "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.12.0"
         },
         "pytest-socket": {
@@ -1196,7 +1184,6 @@
                 "sha256:cca72f134ff01e0023c402e78d31b32e68da3efdf3493bf7788f8eba86a6824c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.6.0"
         },
         "pytest-voluptuous": {
@@ -1204,7 +1191,6 @@
                 "sha256:a3856e9812b219fec1c3f2fd8249c0bac6927e1d5e52a3961e4ae903f54d494f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "pyyaml": {
@@ -1392,6 +1378,7 @@
                 "sha256:2d28eb930dc16ad9499efa0e5f10ddfb98440ab553783426930ff98b0b391917",
                 "sha256:f8e4d61439c7085d9bc5053c7fb0df50b606d5c03db4e642b0d44f74aa1b9ecf"
             ],
+            "index": "pypi",
             "version": "==1.5.0"
         },
         "seed-isort-config": {
@@ -1400,7 +1387,6 @@
                 "sha256:be4cfef8f9a3fe8ea1817069c6b624538ac0b429636ec746edeb27e98ed628c8"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.1'",
             "version": "==2.2.0"
         },
         "setuptools": {
@@ -1452,18 +1438,18 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:9b232b9430c8f57288c1024b34a8f0251ddcc47268927367a0dd3eeaca40deb5",
-                "sha256:baf991e61542da48fe8aef8b779a9ea0aa38d8a54166ee250d5af5ecf4486619"
+                "sha256:f14949d23829023013c47df20b4a76ccd1a85effb786dc060f34de7948361b33",
+                "sha256:fcdaa8ac49c04dfa0ed3ee3384ef6dfdb5d6f3741502be247279407679296772"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.13.0"
+            "version": "==5.14.0"
         },
         "typing-extensions": {
             "hashes": [
                 "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
                 "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.7'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.8.0"
         },
         "urllib3": {
@@ -1480,7 +1466,6 @@
                 "sha256:8fbd4be412e8a7f35f623dd61034e6380a1c8dbd0edf6e87277a3289f6e98093"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==4.3.0"
         },
         "virtualenv": {

--- a/changelog.d/20231115_165150_paul.beslin.ext_implement_auto_ignore.md
+++ b/changelog.d/20231115_165150_paul.beslin.ext_implement_auto_ignore.md
@@ -1,0 +1,3 @@
+### Changed
+
+- IaC incidents ignored on the GitGuardian app will no longer show up in the scan results.

--- a/ggshield/verticals/iac/collection/filter_ignored.py
+++ b/ggshield/verticals/iac/collection/filter_ignored.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from pygitguardian.iac_models import IaCFileResult, IaCVulnerability
+
+
+def filter_unignored_incidents(
+    incidents: List[IaCVulnerability],
+) -> List[IaCVulnerability]:
+    """Removes ignored incidents from the given list"""
+    return [incident for incident in incidents if incident.status != "IGNORED"]
+
+
+def filter_unignored_files(files: List[IaCFileResult]) -> List[IaCFileResult]:
+    unignored_files: List[IaCFileResult] = []
+    for file in files:
+        unignored_incidents = filter_unignored_incidents(file.incidents)
+        if len(unignored_incidents) > 0:
+            unignored_files.append(
+                IaCFileResult(filename=file.filename, incidents=unignored_incidents)
+            )
+    return unignored_files

--- a/ggshield/verticals/iac/collection/iac_diff_scan_collection.py
+++ b/ggshield/verticals/iac/collection/iac_diff_scan_collection.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
-from pygitguardian.iac_models import IaCDiffScanResult
+from pygitguardian.iac_models import IaCDiffScanEntities, IaCDiffScanResult
 
+from ggshield.verticals.iac.collection.filter_ignored import filter_unignored_files
 from ggshield.verticals.iac.collection.iac_scan_collection import (
     CollectionType,
     IaCScanCollection,
@@ -15,3 +16,26 @@ class IaCDiffScanCollection(IaCScanCollection):
     @property
     def has_results(self) -> bool:
         return self.result is not None and bool(self.result.entities_with_incidents.new)
+
+    def get_entities_without_ignored(self) -> Optional[IaCDiffScanEntities]:
+        if self.result is None:
+            return None
+
+        return IaCDiffScanEntities(
+            new=filter_unignored_files(self.result.entities_with_incidents.new),
+            unchanged=filter_unignored_files(
+                self.result.entities_with_incidents.unchanged
+            ),
+            deleted=filter_unignored_files(self.result.entities_with_incidents.deleted),
+        )
+
+    def get_result_without_ignored(self) -> Optional[IaCDiffScanResult]:
+        entities_without_ignored = self.get_entities_without_ignored()
+        if self.result is None or entities_without_ignored is None:
+            return None
+
+        result_dict = self.result.to_dict()
+        del result_dict["entities_with_incidents"]
+        return IaCDiffScanResult(
+            **result_dict, entities_with_incidents=entities_without_ignored
+        )

--- a/ggshield/verticals/iac/collection/iac_path_scan_collection.py
+++ b/ggshield/verticals/iac/collection/iac_path_scan_collection.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import List, Optional
 
-from pygitguardian.iac_models import IaCScanResult
+from pygitguardian.iac_models import IaCFileResult, IaCScanResult
 
+from ggshield.verticals.iac.collection.filter_ignored import filter_unignored_files
 from ggshield.verticals.iac.collection.iac_scan_collection import (
     CollectionType,
     IaCScanCollection,
@@ -15,3 +16,20 @@ class IaCPathScanCollection(IaCScanCollection):
     @property
     def has_results(self) -> bool:
         return self.result is not None and bool(self.result.entities_with_incidents)
+
+    def get_entities_without_ignored(self) -> Optional[List[IaCFileResult]]:
+        if self.result is None:
+            return None
+
+        return filter_unignored_files(self.result.entities_with_incidents)
+
+    def get_result_without_ignored(self) -> Optional[IaCScanResult]:
+        entities_without_ignored = self.get_entities_without_ignored()
+        if self.result is None or entities_without_ignored is None:
+            return None
+
+        result_dict = self.result.to_dict()
+        del result_dict["entities_with_incidents"]
+        return IaCScanResult(
+            **result_dict, entities_with_incidents=entities_without_ignored
+        )

--- a/ggshield/verticals/iac/collection/iac_scan_collection.py
+++ b/ggshield/verticals/iac/collection/iac_scan_collection.py
@@ -1,8 +1,13 @@
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional, Union
+from typing import List, Optional, Union
 
-from pygitguardian.iac_models import IaCDiffScanResult, IaCScanResult
+from pygitguardian.iac_models import (
+    IaCDiffScanEntities,
+    IaCDiffScanResult,
+    IaCFileResult,
+    IaCScanResult,
+)
 
 
 IaCResult = Union[IaCScanResult, IaCDiffScanResult]
@@ -28,9 +33,30 @@ class IaCScanCollection(ABC):
         self.id = id
         self.result = result
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def has_results(self) -> bool:
         """
         Whether the scan found problems
         """
-        return self.result is not None
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_entities_without_ignored(
+        self,
+    ) -> Optional[Union[List[IaCFileResult], IaCDiffScanEntities]]:
+        """
+        Removes vulnerabilities marked as ignored.
+        Removes files that only have ignored vulnerabilities.
+        Returns file list.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_result_without_ignored(self) -> Optional[IaCResult]:
+        """
+        Removes vulnerabilities marked as ignored.
+        Removes files that only have ignored vulnerabilities.
+        Returns result object
+        """
+        raise NotImplementedError()

--- a/ggshield/verticals/iac/output/iac_json_output_handler.py
+++ b/ggshield/verticals/iac/output/iac_json_output_handler.py
@@ -32,14 +32,15 @@ class IaCJSONOutputHandler(IaCOutputHandler):
 
     @staticmethod
     def create_scan_dict(scan: IaCPathScanCollection) -> Dict[str, Any]:
-        if scan.result is None:
+        result_without_ignored = scan.get_result_without_ignored()
+        if result_without_ignored is None:
             return {
                 "id": scan.id,
                 "type": scan.type.value,
                 "total_incidents": 0,
                 "entities_with_incidents": [],
             }
-        scan_dict = scan.result.to_dict()
+        scan_dict = result_without_ignored.to_dict()
         scan_dict["total_incidents"] = 0
 
         for entity in scan_dict["entities_with_incidents"]:
@@ -51,7 +52,8 @@ class IaCJSONOutputHandler(IaCOutputHandler):
 
     @staticmethod
     def create_diff_scan_dict(scan: IaCDiffScanCollection) -> Dict[str, Any]:
-        if scan.result is None:
+        result_without_ignored = scan.get_result_without_ignored()
+        if result_without_ignored is None:
             return {
                 "id": scan.id,
                 "type": scan.type.value,
@@ -62,7 +64,7 @@ class IaCJSONOutputHandler(IaCOutputHandler):
                     "deleted": [],
                 },
             }
-        scan_dict = scan.result.to_dict()
+        scan_dict = result_without_ignored.to_dict()
 
         for category in scan_dict["entities_with_incidents"]:
             for file_result in scan_dict["entities_with_incidents"][category]:

--- a/ggshield/verticals/iac/output/iac_output_handler.py
+++ b/ggshield/verticals/iac/output/iac_output_handler.py
@@ -4,6 +4,7 @@ from typing import Optional
 import click
 
 from ggshield.core.errors import ExitCode
+from ggshield.core.text_utils import display_warning
 from ggshield.verticals.iac.collection.iac_diff_scan_collection import (
     IaCDiffScanCollection,
 )
@@ -120,6 +121,12 @@ class IaCOutputHandler(ABC):
     def _handle_process_scan_result(
         self, scan: IaCScanCollection, text: str
     ) -> ExitCode:
+        source_found = scan.result is not None and scan.result.source_found
+        if self.verbose and not source_found:
+            display_warning(
+                "ggshield cannot fetch incidents monitored by the platform on this repository"
+            )
+
         if self.output:
             with open(self.output, "w+") as f:
                 f.write(text)

--- a/ggshield/verticals/iac/output/schemas.py
+++ b/ggshield/verticals/iac/output/schemas.py
@@ -1,21 +1,10 @@
-from dataclasses import dataclass, field
-from typing import List, Type, cast
-
-import marshmallow_dataclass
 from marshmallow import fields
 from pygitguardian.iac_models import (
-    IaCDiffScanEntities,
-    IaCDiffScanResult,
-    IaCFileResult,
+    IaCDiffScanResultSchema,
     IaCFileResultSchema,
     IaCScanResultSchema,
 )
-from pygitguardian.models import BaseSchema
-
-
-@dataclass
-class IaCJSONFileResult(IaCFileResult):
-    total_incidents: int
+from pygitguardian.models import BaseSchema, FromDictMixin
 
 
 class IaCJSONFileResultSchema(IaCFileResultSchema):
@@ -27,22 +16,11 @@ class IaCJSONScanResultSchema(IaCScanResultSchema):
     total_incidents = fields.Integer(dump_default=0)
 
 
-@dataclass
-class IaCJSONScanDiffEntities(IaCDiffScanEntities):
-    unchanged: List[IaCJSONFileResult] = field(default_factory=list)
-    new: List[IaCJSONFileResult] = field(default_factory=list)
-    deleted: List[IaCJSONFileResult] = field(default_factory=list)
+class IaCJSONScanDiffEntitiesSchema(BaseSchema, FromDictMixin):
+    unchanged = fields.List(fields.Nested(IaCJSONFileResultSchema))
+    new = fields.List(fields.Nested(IaCJSONFileResultSchema))
+    deleted = fields.List(fields.Nested(IaCJSONFileResultSchema))
 
 
-@dataclass
-class IaCJSONScanDiffResult(IaCDiffScanResult):
-    entities_with_incidents: IaCJSONScanDiffEntities = field(
-        default_factory=IaCJSONScanDiffEntities
-    )
-
-
-IaCJSONScanDiffResultSchema = cast(
-    Type[BaseSchema],
-    marshmallow_dataclass.class_schema(IaCJSONScanDiffResult, BaseSchema),
-)
-IaCJSONScanDiffResult.SCHEMA = IaCJSONScanDiffResultSchema()
+class IaCJSONScanDiffResultSchema(IaCDiffScanResultSchema):
+    entities_with_incidents = fields.Nested(IaCJSONScanDiffEntitiesSchema)

--- a/ggshield/verticals/iac/output/schemas.py
+++ b/ggshield/verticals/iac/output/schemas.py
@@ -3,17 +3,27 @@ from pygitguardian.iac_models import (
     IaCDiffScanResultSchema,
     IaCFileResultSchema,
     IaCScanResultSchema,
+    IaCVulnerabilitySchema,
 )
 from pygitguardian.models import BaseSchema, FromDictMixin
 
 
+class IaCJSONVulnerabilitySchema(IaCVulnerabilitySchema):
+    class Meta:
+        exclude = ("url", "status", "ignored_until", "ignore_reason", "ignore_comment")
+
+
 class IaCJSONFileResultSchema(IaCFileResultSchema):
+    incidents = fields.List(fields.Nested(IaCJSONVulnerabilitySchema))
     total_incidents = fields.Integer(dump_default=0)
 
 
 class IaCJSONScanResultSchema(IaCScanResultSchema):
     entities_with_incidents = fields.List(fields.Nested(IaCJSONFileResultSchema))
     total_incidents = fields.Integer(dump_default=0)
+
+    class Meta:
+        exclude = ("source_found",)
 
 
 class IaCJSONScanDiffEntitiesSchema(BaseSchema, FromDictMixin):
@@ -24,3 +34,6 @@ class IaCJSONScanDiffEntitiesSchema(BaseSchema, FromDictMixin):
 
 class IaCJSONScanDiffResultSchema(IaCDiffScanResultSchema):
     entities_with_incidents = fields.Nested(IaCJSONScanDiffEntitiesSchema)
+
+    class Meta:
+        exclude = ("source_found",)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,9 @@ install_requires =
     marshmallow>=3.18.0,<3.19.0
     marshmallow-dataclass>=8.5.8,<8.6.0
     oauthlib>=3.2.1,<3.3.0
-    pygitguardian>=1.11.0,<1.12.0
+    # TODO: replace this with a real version number as soon as a new version of
+    # py-gitguardian is out
+    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@675d6d3d363bb766437b1d88f8d927a0d090e575
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1

--- a/tests/unit/verticals/iac/collection/test_filter_ignored.py
+++ b/tests/unit/verticals/iac/collection/test_filter_ignored.py
@@ -1,0 +1,143 @@
+from typing import List
+
+import pytest
+from pygitguardian.iac_models import IaCFileResult, IaCVulnerability
+
+from ggshield.verticals.iac.collection.filter_ignored import (
+    filter_unignored_files,
+    filter_unignored_incidents,
+)
+
+
+BASE_VULN_INFO = {
+    "policy": "A policy",
+    "line_end": 3,
+    "line_start": 1,
+    "description": "A policy description",
+    "documentation_url": "https://docs.gitguardian.com/iac-security/policies/GG_IAC_0001",
+    "component": "vuln-component",
+    "severity": "HIGH",
+}
+
+
+@pytest.fixture
+def ignored_vulns() -> List[IaCVulnerability]:
+    return [
+        IaCVulnerability.from_dict(
+            {
+                **BASE_VULN_INFO,
+                "status": "IGNORED",
+                **additional_info,
+            }
+        )
+        for additional_info in (
+            {"policy_id": "GG_IAC_0001"},
+            {"policy_id": "GG_IAC_0002", "ignore_reason": "ggshield"},
+            {
+                "policy_id": "GG_IAC_0003",
+                "url": "https://github.com/owner/repo/path",
+                "ignored_until": "2020-01-01T00:00:00",
+                "ignore_reason": "some reason",
+                "ignore_comment": "some comment",
+            },
+        )
+    ]
+
+
+@pytest.fixture
+def non_ignored_vulns() -> List[IaCVulnerability]:
+    return [
+        IaCVulnerability.from_dict(
+            {
+                **BASE_VULN_INFO,
+                **additional_info,
+            }
+        )
+        for additional_info in (
+            {"policy_id": "GG_IAC_1001"},
+            {"policy_id": "GG_IAC_1002", "status": "TRIGGERED"},
+            {"policy_id": "GG_IAC_1003", "url": "https://github.com/owner/repo/path"},
+        )
+    ]
+
+
+def test_filter_unignored_incidents(
+    ignored_vulns: List[IaCVulnerability], non_ignored_vulns: List[IaCVulnerability]
+):
+    """
+    GIVEN   a list of incidents
+    WHEN    calling filter_unignored_incidents
+    THEN    only non ignored incidents are returned
+    """
+    expected_gg_ids = [vuln.policy_id for vuln in non_ignored_vulns]
+    found_gg_ids = [
+        vuln.policy_id
+        for vuln in filter_unignored_incidents([*ignored_vulns, *non_ignored_vulns])
+    ]
+    assert expected_gg_ids == found_gg_ids
+
+
+def test_filter_unignored_files(
+    ignored_vulns: List[IaCVulnerability], non_ignored_vulns: List[IaCVulnerability]
+):
+    """
+    GIVEN   a list of file results with one ignored and one unignored vulns
+    WHEN    calling filter_unignored_files
+    THEN    only non ignored incidents in files are returned
+    """
+    n_files = min(len(ignored_vulns), len(non_ignored_vulns))
+    files = [
+        IaCFileResult(
+            filename=f"file {i}",
+            incidents=[
+                ignored_vulns[i],
+                non_ignored_vulns[i],
+            ],
+        )
+        for i in range(n_files)
+    ]
+    expected_gg_ids = [vuln.policy_id for vuln in non_ignored_vulns]
+
+    found_files = filter_unignored_files(files)
+    for i in range(n_files):
+        assert [incident.policy_id for incident in found_files[i].incidents] == [
+            expected_gg_ids[i]
+        ]
+
+
+def test_filter_unignored_files_no_empty(
+    ignored_vulns: List[IaCVulnerability], non_ignored_vulns: List[IaCVulnerability]
+):
+    """
+    GIVEN   - a file result with only unignored vulns
+            - a file result with ignored and unignored
+            - a file result with only ignored vulns
+    WHEN    calling filter_unignored_files
+    THEN    the file with only ignored issues is removed
+    """
+    files = [
+        IaCFileResult(
+            filename="file 0",
+            incidents=[
+                non_ignored_vulns[0],
+                non_ignored_vulns[1],
+            ],
+        ),
+        IaCFileResult(
+            filename="file 1",
+            incidents=[
+                non_ignored_vulns[2],
+                ignored_vulns[0],
+            ],
+        ),
+        IaCFileResult(
+            filename="file 2",
+            incidents=[
+                ignored_vulns[1],
+                ignored_vulns[2],
+            ],
+        ),
+    ]
+
+    found_files = filter_unignored_files(files)
+    assert [file.filename for file in found_files] == ["file 0", "file 1"]

--- a/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
+++ b/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
@@ -77,3 +77,85 @@ def test_iac_diff_scan_collection_new_results() -> None:
         [generate_file_result_with_vulnerability()]
     )
     assert collection.has_results
+
+
+def test_iac_path_scan_collection_entities_without_ignored() -> None:
+    """
+    GIVEN an IaC path scan collection with some ignored vulns
+    THEN entities_without_ignored excludes ignored vulns
+    """
+    collection = generate_path_scan_collection(
+        [
+            generate_file_result_with_vulnerability(policy_id="GG_IAC_0001"),
+            generate_file_result_with_vulnerability(
+                policy_id="GG_IAC_0002", status="IGNORED"
+            ),
+        ]
+    )
+    entities_without_ignored = collection.get_entities_without_ignored()
+    assert len(entities_without_ignored) == 1
+    assert len(entities_without_ignored[0].incidents) == 1
+    assert entities_without_ignored[0].incidents[0].policy_id == "GG_IAC_0001"
+
+
+def test_iac_diff_scan_collection_entities_without_ignored() -> None:
+    """
+    GIVEN an IaC diff scan collection with some ignored vulns
+    THEN entities_without_ignored excludes ignored vulns
+    """
+    collection = generate_diff_scan_collection(
+        [
+            generate_file_result_with_vulnerability(policy_id="GG_IAC_0001"),
+            generate_file_result_with_vulnerability(
+                policy_id="GG_IAC_0002", status="IGNORED"
+            ),
+        ]
+    )
+    entities_without_ignored = collection.get_entities_without_ignored()
+    assert len(entities_without_ignored.new) == 1
+    assert len(entities_without_ignored.new[0].incidents) == 1
+    assert entities_without_ignored.new[0].incidents[0].policy_id == "GG_IAC_0001"
+
+
+def test_iac_path_scan_collection_result_without_ignored() -> None:
+    """
+    GIVEN an IaC path scan collection with some ignored vulns
+    THEN result_without_ignored excludes ignored vulns
+    """
+    collection = generate_path_scan_collection(
+        [
+            generate_file_result_with_vulnerability(policy_id="GG_IAC_0001"),
+            generate_file_result_with_vulnerability(
+                policy_id="GG_IAC_0002", status="IGNORED"
+            ),
+        ]
+    )
+    result_without_ignored = collection.get_result_without_ignored()
+    assert len(result_without_ignored.entities_with_incidents) == 1
+    assert len(result_without_ignored.entities_with_incidents[0].incidents) == 1
+    assert (
+        result_without_ignored.entities_with_incidents[0].incidents[0].policy_id
+        == "GG_IAC_0001"
+    )
+
+
+def test_iac_diff_scan_collection_result_without_ignored() -> None:
+    """
+    GIVEN an IaC diff scan collection with some ignored vulns
+    THEN result_without_ignored excludes ignored vulns
+    """
+    collection = generate_diff_scan_collection(
+        [
+            generate_file_result_with_vulnerability(policy_id="GG_IAC_0001"),
+            generate_file_result_with_vulnerability(
+                policy_id="GG_IAC_0002", status="IGNORED"
+            ),
+        ]
+    )
+    result_without_ignored = collection.get_result_without_ignored()
+    assert len(result_without_ignored.entities_with_incidents.new) == 1
+    assert len(result_without_ignored.entities_with_incidents.new[0].incidents) == 1
+    assert (
+        result_without_ignored.entities_with_incidents.new[0].incidents[0].policy_id
+        == "GG_IAC_0001"
+    )

--- a/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
+++ b/tests/unit/verticals/iac/collection/test_iac_scan_collection.py
@@ -1,73 +1,21 @@
 import pytest
-from pygitguardian.iac_models import (
-    IaCDiffScanEntities,
-    IaCDiffScanResult,
-    IaCFileResult,
-    IaCScanResult,
-    IaCVulnerability,
-)
 
-from ggshield.verticals.iac.collection.iac_diff_scan_collection import (
-    IaCDiffScanCollection,
-)
-from ggshield.verticals.iac.collection.iac_path_scan_collection import (
-    IaCPathScanCollection,
-)
 from ggshield.verticals.iac.collection.iac_scan_collection import (
     CollectionType,
     IaCScanCollection,
 )
-
-
-def _generate_empty_path_collection() -> IaCPathScanCollection:
-    return IaCPathScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
-        IaCScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
-            type="path_scan",
-            iac_engine_version="1.8.0",
-            entities_with_incidents=[],
-        ),
-    )
-
-
-def _generate_empty_diff_collection() -> IaCDiffScanCollection:
-    return IaCDiffScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
-        IaCDiffScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
-            type="diff_scan",
-            iac_engine_version="1.8.0",
-            entities_with_incidents=IaCDiffScanEntities(
-                unchanged=[], deleted=[], new=[]
-            ),
-        ),
-    )
-
-
-def _generate_file_result_with_vulnerability() -> IaCFileResult:
-    return IaCFileResult(
-        "a.py",
-        [
-            IaCVulnerability(
-                policy="Leaving public access open exposes your service to the internet",
-                policy_id="GG_IAC_0024",
-                line_end=35,
-                line_start=1,
-                description="The API server of an AKS cluster [...]",
-                documentation_url="https://docs.gitguardian.com/iac-security/policies/GG_IAC_0024",
-                component="azurerm_kubernetes_cluster.k8s_cluster",
-                severity="HIGH",
-            )
-        ],
-    )
+from tests.unit.verticals.iac.utils import (
+    generate_diff_scan_collection,
+    generate_file_result_with_vulnerability,
+    generate_path_scan_collection,
+)
 
 
 @pytest.mark.parametrize(
     "collection,expected_type",
     [
-        (_generate_empty_path_collection(), CollectionType.PathScan),
-        (_generate_empty_diff_collection(), CollectionType.DiffScan),
+        (generate_path_scan_collection([]), CollectionType.PathScan),
+        (generate_diff_scan_collection([]), CollectionType.DiffScan),
     ],
 )
 def test_iac_path_scan_collection_type(
@@ -83,8 +31,8 @@ def test_iac_path_scan_collection_type(
 @pytest.mark.parametrize(
     "collection",
     [
-        _generate_empty_path_collection(),
-        _generate_empty_diff_collection(),
+        generate_path_scan_collection([]),
+        generate_diff_scan_collection([]),
     ],
 )
 def test_iac_scan_collection_has_no_results(collection: IaCScanCollection) -> None:
@@ -101,14 +49,8 @@ def test_iac_path_scan_collection_has_results() -> None:
     THEN has_results returns True
     """
 
-    collection = IaCPathScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
-        IaCScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
-            type="path_scan",
-            iac_engine_version="1.8.0",
-            entities_with_incidents=[_generate_file_result_with_vulnerability()],
-        ),
+    collection = generate_path_scan_collection(
+        [generate_file_result_with_vulnerability()]
     )
     assert collection.has_results
 
@@ -118,18 +60,10 @@ def test_iac_diff_scan_collection_no_new_results() -> None:
     GIVEN an IaC diff scan collection with some results in unchanged/deleted only
     THEN has_results returns False
     """
-    collection = IaCDiffScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
-        IaCDiffScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
-            type="diffscan",
-            iac_engine_version="1.8.0",
-            entities_with_incidents=IaCDiffScanEntities(
-                unchanged=[_generate_file_result_with_vulnerability()],
-                deleted=[_generate_file_result_with_vulnerability()],
-                new=[],
-            ),
-        ),
+    collection = generate_diff_scan_collection(
+        unchanged=[generate_file_result_with_vulnerability()],
+        deleted=[generate_file_result_with_vulnerability()],
+        new=[],
     )
     assert not collection.has_results
 
@@ -139,17 +73,7 @@ def test_iac_diff_scan_collection_new_results() -> None:
     GIVEN an IaC diff scan collection with some results in new
     THEN has_results returns True
     """
-    collection = IaCDiffScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
-        IaCDiffScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
-            type="diffscan",
-            iac_engine_version="1.8.0",
-            entities_with_incidents=IaCDiffScanEntities(
-                unchanged=[],
-                deleted=[],
-                new=[_generate_file_result_with_vulnerability()],
-            ),
-        ),
+    collection = generate_diff_scan_collection(
+        [generate_file_result_with_vulnerability()]
     )
     assert collection.has_results

--- a/tests/unit/verticals/iac/output/test_iac_json_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_json_output.py
@@ -3,17 +3,27 @@ import re
 from pathlib import Path
 from typing import Any, Dict
 
+import pytest
 import voluptuous.validators as validators
 from click.testing import CliRunner, Result
+from pygitguardian.iac_models import IaCFileResult
 from pytest_voluptuous import S
 
 from ggshield.__main__ import cli
+from ggshield.core.errors import ExitCode
+from ggshield.core.scan.scan_mode import ScanMode
+from ggshield.verticals.iac.output.iac_json_output_handler import IaCJSONOutputHandler
 from tests.conftest import (
     _IAC_MULTIPLE_VULNERABILITIES,
     _IAC_NO_VULNERABILITIES,
     _IAC_SINGLE_VULNERABILITY,
 )
 from tests.unit.conftest import my_vcr
+from tests.unit.verticals.iac.utils import (
+    generate_diff_scan_collection,
+    generate_path_scan_collection,
+    generate_vulnerability,
+)
 
 
 INCIDENT_SCHEMA = validators.Schema(
@@ -119,6 +129,88 @@ def test_display_multiple_files(cli_fs_runner: CliRunner):
     assert_iac_version_displayed(json_result, 3)
     assert_file_single_vulnerability_displayed(json_result)
     assert_file_multiple_vulnerabilities_displayed(json_result)
+
+
+@pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize("scan_type", [ScanMode.DIRECTORY_ALL, ScanMode.DIRECTORY_DIFF])
+def test_json_all_output_no_ignored(verbose: bool, scan_type: ScanMode, tmp_path: Path):
+    """
+    GIVEN   - a file result with ignored & unignored vulns
+            - a file result with only unignored vulns
+            - a file result with only ignored vulns
+    WHEN    showing scan output
+    THEN    ignored vulns are not shown
+    """
+    output_path = tmp_path / "output"
+
+    collection_factory_fn = (
+        generate_path_scan_collection
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else generate_diff_scan_collection
+    )
+    collection = collection_factory_fn(
+        [
+            IaCFileResult(
+                filename="iac_file_single_vulnerability.tf",
+                incidents=[
+                    generate_vulnerability(policy_id="GG_IAC_0001"),
+                    generate_vulnerability(status="IGNORED", policy_id="GG_IAC_0002"),
+                ],
+            ),
+            IaCFileResult(
+                filename="iac_file_multiple_vulnerabilities.tf",
+                incidents=[
+                    generate_vulnerability(policy_id="GG_IAC_0003"),
+                    generate_vulnerability(policy_id="GG_IAC_0004"),
+                ],
+            ),
+            IaCFileResult(
+                filename="iac_file_no_vulnerabilities.tf",
+                incidents=[
+                    generate_vulnerability(status="IGNORED", policy_id="GG_IAC_0005"),
+                    generate_vulnerability(status="IGNORED", policy_id="GG_IAC_0006"),
+                ],
+            ),
+        ]
+    )
+
+    output_handler = IaCJSONOutputHandler(verbose=verbose, output=str(output_path))
+    process_fn = (
+        output_handler.process_scan
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else output_handler.process_diff_scan
+    )
+    exit_code = process_fn(collection)
+
+    assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
+
+    output = json.loads(output_path.read_text())
+    assert not hasattr(output, "scan_found")
+    entities = (
+        output["entities_with_incidents"]
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else output["entities_with_incidents"]["new"]
+    )
+    assert len(entities) == 2
+    summary = [
+        {
+            "filename": entity["filename"],
+            "policy_ids": [incident["policy_id"] for incident in entity["incidents"]],
+        }
+        for entity in entities
+    ]
+    assert str(summary) == str(
+        [
+            {
+                "filename": "iac_file_single_vulnerability.tf",
+                "policy_ids": ["GG_IAC_0001"],
+            },
+            {
+                "filename": "iac_file_multiple_vulnerabilities.tf",
+                "policy_ids": ["GG_IAC_0003", "GG_IAC_0004"],
+            },
+        ]
+    )
 
 
 def load_json(result: Result) -> Dict[str, Any]:

--- a/tests/unit/verticals/iac/output/test_iac_output.py
+++ b/tests/unit/verticals/iac/output/test_iac_output.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from typing import Any, Type
+
+import pytest
+
+from ggshield.core.errors import ExitCode
+from ggshield.core.scan.scan_mode import ScanMode
+from ggshield.verticals.iac.output.iac_json_output_handler import IaCJSONOutputHandler
+from ggshield.verticals.iac.output.iac_output_handler import IaCOutputHandler
+from ggshield.verticals.iac.output.iac_text_output_handler import IaCTextOutputHandler
+from tests.unit.verticals.iac.utils import (
+    generate_diff_scan_collection,
+    generate_file_result_with_vulnerability,
+    generate_path_scan_collection,
+)
+
+
+@pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize("source_found", [True, False])
+@pytest.mark.parametrize("handler_cls", [IaCTextOutputHandler, IaCJSONOutputHandler])
+@pytest.mark.parametrize("scan_type", [ScanMode.DIRECTORY_ALL, ScanMode.DIRECTORY_DIFF])
+def test_iac_output_no_source_warning(
+    verbose: bool,
+    source_found: bool,
+    handler_cls: Type[IaCOutputHandler],
+    scan_type: ScanMode,
+    tmp_path: Path,
+    capsys: Any,
+):
+    """
+    GIVEN   a scan result
+    WHEN    showing scan output
+    THEN    a warning is shown in verbose mode if the source was not linked
+    """
+    output_path = tmp_path / "output"
+
+    collection_factory_fn = (
+        generate_path_scan_collection
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else generate_diff_scan_collection
+    )
+    collection = collection_factory_fn(
+        [generate_file_result_with_vulnerability()],
+        source_found=source_found,
+    )
+
+    output_handler = handler_cls(verbose=verbose, output=str(output_path))
+    process_fn = (
+        output_handler.process_scan
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else output_handler.process_diff_scan
+    )
+    exit_code = process_fn(collection)
+
+    assert exit_code == ExitCode.SCAN_FOUND_PROBLEMS
+
+    captured = capsys.readouterr().err
+    is_warning_expected = verbose and not source_found
+    warning_text = (
+        "ggshield cannot fetch incidents monitored by the platform on this repository"
+    )
+    assert (warning_text in captured) == is_warning_expected

--- a/tests/unit/verticals/iac/utils.py
+++ b/tests/unit/verticals/iac/utils.py
@@ -1,0 +1,71 @@
+from typing import List, Optional
+
+from pygitguardian.iac_models import (
+    IaCDiffScanEntities,
+    IaCDiffScanResult,
+    IaCFileResult,
+    IaCScanResult,
+    IaCVulnerability,
+)
+
+from ggshield.verticals.iac.collection.iac_diff_scan_collection import (
+    IaCDiffScanCollection,
+)
+from ggshield.verticals.iac.collection.iac_path_scan_collection import (
+    IaCPathScanCollection,
+)
+
+
+def generate_file_result_with_vulnerability(
+    filename: str = "file.py",
+    policy_id: Optional[str] = "GG_IAC_0024",
+    status: Optional[str] = None,
+) -> IaCFileResult:
+    return IaCFileResult(
+        filename,
+        [
+            IaCVulnerability(
+                policy="Leaving public access open exposes your service to the internet",
+                policy_id=policy_id,
+                line_end=35,
+                line_start=1,
+                description="The API server of an AKS cluster [...]",
+                documentation_url="https://docs.gitguardian.com/iac-security/policies/GG_IAC_0024",
+                component="azurerm_kubernetes_cluster.k8s_cluster",
+                severity="HIGH",
+                status=status,
+            )
+        ],
+    )
+
+
+def generate_path_scan_collection(file_results: List[IaCFileResult]):
+    return IaCPathScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="path_scan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=file_results,
+        ),
+    )
+
+
+def generate_diff_scan_collection(
+    new: List[IaCFileResult],
+    unchanged: List[IaCFileResult] = [],
+    deleted: List[IaCFileResult] = [],
+):
+    return IaCDiffScanCollection(
+        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        IaCDiffScanResult(
+            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            type="diff_scan",
+            iac_engine_version="1.8.0",
+            entities_with_incidents=IaCDiffScanEntities(
+                unchanged=unchanged,
+                deleted=deleted,
+                new=new,
+            ),
+        ),
+    )

--- a/tests/unit/verticals/iac/utils.py
+++ b/tests/unit/verticals/iac/utils.py
@@ -16,34 +16,39 @@ from ggshield.verticals.iac.collection.iac_path_scan_collection import (
 )
 
 
+def generate_vulnerability(
+    policy_id: Optional[str] = "GG_IAC_0024",
+    status: Optional[str] = None,
+) -> IaCVulnerability:
+    return IaCVulnerability(
+        policy="Leaving public access open exposes your service to the internet",
+        policy_id=policy_id,
+        line_end=35,
+        line_start=1,
+        description="The API server of an AKS cluster [...]",
+        documentation_url=f"https://docs.gitguardian.com/iac-security/policies/{policy_id}",
+        component="azurerm_kubernetes_cluster.k8s_cluster",
+        severity="HIGH",
+        status=status,
+    )
+
+
 def generate_file_result_with_vulnerability(
-    filename: str = "file.py",
+    filename: str = "file.tf",
     policy_id: Optional[str] = "GG_IAC_0024",
     status: Optional[str] = None,
 ) -> IaCFileResult:
     return IaCFileResult(
         filename,
-        [
-            IaCVulnerability(
-                policy="Leaving public access open exposes your service to the internet",
-                policy_id=policy_id,
-                line_end=35,
-                line_start=1,
-                description="The API server of an AKS cluster [...]",
-                documentation_url="https://docs.gitguardian.com/iac-security/policies/GG_IAC_0024",
-                component="azurerm_kubernetes_cluster.k8s_cluster",
-                severity="HIGH",
-                status=status,
-            )
-        ],
+        [generate_vulnerability(policy_id, status)],
     )
 
 
 def generate_path_scan_collection(file_results: List[IaCFileResult]):
     return IaCPathScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        ".",
         IaCScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            id=".",
             type="path_scan",
             iac_engine_version="1.8.0",
             entities_with_incidents=file_results,
@@ -57,9 +62,9 @@ def generate_diff_scan_collection(
     deleted: List[IaCFileResult] = [],
 ):
     return IaCDiffScanCollection(
-        "3ac2985e-dcf9-49ff-92fb-943548268de8",
+        ".",
         IaCDiffScanResult(
-            id="3ac2985e-dcf9-49ff-92fb-943548268de8",
+            id=".",
             type="diff_scan",
             iac_engine_version="1.8.0",
             entities_with_incidents=IaCDiffScanEntities(

--- a/tests/unit/verticals/iac/utils.py
+++ b/tests/unit/verticals/iac/utils.py
@@ -44,12 +44,15 @@ def generate_file_result_with_vulnerability(
     )
 
 
-def generate_path_scan_collection(file_results: List[IaCFileResult]):
+def generate_path_scan_collection(
+    file_results: List[IaCFileResult], source_found: bool = True
+):
     return IaCPathScanCollection(
         ".",
         IaCScanResult(
             id=".",
             type="path_scan",
+            source_found=source_found,
             iac_engine_version="1.8.0",
             entities_with_incidents=file_results,
         ),
@@ -60,12 +63,14 @@ def generate_diff_scan_collection(
     new: List[IaCFileResult],
     unchanged: List[IaCFileResult] = [],
     deleted: List[IaCFileResult] = [],
+    source_found: bool = True,
 ):
     return IaCDiffScanCollection(
         ".",
         IaCDiffScanResult(
             id=".",
             type="diff_scan",
+            source_found=source_found,
             iac_engine_version="1.8.0",
             entities_with_incidents=IaCDiffScanEntities(
                 unchanged=unchanged,


### PR DESCRIPTION
The API now returns the status of each IaC incident on the GitGuardian app. We should use it to display only incidents that were not ignored on the app.

This applies to all IaC scan commands (all, diff, ci...) in all formats (text, JSON).

Depends on https://github.com/GitGuardian/py-gitguardian/pull/80

Commit 1 bumps the py-gitguardian version
Commits 2 and 3 contain some refactoring
Commit 4 is the main feature, described above
Commit 5 is a warning message in verbose mode when the source is not found by the API