### PR TITLE
chore(env): # Use py-gitguardian v1.13.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,7 @@ install_requires =
     marshmallow>=3.18.0,<3.19.0
     marshmallow-dataclass>=8.5.8,<8.6.0
     oauthlib>=3.2.1,<3.3.0
-    # TODO: replace this with a real version number as soon as a new version of
-    # py-gitguardian is out
-    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@e575ef2648fb7673d9ef6ecf3baea4e6a82e5da9
+    pygitguardian>=1.13.0,<1.14.0
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1


### PR DESCRIPTION
Change required before releasing ggshield 1.24.0

**Side effect:** pipenv also wanted to upgrade ipython to 8.20.0 which I prevented since this version is incompatible with Python 3.8.