### PR TITLE
chore(iac): update performance benchmark with new iac usage

### DIFF
--- a/scripts/perfbench/run_cmd.py
+++ b/scripts/perfbench/run_cmd.py
@@ -26,7 +26,7 @@ DEFAULT_GGSHIELD_VERSIONS = ["prod", "current"]
 REPO_BENCHMARK_COMMANDS = [
     ("secret", "scan", "--exit-zero", "path", "-ry", "."),
     ("secret", "scan", "--exit-zero", "commit-range", "HEAD~6.."),
-    ("iac", "scan", "--exit-zero", "."),
+    ("iac", "scan", "all", "--exit-zero", "."),
 ]
 
 DOCKER_IMAGES = ["ubuntu:22.04", "busybox:1.36.0-musl"]


### PR DESCRIPTION
[IAC-117](https://linear.app/gitguardian/issue/IAC-117/ggshield-update-iac-performance-benchmarks)

Update performance benchmark to follow new IAC command usage.