### PR TITLE
feat(secret): Add option --use-gitignore to command secret scan path

### DIFF
--- a/changelog.d/20240515_144740_salome.voltz_scrt_4125_add_an_option_to_make_ggshield_secret_scan_path_honor.md
+++ b/changelog.d/20240515_144740_salome.voltz_scrt_4125_add_an_option_to_make_ggshield_secret_scan_path_honor.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield secret scan path` supports `--use-gitignore` option to honor .gitignore and related files.

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -14,6 +14,7 @@ from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
 from ggshield.utils.click import RealPath
+from ggshield.utils.files import ListFilesMode
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
 
 
@@ -44,11 +45,10 @@ def archive_cmd(
         files = get_files_from_paths(
             paths=[temp_path],
             exclusion_regexes=ctx_obj.exclusion_regexes,
-            recursive=True,
             yes=True,
             display_scanned_files=verbose,
             display_binary_files=verbose,
-            ignore_git=True,
+            list_files_mode=ListFilesMode.ALL,
         )
 
         with ctx_obj.ui.create_scanner_ui(len(files), verbose=verbose) as ui:

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -16,6 +16,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.utils.files import ListFilesMode
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
 
 
@@ -71,11 +72,10 @@ def get_files_from_package(
     return get_files_from_paths(
         paths=[archive_dir],
         exclusion_regexes=exclusion_regexes,
-        recursive=True,
         yes=True,
         display_scanned_files=verbose,
         display_binary_files=verbose,
-        ignore_git=True,
+        list_files_mode=ListFilesMode.ALL,
     )
 
 

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -4,7 +4,12 @@ from typing import Iterable, Iterator, List, Set, Union
 
 import click
 
-from ggshield.utils.files import UnexpectedDirectoryError, get_filepaths, is_path_binary
+from ggshield.utils.files import (
+    ListFilesMode,
+    UnexpectedDirectoryError,
+    get_filepaths,
+    is_path_binary,
+)
 
 from .scannable import Scannable
 
@@ -52,18 +57,15 @@ class File(Scannable):
 def get_files_from_paths(
     paths: List[Path],
     exclusion_regexes: Set[re.Pattern],
-    recursive: bool,
     yes: bool,
     display_scanned_files: bool,
     display_binary_files: bool,
-    ignore_git: bool = False,
-    ignore_git_staged: bool = False,
+    list_files_mode: ListFilesMode = ListFilesMode.GIT_COMMITTED_OR_STAGED,
 ) -> List[Scannable]:
     """
     Create a scan object from files content.
 
     :param paths: List of file/dir paths from the command
-    :param recursive: Recursive option
     :param yes: Skip confirmation option
     :param display_scanned_files: In some parts of the code (e.g. SCA), we might want
     to display a processed list instead and set this to False
@@ -74,9 +76,7 @@ def get_files_from_paths(
         filepaths = get_filepaths(
             paths,
             exclusion_regexes,
-            recursive,
-            ignore_git=ignore_git,
-            ignore_git_staged=ignore_git_staged,
+            list_files_mode=list_files_mode,
         )
     except UnexpectedDirectoryError as error:
         raise click.UsageError(

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Set
 
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.utils.files import ListFilesMode
 
 
 IAC_EXTENSIONS = {
@@ -37,12 +38,18 @@ def get_iac_files_from_path(
         for x in get_files_from_paths(
             paths=[path],
             exclusion_regexes=exclusion_regexes,
-            recursive=True,
             yes=True,
             display_binary_files=verbose,
-            display_scanned_files=False,  # If True, this displays all files in the directory but we only want IaC files
-            ignore_git=ignore_git,
-            ignore_git_staged=ignore_git_staged,
+            display_scanned_files=False,
+            list_files_mode=(
+                ListFilesMode.ALL
+                if ignore_git
+                else (
+                    ListFilesMode.GIT_COMMITTED
+                    if ignore_git_staged
+                    else ListFilesMode.GIT_COMMITTED_OR_STAGED
+                )
+            ),
         )
         if is_iac_file_path(x.path)
     ]

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -10,7 +10,7 @@ from ggshield.core.errors import APIKeyCheckError, UnexpectedError
 from ggshield.core.scan.file import get_files_from_paths
 from ggshield.core.tar_utils import INDEX_REF
 from ggshield.core.text_utils import display_info
-from ggshield.utils.files import is_path_excluded
+from ggshield.utils.files import ListFilesMode, is_path_excluded
 from ggshield.utils.git_shell import get_filepaths_from_ref, get_staged_filepaths
 
 
@@ -53,11 +53,14 @@ def get_all_files_from_sca_paths(
         for x in get_files_from_paths(
             paths=[path],
             exclusion_regexes=exclusion_regexes | SCA_EXCLUSION_REGEXES,
-            recursive=True,
             yes=True,
             display_binary_files=verbose,
             display_scanned_files=False,  # If True, this displays all files in the directory but we only want SCA files
-            ignore_git=ignore_git,
+            list_files_mode=(
+                ListFilesMode.ALL
+                if ignore_git
+                else ListFilesMode.GIT_COMMITTED_OR_STAGED
+            ),
         )
     ]
 

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -13,6 +13,7 @@ from ggshield.cmd.secret.scan.pypi import (
     save_package_to_tmp,
 )
 from ggshield.core.errors import UnexpectedError
+from ggshield.utils.files import ListFilesMode
 
 
 class TestPipDownload:
@@ -111,9 +112,8 @@ class TestListPackageFiles:
             get_files_from_paths_mock.assert_called_once_with(
                 paths=[tmp_path],
                 exclusion_regexes=expected_exclusion_regexes,
-                recursive=True,
                 yes=True,
                 display_scanned_files=verbose,
                 display_binary_files=verbose,
-                ignore_git=True,
+                list_files_mode=ListFilesMode.ALL,
             )

--- a/tests/unit/verticals/sca/test_file_selection.py
+++ b/tests/unit/verticals/sca/test_file_selection.py
@@ -75,7 +75,6 @@ def test_get_ignored_files(tmp_path, capsysbinary, file_path, expected):
     get_files_from_paths(
         paths=[Path(tmp_path)],
         exclusion_regexes=SCA_EXCLUSION_REGEXES,  # directories we don't want to traverse
-        recursive=True,
         yes=True,
         display_binary_files=True,
         display_scanned_files=False,


### PR DESCRIPTION
## Context

When running a scan at the root of a git checkout with `ggshield secret scan path`, files that are not part of the repository are scanned because the .gitignore is not honored. 
This creates irrelevant results. 
  
## What has been done

`secret scan path` now supports a `--use-gitignore` option to honor .gitignore files and related files (.git/info/exclude, $HOME/.config/git/ignore).

## Validation
- Clone a repo 
- Checkout a branch
- You can scan the current state of the checkout with `ggshield secret scan path -r --use-gitignore .`
- Modify some file
- You can scan the modified files (even unstaged) with the same command 

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.