### PR TITLE
Unbreak PR from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
 
       - name: Functional tests
         shell: bash
+        # See note about steps requiring the GITGUARDIAN_API at the top of this file
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           scripts/build-standalone-exe functests
         env:


### PR DESCRIPTION
Do not run functional tests for standalone executables when the PR comes from a fork: they fail because secrets are not available for PR from forks.