### PR TITLE
Performance benchmark script improvements

### DIFF
--- a/scripts/perfbench/perfbench_utils.py
+++ b/scripts/perfbench/perfbench_utils.py
@@ -1,7 +1,8 @@
+import json
 import subprocess
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, List, Sequence, TextIO
 
 import click
 
@@ -11,12 +12,37 @@ DEFAULT_WORK_DIR = (Path(__file__).parent / ".perfbench").absolute()
 
 @dataclass
 class RawReportEntry:
-    """Represent the fields stored in the benchmark.jsonl file"""
+    """Represent an entry in the benchmark.json file"""
 
     version: str
     dataset: str
     command: str
     duration: float
+
+
+@dataclass
+class RawReport:
+    """Represent the fields stored in the benchmark.json file"""
+
+    versions: List[str]
+    entries: List[RawReportEntry] = field(default_factory=list)
+
+    def add_entry(self, entry: RawReportEntry) -> None:
+        self.entries.append(entry)
+
+    def save(self, fp: TextIO) -> None:
+        json.dump(
+            asdict(self),
+            fp,
+            sort_keys=True,
+            indent=True,
+        )
+
+    @staticmethod
+    def load(fp: TextIO) -> "RawReport":
+        dct = json.load(fp)
+        entries = [RawReportEntry(**x) for x in dct["entries"]]
+        return RawReport(dct["versions"], entries)
 
 
 def check_run(args: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess:
@@ -33,7 +59,7 @@ work_dir_option = click.option(
 
 
 def get_raw_report_path(work_dir: Path) -> Path:
-    return work_dir / "benchmark.jsonl"
+    return work_dir / "benchmark.json"
 
 
 def find_latest_prod_version() -> str:

--- a/scripts/perfbench/perfbench_utils.py
+++ b/scripts/perfbench/perfbench_utils.py
@@ -28,7 +28,7 @@ work_dir_option = click.option(
     "--work-dir",
     help="Where to store benchmark script work files.",
     default=DEFAULT_WORK_DIR,
-    type=click.Path(),
+    type=click.Path(path_type=Path),
 )
 
 


### PR DESCRIPTION
This PR makes the following improvements to our performance benchmark script, following the exploration of tools to build standalone binaries for GGShield (see `agateau/pyinstaller` and `agateau/nuitka` branches):

- `run` command: add the ability to pass the path to a `ggshield` executable to the `-V` option.
- `report` command: add a CSV output mode.

It also fixes a bug in `--work-dir` which made it unusable.

Best reviewed commit by commit.