### PR TITLE
fix(iac): prepush scan all

### DIFF
--- a/changelog.d/20240105_163641_carla.martet.ext_fix_prepush_scan_all.md
+++ b/changelog.d/20240105_163641_carla.martet.ext_fix_prepush_scan_all.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- IAC: Pre-push scans are now diff scans when pushing a new branch, comparing to last commit on the parent branch.
+- IAC: Pre-push scans on empty repos no longer include staged files.

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -75,6 +75,7 @@ def iac_scan_all(
         verbose=False,
         # If the repository is a git repository, ignore untracked files
         ignore_git=False,
+        ignore_git_staged=(scan_mode == ScanMode.PRE_PUSH_ALL),
     )
 
     if not paths:

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -15,7 +15,7 @@ from ggshield.cmd.utils.common_options import all_option
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.scan.scan_mode import ScanMode
-from ggshield.utils.git_shell import EMPTY_SHA
+from ggshield.utils.git_shell import is_valid_git_commit_ref
 
 
 @click.command()
@@ -54,9 +54,9 @@ def scan_pre_push_cmd(
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
     _, remote_commit = collect_commits_refs(prepush_args)
-    # Will happen if this is the first push on the branch
-    has_no_remote_commit = (
-        remote_commit is None or "~1" in remote_commit or remote_commit == EMPTY_SHA
+    # Will happen if this is the first push on the repo
+    has_no_remote_commit = remote_commit is None or not is_valid_git_commit_ref(
+        remote_commit
     )
 
     if scan_all or has_no_remote_commit:

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -61,6 +61,7 @@ def get_files_from_paths(
     display_scanned_files: bool,
     display_binary_files: bool,
     ignore_git: bool = False,
+    ignore_git_staged: bool = False,
 ) -> List[Scannable]:
     """
     Create a scan object from files content.
@@ -75,7 +76,11 @@ def get_files_from_paths(
     """
     try:
         filepaths = get_filepaths(
-            paths, exclusion_regexes, recursive, ignore_git=ignore_git
+            paths,
+            exclusion_regexes,
+            recursive,
+            ignore_git=ignore_git,
+            ignore_git_staged=ignore_git_staged,
         )
     except UnexpectedDirectoryError as error:
         raise click.UsageError(

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -3,7 +3,7 @@ from pathlib import Path, PurePosixPath
 from typing import List, Set, Union
 
 from ggshield.utils._binary_extensions import BINARY_EXTENSIONS
-from ggshield.utils.git_shell import git_ls, is_git_dir
+from ggshield.utils.git_shell import get_filepaths_from_ref, git_ls, is_git_dir
 
 
 class UnexpectedDirectoryError(ValueError):
@@ -25,6 +25,7 @@ def get_filepaths(
     exclusion_regexes: Set[re.Pattern],
     recursive: bool,
     ignore_git: bool,
+    ignore_git_staged: bool = False,
 ) -> Set[Path]:
     """
     Retrieve the filepaths from the command.
@@ -43,7 +44,12 @@ def get_filepaths(
                 raise UnexpectedDirectoryError(path)
 
             if not ignore_git and is_git_dir(path):
-                _targets = {path / target for target in git_ls(path)}
+                target_filepaths = (
+                    get_filepaths_from_ref("HEAD", wd=path)
+                    if ignore_git_staged
+                    else git_ls(path)
+                )
+                _targets = {path / x for x in target_filepaths}
             else:
                 _targets = path.rglob(r"*")
 

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -22,6 +22,7 @@ def get_iac_files_from_path(
     exclusion_regexes: Set[re.Pattern],
     verbose: bool,
     ignore_git: bool = False,
+    ignore_git_staged: bool = False,
 ) -> List[Path]:
     """
     Returns IaC file paths found recursively in a given directory.
@@ -41,6 +42,7 @@ def get_iac_files_from_path(
             display_binary_files=verbose,
             display_scanned_files=False,  # If True, this displays all files in the directory but we only want IaC files
             ignore_git=ignore_git,
+            ignore_git_staged=ignore_git_staged,
         )
         if is_iac_file_path(x.path)
     ]


### PR DESCRIPTION
This MR aims to fix 2 edge cases during IaC pre-push scans:
- Use scan diff (instead of all) when pushing a new branch. The ref commit should be the last one on the parent branch.
- Prevent staged files to be scanned during pre-push "all" scans. It should only occurs on the first push for each repo. This avoids to push a vulnerability that could have been fixed in the staged files only.