### PR TITLE
feat(ignore): add output for no longer ignored incidents

### DIFF
--- a/changelog.d/20231128_134023_carla.martet.ext_update_output_after_end_of_grace_period.md
+++ b/changelog.d/20231128_134023_carla.martet.ext_update_output_after_end_of_grace_period.md
@@ -1,0 +1,3 @@
+### Added
+
+- Adapt ggshield's output when the grace period of an IAC incident ignored by a developer has been expired.

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -10,6 +10,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 )
 from ggshield.cmd.iac.scan.iac_scan_utils import (
     IaCSkipScanResult,
+    augment_unignored_issues,
     create_output_handler,
     handle_scan_error,
 )
@@ -51,6 +52,7 @@ def scan_all_cmd(
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
     result = iac_scan_all(ctx, directory, scan_mode=ScanMode.DIRECTORY_ALL)
+    augment_unignored_issues(ctx.obj["config"].user_config, result)
     return display_iac_scan_all_result(ctx, directory, result)
 
 

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -9,6 +9,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option, directory_argument
 from ggshield.cmd.utils.context_obj import ContextObj
@@ -50,6 +51,7 @@ def scan_ci_cmd(
         result = iac_scan_all(
             ctx, directory, scan_mode=ScanMode.CI_ALL, ci_mode=ci_mode
         )
+        augment_unignored_issues(ctx.obj["config"].user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
 
     current_commit, previous_commit = get_current_and_previous_state_from_ci_env(
@@ -65,4 +67,5 @@ def scan_ci_cmd(
         scan_mode=ScanMode.CI_DIFF,
         ci_mode=ci_mode,
     )
+    augment_unignored_issues(ctx.obj["config"].user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -10,6 +10,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 )
 from ggshield.cmd.iac.scan.iac_scan_utils import (
     IaCSkipScanResult,
+    augment_unignored_issues,
     create_output_handler,
     filter_iac_filepaths,
     get_git_filepaths,
@@ -76,6 +77,7 @@ def scan_diff_cmd(
     result = iac_scan_diff(
         ctx, directory, ref, staged, scan_mode=ScanMode.DIRECTORY_DIFF
     )
+    augment_unignored_issues(ctx.obj["config"].user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)
 
 

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -1,18 +1,22 @@
 from dataclasses import dataclass
 from pathlib import Path
 from re import Pattern
-from typing import Iterable, Optional, Set, Type
+from typing import Iterable, Optional, Set, Type, Union
 
 import click
 from pygitguardian import GGClient
+from pygitguardian.iac_models import IaCDiffScanResult, IaCScanResult
 from pygitguardian.models import Detail
 
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.config.user_config import UserConfig
 from ggshield.core.errors import APIKeyCheckError
+from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.tar_utils import INDEX_REF, tar_from_ref_and_filepaths
 from ggshield.core.text_utils import display_error
 from ggshield.utils.files import is_filepath_excluded
 from ggshield.utils.git_shell import get_filepaths_from_ref, get_staged_filepaths
+from ggshield.verticals.iac.collection.iac_scan_collection import IaCResult
 from ggshield.verticals.iac.filter import is_iac_file_path
 from ggshield.verticals.iac.output import (
     IaCJSONOutputHandler,
@@ -89,3 +93,64 @@ def get_iac_tar(directory: Path, ref: str, exclusion_regexes: Set[Pattern]) -> b
     )
 
     return tar_from_ref_and_filepaths(ref, filtered_paths, wd=str(directory))
+
+
+def augment_unignored_issues(
+    user_config: UserConfig,
+    result: Union[IaCResult, IaCSkipScanResult, None],
+) -> None:
+    """
+    GIVEN a list of vulnerabilities from a scan result
+    WHEN ignored policies and paths are configured but outdated
+    THEN augment the vulnerability with the date it was last ignored
+    """
+    if isinstance(result, IaCScanResult):
+        incidents_list = result.entities_with_incidents
+    elif isinstance(result, IaCDiffScanResult):
+        incidents_list = [
+            *result.entities_with_incidents.new,
+            *result.entities_with_incidents.unchanged,
+            *result.entities_with_incidents.deleted,
+        ]
+    else:
+        return
+    if len(incidents_list) == 0:
+        return
+    outdated_ignored_paths = user_config.iac.outdated_ignored_paths
+    outdated_ignored_policies = user_config.iac.outdated_ignored_policies
+    # Early return if there are no outdated configurations
+    if len(outdated_ignored_paths) == 0 and len(outdated_ignored_policies) == 0:
+        return
+    outdated_ignored_paths_dicts = [
+        {
+            "regex": init_exclusion_regexes({outdated_ignored_path.path}),
+            "until": outdated_ignored_path.until,
+        }
+        for outdated_ignored_path in outdated_ignored_paths
+    ]
+    outdated_ignored_policies_dict = {
+        outdated_policy.policy: outdated_policy.until
+        for outdated_policy in outdated_ignored_policies
+    }
+    # For each file and each vulnerability within
+    for file_result in incidents_list:
+        # Check if path was ignored
+        file_path = file_result.filename
+        file_ignored_until = None
+        for outdated_ignored_path in outdated_ignored_paths_dicts:
+            if is_filepath_excluded(file_path, outdated_ignored_path["regex"]):
+                if (
+                    file_ignored_until is None
+                    or file_ignored_until < outdated_ignored_path["until"]
+                ):
+                    file_ignored_until = outdated_ignored_path["until"]
+        for vulnerability in file_result.incidents:
+            # Check if policy was ignored
+            policy_ignored_until = outdated_ignored_policies_dict.get(
+                vulnerability.policy_id
+            )
+            until_dates = (policy_ignored_until, file_ignored_until)
+            # Augment vulnerability with the most recent ignored_until date
+            vulnerability.ignored_until = max(
+                (d for d in until_dates if d is not None), default=None
+            )

--- a/ggshield/cmd/iac/scan/precommit.py
+++ b/ggshield/cmd/iac/scan/precommit.py
@@ -9,6 +9,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option, directory_argument
 from ggshield.cmd.utils.hooks import check_user_requested_skip
@@ -51,8 +52,10 @@ def scan_pre_commit_cmd(
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
     if scan_all:
         result = iac_scan_all(ctx, directory, scan_mode=ScanMode.PRE_COMMIT_ALL)
+        augment_unignored_issues(ctx.obj["config"].user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
     result = iac_scan_diff(
         ctx, directory, "HEAD", include_staged=True, scan_mode=ScanMode.PRE_COMMIT_DIFF
     )
+    augment_unignored_issues(ctx.obj["config"].user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -9,6 +9,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
     add_iac_scan_common_options,
     update_context,
 )
+from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option
 from ggshield.cmd.utils.hooks import check_user_requested_skip
@@ -60,6 +61,7 @@ def scan_pre_push_cmd(
 
     if scan_all or has_no_remote_commit:
         result = iac_scan_all(ctx, directory, scan_mode=ScanMode.PRE_PUSH_ALL)
+        augment_unignored_issues(ctx.obj["config"].user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
     else:
         result = iac_scan_diff(
@@ -69,4 +71,5 @@ def scan_pre_push_cmd(
             include_staged=False,
             scan_mode=ScanMode.PRE_PUSH_DIFF,
         )
+        augment_unignored_issues(ctx.obj["config"].user_config, result)
         return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prereceive.py
+++ b/ggshield/cmd/iac/scan/prereceive.py
@@ -12,6 +12,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 )
 from ggshield.cmd.iac.scan.iac_scan_utils import (
     IaCSkipScanResult,
+    augment_unignored_issues,
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
@@ -98,6 +99,7 @@ def scan_pre_receive_cmd(
         current_ref=after,
         scan_mode=ScanMode.PRE_RECEIVE_ALL if scan_all else ScanMode.PRE_RECEIVE_DIFF,
     )
+    augment_unignored_issues(ctx.obj["config"].user_config, result)
 
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/verticals/iac/output/iac_text_output_handler.py
+++ b/ggshield/verticals/iac/output/iac_text_output_handler.py
@@ -1,5 +1,6 @@
 import shutil
 from collections import Counter, defaultdict
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 from typing import (
@@ -268,6 +269,10 @@ class IaCTextOutputHandler(IaCOutputHandler):
                         clip_long_lines=not self.verbose,
                     )
                 )
+            if vulnerability.ignored_until is not None:
+                result_buf.write(
+                    iac_vulnerability_end_of_ignored_period(vulnerability.ignored_until)
+                )
 
         return result_buf.getvalue()
 
@@ -314,6 +319,10 @@ class IaCTextOutputHandler(IaCOutputHandler):
                         self.nb_lines,
                         clip_long_lines=not self.verbose,
                     )
+                )
+            if vulnerability.ignored_until is not None:
+                result_buf.write(
+                    iac_vulnerability_end_of_ignored_period(vulnerability.ignored_until)
                 )
 
         return result_buf.getvalue()
@@ -395,6 +404,12 @@ def iac_vulnerability_location_failed(
     line_end: int,
 ) -> str:
     return f"\nThe incident was found between lines {line_start} and {line_end}\n"  # noqa: E501
+
+
+def iac_vulnerability_end_of_ignored_period(
+    ignored_until: datetime,
+) -> str:
+    return f"\nThe incident is no longer ignored in the scan since {ignored_until.strftime('%Y-%m-%d')}\n"  # noqa: E501
 
 
 def iac_engine_version(iac_engine_version: str) -> str:

--- a/tests/unit/cmd/iac/test_iac_scan_utils.py
+++ b/tests/unit/cmd/iac/test_iac_scan_utils.py
@@ -1,11 +1,23 @@
 import tarfile
+from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 
-from ggshield.cmd.iac.scan.iac_scan_utils import get_iac_tar
+import pytest
+from pygitguardian.iac_models import IaCFileResult
+
+from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues, get_iac_tar
+from ggshield.core.config.user_config import UserConfig
 from ggshield.core.filter import init_exclusion_regexes
+from ggshield.core.scan.scan_mode import ScanMode
 from tests.conftest import _IAC_SINGLE_VULNERABILITY
 from tests.repository import Repository
+from tests.unit.conftest import write_yaml
+from tests.unit.verticals.iac.utils import (
+    generate_diff_scan_collection,
+    generate_path_scan_collection,
+    generate_vulnerability,
+)
 
 
 def test_get_iac_tar(tmp_path: Path) -> None:
@@ -38,3 +50,94 @@ def test_get_iac_tar(tmp_path: Path) -> None:
         assert "file1.tf" not in names
         assert "file2.tf" not in names
         assert "file3.tf" in names
+
+
+@pytest.mark.parametrize("scan_type", [ScanMode.DIRECTORY_ALL, ScanMode.DIRECTORY_DIFF])
+def test_augment_unignored_issues(scan_type: ScanMode) -> None:
+    # GIVEN a config file with outdated ignore rules
+    config_path = "config.yaml"
+    date_format = "%Y-%m-%d %H:%M:%S"
+    date_2000 = "2000-01-01 00:00:00"
+    date_2000_utc = datetime.strptime(date_2000, date_format).astimezone(timezone.utc)
+    date_2005 = "2005-01-01 00:00:00"
+    date_2005_utc = datetime.strptime(date_2005, date_format).astimezone(timezone.utc)
+    date_2010 = "2010-01-01 00:00:00"
+    date_2010_utc = datetime.strptime(date_2010, date_format).astimezone(timezone.utc)
+    date_2015 = "2015-01-01 00:00:00"
+    date_2015_utc = datetime.strptime(date_2015, date_format).astimezone(timezone.utc)
+    config_data = {
+        "ignored_paths": [
+            {
+                "path": "ignored_path/*",
+                "until": date_2000,
+            },
+            {
+                "path": "**/ignored_iac_file.tf",
+                "until": date_2010,
+            },
+        ],
+        "ignored_policies": [
+            {
+                "policy": "GG_IAC_0001",
+                "until": date_2005,
+            },
+            {
+                "policy": "GG_IAC_0002",
+                "until": date_2015,
+            },
+        ],
+    }
+    write_yaml(
+        config_path,
+        {
+            "version": 2,
+            "iac": config_data,
+        },
+    )
+    config, _ = UserConfig.load(config_path)
+
+    # GIVEN files whose some vulnerabilities are affected by the outdated config rules
+    collection_factory_fn = (
+        generate_path_scan_collection
+        if scan_type == ScanMode.DIRECTORY_ALL
+        else generate_diff_scan_collection
+    )
+    scan_result = collection_factory_fn(
+        [
+            IaCFileResult(
+                filename=filename,
+                incidents=[
+                    generate_vulnerability(policy_id="GG_IAC_0001"),
+                    generate_vulnerability(policy_id="GG_IAC_0002"),
+                    generate_vulnerability(policy_id="GG_IAC_0003"),
+                ],
+            )
+            for filename in [
+                "ignored_path/ignored_iac_file.tf",
+                "ignored_path/iac_file.tf",
+                "path/iac_file.tf",
+            ]
+        ]
+    ).result
+
+    # WHEN augmenting issues with the outdated ignore rules
+    augment_unignored_issues(config, scan_result)
+
+    if scan_type == ScanMode.DIRECTORY_ALL:
+        files = scan_result.entities_with_incidents
+    else:
+        files = scan_result.entities_with_incidents.new
+
+    # THEN vulnerabilites are associated to the last date they were ignored
+    # # File ignored_path/ignored_iac_file.tf
+    assert files[0].incidents[0].ignored_until == date_2010_utc
+    assert files[0].incidents[1].ignored_until == date_2015_utc
+    assert files[0].incidents[2].ignored_until == date_2010_utc
+    # # File ignored_path/iac_file.tf
+    assert files[1].incidents[0].ignored_until == date_2005_utc
+    assert files[1].incidents[1].ignored_until == date_2015_utc
+    assert files[1].incidents[2].ignored_until == date_2000_utc
+    # # File path/iac_file.tf
+    assert files[2].incidents[0].ignored_until == date_2005_utc
+    assert files[2].incidents[1].ignored_until == date_2015_utc
+    assert files[2].incidents[2].ignored_until is None

--- a/tests/unit/verticals/iac/utils.py
+++ b/tests/unit/verticals/iac/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from pygitguardian.iac_models import (
@@ -19,6 +20,7 @@ from ggshield.verticals.iac.collection.iac_path_scan_collection import (
 def generate_vulnerability(
     policy_id: Optional[str] = "GG_IAC_0024",
     status: Optional[str] = None,
+    ignored_until: Optional[datetime] = None,
 ) -> IaCVulnerability:
     return IaCVulnerability(
         policy="Leaving public access open exposes your service to the internet",
@@ -30,6 +32,7 @@ def generate_vulnerability(
         component="azurerm_kubernetes_cluster.k8s_cluster",
         severity="HIGH",
         status=status,
+        ignored_until=ignored_until,
     )
 
 


### PR DESCRIPTION
Adapt ggshield's output when the grace period of an IAC incident ignored by a developer has been expired, for both all and diff scans.