### PR TITLE
Deprecate dash-separated config keys

### DIFF
--- a/.gitguardian.example.yml
+++ b/.gitguardian.example.yml
@@ -4,7 +4,7 @@ version: 2
 # Set to true if the desired exit code for the CLI is always 0, otherwise the
 # exit code will be 1 if incidents are found.
 # The environment variable GITGUARDIAN_EXIT_ZERO=true can also be used toggle this behavior.
-exit-zero: false # default: false
+exit_zero: false # default: false
 
 verbose: false # default: false
 
@@ -12,34 +12,34 @@ verbose: false # default: false
 instance: https://dashboard.gitguardian.com # default: https://dashboard.gitguardian.com
 
 # Maximum commits to scan in a hook.
-max-commits-for-hook: 50 # default: 50
+max_commits_for_hook: 50 # default: 50
 
 # Accept self-signed certificates for the API.
-allow-self-signed: false # default: false
+allow_self_signed: false # default: false
 
 secret:
   # Exclude files and paths by globbing
-  ignored-paths:
+  ignored_paths:
     - '**/README.md'
     - 'doc/*'
     - 'LICENSE'
 
   # Ignore security incidents with the SHA256 of the occurrence obtained at output or the secret itself
-  ignored-matches:
+  ignored_matches:
     - name:
       match: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
     - name: credentials
       match: MY_TEST_CREDENTIAL
 
-  show-secrets: false # default: false
+  show_secrets: false # default: false
 
   # Detectors to ignore.
-  ignored-detectors: # default: []
+  ignored_detectors: # default: []
     - Generic Password
 
 iac:
   # Exclude files and paths by globbing
-  ignored-paths:
+  ignored_paths:
     - '**/README.md'
     - 'doc/*'
     - 'LICENSE'
@@ -50,7 +50,7 @@ iac:
       until: '2030-06-24T00:00:01Z'
 
   # IaC vulnerabilities to ignore
-  ignored-policies:
+  ignored_policies:
     - GG_IAC_0000
     - GG_IAC_0005
     - policy: 'GG_IAC_0003'
@@ -60,20 +60,20 @@ iac:
       until: '2030-06-24T00:00:01Z'
 
   # Minimum severity of the policies
-  minimum-severity: HIGH
+  minimum_severity: HIGH
 
 sca:
   # Exclude files and paths by globbing
-  ignored-paths:
+  ignored_paths:
     - '**/Pipfile'
     - '/back/**/package.json'
 
   # SCA vulnerabilities to ignore
-  ignored-vulnerabilities:
+  ignored_vulnerabilities:
     - identifier: 'GHSA-0000-aaaa-ZZZZ'
       path: 'Pipfile.lock' # Can be a regex
       comment: 'Check vulnerability later' # Optional
       until: '2023-05-01T00:00:00' # Optional, needs to follow ISO 8061 format 'YYYY-MM-DDTHH:MM:SS' (converted to UTC)
 
   # Minimum severity of the policies
-  minimum-severity: HIGH
+  minimum_severity: HIGH

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 secret:
-  ignored-matches:
+  ignored_matches:
     - match: 56e55937e918b984e285a94ac96de439813a6316c8e184ce7773ee47d700b019
       name:
     - match: 139ed5c2b5ae84b0fbb1bfbce6015ac96e5af5050a16d0ffdba612440fb0ee4d
@@ -33,7 +33,7 @@ secret:
     - match: e90eaa00d17c03309b660e1879c70b815509422c2d4cf0980b2e1221dffa0381
       name: Test secret mentioned in commit 6282ceb9035c1bfcceec5f6372f69063cdd588f7
 
