### PR TITLE
Ignoring with an until date is broken

### DIFF
--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Set, Tuple, Type, Union
 
@@ -39,7 +39,8 @@ def get_scan_params_from_config(sca_config: SCAConfig) -> SCAScanParameters:
                 identifier=ignored_vuln.identifier, path=ignored_vuln.path
             )
             for ignored_vuln in sca_config.ignored_vulnerabilities
-            if ignored_vuln.until is None or ignored_vuln.until >= datetime.utcnow()
+            if ignored_vuln.until is None
+            or ignored_vuln.until >= datetime.now(tz=timezone.utc)
         ],
         ignore_fixable=sca_config.ignore_fixable,
         ignore_not_fixable=sca_config.ignore_not_fixable,

--- a/tests/unit/cassettes/test_sca_scan_subdir_with_ignored_vuln_with_until.yaml
+++ b/tests/unit/cassettes/test_sca_scan_subdir_with_ignored_vuln_with_until.yaml
@@ -1,0 +1,157 @@
+interactions:
+  - request:
+      body: '{"files": ["Pipfile.lock"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '27'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/compute_sca_files/
+    response:
+      body:
+        string: '{"sca_files":["Pipfile.lock"],"potential_siblings":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '54'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 11 Jan 2024 14:13:34 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 6843176f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '53'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.22.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-11T14:02:55.794006+00:00'
+        x-secrets-engine-version:
+          - 2.103.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: !!binary |
+        LS1kNTc5ODg4NmUzNTBkZDE5ZDI0ODMyYzU1NDliYTY0MQ0KQ29udGVudC1EaXNwb3NpdGlvbjog
+        Zm9ybS1kYXRhOyBuYW1lPSJzY2FuX3BhcmFtZXRlcnMiDQoNCnsibWluaW11bV9zZXZlcml0eSI6
+        ICJMT1ciLCAiaWdub3JlZF92dWxuZXJhYmlsaXRpZXMiOiBbeyJpZGVudGlmaWVyIjogIkdIU0Et
+        cnJtNi13dmo3LWN3aDIiLCAicGF0aCI6ICJpbm5lci9kaXIvUGlwZmlsZS5sb2NrIn1dfQ0KLS1k
+        NTc5ODg4NmUzNTBkZDE5ZDI0ODMyYzU1NDliYTY0MQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9y
+        bS1kYXRhOyBuYW1lPSJkaXJlY3RvcnkiOyBmaWxlbmFtZT0iZGlyZWN0b3J5Ig0KDQofiwgAjvef
+        ZQL/7dVPb5swFABwzvkUEecO/A/bRIq04469T1Vl7OcFjQC1SZRqyncfpFMbllS9bJW6vd+FYJtn
+        4+dHsjzLP9+awxcwDkLyV5Anr10J4eLl99ROCaMsWR6Sd7CLgwnj9Mn/ienldqi3sKaKiFIzQUVG
+        NFFE6UWC/nl120LIXR3y27r3dQNZ09nvf77+pTzVOFUFPb9OqCAyoaIQSikuqUwIG78AMlmS96z/
+        g9nXEKrGtHbTDZfj3ur/oBY/FstRer+FwaSr5dPtqWlj4mbWcmqNG8MKObanrPJUKi+NYsYY4oX2
+        hVayFIVnhiuthOeeUuGMK6AsmHXK+dJ50K50TNP0OfDx5mXW/ukYfoo92HEWedYV4GFXB4iXi+of
+        h03X3u8hxLprp8XxjJLrE8RuF+wpyNdZkHnI09DWbGEK1j/2dXpz2b8LzdS9GYY+rvJ8GpZ14Vse
+        623fwLUnxhXW/vE+xunBIexgNuT4fHe3OFt26sCbXTPM0xMfmt6ECJe7MSXuyguepW9FOOOWgGWl
+        dQWrLJjK0kqMiSlUCZxSz0GUklaldlSJsSBdIRkzjFe6AC6uvduv0LK0RhOhhayqKfsMLNcEBJfE
+        aMMFcZXmnljrufEWoBrrXzhP2Hh8FJM6nUW+m0+U1q2Dwys5Sc/yv16TTGT87Aj8tqN7aLp+2rvj
+        4oj/dAghhBBCCCGEEEIIIYQQQgghhD64n62uB5MAKAAADQotLWQ1Nzk4ODg2ZTM1MGRkMTlkMjQ4
+        MzJjNTU0OWJhNjQxLS0NCg==
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '928'
+        Content-Type:
+          - multipart/form-data; boundary=d5798886e350dd19d24832c5549ba641
+        GGShield-Command-Id:
+          - 117db605-4f1d-48de-b70a-588f4edb6277
+        GGShield-Command-Path:
+          - cli sca scan all
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.13
+        GGShield-Version:
+          - 1.23.0
+        User-Agent:
+          - pygitguardian/1.12.0 (Linux;py3.10.13) ggshield
+        mode:
+          - directory
+      method: POST
+      uri: https://api.gitguardian.com/v1/sca/sca_scan_all/
+    response:
+      body:
+        string: '{"scanned_files":["inner/dir/Pipfile.lock"],"found_package_vulns":[]}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '69'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 11 Jan 2024 14:13:34 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - 6843176f
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '93'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.22.0
+        x-sca-last-vuln-fetch:
+          - '2024-01-11T14:02:55.794006+00:00'
+        x-secrets-engine-version:
+          - 2.103.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/sca/test_sca_scan_utils.py
+++ b/tests/unit/cmd/sca/test_sca_scan_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pygitguardian.sca_models import SCAScanParameters
 
