### PR TITLE
Handle IAC scans on CI after force pushing

### DIFF
--- a/changelog.d/20240115_102510_carla.martet.ext_handle_ci_on_force_pushing.md
+++ b/changelog.d/20240115_102510_carla.martet.ext_handle_ci_on_force_pushing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- In CI jobs, IAC/SCA scans on forced pushs no longer trigger an error but perform a scan on all commits instead.

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -118,9 +118,7 @@ def iac_scan_diff(
     verbose = config.user_config.verbose if config and config.user_config else False
     if verbose:
         if previous_ref is None:
-            display_info(
-                "> No file to scan in reference. This might be a new repository."
-            )
+            display_info("> No file to scan in reference.")
         else:
             display_info(f"> Scanned files in reference {previous_ref}")
             filepaths = filter_iac_filepaths(

--- a/tests/repository.py
+++ b/tests/repository.py
@@ -68,6 +68,12 @@ class Repository:
         self.git("config", "user.email", "ggshield-test@example.com")
         self._credentials_set = True
 
+    def remove_unreachable_commits(self):
+        # Remove all unreachable commits and their references.
+        # It is used to simulate the CI env which cannot access detached history.
+        self.git("reflog", "expire", "--expire-unreachable=now", "--all")
+        self.git("gc", "--prune=now")
+
 
 def create_pre_receive_repo(tmp_path) -> Repository:
     repo = Repository.create(tmp_path)

--- a/tests/unit/core/git_hooks/ci/test_previous_commit.py
+++ b/tests/unit/core/git_hooks/ci/test_previous_commit.py
@@ -7,16 +7,19 @@ import pytest
 from pytest import MonkeyPatch
 
 from ggshield.core.git_hooks.ci.previous_commit import get_previous_commit_from_ci_env
-from ggshield.utils.git_shell import EMPTY_SHA, git
+from ggshield.utils.git_shell import EMPTY_SHA, git, is_valid_git_commit_ref
 from ggshield.utils.os import cd
 from tests.repository import Repository
 
 
 def _setup_github_ci_env_new_branch(
-    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str
+    monkeypatch: MonkeyPatch,
+    branch_name: str,
+    head_sha: str,
+    before_sha: str = EMPTY_SHA,
 ):
     monkeypatch.setenv("GITHUB_ACTIONS", "1")
-    monkeypatch.setenv("GITHUB_PUSH_BEFORE_SHA", EMPTY_SHA)
+    monkeypatch.setenv("GITHUB_PUSH_BEFORE_SHA", before_sha)
     monkeypatch.setenv("GITHUB_BASE_REF", "")
     monkeypatch.setenv("GITHUB_SHA", head_sha)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
@@ -25,28 +28,31 @@ def _setup_github_ci_env_new_branch(
 
 
 def _setup_gitlab_ci_env_new_branch(
-    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str
+    monkeypatch: MonkeyPatch,
+    branch_name: str,
+    head_sha: str,
+    before_sha: str = EMPTY_SHA,
 ):
     monkeypatch.setenv("GITLAB_CI", "1")
-    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", EMPTY_SHA)
+    monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", before_sha)
     monkeypatch.setenv("CI_COMMIT_BRANCH", branch_name)
     monkeypatch.setenv("CI_COMMIT_SHA", head_sha)
 
 
 def _setup_jenkins_ci_env_new_branch(
-    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str
+    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str, before_sha: str = ""
 ):
     monkeypatch.setenv("JENKINS_HOME", "1")
-    monkeypatch.setenv("GIT_PREVIOUS_COMMIT", "")
+    monkeypatch.setenv("GIT_PREVIOUS_COMMIT", before_sha)
     monkeypatch.setenv("GIT_BRANCH", branch_name)
     monkeypatch.setenv("GIT_COMMIT", head_sha)
 
 
 def _setup_azure_ci_env_new_branch(
-    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str
+    monkeypatch: MonkeyPatch, branch_name: str, head_sha: str, before_sha: str = ""
 ):
     monkeypatch.setenv("BUILD_BUILDID", "1")
-    monkeypatch.setenv("BUILD_SOURCEVERSION", "")
+    monkeypatch.setenv("BUILD_SOURCEVERSION", before_sha)
     monkeypatch.setenv("BUILD_SOURCEBRANCHNAME", branch_name)
 
 
@@ -120,4 +126,103 @@ def test_get_previous_commit_from_ci_env_new_repo(
     with cd(repository.path), mock.patch.dict(os.environ, clear=True):
         # Simulate CI env
         setup_ci_env(monkeypatch, "new-branch", "HEAD")
+        assert get_previous_commit_from_ci_env(False) is None
+
+
+@parametrized_ci_provider
+def test_get_previous_commit_from_ci_env_sub_branch_forced_push(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    setup_ci_env: Callable[[MonkeyPatch, str, str], None],
+) -> None:
+    """
+    GIVEN   a repository with:
+            - a commit pushed on the main branch
+            - another branch created from main, with commits pushed
+            - a local history rewritten
+    WHEN    calculating the commit sha previous to the forced push,
+            in a simulated CI env where new-branch is newly pushed
+    THEN    the commit SHA (previous HEAD) returned does not exist anymore
+            and a scan all is triggered instead
+    """
+    # Setup main branch
+    remote_repository = Repository.create(tmp_path / "remote", bare=True)
+    repository = Repository.clone(remote_repository.path, tmp_path / "local")
+    repository.create_commit()
+    repository.push()
+
+    # Setup new branch
+    branch_name = "new-branch"
+    repository.create_branch(branch_name)
+    before_sha = repository.create_commit()
+
+    repository.git("commit", "--amend", "--allow-empty", "-m", "message")
+    repository.remove_unreachable_commits()
+
+    assert not is_valid_git_commit_ref(before_sha)
+    assert before_sha != repository.get_top_sha()
+
+    with cd(repository.path), mock.patch.dict(os.environ, clear=True):
+        # Simulate CI env
+        setup_ci_env(monkeypatch, branch_name, "HEAD", before_sha)
+        found_sha = get_previous_commit_from_ci_env(False)
+
+    assert found_sha is None
+
+
+@parametrized_ci_provider
+def test_get_previous_commit_from_ci_env_default_branch_forced_push(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    setup_ci_env: Callable[[MonkeyPatch, str, str], None],
+):
+    """
+    GIVEN   a new, empty repository
+    WHEN    calculating the commit sha previous to the first push,
+            in a simulated CI env
+    THEN    None is returned
+    """
+    remote_repository = Repository.create(tmp_path / "remote", bare=True)
+    repository = Repository.clone(remote_repository.path, tmp_path / "local")
+
+    repository.create_commit()
+    before_sha = repository.create_commit()
+
+    repository.git("commit", "--amend", "--allow-empty", "-m", "message")
+    repository.remove_unreachable_commits()
+
+    assert not is_valid_git_commit_ref(before_sha)
+    assert before_sha != repository.get_top_sha()
+
+    with cd(repository.path), mock.patch.dict(os.environ, clear=True):
+        # Simulate CI env
+        setup_ci_env(monkeypatch, "new-branch", "HEAD", before_sha)
+        assert get_previous_commit_from_ci_env(False) is None
+
+
+@parametrized_ci_provider
+def test_get_previous_commit_from_ci_env_all_commits_forced_push(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    setup_ci_env: Callable[[MonkeyPatch, str, str], None],
+):
+    """
+    GIVEN   a new, empty repository
+    WHEN    calculating the commit sha previous to the first push,
+            in a simulated CI env
+    THEN    None is returned
+    """
+    remote_repository = Repository.create(tmp_path / "remote", bare=True)
+    repository = Repository.clone(remote_repository.path, tmp_path / "local")
+
+    before_sha = repository.create_commit()
+    repository.git("commit", "--amend", "--allow-empty", "-m", "message")
+    repository.remove_unreachable_commits()
+
+    assert not is_valid_git_commit_ref(before_sha)
+    assert before_sha != repository.get_top_sha()
+
+    with cd(repository.path), mock.patch.dict(os.environ, clear=True):
+        # Simulate CI env
+        setup_ci_env(monkeypatch, "new-branch", "HEAD", before_sha)
         assert get_previous_commit_from_ci_env(False) is None


### PR DESCRIPTION
This MR intends to fix the behaviour of CI jobs after a forced push, on both IAC and SCA scans.

It used to trigger an error, trying to access a commit from before the history was rewritten.

This situation will now trigger a scan on all commits instead.