### PR TITLE
Fix Gitlab commit range selection for merged results pipelines

### DIFF
--- a/changelog.d/20231121_154005_paul.beslin.ext_fix_commit_selection_merged_results_gitlab.md
+++ b/changelog.d/20231121_154005_paul.beslin.ext_fix_commit_selection_merged_results_gitlab.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Scans in merged results Gitlab pipelines should now be performed on the intended commit ranges, instead of an empty range.

--- a/ggshield/core/git_hooks/ci/previous_commit.py
+++ b/ggshield/core/git_hooks/ci/previous_commit.py
@@ -92,6 +92,7 @@ def github_pull_request_previous_commit_sha() -> Optional[str]:
 def gitlab_previous_commit_sha(verbose: bool) -> Optional[str]:
     push_before_sha = gitlab_push_previous_commit_sha()
     merge_req_base_sha = gitlab_merge_request_previous_commit_sha(verbose)
+    is_merge_req = bool(os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME"))
 
     if verbose:
         click.echo(
@@ -102,7 +103,7 @@ def gitlab_previous_commit_sha(verbose: bool) -> Optional[str]:
 
     # push_before_sha is always EMPTY_SHA in MR pipeline according with
     # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-    if push_before_sha == EMPTY_SHA and merge_req_base_sha:
+    if (push_before_sha == EMPTY_SHA or is_merge_req) and merge_req_base_sha:
         # Targeted branch is empty
         if merge_req_base_sha == EMPTY_SHA:
             return None


### PR DESCRIPTION
Gitlab provides "merged results pipelines" to run in merge requests, as an alternate behavior to the base MR pipelines.
However, env variables take unexpected values in these pipelines. Particularly, `CI_COMMIT_BEFORE_SHA` has a non-empty SHA, equal to the last commit pushed.
This results in empty commit ranges, meaning CI scans will not detect vulnerabilities in the MR commits.