### PR TITLE
Sign macOS binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,11 +196,11 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ggshield-standalone-${{ matrix.os }}
+          name: ggshield-${{ matrix.os }}
           path: |
-            dist/ggshield-standalone-*.gz
-            dist/ggshield-standalone-*.pkg
-            dist/ggshield-standalone-*.zip
+            dist/ggshield-*.gz
+            dist/ggshield-*.pkg
+            dist/ggshield-*.zip
 
       - name: Override base Docker image used for functional tests on Windows
         if: matrix.os == 'windows-2022'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Install standalone-specific dependencies
         run: |
-          python -m pip install --upgrade pyinstaller
+          python -m pip install pyinstaller==6.5.0
 
       - name: Build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
           name: ggshield-standalone-${{ matrix.os }}
           path: |
             dist/ggshield-standalone-*.gz
+            dist/ggshield-standalone-*.pkg
             dist/ggshield-standalone-*.zip
 
       - name: Override base Docker image used for functional tests on Windows

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,143 @@
+name: Sign
+
+# This is an on-demand workflow to test signing
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-standalone:
+    name: Standalone exe
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+          - os: macos-latest
+            arch: x86_64
+            sha256sum:
+              python: 6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a
+              rcodesign: bca6e648afaddd48f1c3d5dd25aa516659992cbbd2ba7131ba6add739aa895d3
+          - os: macos-14
+            arch: aarch64
+            sha256sum:
+              python: 5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a
+              rcodesign: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Get enough commits to run `ggshield secret scan commit-range` on ourselves
+          fetch-depth: 10
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        if: "!startsWith(matrix.os, 'macos-')"
+        with:
+          python-version: '3.10'
+
+      - name: Install macOS specific dependencies
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          # scripts/download needs the `sha256sum` command
+          brew install coreutils
+
+          # Install Python. We don't use actions/setup-python because on M1
+          # macs it installs the Framework version of Python, and the binaries
+          # produced with that version do not pass Apple notarization step.
+          # (tested with actions/setup-python@v4 and @v5)
+          PYTHON_VERSION=3.10.13
+          PYTHON_BUILD=20240224
+
+          scripts/download \
+            https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${{ matrix.arch }}-apple-darwin-install_only.tar.gz \
+            python.tar.gz \
+            ${{ matrix.sha256sum.python }}
+
+          tar xf python.tar.gz
+
+          # Make Python available
+          echo PATH=$PWD/python/bin:$PATH >> $GITHUB_ENV
+
+          # Install rcodesign
+          RCODESIGN_VERSION=0.27.0
+
+          scripts/download \
+            https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-${{ matrix.arch }}-apple-darwin.tar.gz \
+            rcodesign.tar.gz \
+            ${{ matrix.sha256sum.rcodesign }}
+
+          tar --strip-components=1 -xzf rcodesign.tar.gz
+
+          # Make it available
+          cp rcodesign /usr/local/bin
+
+      - name: Install normal dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pipenv==2023.10.3
+          pipenv install --system --dev
+        env:
+          # Disable lock otherwise Windows-only dependencies like colorama are not installed
+          PIPENV_SKIP_LOCK: 1
+
+      - name: Install standalone-specific dependencies
+        run: |
+          python -m pip install pyinstaller==6.5.0
+
+      - name: Prepare macOS secrets
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          set -euo pipefail
+          SECRETS_DIR=$TMPDIR/secrets
+          mkdir "$SECRETS_DIR"
+          # Prepare our secret files
+          # The p12-file is base64-encoded because it's binary
+          echo "$MACOS_P12_FILE" | base64 --decode > "$SECRETS_DIR/cert.p12"
+          echo "$MACOS_P12_PASSWORD" > "$SECRETS_DIR/cert.pwd"
+          echo "$MACOS_API_KEY_FILE" > "$SECRETS_DIR/rcodesign-notarize-key.json"
+
+          # Tell next steps where to find them
+          cat >> $GITHUB_ENV <<EOF
+          MACOS_P12_FILE=$SECRETS_DIR/cert.p12
+          MACOS_P12_PASSWORD_FILE=$SECRETS_DIR/cert.pwd
+          MACOS_API_KEY_FILE=$SECRETS_DIR/rcodesign-notarize-key.json
+          EOF
+        env:
+          MACOS_P12_FILE: ${{ secrets.MACOS_P12_FILE }}
+          MACOS_P12_PASSWORD: ${{ secrets.MACOS_P12_PASSWORD }}
+          MACOS_API_KEY_FILE: ${{ secrets.MACOS_API_KEY_FILE }}
+
+      - name: Build
+        shell: bash
+        run: |
+          scripts/build-standalone-exe --sign
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ggshield-standalone-${{ matrix.os }}
+          path: |
+            dist/ggshield-standalone-*.gz
+            dist/ggshield-standalone-*.pkg
+            dist/ggshield-standalone-*.zip
+
+      - name: Override base Docker image used for functional tests on Windows
+        if: matrix.os == 'windows-2022'
+        # This is required because GitHub Windows runner is not configured to
+        # run Linux-based Docker images
+        shell: bash
+        run: |
+          echo "GGTEST_DOCKER_IMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022" >> $GITHUB_ENV
+
+      - name: Functional tests
+        shell: bash
+        # See note about steps requiring the GITGUARDIAN_API at the top of this file
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          scripts/build-standalone-exe functests
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
+          TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -3,7 +3,6 @@ name: Sign
 # This is an on-demand workflow to test signing
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -117,11 +117,11 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ggshield-standalone-${{ matrix.os }}
+          name: ggshield-${{ matrix.os }}
           path: |
