### PR TITLE
fix(iac): fix headers value for scanning mode

### DIFF
--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -97,8 +97,10 @@ def iac_scan_all(
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,
-            scan_mode=scan_mode if ci_mode is None else f"{scan_mode}/{ci_mode.value}",
-            extra_headers={"Ci-Mode": str(ci_mode)} if ci_mode else None,
+            scan_mode=scan_mode
+            if ci_mode is None
+            else f"{scan_mode.value}/{ci_mode.value}",
+            extra_headers={"Ci-Mode": str(ci_mode.value)} if ci_mode else None,
             target_path=directory,
         ).get_http_headers(),
     )

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -184,8 +184,10 @@ def iac_scan_diff(
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,
-            scan_mode=scan_mode if ci_mode is None else f"{scan_mode}/{ci_mode.value}",
-            extra_headers={"Ci-Mode": str(ci_mode)} if ci_mode else None,
+            scan_mode=scan_mode
+            if ci_mode is None
+            else f"{scan_mode.value}/{ci_mode.value}",
+            extra_headers={"Ci-Mode": str(ci_mode.value)} if ci_mode else None,
             target_path=directory,
         ).get_http_headers(),
     )


### PR DESCRIPTION
Using an f-string on an enum will not return its value.