### PR TITLE
Fix ggshield binary failing on Windows and Linux

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -112,7 +112,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade \
             pipenv==2023.10.3 \
-            pyinstaller==6.5.0
+            pyinstaller==6.7.0
           pipenv install --system --dev
         env:
           # Disable lock otherwise Windows-only dependencies like colorama are not installed


### PR DESCRIPTION
## Context

The standalone binary smoke test would fail with:

```
build-os-packages: [INFO] test: running --help
Traceback (most recent call last):
  File "PyInstaller/hooks/rthooks/pyi_rth_pkgres.py", line 158, in <module>
  File "PyInstaller/hooks/rthooks/pyi_rth_pkgres.py", line 36, in _pyi_rthook
  File "PyInstaller/loader/pyimod02_importers.py", line 419, in exec_module
  File "pkg_resources/__init__.py", line 77, in <module>
ModuleNotFoundError: No module named 'pkg_resources.extern'
[2870] Failed to execute script 'pyi_rth_pkgres' due to unhandled exception!
```

This is caused by a breaking change in setuptools 70.0.0, fixed in pyinstaller 6.7.0.

References:
https://github.com/pypa/setuptools/issues/4374
https://github.com/pyinstaller/pyinstaller/issues/8554 https://pyinstaller.org/en/v6.7.0/CHANGES.html#id1

## What has been done

Bump pyinstaller to 6.7.0.

## Validation

build-package CI jobs should no longer fail 🤞🏻.