-            dist/ggshield-standalone-*.gz
-            dist/ggshield-standalone-*.pkg
-            dist/ggshield-standalone-*.zip
+            dist/ggshield-*.gz
+            dist/ggshield-*.pkg
+            dist/ggshield-*.zip
 
       - name: Override base Docker image used for functional tests on Windows
         if: matrix.os == 'windows-2022'

--- a/doc/dev/standalone-executables.md
+++ b/doc/dev/standalone-executables.md
@@ -1,0 +1,55 @@
+# Building standalone executables
+
+## Introduction
+
+`ggshield` is written in Python, and this sometimes makes deployment complicated.
+
+To solve those deployment issues, we provide standalone `ggshield` executables, that do not require a Python interpreter. This documentation explains how these executables are produced.
+
+The process of generating the executable is handled by the `scripts/build-standalone-exe` script. This script runs a series of "steps". It has a default list of steps, but you can tell it to run only specific steps using `scripts/build-standalone-exe step1 step2...`.
+
+All functions in the script starting with `step_` can be used as a step. This means you can get a list of all available steps with: `grep -o '^step_[a-z_]*' scripts/build-standalone-exe`.
+
+## Generating the executable
+
+We use [PyInstaller](https://pyinstaller.org) to generate `ggshield` standalone executable.
+
+## macOS-specific information
+
+For macOS, we produce a .pkg archive. The advantage of this file is that it can be installed by double-clicking on it or by using `sudo installer -pkg path/to/ggshield.pkg -target /`, and `ggshield` is immediately usable after install, without the need to alter `$PATH`.
+
+### Inside the pkg
+
+The .pkg itself installs `ggshield` files in `/opt/gitguardian/ggshield-$version` and a `ggshield` symbolic link in `/usr/local/bin/ggshield`.
+
+### Signing & notarizing
+
+The .pkg archive used for releases is signed. Signing the archive is required to ensure macOS Gatekeeper security system does not block `ggshield` when users try to run it.
+
+#### Setting up signing
+
+`build-standalone-exe` won't sign binaries unless it's called with `--sign`. This is because:
+
+- signing requires access to secrets not available for PR from forks.
+- signing (and especially notarizing) can take a long time.
+
+When called with `--sign`, `build-standalone-exe` expects the following environment variables to be set:
+
+- `$MACOS_P12_FILE`: Path to a signing certificate. You can export one from Xcode by following [Apple documentation][apple-signing-certificate].
+- `$MACOS_P12_PASSWORD_FILE`: Path containing the password protecting the signing certificate. Xcode will ask for it when exporting it.
+- `$MACOS_API_KEY_FILE`: Path to a JSON file holding the "App Store Connect API Key". This file is used by `rcodesign` for the notarization step. Follow [`rcodesign` documentation][rcodesign-api-key] to generate one.
+
+Attention: these 3 files should be treated as secrets (even if `$MACOS_P12_FILE` is protected by a password).
+
+[apple-signing-certificate]: https://help.apple.com/xcode/mac/current/#/dev154b28f09
+[rcodesign-api-key]: https://gregoryszorc.com/docs/apple-codesign/0.27.0/apple_codesign_getting_started.html#obtaining-an-app-store-connect-api-key
+
+#### Signing implementation details
+
+Although PyInstaller supports signing, it did not work at the time we tried it, so we use [rcodesign][] to do so.
+
+`rcodesign` is a cross-platform CLI tool to sign, notarize and staple macOS binaries.
+
+For Gatekeeper to accept the app, the executable and all the dynamic libraries must be signed, as well as the .pkg archive itself. Signing the executable and the libraries is done by the `sign` step, whereas signing the .pkg archive is done by the `create_archive` step.
+
+[rcodesign]: https://gregoryszorc.com/docs/apple-codesign/

--- a/scripts/build-standalone-exe
+++ b/scripts/build-standalone-exe
@@ -114,7 +114,7 @@ init_system_vars() {
         die "Unknown OS. uname printed '$out'"
         ;;
     esac
-    ARCHIVE_DIR_NAME=ggshield-standalone-$VERSION-$TARGET
+    ARCHIVE_DIR_NAME=ggshield-$VERSION-$TARGET
 }
 
 step_req() {

--- a/scripts/build-standalone-exe
+++ b/scripts/build-standalone-exe
@@ -5,22 +5,39 @@ PROGNAME=$(basename "$0")
 ROOT_DIR=$(cd "$(dirname "$0")/.." ; pwd)
 RESOURCES_DIR="$ROOT_DIR/scripts/standalone-exe"
 
-DEFAULT_STEPS="req build copy_files test create_archive"
+DEFAULT_STEPS="req build copy_files test sign create_archive"
 
 DIST_DIR=$PWD/dist
 
 REQUIREMENTS="pyinstaller"
+
+# Whether we want a signed binary or not
+DO_SIGN=0
+
+MACOS_P12_FILE=${MACOS_P12_FILE:-}
+MACOS_P12_PASSWORD_FILE=${MACOS_P12_PASSWORD_FILE:-}
+
+# Path to a file used by rcodesign for notarizing.
+# Follow the instructions from
+# https://gregoryszorc.com/docs/apple-codesign/0.27.0/apple_codesign_getting_started.html#apple-codesign-app-store-connect-api-key
+# to generate one.
+MACOS_API_KEY_FILE=${MACOS_API_KEY_FILE:-}
+
+# Colors
+C_RED="\e[31;1m"
+C_GREEN="\e[32;1m"
+C_RESET="\e[0m"
 
 err() {
     echo "$@" >&2
 }
 
 info() {
-    err "$PROGNAME: [INFO] $*"
+    printf "$C_GREEN%s$C_RESET\n" "$PROGNAME: [INFO] $*" >&2
 }
 
 die() {
-    err "$PROGNAME: [ERROR] $*"
+    printf "$C_RED%s$C_RESET\n" "$PROGNAME: [ERROR] $*" >&2
     exit 1
 }
 
@@ -38,6 +55,9 @@ Default steps are: $DEFAULT_STEPS
 
 Options:
   -h, --help      Display this usage message and exit.
+  --sign          Sign the binary, on supported OSes.
+
+For more details, see doc/dev/standalone-executables.md.
 EOF
 
     exit 1
@@ -66,24 +86,29 @@ init_system_vars() {
     local out
     out=$(uname)
 
+    # directory containing ggshield executable, inside the archive
+    INSTALL_PREFIX=""
+
     case "$out" in
     Linux)
         EXE_EXT=""
         TARGET="$arch-unknown-linux-gnu"
         HUMAN_OS=Linux
-        ARCHIVE_FORMAT=tar
         ;;
     Darwin)
         EXE_EXT=""
         HUMAN_OS=macOS
         TARGET="$arch-apple-darwin"
-        ARCHIVE_FORMAT=tar
+        if [ "$DO_SIGN" -eq 1 ] ; then
+            REQUIREMENTS="$REQUIREMENTS rcodesign"
+            DEFAULT_STEPS="$DEFAULT_STEPS notarize"
+        fi
+        INSTALL_PREFIX=opt/gitguardian/ggshield-$VERSION
         ;;
     MINGW*|MSYS*)
         EXE_EXT=".exe"
         HUMAN_OS=Windows
         TARGET="$arch-pc-windows-msvc"
