### PR TITLE
fix: fix gitlab push pipelines for new branches

### DIFF
--- a/changelog.d/20231201_155919_paul.beslin.ext_gitlab_ci_new_branch.md
+++ b/changelog.d/20231201_155919_paul.beslin.ext_gitlab_ci_new_branch.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- IAC/SCA scans now properly find the parent commit sha on Gitlab push pipelines for new branches.

--- a/tests/functional/iac/test_iac_scan_ci.py
+++ b/tests/functional/iac/test_iac_scan_ci.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+from ggshield.utils.git_shell import EMPTY_SHA
 from tests.conftest import _IAC_SINGLE_VULNERABILITY
 from tests.functional.utils import run_ggshield_iac_scan
 from tests.repository import Repository
@@ -96,3 +97,67 @@ def test_gitlab_previous_commit_sha_for_merged_results_pipelines(
     assert "ignored_file.tf" not in result.stdout
     assert "scanned_file.tf" in result.stdout
     assert "[+] 1 new incident detected (HIGH: 1)" in result.stdout
+
+
+def test_gitlab_new_branch(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repository = Repository.create(tmp_path / "remote", bare=True)
+    # AND a local clone with a vulnerability on the same branch
+    repository = Repository.clone(remote_repository.path, tmp_path / "local")
+    ignored_file = repository.path / "ignored_file.tf"
+    ignored_file.write_text(_IAC_SINGLE_VULNERABILITY)
+    repository.add(ignored_file)
+    repository.create_commit()
+    repository.push()
+    # AND another vulnerability on another branch
+    repository.create_branch("branch2")
+    scanned_file = repository.path / "scanned_file.tf"
+    scanned_file.write_text(_IAC_SINGLE_VULNERABILITY)
+    repository.add(scanned_file)
+    repository.create_commit()
+
+    # WHEN scanning in CI on a push pipeline for a new branch
+    result = run_ggshield_iac_scan(
+        "ci",
+        cwd=repository.path,
+        expected_code=1,
+        env={
+            "GITLAB_CI": "1",
+            "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+            "CI_COMMIT_BRANCH": "branch2",
+        },
+    )
+
+    # THEN the scan should be run on the expected commit
+    assert "ignored_file.tf" not in result.stdout
+    assert "scanned_file.tf" in result.stdout
+    assert "[+] 1 new incident detected (HIGH: 1)" in result.stdout
+
+
+def test_gitlab_new_empty_branch(tmp_path: Path) -> None:
+    # GIVEN a remote repository
+    remote_repository = Repository.create(tmp_path / "remote", bare=True)
+    # AND a local clone with a vulnerability on the same branch
+    repository = Repository.clone(remote_repository.path, tmp_path / "local")
+    ignored_file = repository.path / "ignored_file.tf"
+    ignored_file.write_text(_IAC_SINGLE_VULNERABILITY)
+    repository.add(ignored_file)
+    repository.create_commit()
+    repository.push()
+    # AND another branch with no new commits
+    repository.create_branch("branch2")
+
+    # WHEN scanning in CI on a push pipeline for a new branch
+    result = run_ggshield_iac_scan(
+        "ci",
+        cwd=repository.path,
+        expected_code=0,
+        env={
+            "GITLAB_CI": "1",
+            "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
+            "CI_COMMIT_BRANCH": "branch2",
+        },
+    )
+
+    # THEN the scan should be skipped
+    assert "> No IaC files changed. Skipping." in result.stdout


### PR DESCRIPTION
When pushing a new branch for the first time, the GGshield IAC and SCA CI cannot find the commit to use as ref.
As described [here](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html), `CI_COMMIT_BEFORE_SHA` is empty in that case.
Here we use git commands to find the starting commit of the new branch.