### PR TITLE
Finish migrating to ContextObj

### DIFF
--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -44,9 +44,10 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> int:
     exit_code guarantees that the return value of a scan is 0
     when exit_zero is enabled
     """
+    ctx_obj = ContextObj.get(ctx)
     if (
         exit_code == ExitCode.SCAN_FOUND_PROBLEMS
-        and ctx.obj["config"].user_config.exit_zero
+        and ctx_obj.config.user_config.exit_zero
     ):
         logger.debug("scan exit_code forced to 0")
         sys.exit(ExitCode.SUCCESS)

--- a/ggshield/cmd/iac/scan/ci.py
+++ b/ggshield/cmd/iac/scan/ci.py
@@ -41,7 +41,8 @@ def scan_ci_cmd(
     The scan is successful if no *new* IaC vulnerability was found, unless `--all` is used,
     in which case the scan is only successful if no IaC vulnerability (old and new) was found.
     """
-    config = ContextObj.get(ctx).config
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
     if directory is None:
         directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
@@ -51,7 +52,7 @@ def scan_ci_cmd(
         result = iac_scan_all(
             ctx, directory, scan_mode=ScanMode.CI_ALL, ci_mode=ci_mode
         )
-        augment_unignored_issues(ctx.obj["config"].user_config, result)
+        augment_unignored_issues(config.user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
 
     current_commit, previous_commit = get_current_and_previous_state_from_ci_env(
@@ -67,5 +68,5 @@ def scan_ci_cmd(
         scan_mode=ScanMode.CI_DIFF,
         ci_mode=ci_mode,
     )
-    augment_unignored_issues(ctx.obj["config"].user_config, result)
+    augment_unignored_issues(config.user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -77,7 +77,8 @@ def scan_diff_cmd(
     result = iac_scan_diff(
         ctx, directory, ref, staged, scan_mode=ScanMode.DIRECTORY_DIFF
     )
-    augment_unignored_issues(ctx.obj["config"].user_config, result)
+    ctx_obj = ContextObj.get(ctx)
+    augment_unignored_issues(ctx_obj.config.user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)
 
 
@@ -107,9 +108,10 @@ def iac_scan_diff(
     :return: IacDiffScanResult if the scan was performed; IaCSkipScanResult if the scan
     was skipped (i.e. no IaC files were detected or changed between the two references)
     """
-    config = ContextObj.get(ctx).config
-    client = ctx.obj["client"]
-    exclusion_regexes = ctx.obj["exclusion_regexes"]
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
+    client = ctx_obj.client
+    exclusion_regexes = ctx_obj.exclusion_regexes
 
     check_directory_not_ignored(directory, exclusion_regexes)
 
@@ -194,7 +196,7 @@ def iac_scan_diff(
         ).get_http_headers(),
     )
 
-    if not scan.success or not isinstance(scan, IaCDiffScanResult):
+    if not isinstance(scan, IaCDiffScanResult):
         handle_scan_error(client, scan)
         return None
     return scan

--- a/ggshield/cmd/iac/scan/precommit.py
+++ b/ggshield/cmd/iac/scan/precommit.py
@@ -12,6 +12,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option, directory_argument
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core.scan.scan_mode import ScanMode
 
@@ -49,13 +50,14 @@ def scan_pre_commit_cmd(
 
     if directory is None:
         directory = Path().resolve()
+    ctx_obj = ContextObj.get(ctx)
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
     if scan_all:
         result = iac_scan_all(ctx, directory, scan_mode=ScanMode.PRE_COMMIT_ALL)
-        augment_unignored_issues(ctx.obj["config"].user_config, result)
+        augment_unignored_issues(ctx_obj.config.user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
     result = iac_scan_diff(
         ctx, directory, "HEAD", include_staged=True, scan_mode=ScanMode.PRE_COMMIT_DIFF
     )
-    augment_unignored_issues(ctx.obj["config"].user_config, result)
+    augment_unignored_issues(ctx_obj.config.user_config, result)
     return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prepush.py
+++ b/ggshield/cmd/iac/scan/prepush.py
@@ -12,6 +12,7 @@ from ggshield.cmd.iac.scan.iac_scan_common_options import (
 from ggshield.cmd.iac.scan.iac_scan_utils import augment_unignored_issues
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.scan.scan_mode import ScanMode
@@ -50,6 +51,7 @@ def scan_pre_push_cmd(
     if check_user_requested_skip():
         return 0
 
+    ctx_obj = ContextObj.get(ctx)
     directory = Path().resolve()
     update_context(ctx, exit_zero, minimum_severity, ignore_policies, ignore_paths)
 
@@ -61,7 +63,7 @@ def scan_pre_push_cmd(
 
     if scan_all or has_no_remote_commit:
         result = iac_scan_all(ctx, directory, scan_mode=ScanMode.PRE_PUSH_ALL)
-        augment_unignored_issues(ctx.obj["config"].user_config, result)
+        augment_unignored_issues(ctx_obj.config.user_config, result)
         return display_iac_scan_all_result(ctx, directory, result)
     else:
         result = iac_scan_diff(
@@ -71,5 +73,5 @@ def scan_pre_push_cmd(
             include_staged=False,
             scan_mode=ScanMode.PRE_PUSH_DIFF,
         )
-        augment_unignored_issues(ctx.obj["config"].user_config, result)
+        augment_unignored_issues(ctx_obj.config.user_config, result)
         return display_iac_scan_diff_result(ctx, directory, result)

--- a/ggshield/cmd/iac/scan/prereceive.py
+++ b/ggshield/cmd/iac/scan/prereceive.py
@@ -17,6 +17,7 @@ from ggshield.cmd.iac.scan.iac_scan_utils import (
 )
 from ggshield.cmd.utils.common_decorators import display_beta_warning, exception_wrapper
 from ggshield.cmd.utils.common_options import all_option
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.git_hooks.prereceive import get_breakglass_option, parse_stdin
 from ggshield.core.scan.scan_mode import ScanMode
 from ggshield.utils.git_shell import EMPTY_TREE, check_git_ref, is_valid_git_commit_ref
@@ -99,7 +100,7 @@ def scan_pre_receive_cmd(
         current_ref=after,
         scan_mode=ScanMode.PRE_RECEIVE_ALL if scan_all else ScanMode.PRE_RECEIVE_DIFF,
     )
-    augment_unignored_issues(ctx.obj["config"].user_config, result)
+    augment_unignored_issues(ContextObj.get(ctx).config.user_config, result)
 
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -186,9 +186,10 @@ def sca_scan_diff(
     When set to None, the current state is the indexed files currently on disk.
     :return: SCAScanDiffOutput object.
     """
-    config = ContextObj.get(ctx).config
-    client = ctx.obj["client"]
-    exclusion_regexes = ctx.obj["exclusion_regexes"]
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
+    client = ctx_obj.client
+    exclusion_regexes = ctx_obj.exclusion_regexes
 
     check_directory_not_ignored(directory, exclusion_regexes)
 

--- a/ggshield/cmd/secret/ignore.py
+++ b/ggshield/cmd/secret/ignore.py
@@ -34,9 +34,9 @@ def ignore_cmd(
     configuration file. If no local configuration file is found, a `.gitguardian.yaml` file is created.
     """
     if last_found:
-        config = ContextObj.get(ctx).config
-        cache = ctx.obj["cache"]
-        nb = ignore_last_found(config, cache)
+        ctx_obj = ContextObj.get(ctx)
+        config = ctx_obj.config
+        nb = ignore_last_found(config, ctx_obj.cache)
         path = config.config_path
         secrets_word = pluralize("secret", nb)
         click.echo(

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -43,7 +43,7 @@ def archive_cmd(
         verbose = config.user_config.verbose
         files = get_files_from_paths(
             paths=[temp_path],
-            exclusion_regexes=ctx.obj["exclusion_regexes"],
+            exclusion_regexes=ctx_obj.exclusion_regexes,
             recursive=True,
             yes=True,
             display_scanned_files=verbose,

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -51,7 +51,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
         ui=ctx_obj.ui,
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
-        exclusion_regexes=ctx.obj["exclusion_regexes"],
+        exclusion_regexes=ctx_obj.exclusion_regexes,
         matches_ignore=config.user_config.secret.ignored_matches,
         scan_context=scan_context,
         ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -78,8 +78,8 @@ def docset_cmd(
             command_path=ctx.command_path,
         )
         scanner = SecretScanner(
-            client=ctx.obj["client"],
-            cache=ctx.obj["cache"],
+            client=ctx_obj.client,
+            cache=ctx_obj.cache,
             ignored_matches=config.user_config.secret.ignored_matches,
             scan_context=scan_context,
             ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -41,11 +41,11 @@ def path_cmd(
     verbose = config.user_config.verbose
 
     for path in paths:
-        check_directory_not_ignored(path, ctx.obj["exclusion_regexes"])
+        check_directory_not_ignored(path, ctx_obj.exclusion_regexes)
 
     files = get_files_from_paths(
         paths=paths,
-        exclusion_regexes=ctx.obj["exclusion_regexes"],
+        exclusion_regexes=ctx_obj.exclusion_regexes,
         recursive=recursive,
         yes=yes,
         display_scanned_files=verbose,
@@ -64,8 +64,8 @@ def path_cmd(
         )
 
         scanner = SecretScanner(
-            client=ctx.obj["client"],
-            cache=ctx.obj["cache"],
+            client=ctx_obj.client,
+            cache=ctx_obj.cache,
             ignored_matches=config.user_config.secret.ignored_matches,
             scan_context=scan_context,
             ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -61,7 +61,7 @@ def precommit_cmd(
         target_path=Path.cwd(),
     )
 
-    commit = Commit.from_staged(ctx.obj["exclusion_regexes"])
+    commit = Commit.from_staged(ctx_obj.exclusion_regexes)
     scanner = SecretScanner(
         client=ctx_obj.client,
         cache=ctx_obj.cache,

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -104,7 +104,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
         ui=ctx_obj.ui,
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
-        exclusion_regexes=ctx.obj["exclusion_regexes"],
+        exclusion_regexes=ctx_obj.exclusion_regexes,
         matches_ignore=config.user_config.secret.ignored_matches,
         scan_context=scan_context,
         ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -112,7 +112,7 @@ def pypi_cmd(
         files = get_files_from_package(
             archive_dir=temp_path,
             package_name=package_name,
-            exclusion_regexes=ctx.obj["exclusion_regexes"],
+            exclusion_regexes=ctx_obj.exclusion_regexes,
             verbose=config.user_config.verbose,
         )
 
@@ -123,8 +123,8 @@ def pypi_cmd(
             )
 
             scanner = SecretScanner(
-                client=ctx.obj["client"],
-                cache=ctx.obj["cache"],
+                client=ctx_obj.client,
+                cache=ctx_obj.cache,
                 ignored_matches=config.user_config.secret.ignored_matches,
                 scan_context=scan_context,
                 ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -52,7 +52,7 @@ def range_cmd(
         ui=ctx_obj.ui,
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
-        exclusion_regexes=ctx.obj["exclusion_regexes"],
+        exclusion_regexes=ctx_obj.exclusion_regexes,
         matches_ignore=config.user_config.secret.ignored_matches,
         scan_context=scan_context,
         ignored_detectors=config.user_config.secret.ignored_detectors,

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -71,7 +71,8 @@ def _exclude_callback(
         ignored_paths.update(value)
 
     ignored_paths.update(IGNORED_DEFAULT_WILDCARDS)
-    ctx.obj["exclusion_regexes"] = init_exclusion_regexes(ignored_paths)
+    ctx_obj = ContextObj.get(ctx)
+    ctx_obj.exclusion_regexes = init_exclusion_regexes(ignored_paths)
     return value
 
 
@@ -143,6 +144,6 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     return output_handler_cls(
         show_secrets=config.user_config.secret.show_secrets,
         verbose=config.user_config.verbose,
-        output=ctx.obj.output,
+        output=ctx_obj.output,
         ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
     )

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -11,10 +11,11 @@ The `kwargs` argument is required because due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import Any, Callable, Optional, TypeVar
 
 import click
 
+from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.debug_logs import setup_debug_logs
 from ggshield.core.config.user_config import UserConfig
 
@@ -33,7 +34,7 @@ ClickCallback = Callable[
 
 def get_config_from_context(ctx: click.Context) -> UserConfig:
     """Returns the UserConfig object stored in Click context"""
-    return cast(UserConfig, ctx.obj["config"].user_config)
+    return ContextObj.get(ctx).config.user_config
 
 
 def create_ctx_callback(name: str) -> ClickCallback:

--- a/ggshield/cmd/utils/context_obj.py
+++ b/ggshield/cmd/utils/context_obj.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Any, Optional, Set, cast
+from typing import Optional, Set, cast
 
 import click
 from pygitguardian import GGClient
@@ -90,11 +90,3 @@ class ContextObj:
         """The recommended way to get a ContextObj instance, see the class docstring for
         details"""
         return cast(ContextObj, ctx.obj)
-
-    # The two following methods are here for compatibility reasons: ctx.obj used to be
-    # a dict, and not all code has been ported to use it as an object.
-    def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
-
-    def __setitem__(self, key: str, value: Any) -> Any:
-        return setattr(self, key, value)

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -109,7 +109,8 @@ def test_sca_scan_all_ignore_path(client: GGClient, dummy_sca_repo: Repository) 
     """
     dummy_sca_repo.git("checkout", "branch_with_vuln")
     ctx = get_valid_ctx(client)
-    ctx.obj["exclusion_regexes"] = {
+    ctx_obj = ContextObj.get(ctx)
+    ctx_obj.exclusion_regexes = {
         re.compile(r"Pipfile"),
         re.compile(r"Pipfile.lock"),
         re.compile(r"dummy_file.py"),
@@ -162,7 +163,8 @@ def test_sca_scan_diff_ignore_path(
     """
     dummy_sca_repo.git("checkout", "branch_without_vuln")
     ctx = get_valid_ctx(client)
-    ctx.obj["exclusion_regexes"] = {
+    ctx_obj = ContextObj.get(ctx)
+    ctx_obj.exclusion_regexes = {
         re.compile(r"Pipfile"),
         re.compile(r"Pipfile.lock"),
     }
@@ -188,7 +190,8 @@ def test_sca_scan_diff_no_files(
     """
     dummy_sca_repo.git("checkout", "branch_without_vuln")
     ctx = get_valid_ctx(client)
-    ctx.obj["exclusion_regexes"] = {re.compile(r"Pipfile"), re.compile(r"\.py")}
+    ctx_obj = ContextObj.get(ctx)
+    ctx_obj.exclusion_regexes = {re.compile(r"Pipfile"), re.compile(r"\.py")}
     with ctx:
         sca_scan_diff(
             ctx=ctx,


### PR DESCRIPTION
## Description

This PR finishes the migration to ContextObj. It does two things:

- convert the remaining code to use ContextObj instead of dict access.
- remove dict-like support from ContextObj.

## Interesting trivia

Interestingly this pointed out harmless typing errors, for example:

```python
if not scan.success or not isinstance(scan, IaCScanResult):
    handle_scan_error(client, scan)
    return None
```

pyright complained because the 2nd argument of `handle_scan_error()` expects a `Detail` instance, but pyright thought it could be a `IaCScanResult`. From a typing perspective, it could happen if `scan.success` was False but `isinstance(scan, IaCScanResult)` was True. In practice it cannot happen because `scan` is always a `Detail` when `scan.success` is False.

I wondered why it did not complain before, and I realized it's because `client` was previously defined as `client = ctx.obj["client"]`, so pyright had no idea what type it was. And also had no idea what the return type of `client.iac_directory_scan()` was.

Now that `client` is defined as `client.ctx_obj.client`, pyright knows it's a `GGClient` instance and thus knows the return type of `client.iac_directory_scan()`.