### PR TITLE
Fix configuration override

### DIFF
--- a/changelog.d/20240412_143500_aurelien.gateau_fix_config_override.md
+++ b/changelog.d/20240412_143500_aurelien.gateau_fix_config_override.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Configuration keys defined in the global configuration file are no longer ignored if a local configuration file exists.

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -383,12 +383,12 @@ def _load_config_dict(
     except ValueError as exc:
         raise ParseError(str(exc)) from exc
 
-    renamed_keys = replace_dash_in_keys(dct)
+    dash_keys = replace_dash_in_keys(dct)
 
     config_version = dct.pop("version", 1)
     if config_version == 2:
-        if renamed_keys:
-            _warn_about_dash_keys(config_path, renamed_keys)
+        if dash_keys:
+            _warn_about_dash_keys(config_path, dash_keys)
         _fix_ignore_known_secrets(dct)
     elif config_version == 1:
         deprecation_messages.append(
@@ -418,8 +418,8 @@ def _fix_ignore_known_secrets(data: Dict[str, Any]) -> None:
     secret_dct[_IGNORE_KNOWN_SECRETS_KEY] = value
 
 
-def _warn_about_dash_keys(config_path: Path, renamed_keys: Set[str]) -> None:
-    for old_key in sorted(renamed_keys):
+def _warn_about_dash_keys(config_path: Path, dash_keys: Set[str]) -> None:
+    for old_key in sorted(dash_keys):
         new_key = old_key.replace("-", "_")
         display_warning(
             f"{config_path}: Config key {old_key} is deprecated, use {new_key} instead."

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -1,4 +1,3 @@
-from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Union, overload
 
@@ -108,25 +107,24 @@ def find_local_config_path() -> Optional[Path]:
     return None
 
 
-def update_from_other_instance(dst: Any, src: Any) -> None:
+def update_dict_from_other(dct: Dict[str, Any], other: Dict[str, Any]) -> None:
     """
-    Update `dst` with fields from `src` if they are set.
-    `src` must be the same class or a subclass of `dst`.
+    Merge values from `other` dict into `dct`. List entries are appended, sets are
+    updated, dicts are merged.
+
+    The merge happens in-place: `dct` is modified.
     """
-    assert isinstance(src, dst.__class__)
-    for field_ in fields(src):
-        name = field_.name
-        value = src.__dict__[name]
+    for key, value in other.items():
         if value is None:
             continue
         if isinstance(value, list):
-            dst.__dict__[name].extend(value)
+            dct.setdefault(key, []).extend(value)
         elif isinstance(value, set):
-            dst.__dict__[name].update(value)
-        elif is_dataclass(value):
-            update_from_other_instance(dst.__dict__[name], value)
+            dct.setdefault(key, set()).update(value)
+        elif isinstance(value, dict):
+            update_dict_from_other(dct.setdefault(key, {}), value)
         else:
-            dst.__dict__[name] = value
+            dct[key] = value
 
 
 def remove_common_dict_items(dct: Dict, reference_dct: Dict) -> Dict:

--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -16,21 +16,29 @@ from ggshield.utils.git_shell import GitExecutableNotFound
 
 
 def replace_dash_in_keys(data: Union[List, Dict]) -> Set[str]:
-    """Replace '-' with '_' in data keys."""
-    replaced = set()
+    """Replace '-' with '_' in data keys.
+
+    If a key exists in both dash and underscore versions, then only the underscore
+    version is kept.
+
+    Returns a set with the names of the renamed/removed dash keys."""
+    dash_keys = set()
 
     if isinstance(data, dict):
         for key, value in list(data.items()):
-            replaced.update(replace_dash_in_keys(value))
+            dash_keys.update(replace_dash_in_keys(value))
             if "-" in key:
+                dash_value = data.pop(key)
+                # If an underscore-version of the key exist, do not replace it
                 new_key = key.replace("-", "_")
-                data[new_key] = data.pop(key)
-                replaced.add(key)
+                if new_key not in data:
+                    data[new_key] = dash_value
+                dash_keys.add(key)
     elif isinstance(data, list):
         for element in data:
-            replaced.update(replace_dash_in_keys(element))
+            dash_keys.update(replace_dash_in_keys(element))
 
-    return replaced
+    return dash_keys
 
 
 def load_yaml_dict(path: Union[str, Path]) -> Optional[Dict[str, Any]]:

--- a/ggshield/core/config/v1_config.py
+++ b/ggshield/core/config/v1_config.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List, Optional, Union
+
+from ggshield.core.url_utils import api_to_dashboard_url
+
+
+def convert_v1_config_dict(
+    data: Dict[str, Any], deprecation_messages: List[str]
+) -> Dict[str, Any]:
+    """
+    Takes a dict representing a v1 .gitguardian.yaml and returns a v2 dict.
+    Appends any deprecation message to `deprecation_messages`.
+    """
+
+    # If data contains the old "api-url" key, turn it into an "instance" key,
+    # but only if there is no "instance" key
+    try:
+        api_url = data.pop("api_url")
+    except KeyError:
+        pass
+    else:
+        if "instance" not in data:
+            data["instance"] = api_to_dashboard_url(api_url, warn=True)
+
+    if "all_policies" in data:
+        deprecation_messages.append(
+            "The `all_policies` option has been deprecated and is now ignored."
+        )
+
+    if "ignore_default_excludes" in data:
+        deprecation_messages.append(
+            "The `ignore_default_exclude` option has been deprecated and is now ignored."
+        )
+
+    secret_dct = {}
+    if matches_ignore := data.get("matches_ignore"):
+        secret_dct["ignored_matches"] = [
+            _convert_matches_ignore_entry(x) for x in matches_ignore
+        ]
+
+    def copy_if_set(dct: Dict[str, Any], dst_key: str, src_key: Optional[str] = None):
+        """Helper function: if `src_key` exists in `data`, copies its value to
+        `dct[dst_key]`.
+        If `src_key` is None, use `dst_key` as the source key.
+        """
+        if src_key is None:
+            src_key = dst_key
+        try:
+            value = data[src_key]
+        except KeyError:
+            return
+        dct[dst_key] = value
+
+    copy_if_set(secret_dct, "show_secrets")
+    copy_if_set(secret_dct, "ignored_detectors", "banlisted_detectors")
+    copy_if_set(secret_dct, "ignored_paths", "paths_ignore")
+
+    dct = {
+        "secret": secret_dct,
+    }
+    copy_if_set(dct, "instance")
+    copy_if_set(dct, "exit_zero")
+    copy_if_set(dct, "verbose")
+    copy_if_set(dct, "allow_self_signed")
+    copy_if_set(dct, "max_commits_for_hook")
+
+    return dct
+
+
+def _convert_matches_ignore_entry(entry: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    v1 config format allowed to use just a hash of the secret for matches_ignore
+    field v2 does not. This function converts the hash-only entry.
+    """
+    if isinstance(entry, str):
+        return {"name": "", "match": entry}
+    else:
+        return entry

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -84,7 +84,7 @@ class TestAuthConfig:
         THEN it works
         """
         raw_config = deepcopy(TEST_AUTH_CONFIG)
-        raw_config["instances"][0]["accounts"][0]["expire-at"] = None
+        raw_config["instances"][0]["accounts"][0]["expire_at"] = None
         write_yaml(get_auth_config_filepath(), raw_config)
 
         config = Config()

--- a/tests/unit/core/config/test_utils.py
+++ b/tests/unit/core/config/test_utils.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict
 
 import pytest
 
@@ -9,7 +8,7 @@ from ggshield.core.config.utils import (
     remove_common_dict_items,
     remove_url_trailing_slash,
     replace_dash_in_keys,
-    update_from_other_instance,
+    update_dict_from_other,
 )
 from ggshield.utils.os import cd
 from tests.repository import Repository
@@ -36,46 +35,38 @@ def test_replace_dash_in_keys():
     assert modified == {"use-dash", "sub-dash-key"}
 
 
-@dataclass
-class ExampleSubConfig:
-    an_int: Optional[int] = None
-    an_str: Optional[str] = None
-
-
-@dataclass
-class ExampleConfig:
-    path: Optional[str] = None
-    backup: bool = True
-    subconf: ExampleSubConfig = field(default_factory=ExampleSubConfig)
-    a_list: List[str] = field(default_factory=list)
-    a_set: Set[str] = field(default_factory=set)
-
-
-def test_update_from_other_instance():
+def test_update_dict_from_other():
     """
-    GIVEN two dataclass instances
-    WHEN update_from_other_instance(dst_conf, src_conf) is called
+    GIVEN two dictionaries
+    WHEN update_dict_from_other(dst_conf, src_conf) is called
     THEN dst_conf is updated from src_conf fields
     """
 
-    dst_conf = ExampleConfig(path="dst_path")
-    dst_conf.subconf.an_int = 1
-    dst_conf.a_list = ["i1", "i2"]
-    dst_conf.a_set = {"i1", "i2"}
+    dst_conf = {
+        "subconf": {"an_int": 1},
+        "not_overridden_bool": True,
+        "overridden_bool": True,
+        "a_list": ["i1", "i2"],
+        "a_set": {"i1", "i2"},
+    }
 
-    src_conf = ExampleConfig(backup=False)
-    src_conf.subconf.an_str = "src_subconf_str"
-    src_conf.a_list = ["i2", "i3"]
-    src_conf.a_set = {"i2", "i3"}
+    src_conf = {
+        "overridden_bool": False,
+        "subconf": {
+            "an_str": "src_subconf_str",
+        },
+        "a_list": ["i2", "i3"],
+        "a_set": {"i2", "i3"},
+    }
 
-    update_from_other_instance(dst_conf, src_conf)
+    update_dict_from_other(dst_conf, src_conf)
 
-    assert dst_conf.path == "dst_path"
-    assert dst_conf.backup is False
-    assert dst_conf.subconf.an_int == 1
-    assert dst_conf.subconf.an_str == "src_subconf_str"
-    assert dst_conf.a_list == ["i1", "i2", "i2", "i3"]
-    assert dst_conf.a_set == {"i1", "i2", "i3"}
+    assert dst_conf["not_overridden_bool"] is True
+    assert dst_conf["overridden_bool"] is False
+    assert dst_conf["subconf"]["an_int"] == 1
+    assert dst_conf["subconf"]["an_str"] == "src_subconf_str"
+    assert dst_conf["a_list"] == ["i1", "i2", "i2", "i3"]
+    assert dst_conf["a_set"] == {"i1", "i2", "i3"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/config/test_utils.py
+++ b/tests/unit/core/config/test_utils.py
@@ -24,15 +24,20 @@ def test_replace_dash_in_keys():
     data = {
         "use_underscore": 12,
         "use-dash": "hello",
+        "dash-or-underscore": "dash",
+        "dash_or_underscore": "underscore",
         "container": {"sub-dash-key": "values-are-not-affected"},
     }
-    modified = replace_dash_in_keys(data)
+
+    dash_keys = replace_dash_in_keys(data)
+
     assert data == {
         "use_underscore": 12,
         "use_dash": "hello",
+        "dash_or_underscore": "underscore",
         "container": {"sub_dash_key": "values-are-not-affected"},
     }
-    assert modified == {"use-dash", "sub-dash-key"}
+    assert dash_keys == {"use-dash", "sub-dash-key", "dash-or-underscore"}
 
 
 def test_update_dict_from_other():


### PR DESCRIPTION
## Context

If a key is set in the global configuration file, but not in the local one, then the global value is ignored unless it's a list key.

The current code loads each configuration file (global and local) as UserConfig instances, then merge the instances.

When the local UserConfig instance is loaded, if a key is not set, its field uses the default value. This is a problem because then the code responsible for merging the global and local UserConfig instances considers that the local value has explicitly been set and ignores the global value.

With this change, ggshield now loads each config as a *dict*, merges the dicts and creates a UserConfig instance from the merged dict. This fixes the bug because a dict keeps the notion of whether a key was set or not, so the merge works as expected.

## Review

Sorry the changes are quite large to review as I had to rework a good chunk of the loading code.

Important aspects:
- Most of the config loading code moved from `UserConfig._update_from_file()` to a free function `_load_from_dict()`.
- The `UserV1Config` class is gone, replaced with a conversion function in a dedicated module: `v1_config`.