### PR TITLE
fix(auth_login): error handling with invalid instance URL

### DIFF
--- a/changelog.d/20240527_155007_salome.voltz_scrt_4543_ggshield_auth_login_flow_errors_are_not_handled_when.md
+++ b/changelog.d/20240527_155007_salome.voltz_scrt_4543_ggshield_auth_login_flow_errors_are_not_handled_when.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Errors thrown during `ggshield auth login` flow with an invalid instance URL are handled and the stack trace is no longer displayed on the console.

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -13,6 +13,7 @@ from ggshield.core.url_utils import (
     api_to_dashboard_url,
     clean_url,
     dashboard_to_api_url,
+    validate_instance_url,
 )
 
 
@@ -68,6 +69,7 @@ class Config:
         except KeyError:
             pass
         else:
+            validate_instance_url(url)
             return remove_url_trailing_slash(url)
 
         try:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -930,3 +930,22 @@ class TestAuthLoginWeb:
         assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_called()
         self._assert_open_url(host=expected_web_host)
+
+    @pytest.mark.parametrize(
+        "instance_url",
+        [
+            "https://dashboard.gitguardian.com/abc",
+        ],
+    )
+    def test_invalid_instance_url(self, instance_url, cli_fs_runner, monkeypatch):
+        """
+        GIVEN an invalid instance URL
+        WHEN running the login command
+        THEN it fails
+        """
+        monkeypatch.setenv("GITGUARDIAN_INSTANCE", instance_url)
+
+        self.prepare_mocks(monkeypatch)
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.USAGE_ERROR, output
+        self._webbrowser_open_mock.assert_not_called()

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
+from click import UsageError
 
 from ggshield.core.config import AccountConfig, Config, InstanceConfig
 from ggshield.core.config.utils import get_auth_config_filepath, load_yaml_dict
@@ -312,3 +313,19 @@ class TestConfig:
 
         dct = load_yaml_dict(local_config_path)
         assert dct["instance"] == "https://after.com"
+
+    @pytest.mark.parametrize(
+        "instance_url",
+        ["", "http://api.gitguardian.com/", "https://api.gitguardian.com/abc"],
+    )
+    def test_invalid_instance_url(self, monkeypatch, instance_url):
+        """
+        GIVEN an invalid instance url
+        WHEN loading the config
+        THEN it raises a UsageError
+        """
+
+        monkeypatch.setitem(os.environ, "GITGUARDIAN_API_URL", instance_url)
+        with pytest.raises(UsageError):
+            config = Config()
+            config.instance_name


### PR DESCRIPTION
## Context
ggshield auth login flow errors were not handled when instance URL is invalid. 

## What has been done
Error thrown are handled, similarly to how error are handled with `GITGUARDIAN_INSTANCE='https://dashboard.gitguardian.com/abc' ggshield auth login --method=token` 

## Validation
Run the following commands:
- `GITGUARDIAN_INSTANCE='https://dashboard.gitguardian.com/abc' ggshield auth login`
-  `GITGUARDIAN_INSTANCE='https://dashboard.example.com' ggshield auth login`

## Note 
This also fixes the following issue: #892 
![image](https://github.com/GitGuardian/ggshield/assets/80842312/73b0c9b8-3bfc-4acf-96d9-dff72e33c26f)

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
