### PR TITLE
Remove mention of GITGUARDIAN_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 GITGUARDIAN_API_KEY=__________FILL ME__________
-GITGUARDIAN_API_URL=https://api.gitguardian.com
+GITGUARDIAN_INSTANCE=https://dashboard.gitguardian.com/
 
 # Used by functional tests for the --ignore-known-secrets feature
 # Set this to a single-match secret known by your dashboard

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -29,7 +29,7 @@ You should be good to go. Verify it is the case by running unit tests. See below
 
 The `GITGUARDIAN_API_KEY` environment variable must be defined to run functional tests. It is also required when recording VCR.py cassettes or updating existing ones.
 
-If you want to run tests against another GitGuardian instance, define the `GITGUARDIAN_API_URL` environment variable.
+If you want to run tests against another GitGuardian instance, define the `GITGUARDIAN_INSTANCE` environment variable.
 
 The `TEST_KNOWN_SECRET` environment variable must also be defined to run functional tests. It must point to a single-match secret known on the dashboard linked to `GITGUARDIAN_API_KEY`.
 

--- a/doc/pre-receive.sample
+++ b/doc/pre-receive.sample
@@ -12,7 +12,7 @@
 # export GITGUARDIAN_API_KEY=<INSERT YOUR KEY>
 
 # Set this if you use a self-hosted GitGuardian instance
-# export GITGUARDIAN_API_URL="https://dashboard.gitguardian.mycorp.local/exposed/"
+# export GITGUARDIAN_INSTANCE="https://dashboard.gitguardian.mycorp.local/"
 
 set -e
 ggshield secret scan pre-receive

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,6 +15,7 @@ from pygitguardian.models import ScanResult
 from requests.utils import DEFAULT_CA_BUNDLE_PATH, extract_zipped_paths
 
 from ggshield.core.cache import Cache
+from ggshield.core.url_utils import dashboard_to_api_url
 from tests.conftest import GG_VALID_TOKEN
 
 
@@ -571,7 +572,15 @@ def client() -> GGClient:
         )
         os.environ["GITGUARDIAN_API_KEY"] = "not-a-real-key"
     api_key = os.environ["GITGUARDIAN_API_KEY"]
-    base_uri = os.getenv("GITGUARDIAN_API_URL", "https://api.gitguardian.com")
+
+    if "GITGUARDIAN_API_URL" in os.environ:  # deprecated
+        base_uri = os.environ["GITGUARDIAN_API_URL"]
+    else:
+        instance_url = os.getenv(
+            "GITGUARDIAN_INSTANCE", "https://dashboard.gitguardian.com"
+        )
+        base_uri = dashboard_to_api_url(instance_url)
+
     return GGClient(api_key, base_uri)
 
 


### PR DESCRIPTION
- Make use of GITGUARDIAN_INSTANCE in the unittest
- Remove mention of GITGUARDIAN_API_URL in documents