### PR TITLE
Fix IAC scan all on subdirectories

### DIFF
--- a/changelog.d/20231219_154446_paul.beslin.ext.md
+++ b/changelog.d/20231219_154446_paul.beslin.ext.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- File contents will be displayed as intended when executing `ggshield iac scan all` on a subdirectory of a Git repository.

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -16,6 +16,7 @@ from pygitguardian.sca_models import (
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
 from ggshield.core.config.user_config import SCAConfig
+from ggshield.core.dirs import get_project_root_dir
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
 from ggshield.core.scan.scan_context import ScanContext
 from ggshield.core.scan.scan_mode import ScanMode
@@ -75,9 +76,14 @@ def sca_scan_all(
         empty_output.status_code = sca_filter_status_code
         return empty_output
 
+    root = get_project_root_dir(directory)
+    relative_paths = [
+        str((directory / x).resolve().relative_to(root)) for x in sca_filepaths
+    ]
+
     scan_parameters = get_scan_params_from_config(config.user_config.sca)
 
-    tar = _create_tar(directory, sca_filepaths)
+    tar = _create_tar(root, relative_paths)
 
     # Call to full scan API and get results
     scan_result = client.sca_scan_directory(

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from appdirs import user_cache_dir, user_config_dir
 
+from ggshield.utils.git_shell import NotAGitDirectory, get_git_root
+
 
 APPNAME = "ggshield"
 APPAUTHOR = "GitGuardian"
@@ -30,3 +32,16 @@ def get_cache_dir() -> Path:
         return Path(os.environ["GG_CACHE_DIR"])
     except KeyError:
         return Path(user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR))
+
+
+def get_project_root_dir(path: Path) -> Path:
+    """Vulnerability path are relative to either git root path or
+    path provided for the scan.
+
+    Returns the source basedir required to find file within filesystem.
+    """
+    try:
+        return get_git_root(wd=path).resolve()
+    except NotAGitDirectory:
+        # In case we are not in a Git repository
+        return path.resolve()

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -22,7 +22,7 @@ def get_iac_files_from_path(
     exclusion_regexes: Set[re.Pattern],
     verbose: bool,
     ignore_git: bool = False,
-) -> List[str]:
+) -> List[Path]:
     """
     Returns IaC file paths found recursively in a given directory.
 
@@ -31,7 +31,7 @@ def get_iac_files_from_path(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
-    paths = [
+    return [
         x.path
         for x in get_files_from_paths(
             paths=[path],
@@ -44,8 +44,6 @@ def get_iac_files_from_path(
         )
         if is_iac_file_path(x.path)
     ]
-
-    return [str(x.relative_to(path)) for x in paths]
 
 
 def is_iac_file_path(path: Path) -> bool:

--- a/tests/unit/cassettes/test_sca_scan_subdir_tar.yaml
+++ b/tests/unit/cassettes/test_sca_scan_subdir_tar.yaml
@@ -1,0 +1,64 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '27'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.11.0 (Linux;py3.10.4) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 20 Dec 2023 10:37:53 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - fca7d1e9
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '49'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.21.0
+        x-sca-last-vuln-fetch:
+          - '2023-12-20T10:02:43.336730+00:00'
+        x-secrets-engine-version:
+          - 2.102.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/verticals/iac/test_filter.py
+++ b/tests/unit/verticals/iac/test_filter.py
@@ -22,68 +22,65 @@ FILE_NAMES = [
 ]
 
 
-def test_get_iac_files_from_path(tmp_path):
+def test_get_iac_files_from_path(tmp_path: Path):
     """
     GIVEN files added to the temp path
     WHEN calling get_iac_files_from_path
     THEN it returns all iac files
     """
-    tmp_paths = [str(tmp_path / filename) for filename in FILE_NAMES]
-    for path in tmp_paths:
-        Path(path).write_text("something")
+    for filename in FILE_NAMES:
+        (tmp_path / filename).write_text("something")
 
     files = get_iac_files_from_path(tmp_path, set(), True)
     assert len(files) == 9
-    assert "file1.txt" not in files
-    assert "file2.json" in files
+    assert tmp_path / "file1.txt" not in files
+    assert tmp_path / "file2.json" in files
 
 
-def test_get_iac_files_from_path_excluded(tmp_path):
+def test_get_iac_files_from_path_excluded(tmp_path: Path):
     """
     GIVEN files added to the temp path
     WHEN calling get_iac_files_from_path with an excluded pattern
     THEN it returns all iac files expect the ones matching the excluded patterns
     """
-    tmp_paths = [str(tmp_path / filename) for filename in FILE_NAMES]
-    for path in tmp_paths:
-        Path(path).write_text("something")
+    for filename in FILE_NAMES:
+        (tmp_path / filename).write_text("something")
 
     files = get_iac_files_from_path(tmp_path, {re.compile(r"file2")}, True)
     assert len(files) == 8
-    assert "file2.json" not in files
-    assert "file3.yaml" in files
+    assert tmp_path / "file2.json" not in files
+    assert tmp_path / "file3.yaml" in files
 
 
 @pytest.mark.parametrize("ignore_git", (False, True))
-def test_get_iac_files_from_path_ignore_git(tmp_path, ignore_git):
+def test_get_iac_files_from_path_ignore_git(tmp_path: Path, ignore_git: bool):
     """
     GIVEN files added to the temp path, as a git directory
     WHEN calling get_iac_files_from_path with ignore_git
     THEN it returns all iac files added to git and not the ones mentioned in the
     .gitignore if ignore_git is True. Otherwise, it ignores the .gitignore
     """
-    tmp_paths = [str(tmp_path / filename) for filename in FILE_NAMES]
-    for path in tmp_paths:
-        Path(path).write_text("something")
-    Path(str(tmp_path / ".gitignore")).write_text("file2.json")
-    tmp_path_str = str(tmp_path)
-    subprocess.run(["git", "init"], cwd=tmp_path_str)
-    subprocess.run(["git", "add", "."], cwd=tmp_path_str)
+    for filename in FILE_NAMES:
+        (tmp_path / filename).write_text("something")
+    (tmp_path / ".gitignore").write_text("file2.json")
+
+    subprocess.run(["git", "init"], cwd=tmp_path)
+    subprocess.run(["git", "add", "."], cwd=tmp_path)
 
     # Assert the .git folder exists. files.files length assertion ensures it's not
     # included in the get_iac_files_from_path response
-    assert Path(str(tmp_path / ".git")).exists()
+    assert (tmp_path / ".git").exists()
 
     files = get_iac_files_from_path(tmp_path, set(), True, ignore_git)
     if ignore_git:
         assert len(files) == 9
-        assert "file2.json" in files
+        assert tmp_path / "file2.json" in files
     else:
         assert len(files) == 8
-        assert "file2.json" not in files
-        assert "file3.yaml" in files
+        assert tmp_path / "file2.json" not in files
+        assert tmp_path / "file3.yaml" in files
 
 
-def test_is_iac_file_path(tmp_path):
+def test_is_iac_file_path(tmp_path: Path):
     assert is_iac_file_path(tmp_path / "file1.json")
     assert not is_iac_file_path(tmp_path / "file1.jpg")


### PR DESCRIPTION
Currently, tars have two ways to be created in GGShield:

- For iac/sca scan diff, filepaths are listed using `git ls-tree --full-name`, which return filepaths relative to the git root
- For iac/sca scan all, filepaths are listed using `directory.rglob("*")` (where `directory` is the argument passed to the command), then returned relative to the directory using `path.relative_to(directory)`
- The difference comes from the necessity of listing files for a given git reference, for diff scans

However, the `all` behavior introduces two issues for IAC when calling the command with a Git subdirectory as argument:
1. File contents are not shown in the output, as the output handler looks for files relative to the git root, but is given filepaths relative to the subdir argument
2. Only the subdir is added to the tar sent to the API, preventing from linking existing incidents properly (as their paths are relative to the git root)
SCA is not impacted by these issues yet, but would be impacted by 2. when implemented.

This PR solves this issue by using the git root for all scans too as the root directory.
If the scanned directory isn't a Git repository, the current behavior is maintained.