### PR TITLE
Add a script to build a standalone binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,64 @@ jobs:
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
           TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
 
+  build-standalone:
+    name: Standalone exe
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Get enough commits to run `ggshield secret scan commit-range` on ourselves
+          fetch-depth: 10
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install normal dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pipenv==2023.10.3
+          pipenv install --system --dev
+
+      - name: Install standalone-specific dependencies
+        run: |
+          python -m pip install --upgrade pyinstaller
+
+      - name: Build
+        shell: bash
+        run: |
+          scripts/build-standalone-exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ggshield-standalone-${{ matrix.os }}
+          path: |
+            dist/ggshield-standalone-*.gz
+            dist/ggshield-standalone-*.zip
+
+      - name: Override base Docker image used for functional tests on Windows
+        if: matrix.os == 'windows-2022'
+        # This is required because GitHub Windows runner is not configured to
+        # run Linux-based Docker images
+        shell: bash
+        run: |
+          echo "GGTEST_DOCKER_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022" >> $GITHUB_ENV
+
+      - name: Functional tests
+        shell: bash
+        run: |
+          scripts/build-standalone-exe functests
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
+          TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
+
   build_packages:
     # This job ensures the build-packages script is tested on each build, not only at release time
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Use Pipfile.lock on locked version of Python
         # Keep version in sync with scripts/update-pipfile-lock/Dockerfile
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         run: |
           echo "PIPENV_SKIP_LOCK=0" >> $GITHUB_ENV
 
@@ -159,23 +159,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-2022
+          - macos-14
     steps:
       - uses: actions/checkout@v4
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install normal dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipenv==2023.10.3
           pipenv install --system --dev
+        env:
+          # Disable lock otherwise Windows-only dependencies like colorama are not installed
+          PIPENV_SKIP_LOCK: 1
 
       - name: Install standalone-specific dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep image in sync with scripts/update-pipfile-lock/Dockerfile
-FROM python:3.9-slim as build
+FROM python:3.10-slim as build
 
 LABEL maintainer="GitGuardian SRE Team <support@gitguardian.com>"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,11 +16,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.11.17"
