### PR TITLE
Logging fixes

### DIFF
--- a/changelog.d/20240110_144410_aurelien.gateau_logging_fixes.md
+++ b/changelog.d/20240110_144410_aurelien.gateau_logging_fixes.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ggshield secret scan ci --debug` now logs information reported when called with the `--verbose` flag, and the list of commits to scan.

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -14,8 +15,12 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
 from ggshield.core.scan import ScanContext, ScanMode
+from ggshield.core.text_utils import display_info
 from ggshield.utils.git_shell import check_git_dir
 from ggshield.verticals.secret.repo import scan_commit_range
+
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -36,7 +41,8 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     mode_header = f"{ScanMode.CI.value}/{ci_mode.value}"
 
     if config.user_config.verbose:
-        click.echo(f"Commits to scan: {len(commit_list)}", err=True)
+        display_info(f"Commits to scan: {len(commit_list)}")
+    logger.debug("commit_list=%s", commit_list)
 
     scan_context = ScanContext(
         scan_mode=mode_header,

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -131,8 +131,8 @@ class SecretScanner:
                 self.client.secret_scan_preferences.maximum_documents_per_scan,
             )
         )
-        logging.debug("max_doc_size=%d", maximum_document_size)
-        logging.debug("max_docs=%d", maximum_documents_per_scan)
+        logger.debug("max_doc_size=%d", maximum_document_size)
+        logger.debug("max_docs=%d", maximum_documents_per_scan)
         for scannable in scannables:
             try:
                 if scannable.is_longer_than(maximum_document_size):


### PR DESCRIPTION
This small PR make a bunch of small logging fixes, mainly for `secret scan ci` but not only:

- Information reported when called with `--verbose` is now also logged, so using `--debug` without using `--verbose` does not end up with less information.
- When called with `--debug`, `secret scan ci` now also logs the list of commits to scan.
- Fix a case where we were using the root logger instead of the logger defined in the module
