### PR TITLE
Release signed binaries

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,9 +43,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
           - os: windows-2022
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             sha256sum:
               python: 6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -1,18 +1,49 @@
-name: Sign
+name: Build release assets
 
-# This is an on-demand workflow to test signing
+# This workflow is used by the tag workflow to build all release assets. It
+# can also be triggered manually.
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:
-  build-standalone:
-    name: Standalone exe
+  build_packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install packaging tools
+        shell: bash
+        run: |
+          curl -L https://github.com/goreleaser/nfpm/releases/download/v2.15.0/nfpm_amd64.deb -o nfpm_amd64.deb
+          sudo dpkg -i nfpm_amd64.deb
+
+          pip install shiv==1.0.1 build
+
+      - name: Create packages
+        shell: bash
+        run: scripts/build-packages/build-packages
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: |
+            dist
+            packages
+
+  build_standalone_binaries:
+    name: Build signed, standalone binaries
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-latest
           - os: windows-2022
           - os: macos-latest
             arch: x86_64
@@ -113,15 +144,6 @@ jobs:
         run: |
           scripts/build-standalone-exe --sign
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ggshield-${{ matrix.os }}
-          path: |
-            dist/ggshield-*.gz
-            dist/ggshield-*.pkg
-            dist/ggshield-*.zip
-
       - name: Override base Docker image used for functional tests on Windows
         if: matrix.os == 'windows-2022'
         # This is required because GitHub Windows runner is not configured to
@@ -140,3 +162,12 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
           TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: standalone-binaries-${{ matrix.os }}
+          path: |
+            dist/ggshield-*.gz
+            dist/ggshield-*.pkg
+            dist/ggshield-*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   lint:
     name: Lint package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
@@ -160,8 +160,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
+          - ubuntu-22.04
+          - macos-13
           - windows-2022
           - macos-14
     steps:
@@ -223,7 +223,7 @@ jobs:
 
   build_packages:
     # This job ensures the build-packages script is tested on each build, not only at release time
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -265,7 +265,7 @@ jobs:
     name: Test GitHub action for `secret scan`
     # See note about steps requiring the GITGUARDIAN_API at the top of this file
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -284,7 +284,7 @@ jobs:
     name: Test GitHub action for `iac scan`
     # See note about steps requiring the GITGUARDIAN_API at the top of this file
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -303,7 +303,7 @@ jobs:
     name: Test GitHub action for `sca scan`
     # See note about steps requiring the GITGUARDIAN_API at the top of this file
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -320,7 +320,7 @@ jobs:
 
   dockerhub-unstable:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
       - lint
@@ -341,7 +341,7 @@ jobs:
 
   github_packages-unstable:
     name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
       - lint

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -14,7 +14,7 @@ jobs:
   benchmark:
     name: Run performance benchmark
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PYTHONUNBUFFERED: 1
       # How many time to repeat each run

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
 
   push_to_pypi:
     needs: build_release_assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.pypi_password }}
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build_release_assets
     continue-on-error: true
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
@@ -85,7 +85,7 @@ jobs:
 
   push_to_docker_hub:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
@@ -101,7 +101,7 @@ jobs:
 
   push_to_github_packages:
     name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Check out the repo
@@ -119,7 +119,7 @@ jobs:
   push_to_tap:
     needs: push_to_pypi
     name: Push to GitGuardian taps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Set up Python 3.9
@@ -146,7 +146,7 @@ jobs:
 
   push_to_cloudsmith:
     needs: build_release_assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,36 +6,12 @@ on:
       - 'v*'
 
 jobs:
-  build_packages:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install packaging tools
-        shell: bash
-        run: |
-          curl -L https://github.com/goreleaser/nfpm/releases/download/v2.15.0/nfpm_amd64.deb -o nfpm_amd64.deb
-          sudo dpkg -i nfpm_amd64.deb
-
-          pip install shiv==1.0.1 build
-
-      - name: Create packages
-        shell: bash
-        run: scripts/build-packages/build-packages
-
-      - name: Upload packages
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: |
-            dist
-            packages
+  build_release_assets:
+    uses: ./.github/workflows/build_release_assets.yml
+    secrets: inherit
 
   push_to_pypi:
-    needs: build_packages
+    needs: build_release_assets
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
@@ -46,7 +22,7 @@ jobs:
           python-version: '3.x'
 
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
 
@@ -58,7 +34,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build_packages
+    needs: build_release_assets
     continue-on-error: true
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
@@ -79,9 +55,16 @@ jobs:
           echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
+
+      - name: Download standalone binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: standalone-binaries-*
+          path: standalone-binaries
+          merge-multiple: true
 
       - name: Create release
         env:
@@ -97,7 +80,8 @@ jobs:
             ${{ steps.tags.outputs.tag }} \
             packages/ggshield-*.pyz \
             packages/ggshield_*.deb \
-            packages/ggshield-*.rpm
+            packages/ggshield-*.rpm \
+            standalone-binaries/ggshield-*.pkg
 
   push_to_docker_hub:
     name: Push Docker image to Docker Hub
@@ -161,7 +145,7 @@ jobs:
           git push
 
   push_to_cloudsmith:
-    needs: build_packages
+    needs: build_release_assets
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
@@ -169,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
 

--- a/changelog.d/20240410_114708_aurelien.gateau_release_signed_binaries.md
+++ b/changelog.d/20240410_114708_aurelien.gateau_release_signed_binaries.md
@@ -1,0 +1,3 @@
+### Added
+
+- We now provide signed .pkg files for macOS.


### PR DESCRIPTION
## Context

This PR extends our CI so that signed macOS binaries are built on each release.

## What has been done

Since testing CI code which only triggers on tags is not really possible, I used the following workarounds:

1. The existing sign.yml workflow has been turned into a more generic build_release_assets.yml workflow. This workflow is called by the tag.yml workflow. It can also be called manually.

2. I added a faketag.yml workflow. This is a copy of tag.yml except it triggers on pull requests and does not publish anything: each publish step is replaced by a step listing the downloaded artifacts which would be published. This allow verifies the changes to tag.yml as much as possible. You can see a run of it [here](https://github.com/GitGuardian/ggshield/actions/runs/8629377759).
  This faketag.yml will be removed before merging the PR.

## Review

First commit contains the real work. Second commit just adds faketag.yml and can mostly be ignored (apart from verifying changes made to tag.yml are also present in faketag.yml). I will revert that commit before merging.