### PR TITLE
Introduce ContextObj

### DIFF
--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -19,6 +19,7 @@ from ggshield.cmd.secret import secret_group
 from ggshield.cmd.secret.scan import scan_group
 from ggshield.cmd.status import status_cmd
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.debug_logs import disable_logs, setup_debug_logs
 from ggshield.core import check_updates
 from ggshield.core.cache import Cache
@@ -58,9 +59,10 @@ def config_path_callback(
     # The --config option is marked as "is_eager" to ensure it's called before all the
     # others. This makes it the right place to create the configuration object.
     if not ctx.obj:
-        ctx.obj = {"cache": Cache()}
+        ctx.obj = ContextObj()
+        ctx.obj.cache = Cache()
 
-    ctx.obj["config"] = Config(value)
+    ctx.obj.config = Config(value)
     return value
 
 
@@ -96,7 +98,7 @@ def cli(
 ) -> None:
     load_dot_env()
 
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     _set_color(ctx)
 
@@ -157,8 +159,9 @@ def before_exit(ctx: click.Context, exit_code: int, *args: Any, **kwargs: Any) -
     It executes some final functions and then terminates.
     The argument exit_code is the result of the previously executed click command.
     """
-    _display_deprecation_message(ctx.obj["config"])
-    _check_for_updates(ctx.obj.get("check_for_updates", True))
+    ctx_obj = ContextObj.get(ctx)
+    _display_deprecation_message(ctx_obj.config)
+    _check_for_updates(ctx_obj.check_for_updates)
     sys.exit(exit_code)
 
 

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Tuple
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
@@ -137,7 +138,7 @@ def login_cmd(
     If a valid personal access token is already configured, this command simply displays
     a success message indicating that ggshield is already ready to use.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     if method != "web":
         if sso_url is not None:

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -5,6 +5,7 @@ from requests.exceptions import ConnectionError
 
 import ggshield.verticals.hmsl.utils as hmsl_utils
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.errors import AuthError, UnexpectedError
@@ -50,7 +51,7 @@ def logout_cmd(
     If not specified, ggshield will logout from the default instance.
     The `--all` option can be used if you want to logout from all your GitGuardian instances.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     if all_:
         for _instance in config.auth_config.instances:

--- a/ggshield/cmd/config/config_get.py
+++ b/ggshield/cmd/config/config_get.py
@@ -4,7 +4,7 @@ import click
 
 from ggshield.cmd.config.constants import FIELD_NAMES, FIELD_NAMES_DOC, FIELDS
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnknownInstanceError
 
 
@@ -35,7 +35,7 @@ If `--instance` is passed, retrieve the value for this specific instance.
 def config_get_cmd(
     ctx: click.Context, field_name: str, instance_url: Optional[str], **kwargs: Any
 ) -> int:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     field = FIELDS[field_name]
 
     if field.auth_config:

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -3,7 +3,7 @@ from typing import Any, Tuple
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 
 from .constants import DATETIME_FORMAT, FIELDS
 
@@ -15,7 +15,7 @@ def config_list_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Print the list of configuration keys and values.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     default_token_lifetime = config.auth_config.default_token_lifetime
 
     message_lines = []

--- a/ggshield/cmd/config/config_migrate.py
+++ b/ggshield/cmd/config/config_migrate.py
@@ -3,7 +3,7 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 
 
 @click.command()
@@ -13,7 +13,7 @@ def config_migrate_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Migrate configuration file to the latest version
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     # Clear all deprecation messages, so that they do not show up when we quit
     config.user_config.deprecation_messages = []

--- a/ggshield/cmd/config/config_set.py
+++ b/ggshield/cmd/config/config_set.py
@@ -4,7 +4,7 @@ import click
 from click import BadParameter
 
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import find_global_config_path
 
@@ -48,7 +48,7 @@ def config_set_cmd(
     instance: Optional[str],
     **kwargs: Any,
 ) -> int:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     field = FIELDS[field_name]
 

--- a/ggshield/cmd/config/config_unset.py
+++ b/ggshield/cmd/config/config_unset.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 
 from .config_set import set_user_config_field
 from .constants import FIELD_NAMES, FIELD_NAMES_DOC, FIELDS
@@ -42,7 +42,7 @@ def config_unset_cmd(
     all_: bool,
     **kwargs: Any,
 ) -> int:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     field = FIELDS[field_name]
 
     if field.auth_config:

--- a/ggshield/cmd/hmsl/api_status.py
+++ b/ggshield/cmd/hmsl/api_status.py
@@ -4,7 +4,7 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.text_utils import STYLE, format_text
 from ggshield.verticals.hmsl import get_client
 
@@ -24,7 +24,7 @@ def status_cmd(
     """
 
     # Get our client
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = get_client(config, ctx.command_path)
 
     click.echo(

--- a/ggshield/cmd/hmsl/check_secret_manager/hashicorp_vault.py
+++ b/ggshield/cmd/hmsl/check_secret_manager/hashicorp_vault.py
@@ -9,7 +9,7 @@ from ggshield.cmd.hmsl.hmsl_common_options import (
 )
 from ggshield.cmd.hmsl.hmsl_utils import check_secrets
 from ggshield.cmd.utils.common_options import add_common_options, json_option
-from ggshield.core.config.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import display_error, display_info, pluralize
 from ggshield.verticals.hmsl.collection import NamingStrategy, collect_list, prepare
@@ -151,7 +151,7 @@ def check_hashicorp_vault_cmd(
             f"Could not fetch {len(result.not_fetched_paths)} paths. "
             "Make sure your token has access to all the secrets in your vault."
         )
-        config: Config = ctx.obj["config"]
+        config = ContextObj.get(ctx).config
         if config.user_config.verbose:
             display_error("> The following paths could not be fetched:")
             for path in result.not_fetched_paths:

--- a/ggshield/cmd/hmsl/hmsl_utils.py
+++ b/ggshield/cmd/hmsl/hmsl_utils.py
@@ -3,7 +3,7 @@ from typing import Iterable, Optional
 import click
 from requests import HTTPError
 
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import display_info, pluralize
 from ggshield.verticals.hmsl import Secret, get_client
@@ -22,7 +22,7 @@ def check_secrets(
     """
     # Query the API
     display_info("Querying HasMySecretLeaked...")
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = get_client(config, hmsl_command_path=ctx.command_path)
     found: Iterable[Secret] = []
     error: Optional[Exception] = None

--- a/ggshield/cmd/hmsl/query.py
+++ b/ggshield/cmd/hmsl/query.py
@@ -8,7 +8,7 @@ from requests import HTTPError
 
 from ggshield.cmd.hmsl.hmsl_common_options import input_arg
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import ParseError, UnexpectedError
 from ggshield.core.text_utils import display_info, pluralize
 from ggshield.verticals.hmsl import HASH_REGEX, PREFIX_REGEX, get_client
@@ -39,7 +39,7 @@ def query_cmd(
     payload, full_hashes = load_payload(input)
 
     # Get our client
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = get_client(config, ctx.command_path)
 
     # Send the hashes to the API

--- a/ggshield/cmd/hmsl/quota.py
+++ b/ggshield/cmd/hmsl/quota.py
@@ -4,8 +4,8 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.quota import format_quota_color
-from ggshield.core.config import Config
 from ggshield.verticals.hmsl import get_client
 
 
@@ -24,7 +24,7 @@ def quota_cmd(
     """
 
     # Get our client
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = get_client(config, ctx.command_path)
 
     click.echo(

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -15,8 +15,8 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.common_options import directory_argument
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
-from ggshield.core.config import Config
 from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.text_utils import display_info
@@ -60,7 +60,7 @@ def iac_scan_all(
     scan_mode: ScanMode,
     ci_mode: Optional[SupportedCI] = None,
 ) -> Union[IaCScanResult, IaCSkipScanResult, None]:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     exclusion_regexes = ctx.obj["exclusion_regexes"]
 
     check_directory_not_ignored(directory, exclusion_regexes)

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -11,7 +11,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option, directory_argument
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.git_hooks.ci import get_current_and_previous_state_from_ci_env
 from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
 from ggshield.core.scan.scan_mode import ScanMode
@@ -40,7 +40,7 @@ def scan_ci_cmd(
     The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
     in which case the scan is only successful if no IaC vulnerability (old and new) was found.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     if directory is None:
         directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -22,8 +22,8 @@ from ggshield.cmd.utils.common_options import (
     reference_option,
     staged_option,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
-from ggshield.core.config import Config
 from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.tar_utils import INDEX_REF, get_empty_tar
@@ -105,7 +105,7 @@ def iac_scan_diff(
     :return: IacDiffScanResult if the scan was performed; IaCSkipScanResult if the scan
     was skipped (i.e. no IaC files were detected or changed between the two references)
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = ctx.obj["client"]
     exclusion_regexes = ctx.obj["exclusion_regexes"]
 

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -21,8 +21,8 @@ from ggshield.cmd.utils.common_options import (
     json_option,
     minimum_severity_option,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config
-from ggshield.core.config.config import Config
 from ggshield.core.config.user_config import (
     POLICY_ID_PATTERN,
     IaCConfigIgnoredPath,
@@ -73,7 +73,7 @@ def update_context(
     ignore_policies: Sequence[str],
     ignore_paths: Sequence[str],
 ) -> None:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     ctx.obj["client"] = create_client_from_config(config)
 
     if ignore_paths is not None:

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -8,7 +8,7 @@ from pygitguardian import GGClient
 from pygitguardian.models import Detail
 
 from ggshield.cmd.utils.common_options import use_json
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import APIKeyCheckError
 from ggshield.core.tar_utils import INDEX_REF, tar_from_ref_and_filepaths
 from ggshield.core.text_utils import display_error
@@ -35,7 +35,7 @@ def create_output_handler(ctx: click.Context) -> IaCOutputHandler:
         output_handler_cls = IaCJSONOutputHandler
     else:
         output_handler_cls = IaCTextOutputHandler
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     return output_handler_cls(verbose=config.user_config.verbose)
 
 

--- a/ggshield/cmd/iac/scan/iac_scan_utils.py
+++ b/ggshield/cmd/iac/scan/iac_scan_utils.py
@@ -7,7 +7,6 @@ import click
 from pygitguardian import GGClient
 from pygitguardian.models import Detail
 
-from ggshield.cmd.utils.common_options import use_json
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import APIKeyCheckError
 from ggshield.core.tar_utils import INDEX_REF, tar_from_ref_and_filepaths
@@ -30,13 +29,13 @@ class IaCSkipScanResult:
 def create_output_handler(ctx: click.Context) -> IaCOutputHandler:
     """Read objects defined in ctx.obj and create the appropriate OutputHandler
     instance"""
+    ctx_obj = ContextObj.get(ctx)
     output_handler_cls: Type[IaCOutputHandler]
-    if use_json(ctx):
+    if ctx_obj.use_json:
         output_handler_cls = IaCJSONOutputHandler
     else:
         output_handler_cls = IaCTextOutputHandler
-    config = ContextObj.get(ctx).config
-    return output_handler_cls(verbose=config.user_config.verbose)
+    return output_handler_cls(verbose=ctx_obj.config.user_config.verbose)
 
 
 def handle_scan_error(client: GGClient, detail: Detail) -> None:

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -5,7 +5,8 @@ import click
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, Quota, QuotaResponse
 
-from ggshield.cmd.utils.common_options import add_common_options, json_option, use_json
+from ggshield.cmd.utils.common_options import add_common_options, json_option
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.quota import format_quota_color
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
@@ -19,7 +20,8 @@ def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Show the remaining quota of API calls available for the entire workspace.
     """
-    client: GGClient = create_client_from_config(ctx.obj["config"])
+    ctx_obj = ContextObj.get(ctx)
+    client: GGClient = create_client_from_config(ctx_obj.config)
     response: Union[Detail, QuotaResponse] = client.quota_overview()
 
     if not isinstance(response, (Detail, QuotaResponse)):
@@ -32,7 +34,7 @@ def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:
 
     click.echo(
         quota.to_json()
-        if use_json(ctx)
+        if ctx_obj.use_json
         else (
             f"Quota available: {format_quota_color(quota.remaining, quota.limit)}\n"
             f"Quota used in the last 30 days: {quota.count}\n"

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -16,7 +16,7 @@ from ggshield.cmd.sca.scan.scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option, directory_argument
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_hooks.ci import get_current_and_previous_state_from_ci_env
 from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
@@ -56,7 +56,7 @@ def scan_ci_cmd(
     # Adds client and required parameters to the context
     update_context(ctx, exit_zero, minimum_severity, ignore_paths)
 
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     try:
         if not (
             os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -13,7 +13,6 @@ from pygitguardian.sca_models import (
     SCAScanParameters,
 )
 
-from ggshield.cmd.utils.common_options import use_json
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
 from ggshield.core.config.user_config import SCAConfig
@@ -145,12 +144,13 @@ def get_sca_scan_all_filepaths(
 def create_output_handler(ctx: click.Context) -> SCAOutputHandler:
     """Read objects defined in ctx.obj and create the appropriate OutputHandler
     instance"""
+    ctx_obj = ContextObj.get(ctx)
     output_handler_cls: Type[SCAOutputHandler]
-    if use_json(ctx):
+    if ctx_obj.use_json:
         output_handler_cls = SCAJsonOutputHandler
     else:
         output_handler_cls = SCATextOutputHandler
-    config = ContextObj.get(ctx).config
+    config = ctx_obj.config
     return output_handler_cls(
         verbose=config.user_config.verbose, exit_zero=config.user_config.exit_zero
     )

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -14,8 +14,8 @@ from pygitguardian.sca_models import (
 )
 
 from ggshield.cmd.utils.common_options import use_json
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
-from ggshield.core.config import Config
 from ggshield.core.config.user_config import SCAConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
 from ggshield.core.scan.scan_context import ScanContext
@@ -54,9 +54,10 @@ def sca_scan_all(
     - Create a tar archive with the required files contents
     - Launches the scan with a call to SCA public API
     """
-    config: Config = ctx.obj["config"]
-    client = ctx.obj["client"]
-    exclusion_regexes = ctx.obj["exclusion_regexes"]
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
+    client = ctx_obj.client
+    exclusion_regexes = ctx_obj.exclusion_regexes
 
     check_directory_not_ignored(directory, exclusion_regexes)
 
@@ -149,7 +150,7 @@ def create_output_handler(ctx: click.Context) -> SCAOutputHandler:
         output_handler_cls = SCAJsonOutputHandler
     else:
         output_handler_cls = SCATextOutputHandler
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     return output_handler_cls(
         verbose=config.user_config.verbose, exit_zero=config.user_config.exit_zero
     )
@@ -179,7 +180,7 @@ def sca_scan_diff(
     When set to None, the current state is the indexed files currently on disk.
     :return: SCAScanDiffOutput object.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     client = ctx.obj["client"]
     exclusion_regexes = ctx.obj["exclusion_regexes"]
 

--- a/ggshield/cmd/sca/scan/scan_common_options.py
+++ b/ggshield/cmd/sca/scan/scan_common_options.py
@@ -21,8 +21,8 @@ from ggshield.cmd.utils.common_options import (
     json_option,
     minimum_severity_option,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config
-from ggshield.core.config import Config
 from ggshield.core.filter import init_exclusion_regexes
 
 
@@ -44,7 +44,7 @@ def update_context(
     minimum_severity: str,
     ignore_paths: Sequence[str],
 ) -> None:
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     ctx.obj["client"] = create_client_from_config(config)
 
     if ignore_paths is not None:

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -3,6 +3,7 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.text_utils import pluralize
@@ -33,7 +34,7 @@ def ignore_cmd(
     configuration file. If no local configuration file is found, a `.gitguardian.yaml` file is created.
     """
     if last_found:
-        config: Config = ctx.obj["config"]
+        config = ContextObj.get(ctx).config
         cache = ctx.obj["cache"]
         nb = ignore_last_found(config, cache)
         path = config.config_path

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -18,8 +18,8 @@ from ggshield.cmd.secret.scan.repo import repo_cmd
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config
-from ggshield.core.config import Config
 from ggshield.core.text_utils import display_error
 
 
@@ -70,7 +70,7 @@ def scan_group_impl(ctx: click.Context) -> int:
     ctx.obj["client"] = create_client_from_config(ctx.obj["config"])
     return_code = 0
 
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     max_commits = get_max_commits_for_hook()
     if max_commits:

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -9,7 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
@@ -42,7 +42,7 @@ def archive_cmd(
         except Exception as exn:
             raise UnexpectedError(f'Failed to unpack "{path}" archive: {exn}')
 
-        config: Config = ctx.obj["config"]
+        config = ContextObj.get(ctx).config
         verbose = config.user_config.verbose
         files = get_files_from_paths(
             paths=[temp_path],

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -10,8 +10,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.cache import ReadOnlyCache
-from ggshield.core.config import Config
 from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import check_git_dir
@@ -26,7 +26,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Scan the set of pushed commits that triggered the CI pipeline.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     check_git_dir()
     if not (os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")):
         raise UsageError("`secret scan ci` should only be used in a CI environment.")

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -9,7 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.verticals.secret.docker import docker_save_to_tmp, docker_scan_archive
 
@@ -41,7 +41,7 @@ def docker_name_cmd(
     """
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temporary_dir:
-        config: Config = ctx.obj["config"]
+        config = ContextObj.get(ctx).config
         output_handler = create_output_handler(ctx)
 
         archive = Path(temporary_dir) / "archive.tar"

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -8,7 +8,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.click import RealPath
 from ggshield.verticals.secret.docker import docker_scan_archive
@@ -31,7 +31,7 @@ def docker_archive_cmd(
 
     Hidden command `ggshield secret scan docker-archive`
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     output_handler = create_output_handler(ctx)
 
     scan_context = ScanContext(

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -9,7 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.scan import ScanContext, ScanMode, Scannable, StringScannable
 from ggshield.core.text_utils import create_progress_bar, display_info
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -67,7 +67,7 @@ def docset_cmd(
     \b
     [1]: https://docs.gitguardian.com/ggshield-docs/integrations/other-data-sources/other-data-sources
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     output_handler = create_output_handler(ctx)
     with create_progress_bar(doc_type="files") as progress:
 

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -8,8 +8,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
-from ggshield.core.config import Config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
 from ggshield.utils.click import RealPath
@@ -39,7 +39,7 @@ def path_cmd(
     """
     Scan files and directories.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     output_handler = create_output_handler(ctx)
     verbose = config.user_config.verbose
 

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -7,8 +7,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
-from ggshield.core.config import Config
 from ggshield.core.scan import Commit, ScanContext, ScanMode
 from ggshield.utils.git_shell import check_git_dir
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -40,7 +40,7 @@ def precommit_cmd(
     """
     Scan as a pre-commit hook all changes that have been staged in a git repository.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     if check_user_requested_skip():
         return 0

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -9,8 +9,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
-from ggshield.core.config import Config
 from ggshield.core.git_hooks.prepush import BYPASS_MESSAGE, collect_commits_refs
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import (
@@ -40,7 +40,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
     """
     Scan as a pre-push git hook all commits that are about to be pushed.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
 
     if check_user_requested_skip():
         return 0

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -13,6 +13,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
@@ -98,7 +99,7 @@ def prereceive_cmd(
     """
     Scan as a pre-receive git hook all commits about to enter the remote git repository.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     output_handler = create_output_handler(ctx)
     if os.getenv("GL_PROTOCOL") == "web":
         # We are inside GitLab web UI

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -12,7 +12,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import get_files_from_paths
@@ -104,7 +104,7 @@ def pypi_cmd(
 
     [1]: https://pip.pypa.io/en/stable/topics/configuration/
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     output_handler = create_output_handler(ctx)
     verbose = config.user_config.verbose
 

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -9,7 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import get_list_commit_SHA
 from ggshield.verticals.secret.repo import scan_commit_range
@@ -32,7 +32,7 @@ def range_cmd(
 
     Example: `ggshield secret scan commit-range HEAD~1...`
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     commit_list = get_list_commit_SHA(commit_range)
     if not commit_list:
         raise UsageError("invalid commit range")

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -11,8 +11,8 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.cache import Cache
-from ggshield.core.config import Config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import git
 from ggshield.verticals.secret.repo import scan_repo_path
@@ -37,7 +37,7 @@ def repo_cmd(
 
     REPOSITORY is the clone URL or the path of the repository to scan.
     """
-    config: Config = ctx.obj["config"]
+    config = ContextObj.get(ctx).config
     cache: Cache = ctx.obj["cache"]
     client: GGClient = ctx.obj["client"]
 

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -10,7 +10,6 @@ from ggshield.cmd.utils.common_options import (
     exit_zero_option,
     get_config_from_context,
     json_option,
-    use_json,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config.user_config import SecretConfig
@@ -136,10 +135,10 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
 def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     """Read objects defined in ctx.obj and create the appropriate OutputHandler
     instance"""
-    output_handler_cls = (
-        SecretJSONOutputHandler if use_json(ctx) else SecretTextOutputHandler
-    )
     ctx_obj = ContextObj.get(ctx)
+    output_handler_cls = (
+        SecretJSONOutputHandler if ctx_obj.use_json else SecretTextOutputHandler
+    )
     config = ctx_obj.config
     return output_handler_cls(
         show_secrets=config.user_config.secret.show_secrets,

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 import click
 
@@ -13,7 +12,7 @@ from ggshield.cmd.utils.common_options import (
     json_option,
     use_json,
 )
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.utils.click import RealPath
@@ -140,11 +139,11 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     output_handler_cls = (
         SecretJSONOutputHandler if use_json(ctx) else SecretTextOutputHandler
     )
-    config: Config = ctx.obj["config"]
-    output: Union[Path, None] = ctx.obj.get("output")
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
     return output_handler_cls(
         show_secrets=config.user_config.secret.show_secrets,
         verbose=config.user_config.verbose,
-        output=output,
+        output=ctx.obj.output,
         ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
     )

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -2,10 +2,10 @@
 from typing import Any
 
 import click
-from pygitguardian import GGClient
 from pygitguardian.models import HealthCheckResponse
 
 from ggshield.cmd.utils.common_options import add_common_options, json_option, use_json
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import STYLE, format_text
@@ -17,7 +17,8 @@ from ggshield.core.text_utils import STYLE, format_text
 @click.pass_context
 def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """Show API status and version."""
-    client: GGClient = create_client_from_config(ctx.obj["config"])
+    ctx_obj = ContextObj.get(ctx)
+    client = create_client_from_config(ctx_obj.config)
     response: HealthCheckResponse = client.health_check()
 
     if not isinstance(response, HealthCheckResponse):

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -4,7 +4,7 @@ from typing import Any
 import click
 from pygitguardian.models import HealthCheckResponse
 
-from ggshield.cmd.utils.common_options import add_common_options, json_option, use_json
+from ggshield.cmd.utils.common_options import add_common_options, json_option
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
@@ -26,7 +26,7 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
 
     click.echo(
         response.to_json()
-        if use_json(ctx)
+        if ctx_obj.use_json
         else (
             f"{format_text('API URL:', STYLE['key'])} {client.base_uri}\n"
             f"{format_text('Status:', STYLE['key'])} {format_healthcheck_status(response)}\n"

--- a/ggshield/cmd/utils/common_decorators.py
+++ b/ggshield/cmd/utils/common_decorators.py
@@ -4,7 +4,7 @@ from typing import Callable, TypeVar
 import click
 from typing_extensions import ParamSpec
 
-from ggshield.core.config import Config
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import handle_exception
 from ggshield.core.text_utils import display_warning
 
@@ -20,7 +20,7 @@ def exception_wrapper(func: Callable[P, int]) -> Callable[P, int]:
             return func(*args, **kwargs)
         except Exception as error:
             ctx = next(arg for arg in args if isinstance(arg, click.Context))
-            config: Config = ctx.obj["config"]
+            config = ContextObj.get(ctx).config
             return handle_exception(error, config.user_config.verbose)
 
     return wrapper

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -195,11 +195,6 @@ json_option = click.option(
 )
 
 
-def use_json(ctx: click.Context) -> bool:
-    """Tells whether --json has been set"""
-    return ctx.obj.use_json
-
-
 directory_argument = click.argument(
     "directory",
     type=click.Path(exists=True, readable=True, path_type=Path, file_okay=False),

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -45,7 +45,7 @@ def create_ctx_callback(name: str) -> ClickCallback:
         ctx: click.Context, param: click.Parameter, value: Optional[ArgT]
     ) -> Optional[ArgT]:
         if value is not None:
-            ctx.obj[name] = value
+            setattr(ctx.obj, name, value)
         return value
 
     return callback
@@ -197,7 +197,7 @@ json_option = click.option(
 
 def use_json(ctx: click.Context) -> bool:
     """Tells whether --json has been set"""
-    return bool(ctx.obj.get("use_json", False))
+    return ctx.obj.use_json
 
 
 directory_argument = click.argument(

--- a/ggshield/cmd/utils/context_obj.py
+++ b/ggshield/cmd/utils/context_obj.py
@@ -1,0 +1,89 @@
+import re
+from pathlib import Path
+from typing import Any, Optional, Set, cast
+
+import click
+from pygitguardian import GGClient
+
+from ggshield.core.cache import Cache
+from ggshield.core.config import Config
+
+
+class ContextObj:
+    """This object is used as Click "context object": the object accessible via
+    `ctx.obj`.
+
+    While it is possible to use `ctx.obj` directly, it's better to write:
+
+    ```
+    ctx_obj = ContextObj.get(ctx)
+    ```
+
+    Doing so ensures the type checker knows `ctx_obj` is an instance of
+    ContextObj and can verify access to member variables, whereas when using
+    `ctx.obj` directly, the type checker considers it to be of type `Any`.
+
+    Some attributes (`config`, `client` and `cache`) are implemented as
+    properties. These properties check the attribute has been set before
+    returning it. This allows the class to store instance `foo` as
+    `Optional[Foo]` but exposing it as `Foo`.
+    """
+
+    def __init__(self):
+        self._config: Optional[Config] = None
+        self._client: Optional[GGClient] = None
+        self._cache: Optional[Cache] = None
+
+        # Depending on the vertical, this is set by configuration options or
+        # command-line parameters
+        self.exclusion_regexes: Set[re.Pattern] = set()
+
+        # Set to false by the --no-check-for-updates option
+        self.check_for_updates = True
+
+        # Set by the --json option
+        self.use_json = False
+
+        # Set by the --output option
+        self.output: Optional[Path] = None
+
+    @property
+    def config(self) -> Config:
+        assert self._config
+        return self._config
+
+    @config.setter
+    def config(self, value: Config) -> None:
+        self._config = value
+
+    @property
+    def client(self) -> GGClient:
+        assert self._client
+        return self._client
+
+    @client.setter
+    def client(self, value: GGClient) -> None:
+        self._client = value
+
+    @property
+    def cache(self) -> Cache:
+        assert self._cache
+        return self._cache
+
+    @cache.setter
+    def cache(self, value: Cache) -> None:
+        self._cache = value
+
+    @staticmethod
+    def get(ctx: click.Context) -> "ContextObj":
+        """The recommended way to get a ContextObj instance, see the class docstring for
+        details"""
+        return cast(ContextObj, ctx.obj)
+
+    # The two following methods are here for compatibility reasons: ctx.obj used to be
+    # a dict, and not all code has been ported to use it as an object.
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: Any) -> Any:
+        return setattr(self, key, value)

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -19,6 +19,7 @@ from ggshield.cmd.sca.scan.sca_scan_utils import (
     sca_scan_all,
     sca_scan_diff,
 )
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config import Config
 from ggshield.core.errors import ExitCode
 from ggshield.core.scan.scan_mode import ScanMode
@@ -33,9 +34,12 @@ def get_valid_ctx(client: GGClient) -> click.Context:
     """
     config = Config()
     config.user_config.verbose = False
+    ctx_obj = ContextObj()
+    ctx_obj.client = client
+    ctx_obj.config = config
     ctx = click.Context(
         click.Command("sca scan all"),
-        obj={"client": client, "exclusion_regexes": [], "config": config},
+        obj=ctx_obj,
     )
     return ctx
 


### PR DESCRIPTION
This PR changes our Click context object to be an object instead of a dict. It introduces ContextObj, a class holding all fields to store in Click context object.

Using a class instead of a dict improves type safety and ensures the content of the object is not a black hole.