@@ -21,13 +21,13 @@ def test_get_scan_params_from_config():
             SCAConfigIgnoredVulnerability(
                 identifier="GHSA-toto-1234",
                 path="Pipfile.lock",
-                until=datetime(year=1970, month=1, day=1),
+                until=datetime(year=1970, month=1, day=1).replace(tzinfo=timezone.utc),
             ),
             # Ignored ones
             SCAConfigIgnoredVulnerability(
                 identifier="GHSA-4567-8765",
                 path="toto/Pipfile.lock",
-                until=datetime.utcnow() + timedelta(days=1),
+                until=datetime.now(tz=timezone.utc) + timedelta(days=1),
             ),
             SCAConfigIgnoredVulnerability(
                 identifier="GHSA-4567-other",

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -629,6 +629,60 @@ sca:
         assert "GHSA-rrm6-wvj7-cwh2" not in result.stdout
 
 
+@my_vcr.use_cassette("test_sca_scan_subdir_with_ignored_vuln_with_until.yaml")
+def test_sca_scan_subdir_with_ignored_vuln_with_until(
+    tmp_path: Path,
+    cli_fs_runner: CliRunner,
+    pipfile_lock_with_vuln: str,
+) -> None:
+    """
+    GIVEN a git repository
+    GIVEN an inner directory with a vulnerability
+    GIVEN a .gitguardian.yaml file with an ignored vuln in the inner dir until a future date
+    WHEN scanning the inner dir
+    THEN the ignored vuln does not appear in the result
+    """
+    repo = Repository.create(tmp_path)
+    repo.create_commit()
+
+    inner_dir_path = tmp_path / "inner" / "dir"
+    pipfile_path = inner_dir_path / "Pipfile.lock"
+
+    ignored_vuln_text = f"""
+version: 2
+
+sca:
+  ignored-vulnerabilities:
+    - identifier: 'GHSA-rrm6-wvj7-cwh2'
+      path: {str(pipfile_path.relative_to(tmp_path))}
+      comment: 'test ignored'
+      until: '2200-06-30T10:00:00'
+"""
+
+    # Write .gitguardian.yaml config file at the root of the repo
+    (tmp_path / ".gitguardian.yaml").write_text(ignored_vuln_text)
+    inner_dir_path.mkdir(parents=True)
+    pipfile_path.write_text(pipfile_lock_with_vuln)
+
+    repo.add(".gitguardian.yaml")
+    repo.add("inner/dir/Pipfile.lock")
+    repo.create_commit()
+
+    with cd(str(tmp_path)):
+        result = cli_fs_runner.invoke(
+            cli,
+            [
+                "sca",
+                "scan",
+                "all",
+                str(inner_dir_path.relative_to(tmp_path)),
+            ],
+        )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "GHSA-rrm6-wvj7-cwh2" not in result.stdout
+
+
 @my_vcr.use_cassette("test_sca_scan_all_ignore_fixable.yaml")
 def test_scan_all_ignore_fixable(
     cli_fs_runner: click.testing.CliRunner,


### PR DESCRIPTION
### Context

Ggshield breaks when a vulnerability is ignored until a certain date.

## Steps to reproduce

1. Add a Pipfile and a Pipfile.lock with celery=4.4.7 as dependency
2. Ignore by adding the following in .gitguardian.yaml
```
- identifier: GHSA-q4xr-rc97-m4xx
      path: "Pipfile.lock"
      comment: "need to update code for compat"
      until: "2024-06-30T10:00:00"
```
3. Run `ggshield sca scan all`


- [x] It should work with date
- [x] It should work with datetime