### PR TITLE
Fix test_scan_path_ignore_known_secrets functional test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ GG_VALID_TOKEN_IGNORE_SHA = (
 KNOWN_SECRET = os.environ.get("TEST_KNOWN_SECRET", "")
 
 # This secret must not be known by the dashboard running our tests
-UNKNOWN_SECRET = os.environ.get("TEST_UNKNOWN_SECRET", "ggtt-v-0frijog879")  # ggignore
+UNKNOWN_SECRET = os.environ.get("TEST_UNKNOWN_SECRET", "ggtt-v-0d4buhg879")  # ggignore
 
 
 def is_windows():


### PR DESCRIPTION
The `secret/test_scan_path.py::test_scan_path_ignore_known_secrets` functional test broke because our unknown test secret somehow became known. Use another secret.