### PR TITLE
feat(sca): allow ignoring vulnerabilities by CVE id

### DIFF
--- a/changelog.d/20240430_143900_jonathan.griffe_allow_to_ignore_vulns_by_cve_id.md
+++ b/changelog.d/20240430_143900_jonathan.griffe_allow_to_ignore_vulns_by_cve_id.md
@@ -1,0 +1,3 @@
+### Added
+
+- The SCA config `ignored_vulnerabilities` option now supports taking a CVE id as identifier.

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -30,6 +30,7 @@ CURRENT_CONFIG_VERSION = 2
 _IGNORE_KNOWN_SECRETS_KEY = "ignore_known_secrets"
 
 GHSA_ID_PATTERN = re.compile("GHSA(-[a-zA-Z0-9]{4}){3}")
+CVE_ID_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}")
 POLICY_ID_PATTERN = re.compile("GG_IAC_[0-9]{4}")
 
 
@@ -203,10 +204,15 @@ def is_ghsa_valid(ghsa_id: str) -> bool:
     return bool(GHSA_ID_PATTERN.fullmatch(ghsa_id))
 
 
+def is_cve_id_valid(cve_id: str) -> bool:
+    return bool(CVE_ID_PATTERN.fullmatch(cve_id))
+
+
 def validate_vuln_identifier(value: str):
-    if not is_ghsa_valid(value):
+    if not (is_ghsa_valid(value) or is_cve_id_valid(value)):
         raise ValidationError(
-            f"The given GHSA id '{value}' do not match the pattern '{GHSA_ID_PATTERN.pattern}'"
+            f"The given identifier '{value}' do not match any of the allowed patterns"
+            f" '{GHSA_ID_PATTERN.pattern}' or '{CVE_ID_PATTERN.pattern}'"
         )
 
 
@@ -215,7 +221,7 @@ class SCAConfigIgnoredVulnerability(ConfigIgnoredElement):
     """
     A model of an ignored vulnerability for SCA. This allows to ignore all occurrences
     of a given vulnerability in a given dependency file.
-    - identifier: identifier (currently: GHSA id) of the vulnerability to ignore
+    - identifier: identifier (currently: either CVE id or GHSA id) of the vulnerability to ignore
     - path: the path to the file in which ignore the vulnerability
     - comment: The ignored reason
     - until: A datetime until which the vulnerability is ignored

--- a/tests/unit/cmd/sca/test_sca_scan_utils.py
+++ b/tests/unit/cmd/sca/test_sca_scan_utils.py
@@ -33,6 +33,14 @@ def test_get_scan_params_from_config():
                 identifier="GHSA-4567-other",
                 path="toto/Pipfile.lock",
             ),
+            SCAConfigIgnoredVulnerability(
+                identifier="CVE-2023-3068",
+                path="toto/Pipfile.lock",
+            ),
+            SCAConfigIgnoredVulnerability(
+                identifier="CVE-2023-3068712",
+                path="toto/Pipfile.lock",
+            ),
         ],
         ignore_fixable=True,
     )
@@ -42,10 +50,13 @@ def test_get_scan_params_from_config():
     assert isinstance(params, SCAScanParameters)
     assert params.minimum_severity == "high"
 
-    assert len(params.ignored_vulnerabilities) == 2
-    assert {"GHSA-4567-8765", "GHSA-4567-other"} == set(
-        ignored.identifier for ignored in params.ignored_vulnerabilities
-    )
+    assert len(params.ignored_vulnerabilities) == 4
+    assert {
+        "GHSA-4567-8765",
+        "GHSA-4567-other",
+        "CVE-2023-3068",
+        "CVE-2023-3068712",
+    } == set(ignored.identifier for ignored in params.ignored_vulnerabilities)
     for ignored in params.ignored_vulnerabilities:
         assert ignored.path == "toto/Pipfile.lock"
     assert params.ignore_fixable is True


### PR DESCRIPTION
## Context

We want to allow ignoring vulnerabilities by CVE id in the config.
<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

Ignore vulnerabilities identifier validation now additionally allows identifiers following the CVE id pattern.
<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