-        ARCHIVE_FORMAT=zip
         ;;
     *)
         die "Unknown OS. uname printed '$out'"
@@ -113,6 +138,7 @@ step_req() {
 step_build() {
     rm -rf build/ggshield
     rm -rf "$DIST_DIR/ggshield"
+
     pyinstaller ggshield/__main__.py --name ggshield --noupx
 }
 
@@ -126,45 +152,121 @@ step_copy_files() {
         die "Can't find '$pyinstaller_ggshield', maybe 'build' step did not run?"
     fi
 
-    local output_dir="$DIST_DIR/$ARCHIVE_DIR_NAME"
-    info "Copying files to $output_dir"
-    rm -rf "$output_dir"
-    cp -R "$pyinstaller_output_dir" "$output_dir"
-    sed \
-        -e "s/@HUMAN_OS@/$HUMAN_OS/" \
-        -e "s/@HUMAN_ARCH@/$HUMAN_ARCH/" \
-        "$RESOURCES_DIR/README.md" \
-        > "$output_dir/README.md"
+    case "$HUMAN_OS" in
+    Linux|Windows)
+        local output_dir="$DIST_DIR/$ARCHIVE_DIR_NAME"
+        info "Copying files to $output_dir"
+        rm -rf "$output_dir"
+        cp -R "$pyinstaller_output_dir" "$output_dir"
+
+        info "Generating README.md"
+        sed \
+            -e "s/@HUMAN_OS@/$HUMAN_OS/" \
+            -e "s/@HUMAN_ARCH@/$HUMAN_ARCH/" \
+            "$RESOURCES_DIR/README.md" \
+            > "$output_dir/README.md"
+        ;;
+    macOS)
+        local output_dir="$DIST_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX"
+        local bin_dir="$DIST_DIR/$ARCHIVE_DIR_NAME/usr/local/bin"
+        info "Copying files to $output_dir"
+        rm -rf "$output_dir" "$bin_dir"
+        mkdir -p "$(dirname $output_dir)"
+        cp -R "$pyinstaller_output_dir" "$output_dir"
+
+        info "Creating launcher symlink"
+        mkdir -p "$bin_dir"
+        ln -s "/$INSTALL_PREFIX/ggshield" "$bin_dir/ggshield"
+        ;;
+    esac
+}
+
+sign_file() {
+    if [ -z "$MACOS_P12_FILE" ] ; then
+        die "\$MACOS_P12_FILE must be set to sign"
+    fi
+    local file
+    file="$1"
+    info "- Signing $file"
+    rcodesign sign \
+        --p12-file "$MACOS_P12_FILE" \
+        --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
+        --code-signature-flags runtime \
+        --for-notarization \
+        "$file"
+}
+
+list_files_to_sign() {
+    local archive_dir="$DIST_DIR/$ARCHIVE_DIR_NAME"
+    echo "$archive_dir/$INSTALL_PREFIX/ggshield"
+    find "$archive_dir" -name '*.so' -o -name '*.dylib'
+}
+
+step_sign() {
+    if [ "$HUMAN_OS" != "macOS" ] ; then
+        info "Signing not supported on $HUMAN_OS, skipping step"
+        return
+    fi
+    if [ "$DO_SIGN" -eq 0 ] ; then
+        info "Skipping signing step"
+        return
+    fi
+    list_files_to_sign | while read path ; do
+        sign_file "$path"
+    done
 }
 
 step_test() {
     for args in --help --version ; do
         info "test: running $args"
-        "$DIST_DIR/$ARCHIVE_DIR_NAME/ggshield${EXE_EXT}" $args
+        "$DIST_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX/ggshield${EXE_EXT}" $args
         info "test: running $args: OK"
     done
 }
 
 step_functests() {
-    PATH=$DIST_DIR/$ARCHIVE_DIR_NAME:$PATH pytest tests/functional
+    PATH=$DIST_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX:$PATH pytest tests/functional
 }
 
 step_create_archive() {
     local archive_path
-    case "$ARCHIVE_FORMAT" in
-    tar)
+    cd "$DIST_DIR"
+    case "$HUMAN_OS" in
+    Linux)
         archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.tar.gz"
