### PR TITLE
Xblanchot/sca 1345/add flags on fix available

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -273,8 +273,8 @@
             "version": "==2.21"
         },
         "pygitguardian": {
-            "git": "git+https://github.com/GitGuardian/py-gitguardian.git@2f2c455e3b6f09554b3ef202186b981bc7516b4e",
-            "ref": "2f2c455e3b6f09554b3ef202186b981bc7516b4e"
+            "git": "git+https://github.com/GitGuardian/py-gitguardian.git@e575ef2648fb7673d9ef6ecf3baea4e6a82e5da9",
+            "ref": "e575ef2648fb7673d9ef6ecf3baea4e6a82e5da9"
         },
         "pygments": {
             "hashes": [
@@ -331,6 +331,7 @@
                 "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
                 "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
                 "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
@@ -847,12 +848,12 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:3ba18e27f7491ea4a1b22edce00fb820eec968d397feb3f9cb61d5894bb38167",
-                "sha256:70a09719d375c0a2874571b363c8a24be7df8071b80c9aa76bc4551e7297c63c"
+                "sha256:7996507afae316306f9e2290407761157c6f78002dcf7419acb99822143d1c6f",
+                "sha256:85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.21.0"
+            "version": "==4.21.1"
         },
         "jsonschema-specifications": {
             "hashes": [
@@ -872,69 +873,69 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
-                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
-                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
-                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
-                "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
-                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
-                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
-                "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
-                "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
-                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
-                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
-                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
-                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
-                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
-                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
-                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
-                "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
-                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
-                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
-                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
-                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
-                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
-                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
-                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
-                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
-                "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
-                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
-                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
-                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
-                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
-                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
-                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
-                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
-                "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
-                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
-                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
-                "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
-                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
-                "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
-                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
-                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
-                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
-                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
-                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
-                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
-                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
-                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
-                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
-                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
-                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
-                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
-                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
-                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
-                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
-                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
-                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
-                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
-                "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
-                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
-                "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
+                "sha256:0042d6a9880b38e1dd9ff83146cc3c9c18a059b9360ceae207805567aacccc69",
+                "sha256:0c26f67b3fe27302d3a412b85ef696792c4a2386293c53ba683a89562f9399b0",
+                "sha256:0fbad3d346df8f9d72622ac71b69565e621ada2ce6572f37c2eae8dacd60385d",
+                "sha256:15866d7f2dc60cfdde12ebb4e75e41be862348b4728300c36cdf405e258415ec",
+                "sha256:1c98c33ffe20e9a489145d97070a435ea0679fddaabcafe19982fe9c971987d5",
+                "sha256:21e7af8091007bf4bebf4521184f4880a6acab8df0df52ef9e513d8e5db23411",
+                "sha256:23984d1bdae01bee794267424af55eef4dfc038dc5d1272860669b2aa025c9e3",
+                "sha256:31f57d64c336b8ccb1966d156932f3daa4fee74176b0fdc48ef580be774aae74",
+                "sha256:3583a3a3ab7958e354dc1d25be74aee6228938312ee875a22330c4dc2e41beb0",
+                "sha256:36d7626a8cca4d34216875aee5a1d3d654bb3dac201c1c003d182283e3205949",
+                "sha256:396549cea79e8ca4ba65525470d534e8a41070e6b3500ce2414921099cb73e8d",
+                "sha256:3a66c36a3864df95e4f62f9167c734b3b1192cb0851b43d7cc08040c074c6279",
+                "sha256:3aae9af4cac263007fd6309c64c6ab4506dd2b79382d9d19a1994f9240b8db4f",
+                "sha256:3ab3a886a237f6e9c9f4f7d272067e712cdb4efa774bef494dccad08f39d8ae6",
+                "sha256:47bb5f0142b8b64ed1399b6b60f700a580335c8e1c57f2f15587bd072012decc",
+                "sha256:49a3b78a5af63ec10d8604180380c13dcd870aba7928c1fe04e881d5c792dc4e",
+                "sha256:4df98d4a9cd6a88d6a585852f56f2155c9cdb6aec78361a19f938810aa020954",
+                "sha256:5045e892cfdaecc5b4c01822f353cf2c8feb88a6ec1c0adef2a2e705eef0f656",
+                "sha256:5244324676254697fe5c181fc762284e2c5fceeb1c4e3e7f6aca2b6f107e60dc",
+                "sha256:54635102ba3cf5da26eb6f96c4b8c53af8a9c0d97b64bdcb592596a6255d8518",
+                "sha256:54a7e1380dfece8847c71bf7e33da5d084e9b889c75eca19100ef98027bd9f56",
+                "sha256:55d03fea4c4e9fd0ad75dc2e7e2b6757b80c152c032ea1d1de487461d8140efc",
+                "sha256:698e84142f3f884114ea8cf83e7a67ca8f4ace8454e78fe960646c6c91c63bfa",
+                "sha256:6aa5e2e7fc9bc042ae82d8b79d795b9a62bd8f15ba1e7594e3db243f158b5565",
+                "sha256:7653fa39578957bc42e5ebc15cf4361d9e0ee4b702d7d5ec96cdac860953c5b4",
+                "sha256:765f036a3d00395a326df2835d8f86b637dbaf9832f90f5d196c3b8a7a5080cb",
+                "sha256:78bc995e004681246e85e28e068111a4c3f35f34e6c62da1471e844ee1446250",
+                "sha256:7a07f40ef8f0fbc5ef1000d0c78771f4d5ca03b4953fc162749772916b298fc4",
+                "sha256:8b570a1537367b52396e53325769608f2a687ec9a4363647af1cded8928af959",
+                "sha256:987d13fe1d23e12a66ca2073b8d2e2a75cec2ecb8eab43ff5624ba0ad42764bc",
+                "sha256:9896fca4a8eb246defc8b2a7ac77ef7553b638e04fbf170bff78a40fa8a91474",
+                "sha256:9e9e3c4020aa2dc62d5dd6743a69e399ce3de58320522948af6140ac959ab863",
+                "sha256:a0b838c37ba596fcbfca71651a104a611543077156cb0a26fe0c475e1f152ee8",
+                "sha256:a4d176cfdfde84f732c4a53109b293d05883e952bbba68b857ae446fa3119b4f",
+                "sha256:a76055d5cb1c23485d7ddae533229039b850db711c554a12ea64a0fd8a0129e2",
+                "sha256:a76cd37d229fc385738bd1ce4cba2a121cf26b53864c1772694ad0ad348e509e",
+                "sha256:a7cc49ef48a3c7a0005a949f3c04f8baa5409d3f663a1b36f0eba9bfe2a0396e",
+                "sha256:abf5ebbec056817057bfafc0445916bb688a255a5146f900445d081db08cbabb",
+                "sha256:b0fe73bac2fed83839dbdbe6da84ae2a31c11cfc1c777a40dbd8ac8a6ed1560f",
+                "sha256:b6f14a9cd50c3cb100eb94b3273131c80d102e19bb20253ac7bd7336118a673a",
+                "sha256:b83041cda633871572f0d3c41dddd5582ad7d22f65a72eacd8d3d6d00291df26",
+                "sha256:b835aba863195269ea358cecc21b400276747cc977492319fd7682b8cd2c253d",
+                "sha256:bf1196dcc239e608605b716e7b166eb5faf4bc192f8a44b81e85251e62584bd2",
+                "sha256:c669391319973e49a7c6230c218a1e3044710bc1ce4c8e6eb71f7e6d43a2c131",
+                "sha256:c7556bafeaa0a50e2fe7dc86e0382dea349ebcad8f010d5a7dc6ba568eaaa789",
+                "sha256:c8f253a84dbd2c63c19590fa86a032ef3d8cc18923b8049d91bcdeeb2581fbf6",
+                "sha256:d18b66fe626ac412d96c2ab536306c736c66cf2a31c243a45025156cc190dc8a",
+                "sha256:d5291d98cd3ad9a562883468c690a2a238c4a6388ab3bd155b0c75dd55ece858",
+                "sha256:d5c31fe855c77cad679b302aabc42d724ed87c043b1432d457f4976add1c2c3e",
+                "sha256:d6e427c7378c7f1b2bef6a344c925b8b63623d3321c09a237b7cc0e77dd98ceb",
+                "sha256:dac1ebf6983148b45b5fa48593950f90ed6d1d26300604f321c74a9ca1609f8e",
+                "sha256:de8153a7aae3835484ac168a9a9bdaa0c5eee4e0bc595503c95d53b942879c84",
+                "sha256:e1a0d1924a5013d4f294087e00024ad25668234569289650929ab871231668e7",
+                "sha256:e7902211afd0af05fbadcc9a312e4cf10f27b779cf1323e78d52377ae4b72bea",
+                "sha256:e888ff76ceb39601c59e219f281466c6d7e66bd375b4ec1ce83bcdc68306796b",
+                "sha256:f06e5a9e99b7df44640767842f414ed5d7bedaaa78cd817ce04bbd6fd86e2dd6",
+                "sha256:f6be2d708a9d0e9b0054856f07ac7070fbe1754be40ca8525d5adccdbda8f475",
+                "sha256:f9917691f410a2e0897d1ef99619fd3f7dd503647c8ff2475bf90c3cf222ad74",
+                "sha256:fc1a75aa8f11b87910ffd98de62b29d6520b6d6e8a3de69a70ca34dea85d2a8a",
+                "sha256:fe8512ed897d5daf089e5bd010c3dc03bb1bdae00b35588c49b98268d4a01e00"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.3"
+            "version": "==2.1.4"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -1145,12 +1146,12 @@
         },
         "pyfakefs": {
             "hashes": [
-                "sha256:5a62194cfa24542a3c9080b66ce65d78b2e977957edfd3cd6fe98e8349bcca32",
-                "sha256:a83776a3c1046d4d103f2f530029aa6cdff5f0386dffd59c15ee16926135493c"
+                "sha256:dadac1653195a4bfe4c26e9dfa7cc0c0286b1cd8e18706442c2464cae5542a17",
+                "sha256:fc375229f5417f197f0892a7d6dc49a411e67e10eb8142b19d80e60a9d52a13d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==5.3.2"
+            "version": "==5.3.4"
         },
         "pyflakes": {
             "hashes": [
@@ -1243,6 +1244,7 @@
                 "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
                 "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
                 "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef",
                 "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
                 "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
                 "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
@@ -1481,12 +1483,11 @@
         },
         "vcrpy": {
             "hashes": [
-                "sha256:605e7b7a63dcd940db1df3ab2697ca7faf0e835c0852882142bafb19649d599e",
-                "sha256:bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2"
+                "sha256:04fc36b53981b32680d7a860bf4ceca0fbe9948349b2ac7ffd4d8f7324b77006"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==5.1.0"
+            "version": "==6.0.0"
         },
         "virtualenv": {
             "hashes": [

--- a/changelog.d/20240118_114340_xavier.blanchot_add_flags_on_fix_available.md
+++ b/changelog.d/20240118_114340_xavier.blanchot_add_flags_on_fix_available.md
@@ -1,0 +1,7 @@
+### Added
+
+- Adds two new flags for `ggshield sca scan` commands, `--ignore-fixable` and `--ignore-not-fixable` so that the user can filter the returned incidents depending on if incidents can be fixed or not. Both flags cannot be used simultaneously.
+
+### Fixed
+
+- Fixes `ggshield sca scan` commands not taking some user parameters into account.

--- a/ggshield/cmd/sca/scan/all.py
+++ b/ggshield/cmd/sca/scan/all.py
@@ -26,6 +26,8 @@ def scan_all_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     directory: Optional[Path],
     **kwargs: Any,
 ) -> int:
@@ -40,7 +42,14 @@ def scan_all_cmd(
         directory = Path().resolve()
 
     # Adds client and required parameters to the context
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     result = sca_scan_all(ctx, directory)
     scan = SCAScanAllVulnerabilityCollection(id=str(directory), result=result)

--- a/ggshield/cmd/sca/scan/ci.py
+++ b/ggshield/cmd/sca/scan/ci.py
@@ -39,6 +39,8 @@ def scan_ci_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     directory: Optional[Path],
     scan_all: bool,
     **kwargs: Any,
@@ -54,7 +56,14 @@ def scan_ci_cmd(
         directory = Path().resolve()
 
     # Adds client and required parameters to the context
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     config = ContextObj.get(ctx).config
     try:

--- a/ggshield/cmd/sca/scan/diff.py
+++ b/ggshield/cmd/sca/scan/diff.py
@@ -33,6 +33,8 @@ def scan_diff_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     ref: str,
     staged: bool,
     directory: Optional[Path],
@@ -53,7 +55,14 @@ def scan_diff_cmd(
         directory = Path().resolve()
 
     # Adds client and required parameters to the context
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/sca/scan/precommit.py
+++ b/ggshield/cmd/sca/scan/precommit.py
@@ -34,6 +34,8 @@ def scan_pre_commit_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     scan_all: bool,
     directory: Optional[Path],
     **kwargs: Any,
@@ -55,7 +57,14 @@ def scan_pre_commit_cmd(
         directory = Path().resolve()
 
     # Adds client and required parameters to the context
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     if scan_all:
         result = sca_scan_all(ctx, directory, scan_mode=ScanMode.PRE_COMMIT_ALL)

--- a/ggshield/cmd/sca/scan/prepush.py
+++ b/ggshield/cmd/sca/scan/prepush.py
@@ -37,6 +37,8 @@ def scan_pre_push_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     scan_all: bool,
     **kwargs: Any,
 ) -> int:
@@ -56,7 +58,14 @@ def scan_pre_push_cmd(
     directory = Path().resolve()
 
     # Adds client and required parameters to the context
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     _, remote_commit = collect_commits_refs(prepush_args)
     # Will happen if this is the first push on the branch

--- a/ggshield/cmd/sca/scan/prereceive.py
+++ b/ggshield/cmd/sca/scan/prereceive.py
@@ -39,6 +39,8 @@ def scan_pre_receive_cmd(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
     **kwargs: Any,
 ) -> int:
     """
@@ -60,7 +62,14 @@ def scan_pre_receive_cmd(
     else:
         before, after = before_after
 
-    update_context(ctx, exit_zero, minimum_severity, ignore_paths)
+    update_context(
+        ctx,
+        exit_zero,
+        minimum_severity,
+        ignore_paths,
+        ignore_fixable,
+        ignore_not_fixable,
+    )
 
     if scan_all:
         # In the pre-receive context, we do not have access to the files,

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -41,6 +41,8 @@ def get_scan_params_from_config(sca_config: SCAConfig) -> SCAScanParameters:
             for ignored_vuln in sca_config.ignored_vulnerabilities
             if ignored_vuln.until is None or ignored_vuln.until >= datetime.utcnow()
         ],
+        ignore_fixable=sca_config.ignore_fixable,
+        ignore_not_fixable=sca_config.ignore_not_fixable,
     )
 
 

--- a/ggshield/cmd/sca/scan/scan_common_options.py
+++ b/ggshield/cmd/sca/scan/scan_common_options.py
@@ -26,6 +26,22 @@ from ggshield.core.client import create_client_from_config
 from ggshield.core.filter import init_exclusion_regexes
 
 
+ignore_fixable = click.option(
+    "--ignore-fixable",
+    is_flag=True,
+    default=False,
+    help="Ignore incidents related to vulnerabilities that have a fix.",
+)
+
+
+ignore_not_fixable = click.option(
+    "--ignore-not-fixable",
+    is_flag=True,
+    default=False,
+    help="Ignore incidents that cannot be fixed for now.",
+)
+
+
 def add_sca_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
@@ -33,6 +49,8 @@ def add_sca_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         minimum_severity_option(cmd)
         ignore_path_option(cmd)
         json_option(cmd)
+        ignore_fixable(cmd)
+        ignore_not_fixable(cmd)
         return cmd
 
     return decorator

--- a/ggshield/cmd/sca/scan/scan_common_options.py
+++ b/ggshield/cmd/sca/scan/scan_common_options.py
@@ -12,6 +12,7 @@ The `kwargs` argument is required due to the way click works,
 from typing import Callable, Sequence
 
 import click
+from click import UsageError
 
 from ggshield.cmd.utils.common_options import (
     AnyFunction,
@@ -61,9 +62,12 @@ def update_context(
     exit_zero: bool,
     minimum_severity: str,
     ignore_paths: Sequence[str],
+    ignore_fixable: bool,
+    ignore_not_fixable: bool,
 ) -> None:
     ctx_obj = ContextObj.get(ctx)
     config = ctx_obj.config
+
     ctx_obj.client = create_client_from_config(config, ctx_obj.ui)
 
     if ignore_paths is not None:
@@ -78,3 +82,14 @@ def update_context(
 
     if minimum_severity is not None:
         config.user_config.sca.minimum_severity = minimum_severity
+
+    if ignore_not_fixable and ignore_fixable:
+        raise UsageError(
+            "Cannot use simultaneously --ignore-not-fixable and --ignore-fixable flags."
+        )
+
+    if ignore_fixable:
+        config.user_config.sca.ignore_fixable = ignore_fixable
+
+    if ignore_not_fixable:
+        config.user_config.sca.ignore_not_fixable = ignore_not_fixable

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -250,6 +250,8 @@ class SCAConfig(FilteredConfig):
     ignored_vulnerabilities: List[SCAConfigIgnoredVulnerability] = field(
         default_factory=list
     )
+    ignore_not_fixable: bool = False
+    ignore_fixable: bool = False
 
     @post_load
     def validate_ignored_vulns(self, data: Dict[str, Any], **kwargs: Any):

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     oauthlib>=3.2.1,<3.3.0
     # TODO: replace this with a real version number as soon as a new version of
     # py-gitguardian is out
-    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@2f2c455e3b6f09554b3ef202186b981bc7516b4e
+    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@e575ef2648fb7673d9ef6ecf3baea4e6a82e5da9
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,35 @@ PIPFILE_LOCK_WITH_VULN = """
 }
 """
 
+PIPFILE_LOCK_WITH_VULN_NO_FIX = """
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2bf167f6a72aaa0f48f5876945f2a37874f3f114dad5e952cd7df9dfe8d9d281"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "h2o": {
+            "hashes": [],
+            "index": "pypi",
+            "version": "==3.18.0.8"
+        }
+    },
+    "develop": {}
+}
+"""
+
 PIPFILE_NO_VULN = """
 [[source]]
 url = "https://pypi.org/simple"
@@ -227,6 +256,15 @@ def make_dummy_sca_repo():
         repo.create_commit("Empty commit to start with")
         (tmp_path / "Pipfile").write_text(PIPFILE_WITH_VULN)
         (tmp_path / "Pipfile.lock").write_text(PIPFILE_LOCK_WITH_VULN)
+        (tmp_path / "dummy_file.py").touch()
+        repo.add(".")
+        repo.create_commit("pipfile_with_vuln")
+
+        # Adds a branch with a vuln that has no fix
+        repo.create_branch("branch_with_vuln_no_fix", orphan=True)
+        clean_directory(tmp_path)
+        repo.create_commit("Empty commit to start with")
+        (tmp_path / "Pipfile.lock").write_text(PIPFILE_LOCK_WITH_VULN_NO_FIX)
         (tmp_path / "dummy_file.py").touch()
         repo.add(".")
         repo.create_commit("pipfile_with_vuln")

--- a/tests/unit/cassettes/test_sca_scan_all_ignore_fixable.yaml
+++ b/tests/unit/cassettes/test_sca_scan_all_ignore_fixable.yaml
@@ -1,0 +1,158 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock", "dummy_file.py", "Pipfile"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '55'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock","Pipfile"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '64'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:22 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '22'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS1lNWZmMDZjZTg0OTQ5NWMzNWRiZDY3NTVkZDRiOTEyZg0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsibWluaW11bV9zZXZlcml0eSI6
+        ICJMT1ciLCAiaWdub3JlZF92dWxuZXJhYmlsaXRpZXMiOiBbXSwgImlnbm9yZV9ub3RfZml4YWJs
+        ZSI6IGZhbHNlLCAiaWdub3JlX2ZpeGFibGUiOiB0cnVlfQ0KLS1lNWZmMDZjZTg0OTQ5NWMzNWRi
+        ZDY3NTVkZDRiOTEyZg0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJl
+        Y3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAhuKwZQL/7ZZNT+MwEIZzzq+ocobU
+        33GQKu1xj9yrCjn2mEakTYhTVLTqf1+7XWhDi9AeQNrFz8XJeDzjeOz4zaf59Met2v4EZaBPPgV0
+        4L0WIcqOz8GOEcEkmWyTL2DjBtX79Mn3hMjJaqhXMMMFEqjEmOGcY8Kk4GkS+e+5rTtbN5A3rX74
+        rBzhUAuxP+O44Pi0DWCGRIIZ5wwLTPwz8m3Bkwn6yvO/VU819FWj1nrZDud+H/X/o6S/0oknu1vB
+        oLKbyeF1b1oqtxxZ9la3VIQLb89IZbEorFAFUUohy6TlshAl45YoWsiCWWr9D8Uow6HkRJvC2NJY
+        kKY0ROLsNfDu6pi1O2zIa9eB9lnESVcPj5u6B3c+qe55WLbruyfoXd2uw+RojtHlBK7d9HofZD4K
+        Mg65d12rFYRg3XNXZ1fn/Zu+Cd3LYejczXQa3PK2v5+6etU1cGmEn2Ftn++cCwOHfgMjl93r2yI9
+        mXZmwKpNM4zL4x6bTvUOzlcjFO7CB56U7wZRQjUCTUptOKk0qErjivnC8KIEirGlwEqBq1IaXDCC
+        sOGCEEVoJTlQdunb/oQWpVYSMclEVYXqE9BUImBUICUVZchUklqktaXKaoDKn39mLCJ++xREyGwU
+        eTFOlNVrA9t3apKd1H82QznL6ckWeLOiT9C0XVi7Xbr7xjddHvVf1H9R/313/fepOT7Qf4gw/Eb/
+        ccJI1H9fov/m84MgWixSL2cms/flTHoUL95tL16CQApD9pdxms47pR/UPbhF+qJOQu/rXZzO/b17
+        fXRK5y+SbpGOJVwYdpBw8YhGIpFIJBKJRCKRSCQSiUQikUgk8tf8BiscF3cAKAAADQotLWU1ZmYw
+        NmNlODQ5NDk1YzM1ZGJkNjc1NWRkNGI5MTJmLS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '1000'
+        Content-Type:
+          - multipart/form-data; boundary=e5ff06ce849495c35dbd6755dd4b912f
+        GGShield-Command-Id:
+          - a4dee0d1-4762-417c-9dca-d3c5cd03f8fc
+        GGShield-Command-Path:
+          - cli sca scan all
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.13
+        GGShield-Version:
+          - 1.23.0
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_all/
+    response:
+      body:
+        string: '{"scanned_files":["Pipfile","Pipfile.lock"],"found_package_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '69'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:22 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '62'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_sca_scan_all_ignore_not_fixable.yaml
+++ b/tests/unit/cassettes/test_sca_scan_all_ignore_not_fixable.yaml
@@ -1,0 +1,155 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock", "dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '44'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:23 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '20'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS04MGM4MjcwZDcxZDYzMGVlMjIwNmViZDI0OTY1ZTQ4Ng0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsibWluaW11bV9zZXZlcml0eSI6
+        ICJMT1ciLCAiaWdub3JlZF92dWxuZXJhYmlsaXRpZXMiOiBbXSwgImlnbm9yZV9ub3RfZml4YWJs
+        ZSI6IHRydWUsICJpZ25vcmVfZml4YWJsZSI6IGZhbHNlfQ0KLS04MGM4MjcwZDcxZDYzMGVlMjIw
+        NmViZDI0OTY1ZTQ4Ng0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJkaXJl
+        Y3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAh+KwZQL/7dXNbqMwEABgzjwF4twF
+        2wFjKkXa4x57r6rIxfZiLX9rQ5SoyruvTaQWmlZ7aqu2810IYzNj7EySpEn684YffkkupAneBDp7
+        7YrQJnv67OMYEUyC6BC8g8mO3LjywfdEWNSOupVbXCCKSowzklDGMoqyMABf3o0elG5k0vTVn7eq
+        4Zua0rnHcZHj5dXDrt0DnOV5hikmqHD9TzEtggi9Z/8f+F5Lc9/wrqr78XLe/8Y/qfAhjJx418qR
+        x9fR+XYO1dzWq8gctTUnOXXxmNwrd0yK8oJwzpHKmMpZQcssV4RvClZkaqPcD4rgIpdlTipRCFUK
+        JZkoBWE4fkx8unqqOpy/kD/sICtXhS6GjPw7aSPt5aKG41j33W4vjdV95xe3STB6uYDtJ1PNSW5X
+        SdYp56kdb6VPNhwHHV9djk+m8cP1OA72Ok39tKQ3v1Or26GRLz3hVqjVcWetf3A0k1xNOT3e3YWL
+        ZcdCKj4147PjIf3lRvgzO7/b3bp6rDshD6+8TLzYuO3WbR1LUMIW2/dsNXvZ9IMvfgpP8C8BAAAA
+        AAAAAAAAAAAAAAAAAAAAfLh/AgtfWwAoAAANCi0tODBjODI3MGQ3MWQ2MzBlZTIyMDZlYmQyNDk2
+        NWU0ODYtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '807'
+        Content-Type:
+          - multipart/form-data; boundary=80c8270d71d630ee2206ebd24965e486
+        GGShield-Command-Id:
+          - ff3c717d-e4c1-457a-ab30-0d35b86ef582
+        GGShield-Command-Path:
+          - cli sca scan all
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.13
+        GGShield-Version:
+          - 1.23.0
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_all/
+    response:
+      body:
+        string: '{"scanned_files":["Pipfile.lock"],"found_package_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '59'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:23 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '63'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_sca_scan_diff_ignore_fixable.yaml
+++ b/tests/unit/cassettes/test_sca_scan_diff_ignore_fixable.yaml
@@ -1,0 +1,230 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile", "Pipfile.lock", "dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '55'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile","Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '64'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:14 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '51'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"files": ["Pipfile", "Pipfile.lock", "dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '55'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile","Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '64'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:15 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '25'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS02NDY3YjBhNDAxMDY4YzBhYzJiNDhhY2JhOTE2ZjJiZQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsibWluaW11bV9zZXZlcml0eSI6
+        ICJMT1ciLCAiaWdub3JlZF92dWxuZXJhYmlsaXRpZXMiOiBbXSwgImlnbm9yZV9ub3RfZml4YWJs
+        ZSI6IGZhbHNlLCAiaWdub3JlX2ZpeGFibGUiOiB0cnVlfQ0KLS02NDY3YjBhNDAxMDY4YzBhYzJi
+        NDhhY2JhOTE2ZjJiZQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJyZWZl
+        cmVuY2UiOyBmaWxlbmFtZT0icmVmZXJlbmNlIg0KDQofiwgAf+KwZQL/7ZXdjqIwFMe95ilMr2e0
+        XxQw8R3m3hhTyulIBoWhYNZsfPdtcUdldS5nNps9vxvgfJaW8+elbGxZweQroR4l5XD1/HmlXF7v
+        z/aEx3IypZNvoHedbn3Lyf9JtFq5um8NrNdR31bT5ZRsu65xi/m8OTblrG5f567cNRWQ6ABtaY8b
+        50JY1/YQ7fUOQkoIJVG0arR506/g1pF7rxrdusG7XNKZnMkQUMDh+RoUrVp478s23DfHblvvN76H
+        K+t9SBMzRskE+VJezvM/q2rz9pfmn0kaj+efUU4TnP9vmf+f0dRDNjvoNFlMz4+DaavddmQZrG6r
+        eay8nWRAeZxIlZiccZXGEqTOOLdMikwyI6wtRJobzUyc0tgkSWozpa1IBbeZ95FL4dPTtWtz/iCf
+        XQPGd1E3rg+xuF/UWDzC4gbxeNjgLHehyGpUZFxyCA3yFooN8vZ07/eCGdyfCeaDjKuE+sRBQm/d
+        p8vTOrpZNinA6r7qxsfzobD3uxEO7sEL3hzfIpaCammBa5MU1GYClLIMrFHAhEi1ZGkq86QoLNci
+        pgaKglNjjCyygqdWPHq336ULKRVLBfj8VMjMakEVs9RCYqkyOpO5VnEuucqkshZyUOCDeRYLwaVv
+        QkaV1+NGpNwX8OOTMyE353/554z39rqjB6jqJuzdKTrhbwBBEARBEARBEARBEARBEARBEARBEAT5
+        x/kFLRV+aAAoAAANCi0tNjQ2N2IwYTQwMTA2OGMwYWMyYjQ4YWNiYTkxNmYyYmUNCkNvbnRlbnQt
+        RGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iY3VycmVudCI7IGZpbGVuYW1lPSJjdXJyZW50
+        Ig0KDQofiwgAf+KwZQL/7ZXNbqMwEMdz5ikin9vEX4CJlHfoPYoiY48bVBIohmijVd59MdkmYZMe
+        29Vq53cBZsYzxsP8eSlqV5Qw+UpoTyLlcO3580q5vN6f7SmP5WRKJ99A51vd9CUn/yfRauWrrjGw
+        XkddU06XU7Jt29ov5vP6WBezqnmd+2JXl0CiAzSFO268D2Ft00G01zsIS0IoiaJVrc2bfgW/jvx7
+        WevGD97lks7kTIQAC4fna1C0auC9K5pwXx/bbbXf9DV8Ue3DMjFjlEyQL+XlPP+zsjJvf2n+maTx
+        eP4Z5TTF+f+W+f8ZTXvIZgetJovp+XEwbbXfjiyD1W81j5PeTnjuWJK6RKdca02dVC5WaZLJ2HEt
+        UpVKJxxj0mobQxZzY1PrMutA2cxyxcgl8enpWrU+f5DPvgbTV0luXB9icb+psXiEzQ3i8bDAWe5C
+        ktUoyTjlEBrkLSQb5O3p3t8LZnB/JpgPVlwltF84SOit+3R5Wkc32yYWnO7KdtyeD4W9P43QuAcv
+        eNO+BRVcGAqGZ8bGPDegc8Ny2TcmTjMQjDkBMktYninLUskps3HCueYiVzEI+ejdfqdOMqMVlUom
+        eR66z8EIRUGKhGqlhaQ2V8JRY5zQzgDk/fxL6yjvP5+UJ4qMMq/HhUixt/Djk56Qm/5f/jnjs72e
+        6AHKqg5nd4pO+BtAEARBEARBEARBEARBEARBEARBEARB/nF+AXOIyCYAKAAADQotLTY0NjdiMGE0
+        MDEwNjhjMGFjMmI0OGFjYmE5MTZmMmJlLS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '1567'
+        Content-Type:
+          - multipart/form-data; boundary=6467b0a401068c0ac2b48acba916f2be
+        GGShield-Command-Id:
+          - 9716362f-fef4-41ae-a07b-995fbe790331
+        GGShield-Command-Path:
+          - cli sca scan diff
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.13
+        GGShield-Version:
+          - 1.23.0
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+        mode:
+          - diff
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_diff/
+    response:
+      body:
+        string: '{"scanned_files":["Pipfile","Pipfile.lock"],"added_vulns":[],"removed_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '80'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:15 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '133'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cassettes/test_sca_scan_diff_ignore_not_fixable.yaml
+++ b/tests/unit/cassettes/test_sca_scan_diff_ignore_not_fixable.yaml
@@ -1,0 +1,227 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile", "Pipfile.lock", "dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '55'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile","Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '64'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:16 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '50'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"files": ["Pipfile.lock", "dummy_file.py"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '44'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:16 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '31'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS0zY2M0ODUxMzYyN2Y2NjlkMmFjMzlmYmU5YzRhMjY4OA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsibWluaW11bV9zZXZlcml0eSI6
+        ICJMT1ciLCAiaWdub3JlZF92dWxuZXJhYmlsaXRpZXMiOiBbXSwgImlnbm9yZV9ub3RfZml4YWJs
+        ZSI6IHRydWUsICJpZ25vcmVfZml4YWJsZSI6IGZhbHNlfQ0KLS0zY2M0ODUxMzYyN2Y2NjlkMmFj
+        MzlmYmU5YzRhMjY4OA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJyZWZl
+        cmVuY2UiOyBmaWxlbmFtZT0icmVmZXJlbmNlIg0KDQofiwgAgOKwZQL/7ZXdjqIwFMe95ilMr2e0
+        XxQw8R3m3hhTyulIBoWhYNZsfPdtcUdldS5nNps9vxvgfJaW8+elbGxZweQroR4l5XD1/HmlXF7v
+        z/aEx3IypZNvoHedbn3Lyf9JtFq5um8NrNdR31bT5ZRsu65xi/m8OTblrG5f567cNRWQ6ABtaY8b
+        50JY1/YQ7fUOQkoIJVG0arR506/g1pF7rxrdusG7XNKZnMkQUMDh+RoUrVp478s23DfHblvvN76H
+        K+t9SBMzRskE+VJezvM/q2rz9pfmn0kaj+efUU4TnP9vmf+f0dRDNjvoNFlMz4+DaavddmQZrG6r
+        eay8nWRAeZxIlZiccZXGEqTOOLdMikwyI6wtRJobzUyc0tgkSWozpa1IBbeZ95FL4dPTtWtz/iCf
+        XQPGd1E3rg+xuF/UWDzC4gbxeNjgLHehyGpUZFxyCA3yFooN8vZ07/eCGdyfCeaDjKuE+sRBQm/d
+        p8vTOrpZNinA6r7qxsfzobD3uxEO7sEL3hzfIpaCammBa5MU1GYClLIMrFHAhEi1ZGkq86QoLNci
+        pgaKglNjjCyygqdWPHq336ULKRVLBfj8VMjMakEVs9RCYqkyOpO5VnEuucqkshZyUOCDeRYLwaVv
+        QkaV1+NGpNwX8OOTMyE353/554z39rqjB6jqJuzdKTrhbwBBEARBEARBEARBEARBEARBEARBEAT5
+        x/kFLRV+aAAoAAANCi0tM2NjNDg1MTM2MjdmNjY5ZDJhYzM5ZmJlOWM0YTI2ODgNCkNvbnRlbnQt
+        RGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iY3VycmVudCI7IGZpbGVuYW1lPSJjdXJyZW50
+        Ig0KDQofiwgAgOKwZQL/7dLdToMwFAdwrnmKpdeTUcbnkr2D92ZZKm2FyKC2sLgY3t0CcY5NL9UL
+        /7+bwmk557TlvlSyrIRXNfmz80N8Kw7DcbSuR0p9+vE8xakf2GHhO7+gMy3TtrzzP7lv7sIi+4No
+        GdksptcxVDBTzCJj1BQsiGIbJ8GjpHEiY5YEjDFfhqmM0iTOwkgGbJ2kSSjXktKQMx6JLApynnCZ
+        cSlSnvEgpeScuF9+VlXTD3lnlMhtlfhiSouXrtTC3DalTm3R1Puj0KZs6qG5tUf9rwuYptP5mORh
+        lmSeclxas4MYkqmTKsnydr7T1TBdtK0ym9VqWOY1+mllyoOqxFdf2A5LedobM3zY6k7MlvTnt517
+        0TbhQrKuaq+uJ2huD2K4s2lvu3l1UtZcvH6zGXJxcNutPbrU87304viuujmKqlFD8d7tHQAAAAAA
+        AAAAAAAAAAAAAAAA+CvvD82fiwAoAAANCi0tM2NjNDg1MTM2MjdmNjY5ZDJhYzM5ZmJlOWM0YTI2
+        ODgtLQ0K
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '1374'
+        Content-Type:
+          - multipart/form-data; boundary=3cc48513627f669d2ac39fbe9c4a2688
+        GGShield-Command-Id:
+          - 36ab44ee-b9a9-42fb-a57d-3ba81bb3caac
+        GGShield-Command-Path:
+          - cli sca scan diff
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.13
+        GGShield-Version:
+          - 1.23.0
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+        mode:
+          - diff
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_diff/
+    response:
+      body:
+        string: '{"scanned_files":["Pipfile","Pipfile.lock"],"added_vulns":[],"removed_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '80'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Wed, 24 Jan 2024 10:12:16 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 16dcd71f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '128'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.23.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-24T10:03:14.219173+00:00'
+        x-secrets-engine-version:
+          - 2.104.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/sca/test_sca_scan_utils.py
+++ b/tests/unit/cmd/sca/test_sca_scan_utils.py
@@ -34,6 +34,7 @@ def test_get_scan_params_from_config():
                 path="toto/Pipfile.lock",
             ),
         ],
+        ignore_fixable=True,
     )
 
     params = get_scan_params_from_config(config)
@@ -47,3 +48,5 @@ def test_get_scan_params_from_config():
     )
     for ignored in params.ignored_vulnerabilities:
         assert ignored.path == "toto/Pipfile.lock"
+    assert params.ignore_fixable is True
+    assert params.ignore_not_fixable is False

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -580,3 +580,113 @@ sca:
 
         assert result.exit_code == ExitCode.SUCCESS
         assert "GHSA-rrm6-wvj7-cwh2" not in result.stdout
+
+
+@my_vcr.use_cassette("test_sca_scan_all_ignore_fixable.yaml")
+def test_scan_all_ignore_fixable(
+    cli_fs_runner: click.testing.CliRunner,
+    dummy_sca_repo: Repository,
+):
+    """
+    GIVEN a directory with a fixable vuln
+    WHEN running the sca scan all command on this directory with the --ignore-fixable flag
+    THEN no incidents are returned
+    """
+    dummy_sca_repo.git("checkout", "branch_with_vuln")
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "sca",
+            "scan",
+            "all",
+            "--ignore-fixable",
+            str(dummy_sca_repo.path),
+        ],
+    )
+
+    assert_invoke_exited_with(result, ExitCode.SUCCESS)
+    assert "No SCA vulnerability has been found." in result.stdout
+
+
+@my_vcr.use_cassette("test_sca_scan_diff_ignore_fixable.yaml")
+def test_scan_diff_ignore_fixable(
+    cli_fs_runner: click.testing.CliRunner,
+    dummy_sca_repo: Repository,
+) -> None:
+    """
+    GIVEN a directory which is ignored
+    WHEN running the sca scan diff command on this directory with the --ignore-fixable flag
+    THEN the scan succeeds
+    THEN no incidents are returned
+    """
+    dummy_sca_repo.git("checkout", "branch_with_vuln")
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "sca",
+            "scan",
+            "diff",
+            "--ignore-fixable",
+            "--ref",
+            "branch_without_vuln",
+            str(dummy_sca_repo.path),
+        ],
+    )
+
+    assert_invoke_exited_with(result, ExitCode.SUCCESS)
+    assert "No SCA vulnerability has been added." in result.stdout
+
+
+@my_vcr.use_cassette("test_sca_scan_all_ignore_not_fixable.yaml")
+def test_scan_all_ignore_not_fixable(
+    cli_fs_runner: click.testing.CliRunner,
+    dummy_sca_repo: Repository,
+):
+    """
+    GIVEN a directory with a fixable vuln
+    WHEN running the sca scan all command on this directory with the --ignore-not-fixable flag
+    THEN no incidents are returned
+    """
+    dummy_sca_repo.git("checkout", "branch_with_vuln_no_fix")
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "sca",
+            "scan",
+            "all",
+            "--ignore-not-fixable",
+            str(dummy_sca_repo.path),
+        ],
+    )
+
+    assert_invoke_exited_with(result, ExitCode.SUCCESS)
+    assert "No SCA vulnerability has been found." in result.stdout
+
+
+@my_vcr.use_cassette("test_sca_scan_diff_ignore_not_fixable.yaml")
+def test_scan_diff_ignore_not_fixable(
+    cli_fs_runner: click.testing.CliRunner,
+    dummy_sca_repo: Repository,
+) -> None:
+    """
+    GIVEN a directory which is ignored
+    WHEN running the sca scan diff command on this directory with the --ignore-not-fixable flag
+    THEN the scan succeeds
+    THEN no incidents are returned
+    """
+    dummy_sca_repo.git("checkout", "branch_with_vuln_no_fix")
+    result = cli_fs_runner.invoke(
+        cli,
+        [
+            "sca",
+            "scan",
+            "diff",
+            "--ignore-not-fixable",
+            "--ref",
+            "branch_without_vuln",
+            str(dummy_sca_repo.path),
+        ],
+    )
+
+    assert_invoke_exited_with(result, ExitCode.SUCCESS)
+    assert "No SCA vulnerability has been added." in result.stdout

