### PR TITLE
fix(sca): fixing functional tests after remote data being modified

### DIFF
--- a/tests/functional/sca/test_sca_scan_ci.py
+++ b/tests/functional/sca/test_sca_scan_ci.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from tests.functional.utils import run_ggshield_sca_scan
@@ -31,7 +32,7 @@ def test_scan_ci_diff(tmp_path: Path, monkeypatch, pipfile_lock_with_vuln) -> No
 
     monkeypatch.setenv("CI_COMMIT_BEFORE_SHA", "HEAD~3")
     proc = run_ggshield_sca_scan("ci", expected_code=1, cwd=repo.path)
-    assert "> Pipfile.lock: 1 incident detected" in proc.stdout
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", proc.stdout))
     assert (
         """
 Severity: Medium
@@ -74,7 +75,7 @@ def test_scan_ci_all(tmp_path, monkeypatch, pipfile_lock_with_vuln) -> None:
         monkeypatch.setenv(key, value)
 
     proc = run_ggshield_sca_scan("ci", "--all", expected_code=1, cwd=tmp_path)
-    assert "> Pipfile.lock: 1 incident detected" in proc.stdout
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", proc.stdout))
     assert (
         """
 Severity: Medium

--- a/tests/functional/sca/test_sca_scan_diff.py
+++ b/tests/functional/sca/test_sca_scan_diff.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict
 
@@ -27,7 +28,7 @@ def test_scan_diff(tmp_path: Path, pipfile_lock_with_vuln) -> None:
     proc = run_ggshield_sca_scan(
         "diff", "--ref=HEAD", "--staged", expected_code=1, cwd=repo.path
     )
-    assert "> Pipfile.lock: 1 incident detected" in proc.stdout
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", proc.stdout))
     assert (
         """
 Severity: Medium
@@ -44,7 +45,7 @@ CVE IDs: CVE-2023-30608"""
     run_ggshield_sca_scan("diff", "--ref=HEAD~1", expected_code=0, cwd=repo.path)
 
     proc = run_ggshield_sca_scan("diff", "--ref=HEAD~2", expected_code=1, cwd=repo.path)
-    assert "> Pipfile.lock: 1 incident detected" in proc.stdout
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", proc.stdout))
     assert (
         """
 Severity: Medium

--- a/tests/functional/sca/test_sca_scan_prepush.py
+++ b/tests/functional/sca/test_sca_scan_prepush.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import List, Optional
@@ -32,7 +33,7 @@ def test_sca_scan_prepush(tmp_path: Path, pipfile_lock_with_vuln) -> None:
         local_repo.push()
 
     stdout = exc.value.stdout.decode()
-    assert "> Pipfile.lock: 1 incident detected" in stdout
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", stdout))
 
 
 def test_sca_scan_prepush_branch_without_new_commits(tmp_path: Path) -> None:

--- a/tests/functional/sca/test_sca_scan_prereceive.py
+++ b/tests/functional/sca/test_sca_scan_prereceive.py
@@ -1,3 +1,4 @@
+import re
 from subprocess import CalledProcessError
 
 import pytest
@@ -19,7 +20,7 @@ def test_sca_scan_prereceive(sca_repo_with_hook, pipfile_lock_with_vuln) -> None
 
     # AND the error message contains the vulnerability details
     stderr = exc.value.stderr.decode()
-    assert "> Pipfile.lock: 1 incident detected" in stderr
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", stderr))
 
 
 def test_sca_scan_prereceive_no_vuln(sca_repo_with_hook) -> None:
@@ -70,7 +71,7 @@ def test_sca_scan_prereceive_all(
     # AND the error message contains the leaked secret
     stderr = exc.value.stderr.decode()
     # testing the all variant of the output
-    assert "> Pipfile.lock: 1 incident detected" in stderr
+    assert bool(re.search(r"> Pipfile\.lock: \d+ incidents? detected", stderr))
 
 
 def test_sca_scan_prereceive_branch_without_new_commits(sca_repo_with_hook) -> None:


### PR DESCRIPTION
New vulnerability on packages used for SCA testing were declared, making the tests fail because of the test on the number of found vulnerabilities.
Modifying functional test so that they're not dependant anymore on the number of found vulnerabilities (assuming they will remain greater than 1).