### PR TITLE
feat(sca): Add support for malicious package detection

### DIFF
--- a/actions-unstable/sca/action.yml
+++ b/actions-unstable/sca/action.yml
@@ -10,7 +10,7 @@ inputs:
         --exit-zero                     Always return a 0 (non-error) status code, even if issues
                                         are found. The env var GITGUARDIAN_EXIT_ZERO can also be used
                                         to set this option.
-        --minimum-severity              [LOW|MEDIUM|HIGH|CRITICAL]
+        --minimum-severity              [LOW|MEDIUM|HIGH|CRITICAL|MALICIOUS]
                                         Minimum severity of the policies
         --ignore-path, --ipa PATH       Do not scan the specified paths.
     required: false

--- a/ggshield/core/constants.py
+++ b/ggshield/core/constants.py
@@ -33,6 +33,7 @@ class IncidentStatus(str, Enum):
 
 
 class IncidentSeverity(str, Enum):
+    MALICIOUS = "malicious"
     CRITICAL = "critical"
     HIGH = "high"
     MEDIUM = "medium"
@@ -41,6 +42,8 @@ class IncidentSeverity(str, Enum):
 
     def _weight(self) -> int:
         """returns a weight to define `__lt__` method"""
+        if self == IncidentSeverity.MALICIOUS:
+            return -10
         if self == IncidentSeverity.CRITICAL:
             return 0
         if self == IncidentSeverity.HIGH:

--- a/ggshield/verticals/sca/output/text_handler.py
+++ b/ggshield/verticals/sca/output/text_handler.py
@@ -283,7 +283,10 @@ def sca_incident_severity_line(vulnerability: OutputIncidentData) -> str:
     """
     Returns the severity line, with associated style
     """
-    if vulnerability.severity.lower() == IncidentSeverity.CRITICAL:
+    if vulnerability.severity.lower() == IncidentSeverity.MALICIOUS:
+        severity_string = IncidentSeverity.MALICIOUS.value.capitalize()
+        style = STYLE["sca_vulnerability_critical"]
+    elif vulnerability.severity.lower() == IncidentSeverity.CRITICAL:
         severity_string = IncidentSeverity.CRITICAL.value.capitalize()
         style = STYLE["sca_vulnerability_critical"]
     elif vulnerability.severity.lower() == IncidentSeverity.HIGH:

--- a/tests/unit/cmd/sca/test_precommit.py
+++ b/tests/unit/cmd/sca/test_precommit.py
@@ -83,7 +83,25 @@ def test_sca_scan_pre_commit_with_added_vulns(
                         ],
                     )
                 ],
-            )
+            ),
+            SCALocationVulnerability(
+                location="Pipfile.lock",
+                package_vulns=[
+                    SCAVulnerablePackageVersion(
+                        package_full_name="mal_toto",
+                        version="2.0.0",
+                        ecosystem="pypi",
+                        vulns=[
+                            SCAVulnerability(
+                                severity="malicious",
+                                summary="a malicious vuln",
+                                cve_ids=["CVE-2024"],
+                                identifier="MAL-abcd-1234-xxxx",
+                            )
+                        ],
+                    )
+                ],
+            ),
         ],
         removed_vulns=[
             SCALocationVulnerability(
@@ -128,10 +146,22 @@ def test_sca_scan_pre_commit_with_added_vulns(
         assert result.exit_code == ExitCode.SCAN_FOUND_PROBLEMS
 
         # Output on added vuln
-        assert "> Pipfile.lock: 1 incident detected" in result.stdout
+        assert "> Pipfile.lock: 2 incidents detected" in result.stdout
+
         assert (
             """
->>> NEW: Incident 1 (SCA): toto@1.2.3
+>>> NEW: Incident 1 (SCA): mal_toto@2.0.0
+Severity: Malicious
+Summary: a malicious vuln
+No fix is currently available.
+Identifier: MAL-abcd-1234-xxxx
+CVE IDs: CVE-2024"""
+            in result.stdout
+        )
+
+        assert (
+            """
+>>> NEW: Incident 2 (SCA): toto@1.2.3
 Severity: Critical
 Summary: a vuln
 No fix is currently available.
@@ -144,7 +174,7 @@ CVE IDs: CVE-2023"""
             # Output on removed vuln
             assert (
                 """
->>> REMOVED: Incident 2 (SCA): bar@4.5.6
+>>> REMOVED: Incident 3 (SCA): bar@4.5.6
 Severity: Low
 Identifier: GHSA-efgh-5678-xxxx
 CVE IDs: CVE-2023-bis"""

--- a/tests/unit/cmd/sca/test_scan.py
+++ b/tests/unit/cmd/sca/test_scan.py
@@ -337,6 +337,21 @@ def test_sca_text_handler_ordering(patch_scan_all, cli_fs_runner):
                     ),
                 ],
             ),
+            SCALocationVulnerability(
+                location="mal/Pipfile.lock",
+                package_vulns=[
+                    SCAVulnerablePackageVersion(
+                        package_full_name="mal",
+                        version="1.0.0",
+                        ecosystem="pypi",
+                        vulns=[
+                            SCAVulnerability(
+                                severity="malicious", summary="", identifier=""
+                            )
+                        ],
+                    ),
+                ],
+            ),
         ],
     )
 
@@ -351,7 +366,17 @@ def test_sca_text_handler_ordering(patch_scan_all, cli_fs_runner):
 
     assert result.exit_code == ExitCode.SCAN_FOUND_PROBLEMS
     assert (
-        """> toto/Pipfile.lock: 2 incidents detected
+        """
+> mal/Pipfile.lock: 1 incident detected
+
+>>> : Incident 1 (SCA): mal@1.0.0
+Severity: Malicious
+Summary: 
+No fix is currently available.
+Identifier: 
+CVE IDs: -
+
+> toto/Pipfile.lock: 2 incidents detected
 
 >>> : Incident 1 (SCA): bar@2.5.6
 Severity: Critical
@@ -381,7 +406,9 @@ Severity: Low
 Summary: 
 No fix is currently available.
 Identifier: 
-CVE IDs: -"""  # noqa W291
+CVE IDs: -
+
+"""  # noqa W291
         in result.stdout
     )
 


### PR DESCRIPTION
## Context
We want to see malicious vulnerabilities in the output of `ggshield sca scan all`

## What has been done
1. Updated `IncidentSeverity`
2. Changed some tests

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