-  ignored-paths:
+  ignored_paths:
     - '**/README.md'
     - doc/*
     - LICENSE
@@ -43,12 +43,12 @@ secret:
     - 'tests/cassettes/*'
 
 iac:
-  ignored-policies:
+  ignored_policies:
     # We don't want to fix this vulnerability because many CI systems
     # (including GitHub action and Azure pipelines) expect the user inside the
     # container to be root.
     - GG_IAC_0079
 
 sca:
-  ignored-paths:
+  ignored_paths:
     - tests/

--- a/changelog.d/20240405_171107_aurelien.gateau_deprecate_dash_config_keys.md
+++ b/changelog.d/20240405_171107_aurelien.gateau_deprecate_dash_config_keys.md
@@ -1,0 +1,3 @@
+### Deprecated
+
+- Dash-separated configuration keys are now deprecated, they should be replaced with underscore-separated keys. For example `show-secrets` should become `show_secrets`. GGShield still supports reading from dash-separate configuration keys, but it prints a warning when it finds one.

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -9,7 +9,7 @@ from pygitguardian.models import FromDictMixin, ToDictMixin
 from ggshield.core.config.utils import (
     get_auth_config_filepath,
     load_yaml_dict,
-    replace_in_keys,
+    replace_dash_in_keys,
     save_yaml_dict,
 )
 from ggshield.core.errors import (
@@ -71,7 +71,7 @@ def prepare_auth_config_dict_for_parse(data: Dict[str, Any]) -> Dict[str, Any]:
 
     We replace `-` with `_` for compatibility reasons.
     """
-    replace_in_keys(data, "-", "_")
+    replace_dash_in_keys(data)
     data = deepcopy(data)
     try:
         instances = data["instances"]

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -14,7 +14,7 @@ from ggshield.core.config.utils import (
     find_local_config_path,
     load_yaml_dict,
     remove_common_dict_items,
-    replace_in_keys,
+    replace_dash_in_keys,
     save_yaml_dict,
     update_from_other_instance,
 )
@@ -339,7 +339,7 @@ class UserConfig(FilteredConfig):
     def _update_from_file(self, config_path: Path) -> None:
         try:
             data = load_yaml_dict(config_path) or {"version": CURRENT_CONFIG_VERSION}
-            replace_in_keys(data, old_char="-", new_char="_")
+            replace_dash_in_keys(data)
 
             config_version = data.pop("version", 1)
             if config_version == 2:

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -28,7 +28,7 @@ from ggshield.core.url_utils import api_to_dashboard_url
 logger = logging.getLogger(__name__)
 CURRENT_CONFIG_VERSION = 2
 
-_IGNORE_KNOWN_SECRETS_KEY = "ignore-known-secrets"
+_IGNORE_KNOWN_SECRETS_KEY = "ignore_known_secrets"
 
 GHSA_ID_PATTERN = re.compile("GHSA(-[a-zA-Z0-9]{4}){3}")
 POLICY_ID_PATTERN = re.compile("GG_IAC_[0-9]{4}")
@@ -300,7 +300,6 @@ class UserConfig(FilteredConfig):
 
         dct["version"] = CURRENT_CONFIG_VERSION
 
-        replace_in_keys(dct, old_char="_", new_char="-")
         save_yaml_dict(dct, config_path)
 
     @classmethod
@@ -340,12 +339,13 @@ class UserConfig(FilteredConfig):
     def _update_from_file(self, config_path: Path) -> None:
         try:
             data = load_yaml_dict(config_path) or {"version": CURRENT_CONFIG_VERSION}
+            replace_in_keys(data, old_char="-", new_char="_")
+
             config_version = data.pop("version", 1)
             if config_version == 2:
                 _fix_ignore_known_secrets(data)
                 obj = UserConfig.from_dict(data)
             elif config_version == 1:
-                replace_in_keys(data, old_char="-", new_char="_")
                 self.deprecation_messages.append(
                     f"{config_path} uses a deprecated configuration file format."
                     " Run `ggshield config migrate` to migrate it to the latest version."
@@ -378,18 +378,13 @@ def _fix_ignore_known_secrets(data: Dict[str, Any]) -> None:
     specific key, it should have been stored in the "secret" mapping, not in the root
     one"""
 
-    underscore_key = _IGNORE_KNOWN_SECRETS_KEY.replace("-", "_")
-
-    for key in _IGNORE_KNOWN_SECRETS_KEY, underscore_key:
-        value = data.pop(key, None)
-        if value is not None:
-            break
-    else:
+    value = data.pop(_IGNORE_KNOWN_SECRETS_KEY, None)
+    if value is None:
         # No key to fix
         return
 
     secret_dct = data.setdefault("secret", {})
-    if _IGNORE_KNOWN_SECRETS_KEY in secret_dct or underscore_key in secret_dct:
+    if _IGNORE_KNOWN_SECRETS_KEY in secret_dct:
         # Do not override if it's already there
         return
     secret_dct[_IGNORE_KNOWN_SECRETS_KEY] = value

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -16,17 +16,18 @@ from ggshield.core.errors import UnexpectedError
 from ggshield.utils.git_shell import GitExecutableNotFound
 
 
-def replace_in_keys(data: Union[List, Dict], old_char: str, new_char: str) -> None:
-    """Replace old_char with new_char in data keys."""
+def replace_dash_in_keys(data: Union[List, Dict]) -> None:
+    """Replace '-' with '_' in data keys."""
+
     if isinstance(data, dict):
         for key, value in list(data.items()):
-            replace_in_keys(value, old_char=old_char, new_char=new_char)
-            if old_char in key:
-                new_key = key.replace(old_char, new_char)
+            replace_dash_in_keys(value)
+            if "-" in key:
+                new_key = key.replace("-", "_")
                 data[new_key] = data.pop(key)
     elif isinstance(data, list):
         for element in data:
-            replace_in_keys(element, old_char=old_char, new_char=new_char)
+            replace_dash_in_keys(element)
 
 
 def load_yaml_dict(path: Union[str, Path]) -> Optional[Dict[str, Any]]:

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -1,6 +1,6 @@
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Set, Union, overload
 
 import yaml
 import yaml.parser
@@ -16,18 +16,22 @@ from ggshield.core.errors import UnexpectedError
 from ggshield.utils.git_shell import GitExecutableNotFound
 
 
-def replace_dash_in_keys(data: Union[List, Dict]) -> None:
+def replace_dash_in_keys(data: Union[List, Dict]) -> Set[str]:
     """Replace '-' with '_' in data keys."""
+    replaced = set()
 
     if isinstance(data, dict):
         for key, value in list(data.items()):
-            replace_dash_in_keys(value)
+            replaced.update(replace_dash_in_keys(value))
             if "-" in key:
                 new_key = key.replace("-", "_")
                 data[new_key] = data.pop(key)
+                replaced.add(key)
     elif isinstance(data, list):
         for element in data:
-            replace_dash_in_keys(element)
+            replaced.update(replace_dash_in_keys(element))
+
+    return replaced
 
 
 def load_yaml_dict(path: Union[str, Path]) -> Optional[Dict[str, Any]]:

--- a/ggshield/core/types.py
+++ b/ggshield/core/types.py
@@ -19,9 +19,8 @@ class FilteredConfig(FromDictMixin, ToDictMixin):
         field_names = {field_.name for field_ in fields(cls)}
         filtered_fields = {}
         for key, item in data.items():
-            filtered_key = key.replace("-", "_")
-            if filtered_key in field_names:
-                filtered_fields[filtered_key] = item
+            if key in field_names:
+                filtered_fields[key] = item
             else:
                 display_warning(f"Unrecognized key in config: {key}")
 

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -239,7 +239,7 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[Scannable]) -> None:
         # if the details had per file details
         display_error(
             f"Add the following {pluralize('file', len(details))}"
-            " to your paths-ignore:"
+            " to your ignored_paths:"
         )
         for i, inner_detail in enumerate(details):
             if inner_detail:

--- a/tests/unit/cmd/iac/test_scan_all.py
+++ b/tests/unit/cmd/iac/test_scan_all.py
@@ -297,7 +297,7 @@ def test_iac_scan_all_ignored_directory_config(
     config = """
 version: 2
 iac:
-    ignored-paths:
+    ignored_paths:
         - "dir/subdir/"
 
 """

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -439,7 +439,7 @@ def test_sca_scan_all_ignored_directory_config(
     config = """
 version: 2
 sca:
-    ignored-paths:
+    ignored_paths:
         - "dir/subdir/"
 
 """

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -202,7 +202,7 @@ class TestPathScan:
         config = """
 version: 2
 secret:
-    ignored-paths:
+    ignored_paths:
         - "file1"
 
 """

--- a/tests/unit/cmd/test_config_migrate.py
+++ b/tests/unit/cmd/test_config_migrate.py
@@ -32,14 +32,14 @@ show-secrets: true
 V2_CONFIG_DICT = {
     "version": 2,
     "secret": {
-        "ignored-paths": [
+        "ignored_paths": [
             "**/snap*",
             "**/migrations/**/*",
             ".gitlab/*",
             "LICENSE",
         ],