--- a/tests/unit/cmd/sca/test_scan_common_options.py
+++ b/tests/unit/cmd/sca/test_scan_common_options.py
@@ -1,0 +1,47 @@
+import click
+
+from ggshield.cmd.sca.scan.scan_common_options import update_context
+from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.config import Config
+from ggshield.core.ui.plain_text.plain_text_ggshield_ui import PlainTextGGShieldUI
+
+
+def test_update_context():
+    """
+    GIVEN some parameters
+    WHEN calling update context from sca
+    THEN those parameters are given to the SCAUserConfig
+    """
+    # Create click context
+    config = Config()
+    config.user_config.verbose = False
+    ctx_obj = ContextObj()
+    ctx_obj.config = config
+    ctx_obj.ui = PlainTextGGShieldUI()
+    ctx = click.Context(
+        click.Command("sca scan all"),
+        obj=ctx_obj,
+    )
+
+    assert ctx_obj.config.user_config.sca.minimum_severity == "LOW"
+    assert ctx_obj.config.user_config.exit_zero is False
+    assert ctx_obj.config.user_config.sca.ignored_paths == {"tests/"}
+    assert ctx_obj.config.user_config.sca.ignore_fixable is False
+    assert ctx_obj.config.user_config.sca.ignore_not_fixable is False
+
+    update_context(
+        ctx,
+        exit_zero=True,
+        minimum_severity="HIGH",
+        ignore_paths=[],
+        ignore_fixable=True,
+        ignore_not_fixable=False,
+    )
+
+    ctx_obj = ContextObj.get(ctx)
+
+    assert ctx_obj.config.user_config.sca.minimum_severity == "HIGH"
+    assert ctx_obj.config.user_config.exit_zero is True
+    assert ctx_obj.config.user_config.sca.ignored_paths == {"tests/"}
+    assert ctx_obj.config.user_config.sca.ignore_fixable is True
+    assert ctx_obj.config.user_config.sca.ignore_not_fixable is False


### PR DESCRIPTION
- Adds two new flags for sca scan commands : `--ignore-fix-available` and `--ignore-no-fix`
- Bump py-gitguardian version that fixes scan diff commands not sending user params to backend