### PR TITLE
Fix our pre-receive docker sample

### DIFF
--- a/doc/pre-receive-docker.sample
+++ b/doc/pre-receive-docker.sample
@@ -9,4 +9,14 @@
 #export GITGUARDIAN_API_KEY=<INSERT YOUR KEY>
 
 set -x
-docker run -i --rm -v $(pwd):/data ggshield -e GIT_PUSH_OPTION_COUNT -e GIT_PUSH_OPTION_0 -e GIT_PUSH_OPTION_1 -e GITGUARDIAN_API_KEY gitguardian/ggshield:latest ggshield secret scan pre-receive
+docker run -i --rm \
+    -v $PWD:$PWD \
+    -w $PWD \
+    -e GITGUARDIAN_API_KEY \
+    -e GIT_PUSH_OPTION_COUNT \
+    -e GIT_PUSH_OPTION_0 \
+    -e GIT_PUSH_OPTION_1 \
+    -e GIT_ALTERNATE_OBJECT_DIRECTORIES \
+    -e GIT_OBJECT_DIRECTORY \
+    -e GIT_QUARANTINE_PATH \
+    gitguardian/ggshield:latest ggshield secret scan pre-receive


### PR DESCRIPTION
## Description

Our sample script to run GGShield as pre-receive via Docker does not work. This is because pre-receive commits are kept in a "quarantine" environment (see https://git-scm.com/docs/git-receive-pack#_quarantine_environment), git sets some environment variables before running the pre-receive hook so that git commands run by the hook can find the quarantined commits.

Furthermore, since these environment variables contain absolute path to directories, the path to the git checkout inside the Docker container must be the same as the path on the host.

## What has been done

- Propagate GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_OBJECT_DIRECTORY and GIT_QUARANTINE_PATH,
- Map PWD to PWD and use it as the current work directory.