+            "version": "==2024.2.2"
         },
         "cffi": {
             "hashes": [
@@ -207,6 +207,7 @@
         },
         "ggshield": {
             "editable": true,
+            "markers": "python_version >= '3.8'",
             "path": "."
         },
         "idna": {
@@ -394,11 +395,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
-                "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
+                "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
+                "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         }
     },
     "develop": {
@@ -445,15 +446,16 @@
                 "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.6.2'",
             "version": "==22.3.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.11.17"
+            "version": "==2024.2.2"
         },
         "cfgv": {
             "hashes": [
@@ -615,6 +617,7 @@
                 "sha256:fe558371c1bdf3b8fa03e097c523fb9645b8730399c14fe7721ee9c9e2a545d3"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==7.4.1"
         },
         "distlib": {
@@ -653,6 +656,7 @@
                 "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.1'",
             "version": "==7.0.0"
         },
         "flake8-isort": {
@@ -661,6 +665,7 @@
                 "sha256:c1f82f3cf06a80c13e1d09bfae460e9666255d5c780b859f19f8318d420370b3"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==6.1.1"
         },
         "flake8-quotes": {
@@ -771,6 +776,7 @@
                 "sha256:b067cf0cdbf11c4f87524e32c2e3eaa62d46572e9e06511e6b453198b15b1c9a"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.0"
         },
         "iniconfig": {
@@ -803,6 +809,7 @@
                 "sha256:85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==4.21.1"
         },
         "jsonschema-specifications": {
@@ -905,83 +912,99 @@
         },
         "multidict": {
             "hashes": [
-                "sha256:01a3a55bd90018c9c080fbb0b9f4891db37d148a0a18722b42f94694f8b6d4c9",
-                "sha256:0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8",
-                "sha256:0dfad7a5a1e39c53ed00d2dd0c2e36aed4650936dc18fd9a1826a5ae1cad6f03",
-                "sha256:11bdf3f5e1518b24530b8241529d2050014c884cf18b6fc69c0c2b30ca248710",
-                "sha256:1502e24330eb681bdaa3eb70d6358e818e8e8f908a22a1851dfd4e15bc2f8161",
-                "sha256:16ab77bbeb596e14212e7bab8429f24c1579234a3a462105cda4a66904998664",
-                "sha256:16d232d4e5396c2efbbf4f6d4df89bfa905eb0d4dc5b3549d872ab898451f569",
-                "sha256:21a12c4eb6ddc9952c415f24eef97e3e55ba3af61f67c7bc388dcdec1404a067",
-                "sha256:27c523fbfbdfd19c6867af7346332b62b586eed663887392cff78d614f9ec313",
-                "sha256:281af09f488903fde97923c7744bb001a9b23b039a909460d0f14edc7bf59706",
-                "sha256:33029f5734336aa0d4c0384525da0387ef89148dc7191aae00ca5fb23d7aafc2",
-                "sha256:3601a3cece3819534b11d4efc1eb76047488fddd0c85a3948099d5da4d504636",
-                "sha256:3666906492efb76453c0e7b97f2cf459b0682e7402c0489a95484965dbc1da49",
-                "sha256:36c63aaa167f6c6b04ef2c85704e93af16c11d20de1d133e39de6a0e84582a93",
-                "sha256:39ff62e7d0f26c248b15e364517a72932a611a9b75f35b45be078d81bdb86603",
-                "sha256:43644e38f42e3af682690876cff722d301ac585c5b9e1eacc013b7a3f7b696a0",
-                "sha256:4372381634485bec7e46718edc71528024fcdc6f835baefe517b34a33c731d60",
-                "sha256:458f37be2d9e4c95e2d8866a851663cbc76e865b78395090786f6cd9b3bbf4f4",
-                "sha256:45e1ecb0379bfaab5eef059f50115b54571acfbe422a14f668fc8c27ba410e7e",
-                "sha256:4b9d9e4e2b37daddb5c23ea33a3417901fa7c7b3dee2d855f63ee67a0b21e5b1",
-                "sha256:4ceef517eca3e03c1cceb22030a3e39cb399ac86bff4e426d4fc6ae49052cc60",
-                "sha256:4d1a3d7ef5e96b1c9e92f973e43aa5e5b96c659c9bc3124acbbd81b0b9c8a951",
-                "sha256:4dcbb0906e38440fa3e325df2359ac6cb043df8e58c965bb45f4e406ecb162cc",
-                "sha256:509eac6cf09c794aa27bcacfd4d62c885cce62bef7b2c3e8b2e49d365b5003fe",
-                "sha256:52509b5be062d9eafc8170e53026fbc54cf3b32759a23d07fd935fb04fc22d95",
-                "sha256:52f2dffc8acaba9a2f27174c41c9e57f60b907bb9f096b36b1a1f3be71c6284d",
-                "sha256:574b7eae1ab267e5f8285f0fe881f17efe4b98c39a40858247720935b893bba8",
-                "sha256:5979b5632c3e3534e42ca6ff856bb24b2e3071b37861c2c727ce220d80eee9ed",
-                "sha256:59d43b61c59d82f2effb39a93c48b845efe23a3852d201ed2d24ba830d0b4cf2",
-                "sha256:5a4dcf02b908c3b8b17a45fb0f15b695bf117a67b76b7ad18b73cf8e92608775",
-                "sha256:5cad9430ab3e2e4fa4a2ef4450f548768400a2ac635841bc2a56a2052cdbeb87",
-                "sha256:5fc1b16f586f049820c5c5b17bb4ee7583092fa0d1c4e28b5239181ff9532e0c",
-                "sha256:62501642008a8b9871ddfccbf83e4222cf8ac0d5aeedf73da36153ef2ec222d2",
-                "sha256:64bdf1086b6043bf519869678f5f2757f473dee970d7abf6da91ec00acb9cb98",
-                "sha256:64da238a09d6039e3bd39bb3aee9c21a5e34f28bfa5aa22518581f910ff94af3",
-                "sha256:666daae833559deb2d609afa4490b85830ab0dfca811a98b70a205621a6109fe",
-                "sha256:67040058f37a2a51ed8ea8f6b0e6ee5bd78ca67f169ce6122f3e2ec80dfe9b78",
-                "sha256:6748717bb10339c4760c1e63da040f5f29f5ed6e59d76daee30305894069a660",
-                "sha256:6b181d8c23da913d4ff585afd1155a0e1194c0b50c54fcfe286f70cdaf2b7176",
-                "sha256:6ed5f161328b7df384d71b07317f4d8656434e34591f20552c7bcef27b0ab88e",
-                "sha256:7582a1d1030e15422262de9f58711774e02fa80df0d1578995c76214f6954988",
-                "sha256:7d18748f2d30f94f498e852c67d61261c643b349b9d2a581131725595c45ec6c",
-                "sha256:7d6ae9d593ef8641544d6263c7fa6408cc90370c8cb2bbb65f8d43e5b0351d9c",
-                "sha256:81a4f0b34bd92df3da93315c6a59034df95866014ac08535fc819f043bfd51f0",
-                "sha256:8316a77808c501004802f9beebde51c9f857054a0c871bd6da8280e718444449",
-                "sha256:853888594621e6604c978ce2a0444a1e6e70c8d253ab65ba11657659dcc9100f",
-                "sha256:99b76c052e9f1bc0721f7541e5e8c05db3941eb9ebe7b8553c625ef88d6eefde",
-                "sha256:a2e4369eb3d47d2034032a26c7a80fcb21a2cb22e1173d761a162f11e562caa5",
-                "sha256:ab55edc2e84460694295f401215f4a58597f8f7c9466faec545093045476327d",
-                "sha256:af048912e045a2dc732847d33821a9d84ba553f5c5f028adbd364dd4765092ac",
-                "sha256:b1a2eeedcead3a41694130495593a559a668f382eee0727352b9a41e1c45759a",
-                "sha256:b1e8b901e607795ec06c9e42530788c45ac21ef3aaa11dbd0c69de543bfb79a9",
-                "sha256:b41156839806aecb3641f3208c0dafd3ac7775b9c4c422d82ee2a45c34ba81ca",
-                "sha256:b692f419760c0e65d060959df05f2a531945af31fda0c8a3b3195d4efd06de11",
-                "sha256:bc779e9e6f7fda81b3f9aa58e3a6091d49ad528b11ed19f6621408806204ad35",
-                "sha256:bf6774e60d67a9efe02b3616fee22441d86fab4c6d335f9d2051d19d90a40063",
-                "sha256:c048099e4c9e9d615545e2001d3d8a4380bd403e1a0578734e0d31703d1b0c0b",
-                "sha256:c5cb09abb18c1ea940fb99360ea0396f34d46566f157122c92dfa069d3e0e982",
-                "sha256:cc8e1d0c705233c5dd0c5e6460fbad7827d5d36f310a0fadfd45cc3029762258",
-                "sha256:d5e3fc56f88cc98ef8139255cf8cd63eb2c586531e43310ff859d6bb3a6b51f1",
-                "sha256:d6aa0418fcc838522256761b3415822626f866758ee0bc6632c9486b179d0b52",
-                "sha256:d6c254ba6e45d8e72739281ebc46ea5eb5f101234f3ce171f0e9f5cc86991480",
-                "sha256:d6d635d5209b82a3492508cf5b365f3446afb65ae7ebd755e70e18f287b0adf7",
-                "sha256:dcfe792765fab89c365123c81046ad4103fcabbc4f56d1c1997e6715e8015461",
-                "sha256:ddd3915998d93fbcd2566ddf9cf62cdb35c9e093075f862935573d265cf8f65d",
-                "sha256:ddff9c4e225a63a5afab9dd15590432c22e8057e1a9a13d28ed128ecf047bbdc",
-                "sha256:e41b7e2b59679edfa309e8db64fdf22399eec4b0b24694e1b2104fb789207779",
-                "sha256:e69924bfcdda39b722ef4d9aa762b2dd38e4632b3641b1d9a57ca9cd18f2f83a",
-                "sha256:ea20853c6dbbb53ed34cb4d080382169b6f4554d394015f1bef35e881bf83547",
-                "sha256:ee2a1ece51b9b9e7752e742cfb661d2a29e7bcdba2d27e66e28a99f1890e4fa0",
-                "sha256:eeb6dcc05e911516ae3d1f207d4b0520d07f54484c49dfc294d6e7d63b734171",
-                "sha256:f70b98cd94886b49d91170ef23ec5c0e8ebb6f242d734ed7ed677b24d50c82cf",
-                "sha256:fc35cb4676846ef752816d5be2193a1e8367b4c1397b74a565a9d0389c433a1d",
-                "sha256:ff959bee35038c4624250473988b24f846cbeb2c6639de3602c073f10410ceba"
+                "sha256:01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556",
+                "sha256:0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c",
+                "sha256:04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29",
+                "sha256:04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b",
+                "sha256:09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8",
+                "sha256:0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7",
+                "sha256:107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd",
+                "sha256:141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40",
+                "sha256:14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6",
+                "sha256:19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3",
+                "sha256:1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c",
+                "sha256:1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9",
+                "sha256:215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5",
+                "sha256:21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae",
+                "sha256:220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442",
+                "sha256:228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9",
+                "sha256:29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc",
+                "sha256:2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c",
+                "sha256:2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea",
+                "sha256:2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5",
+                "sha256:37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50",
+                "sha256:3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182",
+                "sha256:3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453",
+                "sha256:403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e",
+                "sha256:411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600",
+                "sha256:425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733",
+                "sha256:435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda",
+                "sha256:4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241",
+                "sha256:4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461",
+                "sha256:51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e",
+                "sha256:53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e",
+                "sha256:55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b",
+                "sha256:5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e",
+                "sha256:5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7",
+                "sha256:60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386",
+                "sha256:612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd",
+                "sha256:6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9",
+                "sha256:6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf",
+                "sha256:69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee",
+                "sha256:6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5",
+                "sha256:766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a",
+                "sha256:76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271",
+                "sha256:76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54",
+                "sha256:7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4",
+                "sha256:79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496",
+                "sha256:79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb",
+                "sha256:7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319",
+                "sha256:7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3",
+                "sha256:7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f",
+                "sha256:7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527",
+                "sha256:85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed",
+                "sha256:896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604",
+                "sha256:92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef",
+                "sha256:99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8",
+                "sha256:9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5",
+                "sha256:a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5",
+                "sha256:aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626",
+                "sha256:b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c",
+                "sha256:b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d",
+                "sha256:c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c",
+                "sha256:c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc",
+                "sha256:c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc",
+                "sha256:cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b",
+                "sha256:cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38",
+                "sha256:ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450",
+                "sha256:cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1",
+                "sha256:d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f",
+                "sha256:d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3",
+                "sha256:d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755",
+                "sha256:d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226",
+                "sha256:d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a",
+                "sha256:dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046",
+                "sha256:de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf",
+                "sha256:e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479",
+                "sha256:e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e",
+                "sha256:e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1",
+                "sha256:e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a",
+                "sha256:e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83",
+                "sha256:e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929",
+                "sha256:e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93",
+                "sha256:ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a",
+                "sha256:ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c",
+                "sha256:eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44",
+                "sha256:edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89",
+                "sha256:f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba",
+                "sha256:f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e",
+                "sha256:f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da",
+                "sha256:fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24",
+                "sha256:fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423",
+                "sha256:fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.0.4"
+            "version": "==6.0.5"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1037,6 +1060,7 @@
                 "sha256:d30bad9abf165f7785c15a21a1f46da7d0677cb00ee7ff4c579fd38922efe15d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.9'",
             "version": "==3.6.0"
         },
         "pycodestyle": {
@@ -1049,11 +1073,12 @@
         },
         "pyfakefs": {
             "hashes": [
-                "sha256:dadac1653195a4bfe4c26e9dfa7cc0c0286b1cd8e18706442c2464cae5542a17",
-                "sha256:fc375229f5417f197f0892a7d6dc49a411e67e10eb8142b19d80e60a9d52a13d"
+                "sha256:751015c1de94e1390128c82b48cdedc3f088bbdbe4bc713c79d02a27f0f61e69",
+                "sha256:7cdc500b35a214cb7a614e1940543acc6650e69a94ac76e30f33c9373bd9cf90"
             ],
             "index": "pypi",
-            "version": "==5.3.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==5.3.5"
         },
         "pyflakes": {
             "hashes": [
@@ -1069,6 +1094,7 @@
                 "sha256:95fa963337e2cfd4900601197d0f866d8c51732dea6c0bb12f962f92a79c77e3"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==1.1.313"
         },
         "pytest": {
@@ -1077,6 +1103,7 @@
                 "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==7.2.1"
         },
         "pytest-mock": {
@@ -1085,6 +1112,7 @@
                 "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==3.12.0"
         },
         "pytest-socket": {
@@ -1093,6 +1121,7 @@
                 "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
             "version": "==0.7.0"
         },
         "pytest-voluptuous": {
@@ -1100,6 +1129,7 @@
                 "sha256:a3856e9812b219fec1c3f2fd8249c0bac6927e1d5e52a3961e4ae903f54d494f"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "pyyaml": {
@@ -1288,7 +1318,6 @@
                 "sha256:30ae9ff8d144f8e0cf394c4e1d379542f1b3823767642955b54ec40dc00b32b6",
                 "sha256:a3adc657733b4124fcb54527a5f3daab0d3c300de82d0fd2b9b297b243151b78"
             ],
-            "index": "pypi",
             "version": "==1.5.1"
         },
         "seed-isort-config": {
@@ -1297,6 +1326,7 @@
                 "sha256:be4cfef8f9a3fe8ea1817069c6b624538ac0b429636ec746edeb27e98ed628c8"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.6.1'",
             "version": "==2.2.0"
         },
         "setuptools": {
@@ -1312,7 +1342,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "snapshottest": {
@@ -1349,17 +1379,18 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
-                "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
+                "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
+                "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         },
         "vcrpy": {
             "hashes": [
                 "sha256:9e023fee7f892baa0bbda2f7da7c8ac51165c1c6e38ff8688683a12a4bde9278"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==6.0.1"
         },
         "virtualenv": {

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional
 
 import click
 
+from ggshield import __version__
 from ggshield.cmd.auth import auth_group
 from ggshield.cmd.config import config_group
 from ggshield.cmd.hmsl import hmsl_group
@@ -98,7 +99,7 @@ def config_path_callback(
     callback=config_path_callback,
 )
 @add_common_options()
-@click.version_option()
+@click.version_option(version=__version__)
 @click.pass_context
 def cli(
     ctx: click.Context,

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import logging
+import multiprocessing
 import os
 import sys
 from pathlib import Path
@@ -178,6 +179,11 @@ def main(args: Optional[List[str]] = None) -> Any:
 
     `args` is only used by unit-tests.
     """
+
+    # Required by pyinstaller when forking.
+    # See https://pyinstaller.org/en/latest/common-issues-and-pitfalls.html#multi-processing
+    multiprocessing.freeze_support()
+
     disable_logs()
     show_crash_log = getenv_bool("GITGUARDIAN_CRASH_LOG")
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)

--- a/scripts/build-standalone-exe
+++ b/scripts/build-standalone-exe
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGNAME=$(basename "$0")
+ROOT_DIR=$(cd "$(dirname "$0")/.." ; pwd)
+
+DEFAULT_STEPS="req build copy_files test create_archive"
+
+DIST_DIR=$PWD/dist
+
+REQUIREMENTS="pyinstaller"
+
+err() {
+    echo "$@" >&2
+}
+
+info() {
+    err "$PROGNAME: [INFO] $*"
+}
+
+die() {
+    err "$PROGNAME: [ERROR] $*"
+    exit 1
+}
+
+usage() {
+    if [ "$*" != "" ] ; then
+        err "Error: $*"
+        err
+    fi
+
+    cat << EOF
+Usage: $PROGNAME [OPTION ...] [STEPS]
+Build a standalone executable for ggshield.
+
+Default steps are: $DEFAULT_STEPS
+
+Options:
+  -h, --help      Display this usage message and exit.
+EOF
+
+    exit 1
+}
+
+read_version() {
+    VERSION=$(grep -o "[0-9]*\.[0-9]*\.[0-9]*" "$ROOT_DIR/ggshield/__init__.py")
+}
+
+init_system_vars() {
+    local arch
+    arch=$(uname -m)
+    if [ "$arch" = "aarch64" ] ; then
+        arch=arm64
+    fi
+
+    local out
+    out=$(uname)
+
+    case "$out" in
+    Linux)
+        EXE_EXT=""
+        TARGET="$arch-unknown-linux-gnu"
+        ARCHIVE_FORMAT=tar
+        ;;
+    Darwin)
+        EXE_EXT=""
+        TARGET="$arch-apple-darwin"
+        ARCHIVE_FORMAT=tar
+        ;;
+    MINGW*|MSYS*)
+        EXE_EXT=".exe"
+        TARGET="$arch-pc-windows-msvc"
+        ARCHIVE_FORMAT=zip
+        ;;
+    *)
+        die "Unknown OS. uname printed '$out'"
+        ;;
+    esac
+    ARCHIVE_DIR_NAME=ggshield-standalone-$VERSION-$TARGET
+}
+
+step_req() {
+    local fail=0
+    info "Checking requirements"
+    local requirements=$REQUIREMENTS
+    for exe in $requirements ; do
+        err -n "$exe: "
+        if command -v "$exe" > /dev/null ; then
+            err OK
+        else
+            err FAIL
+            fail=1
+        fi
+    done
+    if [ $fail -ne 0 ] ; then
+        die "Not all requirements are installed"
+    fi
+}
+
+step_build() {
+    rm -rf build/ggshield
+    rm -rf "$DIST_DIR/ggshield"
+    pyinstaller ggshield/__main__.py --name ggshield --noupx
+}
+
+step_copy_files() {
+    local pyinstaller_output_dir=$DIST_DIR/ggshield
+    if ! [ -d "$pyinstaller_output_dir" ] ; then
+        die "$pyinstaller_output_dir does not exist"
+    fi
+    local pyinstaller_ggshield=$pyinstaller_output_dir/ggshield$EXE_EXT
+    if ! [ -f "$pyinstaller_ggshield" ] ; then
+        die "Can't find '$pyinstaller_ggshield', maybe 'build' step did not run?"
+    fi
+
+    local output_dir="$DIST_DIR/$ARCHIVE_DIR_NAME"
+    info "Copying files to $output_dir"
+    rm -rf "$output_dir"
+    cp -R "$pyinstaller_output_dir" "$output_dir"
+}
+
+step_test() {
+    info "test: running --help"
+    "$DIST_DIR/$ARCHIVE_DIR_NAME/ggshield${EXE_EXT}" --help > /dev/null
+    info "test: running --help: OK"
+}
+
+step_functests() {
+    PATH=$DIST_DIR/$ARCHIVE_DIR_NAME:$PATH pytest tests/functional
+}
+
+step_create_archive() {
+    local archive_path
+    case "$ARCHIVE_FORMAT" in
+    tar)
+        archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.tar.gz"
+        tar -C "$DIST_DIR" -czf "$archive_path" "$ARCHIVE_DIR_NAME"
+        ;;
+    zip)
+        archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.zip"
+        env -C "$DIST_DIR" 7z a "$archive_path" "$ARCHIVE_DIR_NAME"
+        ;;
+    *)
+        die "Unsupported archive format $ARCHIVE_FORMAT"
+        ;;
+    esac
+    info "Archive created in $archive_path"
+}
+
+steps=""
+while [ $# -gt 0 ] ; do
+    case "$1" in
+    -h|--help)
+        usage
+        ;;
+    -*)
+        usage "Unknown option '$1'"
+        ;;
+    *)
+        steps="$steps $1"
+        ;;
+    esac
+    shift
+done
+
+if [ -z "$steps" ] ; then
+    steps=$DEFAULT_STEPS
+fi
+
+cd "$ROOT_DIR"
+read_version
+init_system_vars
+for step in $steps ; do
+    info "step $step"
+    "step_$step"
+done

--- a/scripts/build-standalone-exe
+++ b/scripts/build-standalone-exe
@@ -138,9 +138,11 @@ step_copy_files() {
 }
 
 step_test() {
-    info "test: running --help"
-    "$DIST_DIR/$ARCHIVE_DIR_NAME/ggshield${EXE_EXT}" --help > /dev/null
-    info "test: running --help: OK"
+    for args in --help --version ; do
+        info "test: running $args"
+        "$DIST_DIR/$ARCHIVE_DIR_NAME/ggshield${EXE_EXT}" $args
+        info "test: running $args: OK"
+    done
 }
 
 step_functests() {

--- a/scripts/build-standalone-exe
+++ b/scripts/build-standalone-exe
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PROGNAME=$(basename "$0")
 ROOT_DIR=$(cd "$(dirname "$0")/.." ; pwd)
+RESOURCES_DIR="$ROOT_DIR/scripts/standalone-exe"
 
 DEFAULT_STEPS="req build copy_files test create_archive"
 
@@ -49,9 +50,18 @@ read_version() {
 init_system_vars() {
     local arch
     arch=$(uname -m)
-    if [ "$arch" = "aarch64" ] ; then
-        arch=arm64
-    fi
+
+    case "$arch" in
+    arm64)
+        HUMAN_ARCH=ARM-based
+        ;;
+    x86_64)
+        HUMAN_ARCH=Intel-based
+        ;;
+    *)
+        die "Unsupported architecture '$arch'"
+        ;;
+    esac
 
     local out
     out=$(uname)
@@ -60,15 +70,18 @@ init_system_vars() {
     Linux)
         EXE_EXT=""
         TARGET="$arch-unknown-linux-gnu"
+        HUMAN_OS=Linux
         ARCHIVE_FORMAT=tar
         ;;
     Darwin)
         EXE_EXT=""
+        HUMAN_OS=macOS
         TARGET="$arch-apple-darwin"
         ARCHIVE_FORMAT=tar
         ;;
     MINGW*|MSYS*)
         EXE_EXT=".exe"
+        HUMAN_OS=Windows
         TARGET="$arch-pc-windows-msvc"
         ARCHIVE_FORMAT=zip
         ;;
@@ -117,6 +130,11 @@ step_copy_files() {
     info "Copying files to $output_dir"
     rm -rf "$output_dir"
     cp -R "$pyinstaller_output_dir" "$output_dir"
+    sed \
+        -e "s/@HUMAN_OS@/$HUMAN_OS/" \
+        -e "s/@HUMAN_ARCH@/$HUMAN_ARCH/" \
+        "$RESOURCES_DIR/README.md" \
+        > "$output_dir/README.md"
 }
 
 step_test() {

--- a/scripts/standalone-exe/README.md
+++ b/scripts/standalone-exe/README.md
@@ -1,0 +1,17 @@
+# `ggshield` standalone executable
+
+This archive contains a standalone version of `ggshield`.
+
+`ggshield` is [GitGuardian](https://gitguardian.com) CLI application. It runs in your local environment or in a CI environment to help you detect more than 350+ types of secrets, as well as other potential security vulnerabilities or policy breaks affecting your codebase.
+
+To learn more, visit https://github.com/GitGuardian/ggshield.
+
+## Installation
+
+Before starting, make sure you use the right `ggshield` archive: this archive only works on **@HUMAN_ARCH@** machines running **@HUMAN_OS@**.
+
+1. Unpack/copy this directory to a destination directory of your choice.
+
+2. Add said directory to your `$PATH` environment variable.
+
+Note: Do not copy only the `ggshield` executable. All files inside this directory are required.

--- a/scripts/update-pipfile-lock/Dockerfile
+++ b/scripts/update-pipfile-lock/Dockerfile
@@ -4,7 +4,7 @@
 # If you change this version, you must also change:
 # - The image version in the root Dockerfile
 # - The version in .github/workflows/main.yml
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG UID
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -15,6 +15,8 @@ from pygitguardian.config import DEFAULT_BASE_URI
 from tests.repository import Repository
 
 
+GGSHIELD_PATH = shutil.which("ggshield")
+
 FUNCTESTS_DATA_PATH = Path(__file__).parent / "data"
 
 # Path to the root of ggshield repository
@@ -170,3 +172,9 @@ def sca_repo_with_hook_all(tmp_path: Path) -> Repository:
     return repo_with_hook_content(
         tmp_path=tmp_path, hook_content=HOOK_CONTENT_ALL.format("sca")
     )
+
+
+def pytest_report_header(config, start_path, startdir):
+    """This function is called by pytest, it lets us insert messages in its report
+    header"""
+    return f"ggshield path: {GGSHIELD_PATH}"

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -8,6 +8,7 @@ import pytest
 from pygitguardian.models import Match
 
 from ggshield.core.filter import censor_match
+from tests.functional.conftest import GGSHIELD_PATH
 
 
 PathLike = Union[Path, str]
@@ -20,7 +21,8 @@ def run_ggshield(
     env: Optional[Dict] = None,
 ) -> subprocess.CompletedProcess:
     env = env or dict()
-    cmd = ("ggshield", *args)
+    assert GGSHIELD_PATH is not None
+    cmd = (GGSHIELD_PATH, *args)
     cwd = None if cwd is None else str(cwd)
     result = subprocess.run(
         cmd,


### PR DESCRIPTION
This PR adds the `scripts/build-standalone-exe` script. This script builds a standalone ggshield executable using [Pyinstaller](https://pyinstaller.org/en/stable/).

It builds binaries for:
- Windows x86_64
- Linux x86_64
- Mac x86_64
- Mac M1

The binaries can be downloaded from the bottom of the [summary page](https://github.com/GitGuardian/ggshield/actions/runs/7888013682?pr=833) of the action run (after all the deprecation warnings 😅)

Note: Building for Mac M1 required bumping the default Python version to 3.10 because 3.9 was not available on the GitHub M1 runner.

Best reviewed commit-by-commit.