### PR TITLE
Update Black to 24.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 ggshield = { editable = true, path = "." }
 
 [dev-packages]
-black = "==22.3.0"
+black = "==24.3.0"
 coverage = "*"
 flake8 = "*"
 flake8-isort = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb91c773d42e0257b3994706adf79c8727e36b713636b1e641a94bca2bfba206"
+            "sha256": "4c275ab5e30b5d81f8648a63f5f235967f66832bd7955e4fe7d749e02990aff7"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -277,10 +277,11 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+                "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+                "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"
             ],
-            "version": "==2.21"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.22"
         },
         "pygitguardian": {
             "hashes": [
@@ -430,33 +431,32 @@
         },
         "black": {
             "hashes": [
-                "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b",
-                "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176",
-                "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09",
-                "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a",
-                "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015",
-                "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
-                "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb",
-                "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20",
-                "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464",
-                "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968",
-                "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82",
-                "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21",
-                "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0",
-                "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265",
-                "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b",
-                "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a",
-                "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72",
-                "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce",
-                "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0",
-                "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a",
-                "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163",
-                "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad",
-                "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
+                "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f",
+                "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93",
+                "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11",
+                "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0",
+                "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9",
+                "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5",
+                "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213",
+                "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d",
+                "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7",
+                "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837",
+                "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f",
+                "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395",
+                "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995",
+                "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f",
+                "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597",
+                "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959",
+                "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5",
+                "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb",
+                "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4",
+                "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7",
+                "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd",
+                "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==22.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.3.0"
         },
         "certifi": {
             "hashes": [

--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -105,9 +105,9 @@ def iac_scan_all(
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,
-            scan_mode=scan_mode
-            if ci_mode is None
-            else f"{scan_mode.value}/{ci_mode.value}",
+            scan_mode=(
+                scan_mode if ci_mode is None else f"{scan_mode.value}/{ci_mode.value}"
+            ),
             extra_headers={"Ci-Mode": str(ci_mode.value)} if ci_mode else None,
             target_path=directory,
         ).get_http_headers(),

--- a/ggshield/cmd/iac/scan/diff.py
+++ b/ggshield/cmd/iac/scan/diff.py
@@ -186,9 +186,9 @@ def iac_scan_diff(
         scan_parameters,
         ScanContext(
             command_path=ctx.command_path,
-            scan_mode=scan_mode
-            if ci_mode is None
-            else f"{scan_mode.value}/{ci_mode.value}",
+            scan_mode=(
+                scan_mode if ci_mode is None else f"{scan_mode.value}/{ci_mode.value}"
+            ),
             extra_headers={"Ci-Mode": str(ci_mode.value)} if ci_mode else None,
             target_path=directory,
         ).get_http_headers(),

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -9,6 +9,7 @@ To use it:
 The `kwargs` argument is required due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
+
 from typing import Any, Callable, Sequence
 
 import click

--- a/ggshield/cmd/sca/scan/scan_common_options.py
+++ b/ggshield/cmd/sca/scan/scan_common_options.py
@@ -9,6 +9,7 @@ To use it:
 The `kwargs` argument is required due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
+
 from typing import Callable, Sequence
 
 import click

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -10,6 +10,7 @@ To use it:
 The `kwargs` argument is required because due to the way click works,
 `add_common_options()` adds an argument for each option it defines.
 """
+
 from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar
 

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -67,13 +67,11 @@ def get_global_path(filename: str) -> Path:
 
 
 @overload
-def find_global_config_path(*, to_write: Literal[False] = False) -> Optional[Path]:
-    ...
+def find_global_config_path(*, to_write: Literal[False] = False) -> Optional[Path]: ...
 
 
 @overload
-def find_global_config_path(*, to_write: Literal[True]) -> Path:
-    ...
+def find_global_config_path(*, to_write: Literal[True]) -> Path: ...
 
 
 def find_global_config_path(*, to_write: bool = False) -> Optional[Path]:

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -2,6 +2,7 @@
 This module centralizes GGShield error handling. For more details, have a look
 at doc/dev/error-handling.md.
 """
+
 import platform
 import traceback
 from enum import IntEnum

--- a/ggshield/core/scan/scan_context.py
+++ b/ggshield/core/scan/scan_context.py
@@ -56,7 +56,9 @@ class ScanContext:
 
         return {
             **{f"GGShield-{key}": str(value) for key, value in headers.items()},
-            "mode": self.scan_mode.value
-            if isinstance(self.scan_mode, ScanMode)
-            else self.scan_mode,
+            "mode": (
+                self.scan_mode.value
+                if isinstance(self.scan_mode, ScanMode)
+                else self.scan_mode
+            ),
         }

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -129,7 +129,7 @@ def simplify_git_url(url: str) -> str:
     - extension
     https://user:pass@mygitlab.corp.com:84/path/to/repo.git -> mygitlab.corp.com/toto/titi/tata
     """
-    for (pattern, replace) in (
+    for pattern, replace in (
         (r"https?://", ""),  # Scheme
         (r".+@", ""),  # Credentials
         (r":\d*/", "/"),  # Port

--- a/ggshield/utils/os.py
+++ b/ggshield/utils/os.py
@@ -67,13 +67,11 @@ def cd(newdir: Union[str, Path]) -> Iterator[None]:
 
 
 @overload
-def getenv_int(key: str, default: None = None) -> Optional[int]:
-    ...
+def getenv_int(key: str, default: None = None) -> Optional[int]: ...
 
 
 @overload
-def getenv_int(key: str, default: int) -> int:
-    ...
+def getenv_int(key: str, default: int) -> int: ...
 
 
 def getenv_int(key: str, default: Optional[int] = None) -> Optional[int]:
@@ -84,13 +82,11 @@ def getenv_int(key: str, default: Optional[int] = None) -> Optional[int]:
 
 
 @overload
-def getenv_float(key: str, default: None = None) -> Optional[float]:
-    ...
+def getenv_float(key: str, default: None = None) -> Optional[float]: ...
 
 
 @overload
-def getenv_float(key: str, default: float) -> float:
-    ...
+def getenv_float(key: str, default: float) -> float: ...
 
 
 def getenv_float(key: str, default: Optional[float] = None) -> Optional[float]:
@@ -101,13 +97,11 @@ def getenv_float(key: str, default: Optional[float] = None) -> Optional[float]:
 
 
 @overload
-def getenv_bool(key: str, default: None = None) -> Optional[bool]:
-    ...
+def getenv_bool(key: str, default: None = None) -> Optional[bool]: ...
 
 
 @overload
-def getenv_bool(key: str, default: bool) -> bool:
-    ...
+def getenv_bool(key: str, default: bool) -> bool: ...
 
 
 def getenv_bool(key: str, default: Optional[bool] = None) -> Optional[bool]:

--- a/ggshield/verticals/iac/output/iac_text_output_handler.py
+++ b/ggshield/verticals/iac/output/iac_text_output_handler.py
@@ -462,9 +462,11 @@ def diff_scan_summary(
         format_text(
             f"[~] {num_unchanged} {label_incident(num_unchanged)} remaining",
             STYLE[
-                "iac_remaining_vulnerability"
-                if num_unchanged > 0
-                else "iac_dim_summary"
+                (
+                    "iac_remaining_vulnerability"
+                    if num_unchanged > 0
+                    else "iac_dim_summary"
+                )
             ],
         )
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,5 +63,5 @@ console_scripts = ggshield=ggshield.__main__:main
 [flake8]
 inline-quotes = double
 max-line-length = 120
-ignore = E203, W503
+ignore = E203, E704, W503
 exclude = **/snapshots/*.py, .venv, build


### PR DESCRIPTION
Update Black to 24.3.0 to fix [CVE-2024-21503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21503).

This required disabling E704 in flake8. That seems to be expected: https://github.com/psf/black/issues/3887.

Needs #867 for CI to be green.
