### PR TITLE
Print name of what is being scanned when scanning with --verbose

### DIFF
--- a/changelog.d/20231120_192320_samuel.guillaume_scrt_3964_print_name_of_what_is_being_scanned_when_scanning_with.md
+++ b/changelog.d/20231120_192320_samuel.guillaume_scrt_3964_print_name_of_what_is_being_scanned_when_scanning_with.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+-->
+
+### Added
+
+- Print name of what is being scanned when scanning with --verbose
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -54,7 +54,9 @@ def archive_cmd(
             ignore_git=True,
         )
 
-        with RichSecretScannerUI(len(files), dataset_type="Archive") as ui:
+        with RichSecretScannerUI(
+            len(files), dataset_type="Archive", verbose=verbose
+        ) as ui:
             scan_context = ScanContext(
                 scan_mode=ScanMode.ARCHIVE,
                 command_path=ctx.command_path,

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -59,6 +59,7 @@ def docker_name_cmd(
             scan_context=scan_context,
             matches_ignore=config.user_config.secret.ignored_matches,
             ignored_detectors=config.user_config.secret.ignored_detectors,
+            verbose=config.user_config.verbose,
         )
 
         return output_handler.process_scan(scan)

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -59,7 +59,7 @@ def path_cmd(
 
     target = paths[0] if len(paths) == 1 else Path.cwd()
     target_path = target if target.is_dir() else target.parent
-    with RichSecretScannerUI(len(files), dataset_type="Path") as ui:
+    with RichSecretScannerUI(len(files), dataset_type="Path", verbose=verbose) as ui:
         scan_context = ScanContext(
             scan_mode=ScanMode.PATH,
             command_path=ctx.command_path,

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -106,6 +106,7 @@ def pypi_cmd(
     """
     config: Config = ctx.obj["config"]
     output_handler = create_output_handler(ctx)
+    verbose = config.user_config.verbose
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temp_dir:
         temp_path = Path(temp_dir)
@@ -118,7 +119,9 @@ def pypi_cmd(
             verbose=config.user_config.verbose,
         )
 
-        with RichSecretScannerUI(len(files), dataset_type="PyPI Package") as ui:
+        with RichSecretScannerUI(
+            len(files), dataset_type="PyPI Package", verbose=verbose
+        ) as ui:
             scan_context = ScanContext(
                 scan_mode=ScanMode.PYPI,
                 command_path=ctx.command_path,

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -54,4 +54,5 @@ def range_cmd(
         matches_ignore=config.user_config.secret.ignored_matches,
         scan_context=scan_context,
         ignored_detectors=config.user_config.secret.ignored_detectors,
+        verbose=config.user_config.verbose,
     )

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -333,6 +333,7 @@ def docker_scan_archive(
     matches_ignore: Iterable[IgnoredMatch],
     scan_context: ScanContext,
     ignored_detectors: Optional[Set[str]] = None,
+    verbose: bool = False,
 ) -> SecretScanCollection:
     scanner = SecretScanner(
         client=client,
@@ -346,7 +347,6 @@ def docker_scan_archive(
     layer_id_cache = _get_layer_id_cache(secrets_engine_version)
 
     with DockerImage.open(archive_path) as docker_image:
-
         display_heading("Scanning Docker config")
         with RichSecretScannerUI(1) as ui:
             results = scanner.scan([docker_image.config_scannable], scanner_ui=ui)

--- a/ggshield/verticals/secret/rich_secret_scanner_ui.py
+++ b/ggshield/verticals/secret/rich_secret_scanner_ui.py
@@ -13,11 +13,16 @@ class RichSecretScannerUI(SecretScannerUI):
     """
 
     def __init__(
-        self, total: int, dataset_type: str = "", scannable_type: str = "files"
+        self,
+        total: int,
+        dataset_type: str = "",
+        scannable_type: str = "files",
+        verbose: bool = False,
     ):
         self.progress = create_progress_bar(scannable_type)
         task_title = f"Scanning {dataset_type}..." if dataset_type else "Scanning..."
         self.task = self.progress.add_task(task_title, total=total)
+        self.verbose = verbose
 
     def __enter__(self) -> "RichSecretScannerUI":
         self.progress.__enter__()
@@ -27,6 +32,9 @@ class RichSecretScannerUI(SecretScannerUI):
         self.progress.__exit__(*args)
 
     def on_scanned(self, scannables: Sequence[Scannable]) -> None:
+        if self.verbose:
+            for scannable in scannables:
+                self.progress.console.print(f"Scanned {scannable.path}")
         self.progress.advance(self.task, len(scannables))
 
     def on_skipped(self, scannable: Scannable, reason: str) -> None:

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -139,6 +139,7 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
         matches_ignore=[],
         scan_context=MagicMock(),
         progress_callback=(lambda advance: None),
+        commit_scanned_callback=(lambda commit: None),
     )
 
     assert len(scan_collection.scans) == 2
@@ -217,6 +218,7 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
         matches_ignore=[],
         scan_context=MagicMock(),
         progress_callback=(lambda advance: None),
+        commit_scanned_callback=(lambda commit: None),
     )
 
     assert len(scan_collection.scans) == 2


### PR DESCRIPTION
Closes #212 

When using `--verbose` additional logs are printed per element scan: `Scanned {name of the element}`:
- `scan path`, `scan archive` and `scan pypi` print the filenames
- `scan repo` and `scan commit-range` print the commit ids
- `scan docker` keep the same behavior and print the name of the layers