-        tar -C "$DIST_DIR" -czf "$archive_path" "$ARCHIVE_DIR_NAME"
+        tar -czf "$archive_path" "$ARCHIVE_DIR_NAME"
         ;;
-    zip)
+    macOS)
+        archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.pkg"
+        
+        pkgbuild \
+            --identifier com.gitguardian.ggshield \
+            --version "$VERSION" \
+            --root "$DIST_DIR/$ARCHIVE_DIR_NAME" \
+            "$archive_path"
+
+        if [ "$DO_SIGN" -eq 1 ] ; then
+            sign_file "$archive_path"
+        fi
+        ;;
+    Windows)
         archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.zip"
-        env -C "$DIST_DIR" 7z a "$archive_path" "$ARCHIVE_DIR_NAME"
-        ;;
-    *)
-        die "Unsupported archive format $ARCHIVE_FORMAT"
+        7z a "$archive_path" "$ARCHIVE_DIR_NAME"
         ;;
     esac
+    cd -
     info "Archive created in $archive_path"
+}
+
+step_notarize() {
+    if [ "$DO_SIGN" -eq 0 ] ; then
+        info "Skipping notarize step"
+    fi
+    info "Notarizing"
+    rcodesign notary-submit \
+        --api-key-file "$MACOS_API_KEY_FILE" \
+        --staple \
+        "$DIST_DIR/$ARCHIVE_DIR_NAME.pkg"
 }
 
 steps=""