-        "show-secrets": True,
-        "ignored-matches": [
+        "show_secrets": True,
+        "ignored_matches": [
             {"name": "", "match": "vLXyx1iAhFo2xgb71tTa"},
             {"name": "generic password", "match": "05Panda_8463"},
             {
@@ -58,12 +58,12 @@ def normalize_config_dict(dct: Dict[str, Any]) -> Dict[str, Any]:
     """
     dct = deepcopy(dct)
     try:
-        dct["secret"]["ignored-paths"] = sorted(dct["secret"]["ignored-paths"])
+        dct["secret"]["ignored_paths"] = sorted(dct["secret"]["ignored_paths"])
     except KeyError:
         pass
     try:
-        dct["secret"]["ignored-matches"] = sorted(
-            dct["secret"]["ignored-matches"], key=itemgetter("match")
+        dct["secret"]["ignored_matches"] = sorted(
+            dct["secret"]["ignored_matches"], key=itemgetter("match")
         )
     except KeyError:
         pass

--- a/tests/unit/core/config/conftest.py
+++ b/tests/unit/core/config/conftest.py
@@ -4,33 +4,33 @@ from ggshield.core.config.utils import get_global_path
 
 
 TEST_AUTH_CONFIG = {
-    "default-token-lifetime": 2,
+    "default_token_lifetime": 2,
     "instances": [
         {
             "name": "default",
             "url": "https://dashboard.gitguardian.com",
-            "default-token-lifetime": 1,
+            "default_token_lifetime": 1,
             "accounts": [
                 {
-                    "workspace-id": 23,
+                    "workspace_id": 23,
                     "token": "62890f237c703c92fbda8236ec2a055ac21332a46115005c976d68b900535fb5",  # ggignore
                     "type": "pat",
-                    "token-name": "my_token",
-                    "expire-at": "2022-02-23T12:34:56+00:00",
+                    "token_name": "my_token",
+                    "expire_at": "2022-02-23T12:34:56+00:00",
                 }
             ],
         },
         {
             "name": None,
             "url": "https://dashboard.onprem.example.com",
-            "default-token-lifetime": 0,  # no expiry
+            "default_token_lifetime": 0,  # no expiry
             "accounts": [
                 {
-                    "workspace-id": 1,
+                    "workspace_id": 1,
                     "token": "8ecffbaeedcd2f090546efeed3bc48a5f4a04a1196637aef6b3f6bbcfd58a96b",  # ggignore
                     "type": "sat",
-                    "token-name": "my_other_token",
-                    "expire-at": "2022-02-24T12:34:56+00:00",
+                    "token_name": "my_other_token",
+                    "expire_at": "2022-02-24T12:34:56+00:00",
                 }
             ],
         },

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -10,7 +10,7 @@ from ggshield.core.config.auth_config import (
     InstanceConfig,
     prepare_auth_config_dict_for_save,
 )
-from ggshield.core.config.utils import get_auth_config_filepath, replace_in_keys
+from ggshield.core.config.utils import get_auth_config_filepath
 from ggshield.core.errors import UnknownInstanceError
 from tests.unit.conftest import write_text, write_yaml
 from tests.unit.core.config.conftest import TEST_AUTH_CONFIG
@@ -39,7 +39,6 @@ class TestAuthConfig:
 
         config_data = config.auth_config.to_dict()
         config_data = prepare_auth_config_dict_for_save(config_data)
-        replace_in_keys(config_data, old_char="_", new_char="-")
         assert config_data == TEST_AUTH_CONFIG
 
     @pytest.mark.parametrize("n", [0, 2])

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -546,6 +546,30 @@ class TestUserConfig:
         assert "Unrecognized key in config: hashed_key" in captured.err
         assert "Unrecognized key in config: nested_hashed" in captured.err
 
+    def test_user_config_dash_keys(self, local_config_path, capsys):
+        """
+        GIVEN a config containing keys separated with dashes
+        WHEN deserializing it
+        THEN the keys are loaded and a warning is raised for config keys
+        """
+        write_yaml(
+            local_config_path,
+            {
+                "version": 2,
+                "iac": {
+                    "ignored-paths": ["myglobalpath"],
+                },
+            },
+        )
+        cfg, _ = UserConfig.load(local_config_path)
+        captured = capsys.readouterr()
+
+        assert cfg.iac.ignored_paths[0].path == "myglobalpath"
+        assert (
+            f"{local_config_path}: Config key ignored-paths is deprecated, use ignored_paths instead."
+            in captured.err
+        )
+
     def test_can_load_ignored_known_secrets_from_root(self, local_config_path):
         """
         GIVEN a config file containing the `ignore_known_secrets` key in the root mapping

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -543,8 +543,8 @@ class TestUserConfig:
         assert "Unrecognized key in config: iac_unknown" in captured.err
         assert "Unrecognized key in config: secret_invalid_key" in captured.err
         assert "Unrecognized key in config: match_invalid_key" in captured.err
-        assert "Unrecognized key in config: hashed-key" in captured.err
-        assert "Unrecognized key in config: nested-hashed" in captured.err
+        assert "Unrecognized key in config: hashed_key" in captured.err
+        assert "Unrecognized key in config: nested_hashed" in captured.err
 
     def test_can_load_ignored_known_secrets_from_root(self, local_config_path):
         """

--- a/tests/unit/core/config/test_utils.py
+++ b/tests/unit/core/config/test_utils.py
@@ -8,19 +8,17 @@ from ggshield.core.config.utils import (
     find_local_config_path,
     remove_common_dict_items,
     remove_url_trailing_slash,
-    replace_in_keys,
+    replace_dash_in_keys,
     update_from_other_instance,
 )
 from ggshield.utils.os import cd
 from tests.repository import Repository
 
 
-def test_replace_in_keys():
+def test_replace_dash_in_keys():
     data = {"last-found-secrets": {"XXX"}}
-    replace_in_keys(data, "-", "_")
+    replace_dash_in_keys(data)
     assert data == {"last_found_secrets": {"XXX"}}
-    replace_in_keys(data, "_", "-")
-    assert data == {"last-found-secrets": {"XXX"}}
 
 
 @dataclass

--- a/tests/unit/core/config/test_utils.py
+++ b/tests/unit/core/config/test_utils.py
@@ -16,9 +16,24 @@ from tests.repository import Repository
 
 
 def test_replace_dash_in_keys():
-    data = {"last-found-secrets": {"XXX"}}
-    replace_dash_in_keys(data)
-    assert data == {"last_found_secrets": {"XXX"}}
+    """
+    GIVEN a dict with some keys using dash
+    WHEN replace_dash_in_keys() is called
+    THEN the dict keys all use underscore
+    AND replace_dash_in_keys() returned a set of all the modified keys
+    """
+    data = {
+        "use_underscore": 12,
+        "use-dash": "hello",
+        "container": {"sub-dash-key": "values-are-not-affected"},
+    }
+    modified = replace_dash_in_keys(data)
+    assert data == {
+        "use_underscore": 12,
+        "use_dash": "hello",
+        "container": {"sub_dash_key": "values-are-not-affected"},
+    }
+    assert modified == {"use-dash", "sub-dash-key"}
 
 
 @dataclass

--- a/tests/unit/verticals/secret/snapshots/snap_test_secret_scanner.py
+++ b/tests/unit/verticals/secret/snapshots/snap_test_secret_scanner.py
@@ -7,7 +7,7 @@ snapshots = Snapshot()
 
 snapshots['test_handle_scan_error[single file exception] 1'] = '''
 Scanning failed. Results may be incomplete.
-Add the following files to your paths-ignore:
+Add the following files to your ignored_paths:
 - /home/user/too/long/file/name: filename:: [ErrorDetail(string='Ensure this field has no more than 256 characters.', code='max_length')]
 '''
 


### PR DESCRIPTION
## Context

This PR makes deprecate dash-separated config keys and suggest using underscore-separate keys instead. This means one must use `show_secrets` and not `show-secrets`.

Using dash syntax still works but ggshield prints a warning message when it finds them and no longer makes any effort to refer to a key in the syntax it was written.

## Output

Here is what the output looks like with a dash-separated key in the "global" config and 3 other dash-separated keys in the current directory (~/src/ggshield-alt in my example):

```
$ ggshield api-status
/home/agateau/.gitguardian.yaml: Config key show-secrets is deprecated, use show_secrets instead.
/home/agateau/src/ggshield-alt/.gitguardian.yaml: Config key ignored-matches is deprecated, use ignored_matches instead.
/home/agateau/src/ggshield-alt/.gitguardian.yaml: Config key ignored-paths is deprecated, use ignored_paths instead.
/home/agateau/src/ggshield-alt/.gitguardian.yaml: Config key ignored-policies is deprecated, use ignored_policies instead.
API URL: https://api.gitguardian.com
Status: healthy
App version: v2.62.1
Secrets engine version: 2.109.0
```

## Review

Best reviewed commit by commit.