### PR TITLE
Add cmd to scan changes between the default branch and the current state (commits + staged)

### DIFF
--- a/changelog.d/20240520_164203_samuel.guillaume_secret_scan_change.md
+++ b/changelog.d/20240520_164203_samuel.guillaume_secret_scan_change.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- `ggshield secret scan changes` to scan the set of changes made in comparison to the default branch
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import click
 
 from ggshield.cmd.secret.scan.archive import archive_cmd
+from ggshield.cmd.secret.scan.changes import changes_cmd
 from ggshield.cmd.secret.scan.ci import ci_cmd
 from ggshield.cmd.secret.scan.docker import docker_name_cmd
 from ggshield.cmd.secret.scan.dockerarchive import docker_archive_cmd
@@ -26,6 +27,7 @@ from ggshield.core.text_utils import display_error
 @click.group(
     commands={
         "commit-range": range_cmd,
+        "changes": changes_cmd,
         "pre-commit": precommit_cmd,
         "pre-push": prepush_cmd,
         "pre-receive": prereceive_cmd,

--- a/ggshield/cmd/secret/scan/changes.py
+++ b/ggshield/cmd/secret/scan/changes.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from typing import Any
+
+import click
+
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    add_secret_scan_common_options,
+    create_output_handler,
+)
+from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.scan import ScanContext, ScanMode
+from ggshield.core.text_utils import display_info, pluralize
+from ggshield.utils.git_shell import (
+    check_git_dir,
+    get_default_branch,
+    get_list_commit_SHA,
+)
+from ggshield.verticals.secret.repo import scan_commit_range
+
+
+@click.command()
+@add_secret_scan_common_options()
+@click.pass_context
+@exception_wrapper
+def changes_cmd(ctx: click.Context, **kwargs: Any) -> int:
+    """
+    Scan the set of changes between the default branch and the current HEAD, including staged changes.
+    """
+    ctx_obj = ContextObj.get(ctx)
+    config = ctx_obj.config
+    check_git_dir()
+
+    default_branch = get_default_branch()
+    commit_list = get_list_commit_SHA(f"{default_branch}..HEAD")
+
+    if config.user_config.verbose:
+        display_info(
+            f"Scan staged changes and {len(commit_list)} new {pluralize('commit', len(commit_list))}"
+        )
+
+    scan_context = ScanContext(
+        scan_mode=ScanMode.CHANGE,
+        command_path=ctx.command_path,
+        target_path=Path.cwd(),
+    )
+
+    return scan_commit_range(
+        client=ctx_obj.client,
+        cache=ctx_obj.cache,
+        ui=ctx_obj.ui,
+        commit_list=commit_list,
+        output_handler=create_output_handler(ctx),
+        exclusion_regexes=ctx_obj.exclusion_regexes,
+        matches_ignore=config.user_config.secret.ignored_matches,
+        scan_context=scan_context,
+        ignored_detectors=config.user_config.secret.ignored_detectors,
+        verbose=config.user_config.verbose,
+        include_staged=True,
+    )

--- a/ggshield/core/scan/scan_mode.py
+++ b/ggshield/core/scan/scan_mode.py
@@ -15,6 +15,7 @@ class ScanMode(Enum):
     DIRECTORY = "directory"
     DIFF = "diff"
     DOCSET = "docset"
+    CHANGE = "change"
     # IAC/SCA scan modes
     DIRECTORY_ALL = "directory_all"
     DIRECTORY_DIFF = "directory_diff"

--- a/tests/repository.py
+++ b/tests/repository.py
@@ -28,8 +28,8 @@ class Repository:
             raise exc
 
     @classmethod
-    def create(cls, path: Path, bare=False) -> "Repository":
-        cmd = ["init", str(path), "--initial-branch", "main"]
+    def create(cls, path: Path, bare=False, initial_branch="main") -> "Repository":
+        cmd = ["init", str(path), "--initial-branch", initial_branch]
         if bare:
             cmd.append("--bare")
         git(cmd)


### PR DESCRIPTION
## Context

Add a command to scan the change between the current state and the default branch. Useful to check a feature branch does not add any new secret.

The naming (`changes`) may be discussed.

## What has been done

- Add an util to list the remotes
- Add an util to get the default branch
- Add a `changes` command under `secret scan`

## Validation

- Clone a repository
- Checkout an un-merged feature branch
- Run `ggshield secret scan changes`

```
$ git clone git@github.com:GitGuardian/ggshield.git
$ git checkout sguillaume/secret-scan-change
$ ggshield secret scan change
Scanning... ━━━━━━━━━━━━━━━━━━ 100% 2 / 2

No secrets have been found
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