@@ -172,6 +274,9 @@ while [ $# -gt 0 ] ; do
     case "$1" in
     -h|--help)
         usage
+        ;;
+    --sign)
+        DO_SIGN=1
         ;;
     -*)
         usage "Unknown option '$1'"
@@ -183,14 +288,17 @@ while [ $# -gt 0 ] ; do
     shift
 done
 
-if [ -z "$steps" ] ; then
-    steps=$DEFAULT_STEPS
-fi
-
 cd "$ROOT_DIR"
 read_version
 init_system_vars
+
+if [ -z "$steps" ] ; then
+    steps=$DEFAULT_STEPS
+fi
+info "Steps: $steps"
+
 for step in $steps ; do
     info "step $step"
     "step_$step"
 done
+info "Success!"

--- a/scripts/download
+++ b/scripts/download
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROGNAME=$(basename "$0")
+
+usage() {
+    if [ "$*" != "" ] ; then
+        echo "Error: $*" >&2
+        echo >&2
+    fi
+
+    cat << EOF
+Usage: $PROGNAME [OPTION ...] URL DEST_FILENAME SHA256SUM
+Download a file and verify its checksum.
+
+Options:
+  -h, --help          display this usage message and exit
+EOF
+
+    exit 1
+}
+
+url=""
+filename=""
+sum=""
+while [ $# -gt 0 ] ; do
+    case "$1" in
+    -h|--help)
+        usage
+        ;;
+    -*)
+        usage "Unknown option '$1'"
+        ;;
+    *)
+        if [ -z "$url" ] ; then
+            url="$1"
+        elif [ -z "$filename" ] ; then
+            filename="$1"
+        elif [ -z "$sum" ] ; then
+            sum="$1"
+        else
+            usage "Too many arguments"
+        fi
+        ;;
+    esac
+    shift
+done
+
+if [ -z "$sum" ] ; then
+    usage "Not enough arguments"
+fi
+
+echo "Downloading $url to $filename"
+curl --fail --location \
+    --output "$filename" \
+    "$url"
+
+echo "Verifying integrity"
+echo "$sum  $filename" | sha256sum --check


### PR DESCRIPTION
This PR extends `scripts/build-standalone-exe` to produce signed macOS binaries.

## .pkg installers

Signing .zip archives is not supported so the PR switches to producing .pkg installers for macOS.

GGShield files are installed in `/opt/gitguardian/ggshield-$version` and a `ggshield` symlink is created in `/usr/local/bin` so that ggshield can be started without having to modify $PATH.

## How signing works

Signing and notarizing is done using [rcodesign](https://gregoryszorc.com/docs/apple-codesign/0.27.0/index.html), a cross-platform tool to sign and notarize macOS applications.

Signing a .pkg installer requires first signing all executables and libraries we ship, then creating the .pkg, then signing the .pkg itself.

`scripts/build-standalone-exe` does not sign binaries unless called with `--sign`. It then expect some environment variables to be set. They are documented in `doc/dev/standalone-executable.md`. They are defined as secrets in GitHub configuration, and then pulled as environment variables by the CI.

## Testing

The whole signing process can take a long time, so we don't want to do it for every pull request. For now I added a separate workflow file called `sign.yml`, which can be manually triggered from GitHub UI. The next step will be to integrate signing in the release process.

There's a chicken-and-egg problem though: this new workflow cannot be triggered until  `sign.yml` exists in the default branch, so to test the full process the workflow is currently triggered on pull requests too, but I will remove this before merging.