### PR TITLE
Refactor: save lines in extended match and add censor method

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -2,6 +2,8 @@ version: 2
 
 secret:
   ignored_matches:
+    - match: a288e2a549678ef0b9aa0f9446be30388918f2a4647d7327bea8802ba9c3ac89
+      name: fake secret partially censored
     - match: 56e55937e918b984e285a94ac96de439813a6316c8e184ce7773ee47d700b019
       name:
     - match: 139ed5c2b5ae84b0fbb1bfbce6015ac96e5af5050a16d0ffdba612440fb0ee4d

--- a/changelog.d/20240604_110454_fnareoh_refacto_censor_lines.md
+++ b/changelog.d/20240604_110454_fnareoh_refacto_censor_lines.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Patch symbols at the start of lines are now always displayed, even for single line secrets.

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -193,21 +193,3 @@ def censor_string(text: str) -> str:
 
 def censor_match(match: Match) -> str:
     return censor_string(match.match)
-
-
-def censor_content(content: str, policy_breaks: List[PolicyBreak]) -> str:
-    for policy_break in policy_breaks:
-        for match in policy_break.matches:
-            if match.index_start is None:
-                continue
-
-            match.match = censor_match(match)
-
-            content = "".join(
-                (
-                    content[: match.index_start],
-                    match.match,
-                    content[len(match.match) + match.index_start :],
-                )
-            )
-    return content

--- a/ggshield/core/lines.py
+++ b/ggshield/core/lines.py
@@ -24,6 +24,16 @@ class LineCategory(Enum):
     DELETION = auto()
     EMPTY = auto()  # Used for empty lines and patch headers.
 
+    @property
+    def symbol(self) -> str:
+        if self == LineCategory.ADDITION:
+            return "+"
+        if self == LineCategory.DELETION:
+            return "-"
+        if self == LineCategory.EMPTY:
+            return ""
+        return " "
+
 
 class Line(SimpleNamespace):
     """
@@ -97,12 +107,6 @@ class Line(SimpleNamespace):
         # Patch
         pre_index = format_line_count(self.pre_index, padding)
         post_index = format_line_count(self.post_index, padding)
-
-        if self.category == LineCategory.ADDITION:
-            pre_index = " " * padding
-
-        elif self.category == LineCategory.DELETION:
-            post_index = " " * padding
 
         return PATCH_LINE_PREFIX.format(
             format_text(pre_index, line_count_style),

--- a/ggshield/core/lines.py
+++ b/ggshield/core/lines.py
@@ -1,6 +1,7 @@
 import re
 from enum import Enum, auto
-from typing import Iterable, List, NamedTuple, Optional
+from types import SimpleNamespace
+from typing import Iterable, List, Optional
 
 from ggshield.core.text_utils import STYLE, format_line_count, format_text
 from ggshield.utils.git_shell import Filemode
@@ -21,10 +22,10 @@ class LineCategory(Enum):
     ADDITION = auto()
     DATA = auto()
     DELETION = auto()
-    EMPTY = auto()
+    EMPTY = auto()  # Used for empty lines and patch headers.
 
 
-class Line(NamedTuple):
+class Line(SimpleNamespace):
     """
     Represent a line in a document.
 
@@ -66,6 +67,16 @@ class Line(NamedTuple):
     category: Optional[LineCategory] = None
     pre_index: Optional[int] = None
     post_index: Optional[int] = None
+
+    def __hash__(self):
+        return hash(
+            (
+                self.content,
+                self.category,
+                self.pre_index,
+                self.post_index,
+            )
+        )
 
     def build_line_count(self, padding: int, is_secret: bool = False) -> str:
         """Return the formatted line count."""

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, cast
 from pygitguardian.client import VERSIONS
 from pygitguardian.models import PolicyBreak
 
-from ggshield.core.filter import censor_content, leak_dictionary_by_ignore_sha
+from ggshield.core.filter import leak_dictionary_by_ignore_sha
 
 from ..secret_scan_collection import Error, Result, SecretScanCollection
 from .schemas import JSONScanCollectionSchema
@@ -61,11 +61,11 @@ class SecretJSONOutputHandler(SecretOutputHandler):
         }
         sha_dict = leak_dictionary_by_ignore_sha(result.scan.policy_breaks)
         result_dict["total_incidents"] = len(sha_dict)
+        result.enrich_matches()
 
         if not self.show_secrets:
-            censor_content(result.content, result.scan.policy_breaks)
+            result.censor()
 
-        result.enrich_matches()  # important to keep this call after censor content
         for ignore_sha, policy_breaks in sha_dict.items():
             flattened_dict = self.flattened_policy_break(
                 ignore_sha,

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -38,6 +38,11 @@ class Result(NamedTuple):
                 ],
             )
 
+    def censor(self) -> None:
+        for policy_break in self.scan.policy_breaks:
+            for extended_match in policy_break.matches:
+                cast(ExtendedMatch, extended_match).censor()
+
     @property
     def filename(self) -> str:
         return self.file.filename

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -22,18 +22,21 @@ class Result(NamedTuple):
     file: Scannable  # filename that was scanned
     scan: ScanResult  # Result of content scan
 
+    @property
+    def is_on_patch(self) -> bool:
+        return self.file.filemode != Filemode.FILE
+
     def enrich_matches(self, lines: Optional[List[Line]] = None) -> None:
         if not lines:
             content = self.content
             lines = get_lines_from_content(content, self.filemode)
         if len(lines) == 0:
             raise UnexpectedError("Parsing of scan result failed.")
-        is_patch = self.filemode != Filemode.FILE
         for policy_break in self.scan.policy_breaks:
             policy_break.matches = cast(
                 List[Match],
                 [
-                    ExtendedMatch.from_match(match, lines, is_patch)
+                    ExtendedMatch.from_match(match, lines, self.is_on_patch)
                     for match in policy_break.matches
                 ],
             )

--- a/tests/unit/cassettes/multiple_secret_one_line.yaml
+++ b/tests/unit/cassettes/multiple_secret_one_line.yaml
@@ -9,25 +9,25 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.14.0 (Linux;py3.10.13)
       method: GET
       uri: https://api.gitguardian.com/v1/metadata
     response:
       body:
-        string: '{"version":"v2.30.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"public_api__ggshield_auth_flow_enabled":true,"general__onboarding_segmentation_v1_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
+        string: '{"version":"v2.70.1","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"onboarding__segmentation_v1_enabled":true,"general__maximum_payload_size":26214400},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576}}'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - GET, HEAD, OPTIONS
         content-length:
-          - '446'
+          - '433'
         content-type:
           - application/json
         cross-origin-opener-policy:
           - same-origin
         date:
-          - Mon, 22 May 2023 12:28:53 GMT
+          - Thu, 30 May 2024 10:00:59 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -37,17 +37,21 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.30.2
+          - v2.70.1
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '42'
+          - '25'
         x-frame-options:
           - DENY
           - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.35.0
+        x-sca-last-vuln-fetch:
+          - '2024-05-30T09:06:08.486219+00:00'
         x-secrets-engine-version:
-          - 2.89.0
+          - 2.113.0
         x-xss-protection:
           - 1; mode=block
       status:
@@ -55,11 +59,8 @@ interactions:
         message: OK
   - request:
       body:
-        '[{"filename": "file_secret", "document": "commit 9537b6343a81f88d471e93f20ffb2e2665bbab00\nAuthor:
-        GitGuardian Owl <owl@example.com>\nDate:   Thu Aug 18 18:20:21 2022 +0200\n\nA
-        message\n\n:000000 100644 0000000 e965047 A\ufffdtest\ufffd\ufffddiff --git
-        a/test b/test\nnew file mode 100644\nindex 0000000..b80e3df\n--- /dev/null\n+++
-        b/test\n@@ -0,0 +2 @@\n+# gg token\n+apikey = \"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345\";\n"}]'
+        '[{"filename": "commit://patch/test", "document": "@@ -0,0 +1 @@\n+FacebookAppId
+        = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;\n\n"}]'
       headers:
         Accept:
           - '*/*'
@@ -68,46 +69,43 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - '659'
+          - '159'
         Content-Type:
           - application/json
         GGShield-Command-Id:
-          - 5e8051d6-7ccf-4b69-9251-9a2afc61b62a
+          - f65bf7e9-e75c-4100-8340-3b7d8c7ef9e3
         GGShield-Command-Path:
-          - cli secret scan docker-archive
+          - external
         GGShield-OS-Name:
           - ubuntu
         GGShield-OS-Version:
           - '22.04'
         GGShield-Python-Version:
-          - 3.10.6
+          - 3.10.13
         GGShield-Version:
-          - 1.15.1
+          - 1.27.0
         User-Agent:
-          - pygitguardian/1.6.0 (Linux;py3.10.6) ggshield
+          - pygitguardian/1.14.0 (Linux;py3.10.13)
         mode:
-          - docker
+          - path
       method: POST
       uri: https://api.gitguardian.com/v1/multiscan?ignore_known_secrets=True
     response:
       body:
-        string:
-          '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
-          detection"],"policy_breaks":[{"type":"GitGuardian Development Secret","policy":"Secrets
-          detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":314,"index_end":582,"line_start":14,"line_end":14}],"validity":"no_checker"}]}]'
+        string: '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets detection"],"policy_breaks":[{"type":"Facebook Access Tokens","policy":"Secrets Detection","matches":[{"match":"294790898041575","index_start":31,"index_end":45,"line_start":1,"line_end":1,"type":"client_id"},{"match":"ce3f9f0362bbe5ab01dfc8ee565e4372","index_start":68,"index_end":99,"line_start":1,"line_end":1,"type":"client_secret"}]}]}]'
       headers:
         access-control-expose-headers:
           - X-App-Version
         allow:
           - POST, OPTIONS
         content-length:
-          - '576'
+          - '108'
         content-type:
           - application/json
         cross-origin-opener-policy:
           - same-origin
         date:
-          - Mon, 22 May 2023 12:28:54 GMT
+          - Thu, 30 May 2024 10:01:00 GMT
         referrer-policy:
           - strict-origin-when-cross-origin
         server:
@@ -117,17 +115,21 @@ interactions:
         vary:
           - Cookie
         x-app-version:
-          - v2.30.2
+          - v2.70.1
         x-content-type-options:
           - nosniff
           - nosniff
         x-envoy-upstream-service-time:
-          - '82'
+          - '314'
         x-frame-options:
           - DENY
           - SAMEORIGIN
+        x-sca-engine-version:
+          - 1.35.0
+        x-sca-last-vuln-fetch:
+          - '2024-05-30T09:06:08.486219+00:00'
         x-secrets-engine-version:
-          - 2.89.0
+          - 2.113.0
         x-xss-protection:
           - 1; mode=block
       status:

--- a/tests/unit/cassettes/test_scan_file_secret-False.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-False.yaml
@@ -94,7 +94,7 @@ interactions:
         string:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"GitGuardian Development Secret","policy":"Secrets
-          detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":311,"index_end":579,"line_start":14,"line_end":14}],"validity":"no_checker"}]}]'
+          detection","matches":[{"type":"apikey","match":"8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWAanbe712Jtc3nY8veZux5raL1bhpaxiv0rfyhFoAIMZUCh2Njyk7gRVsSQFPrEphSJnxa16SIdWKb03sRft770LUTTYTAy3IM18A7Su4HjiHlGA9ihLj9ou3luadfRAATlKH6kAZwTw289Kq9uip67zxyWkUJdh6PTeFpMgCh3AhHcZ21VeZHlu12345","index_start":314,"index_end":582,"line_start":14,"line_end":14}],"validity":"no_checker"}]}]'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_scan_file_secret-True.yaml
+++ b/tests/unit/cassettes/test_scan_file_secret-True.yaml
@@ -94,7 +94,7 @@ interactions:
         string:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"GitGuardian Test Token Checked","policy":"Secrets
-          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":311,"index_end":327,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
+          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":314,"index_end":330,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
+++ b/tests/unit/cassettes/test_scan_path_file_secret_with_validity.yaml
@@ -94,7 +94,7 @@ interactions:
         string:
           '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
           detection"],"policy_breaks":[{"type":"GitGuardian Test Token Checked","policy":"Secrets
-          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":311,"index_end":327,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
+          detection","matches":[{"type":"apikey","match":"ggtt-v-12345azert","index_start":314,"index_end":330,"line_start":14,"line_end":14}],"validity":"valid"}]}]'
       headers:
         access-control-expose-headers:
           - X-App-Version

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -275,7 +275,7 @@ _MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                     {
                         "match": "294790898041575",
                         "index_start": 31,
-                        "index_end": 46,
+                        "index_end": 45,
                         "type": "client_id",
                     },
                     {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -198,6 +198,22 @@ _MULTI_SECRET_ONE_LINE_PATCH = """@@ -0,0 +1 @@
 
 """
 
+_MULTI_SECRET_ONE_LINE_FULL_PATCH = (
+    """commit 9537b6343a81f88d471e93f20ffb2e2665bbab00
+Author: GitGuardian Owl <owl@example.com>
+Date:   Thu Aug 18 18:20:21 2022 +0200
+
+A message
+
+:000000 100644 0000000 e965047 A\0test\0\0diff --git a/test b/test
+new file mode 100644
+index 0000000..3c9af3f
+--- /dev/null
++++ b/test
+"""
+    + _MULTI_SECRET_ONE_LINE_PATCH
+)
+
 _MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
     {
         "policies": ["File extensions", "Filenames", "Secrets detection"],
@@ -209,13 +225,13 @@ _MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                     {
                         "match": "294790898041575",
                         "index_start": 31,
-                        "index_end": 46,
+                        "index_end": 45,
                         "type": "client_id",
                     },
                     {
                         "match": "ce3f9f0362bbe5ab01dfc8ee565e4372",
                         "index_start": 68,
-                        "index_end": 100,
+                        "index_end": 99,
                         "type": "client_secret",
                     },
                 ],
@@ -242,13 +258,13 @@ _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT = ScanResult.SCHEMA.load(
                     {
                         "match": "294790898041575",
                         "index_start": 26,
-                        "index_end": 41,
+                        "index_end": 40,
                         "type": "client_id",
                     },
                     {
                         "match": "ce3f9f0362bbe5ab01dfc8ee565e4372",
                         "index_start": 44,
-                        "index_end": 76,
+                        "index_end": 75,
                         "type": "client_secret",
                     },
                 ],
@@ -281,7 +297,7 @@ _MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                     {
                         "match": "ce3f9f0362bbe5ab01dfc8ee565e4372",
                         "index_start": 69,
-                        "index_end": 101,
+                        "index_end": 100,
                         "type": "client_secret",
                     },
                 ],
@@ -341,7 +357,7 @@ _ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                         "match": "294790898041573",
                         "line_start": 2,
                         "line_end": 2,
-                        "index_start": 34,
+                        "index_start": 35,
                         "index_end": 49,
                         "type": "client_id",
                     },
@@ -349,7 +365,7 @@ _ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT = ScanResult.SCHEMA.load(
                         "match": "ce3f9f0362bbe5ab01dfc8ee565e4371",
                         "line_start": 2,
                         "line_end": 2,
-                        "index_start": 52,
+                        "index_start": 53,
                         "index_end": 84,
                         "type": "client_secret",
                     },

--- a/tests/unit/core/test_filter.py
+++ b/tests/unit/core/test_filter.py
@@ -7,27 +7,15 @@ from pygitguardian.models import Match, PolicyBreak, ScanResult
 from snapshottest import Snapshot
 
 from ggshield.core.filter import (
-    censor_content,
     censor_match,
     get_ignore_sha,
     remove_ignored_from_result,
 )
 from ggshield.core.types import IgnoredMatch
 from tests.unit.conftest import (
-    _MULTI_SECRET_ONE_LINE_PATCH,
-    _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
-    _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT,
-    _MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT,
-    _MULTI_SECRET_TWO_LINES_PATCH,
-    _MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT,
     _MULTILINE_SECRET,
-    _MULTIPLE_SECRETS_PATCH_CONTENT,
     _MULTIPLE_SECRETS_SCAN_RESULT,
-    _ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
     _ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT,
-    _SIMPLE_SECRET_MULTILINE_PATCH,
-    _SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT,
-    _SIMPLE_SECRET_PATCH,
     _SIMPLE_SECRET_PATCH_SCAN_RESULT,
     _SIMPLE_SECRET_WITH_FILENAME_PATCH_SCAN_RESULT,
 )
@@ -183,57 +171,3 @@ def test_censor_match(input_match: Match, expected_value: str) -> None:
     value = censor_match(input_match)
     assert len(value) == len(input_match.match)
     assert value == expected_value
-
-
-@pytest.mark.parametrize(
-    "content, policy_breaks",
-    [
-        pytest.param(
-            _MULTIPLE_SECRETS_PATCH_CONTENT,
-            _MULTIPLE_SECRETS_SCAN_RESULT.policy_breaks,
-            id="_MULTIPLE_SECRETS",
-        ),
-        pytest.param(
-            _ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
-            _ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT.policy_breaks,
-            id="_ONE_LINE_AND_MULTILINE_PATCH_SCAN_CONTENT",
-        ),
-        pytest.param(
-            _MULTI_SECRET_ONE_LINE_PATCH,
-            _MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT.policy_breaks,
-            id="_MULTI_SECRET_ONE_LINE_PATCH",
-        ),
-        pytest.param(
-            _SIMPLE_SECRET_PATCH,
-            _SIMPLE_SECRET_PATCH_SCAN_RESULT.policy_breaks,
-            id="_SIMPLE_SECRET_PATCH",
-        ),
-        pytest.param(
-            _SIMPLE_SECRET_MULTILINE_PATCH,
-            _SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT.policy_breaks,
-            id="_SIMPLE_SECRET_MULTILINE_PATCH",
-        ),
-        pytest.param(
-            _SIMPLE_SECRET_PATCH,
-            _SIMPLE_SECRET_WITH_FILENAME_PATCH_SCAN_RESULT.policy_breaks,
-            id="_SIMPLE_SECRET_WITH_FILENAME_PATCH",
-        ),
-        pytest.param(
-            _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
-            _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT.policy_breaks,
-            id="_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY",
-        ),
-        pytest.param(
-            _MULTI_SECRET_TWO_LINES_PATCH,
-            _MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT.policy_breaks,
-            id="_MULTI_SECRET_TWO_LINES_PATCH",
-        ),
-    ],
-)
-def test_censor_content(content: str, policy_breaks: List[PolicyBreak]) -> None:
-    copy_policy_breaks = copy.deepcopy(policy_breaks)
-    new_content = censor_content(content, copy_policy_breaks)
-    assert len(new_content) == len(content)
-    for policy_break in policy_breaks:
-        for match in policy_break.matches:
-            assert match.match not in new_content

--- a/tests/unit/core/test_lines.py
+++ b/tests/unit/core/test_lines.py
@@ -6,10 +6,10 @@ from ggshield.core.lines import Line, LineCategory, get_offset, get_padding
 
 
 def test_line_validation():
-    line_to_test = Line("hello", category=" ")  # type: ignore
+    line_to_test = Line(content="hello", category=" ")  # type: ignore
     with pytest.raises(TypeError):
         line_to_test.build_line_count(0, False)
-    Line("hello", category=None).build_line_count(0)
+    Line(content="hello", category=None).build_line_count(0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/test_match_span.py
+++ b/tests/unit/core/test_match_span.py
@@ -10,6 +10,7 @@ from ggshield.core.match_span import MatchSpan
 from ggshield.core.scan import Commit, ScanContext, ScanMode, StringScannable
 from ggshield.verticals.secret import SecretScanner
 from tests.unit.conftest import (
+    _MULTI_SECRET_ONE_LINE_FULL_PATCH,
     _PATCH_WITH_NONEWLINE_BEFORE_SECRET,
     _SECRET_RAW_FILE,
     _SINGLE_ADD_PATCH,
@@ -56,6 +57,13 @@ from tests.unit.conftest import (
             True,
             [MatchSpan(5, 5, 10, 79)],
             id="no_newline_before_secret",
+        ),
+        pytest.param(
+            "multiple_secret_one_line",
+            _MULTI_SECRET_ONE_LINE_FULL_PATCH,
+            True,
+            [MatchSpan(1, 1, 16, 31), MatchSpan(1, 1, 53, 85)],
+            id="multiple_secret_one_line",
         ),
     ],
 )

--- a/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
+++ b/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
@@ -18,9 +18,9 @@ snapshots[
 
     | @@ -0,0 +1 @
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
-                  |___client_id__|
+                  |__client_id__|
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
-                                    |_________client_secret_________|
+                                    |_________client_secret________|
 """
 
 snapshots[
@@ -36,9 +36,9 @@ snapshots[
 
     | @@ -0,0 +1 @
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                  |___client_id__|
+                  |__client_id__|
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                    |_________client_secret_________|
+                                    |_________client_secret________|
 """
 
 snapshots[
@@ -56,9 +56,9 @@ secrets-engine-version: 3.14.159
 
     | @@ -0,0 +1 @
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
-                  |___client_id__|
+                  |__client_id__|
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
-                                    |_________client_secret_________|
+                                    |_________client_secret________|
 """
 
 snapshots[
@@ -76,9 +76,9 @@ secrets-engine-version: 3.14.159
 
     | @@ -0,0 +1 @
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                  |___client_id__|
+                  |__client_id__|
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                    |_________client_secret_________|
+                                    |_________client_secret________|
 """
 
 snapshots[
@@ -94,9 +94,9 @@ snapshots[
 
     | @@ -0,0 +1 @
   1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f*************…
-                       |___client_id__|
+                       |__client_id__|
   1 | +…= 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
-                                               |_________client_secret_________|
+                                               |_________client_secret________|
 """
 
 snapshots[
@@ -112,9 +112,9 @@ snapshots[
 
     | @@ -0,0 +1 @
   1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01d…
-                       |___client_id__|
+                       |__client_id__|
   1 | +…= 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                               |_________client_secret_________|
+                                               |_________client_secret________|
 """
 
 snapshots[
@@ -132,9 +132,9 @@ secrets-engine-version: 3.14.159
 
     | @@ -0,0 +1 @
   1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
-                       |___client_id__|
+                       |__client_id__|
   1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
-                                                            |_________client_secret_________|
+                                                            |_________client_secret________|
 """
 
 snapshots[
@@ -152,9 +152,9 @@ secrets-engine-version: 3.14.159
 
     | @@ -0,0 +1 @
   1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                       |___client_id__|
+                       |__client_id__|
   1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                                            |_________client_secret_________|
+                                                            |_________client_secret________|
 """
 
 snapshots[
@@ -172,7 +172,7 @@ snapshots[
   1 | +FacebookAppId = 294*********575;
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f********************5e4372;
-                           |_________client_secret_________|
+                           |_________client_secret________|
 """
 
 snapshots[
@@ -190,7 +190,7 @@ snapshots[
   1 | +FacebookAppId = 294790898041575;
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                           |_________client_secret_________|
+                           |_________client_secret________|
 """
 
 snapshots[
@@ -210,7 +210,7 @@ secrets-engine-version: 3.14.159
   1 | +FacebookAppId = 294*********575;
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f********************5e4372;
-                           |_________client_secret_________|
+                           |_________client_secret________|
 """
 
 snapshots[
@@ -230,7 +230,7 @@ secrets-engine-version: 3.14.159
   1 | +FacebookAppId = 294790898041575;
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                           |_________client_secret_________|
+                           |_________client_secret________|
 """
 
 snapshots[
@@ -245,11 +245,11 @@ snapshots[
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 ----…
-                       |___client_id__|
-  1 | +…:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRI…
-                           |_________client_secret_________|
-  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  1 | +FacebookAppKeys: 294*********573 / ce3f9f********************5e4371 ----…
+                        |__client_id__|
+  1 | +… 294*********573 / ce3f9f********************5e4371 -----BEGIN RSA PRI…
+                           |_________client_secret________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
   3 | +****************************************************************
 
 >> Secret detected: RSA Private Key
@@ -259,14 +259,14 @@ snapshots[
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | +…*5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  1 | +…**573 / ce3f9f********************5e4371 -----BEGIN RSA PRIVATE KEY-----
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
   3 | +****************************************************************
   4 | +****************************************************************
   5 | +***********+****************************************************
   6 | +****************+***********************************************
   7 | +**********************+*****************************************
-  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  8 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj***********************…
        |_________________________________apikey________________________________|
 
@@ -277,7 +277,7 @@ snapshots[
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
   7 | +**********************+*****************************************
-  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  8 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +…-- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
                   |_______________________________apikey______________________________|
 """
@@ -295,9 +295,9 @@ snapshots[
 
     | @@ -0,0 +1,29 @
   1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 ----…
-                       |___client_id__|
-  1 | +…: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRI…
-                           |_________client_secret_________|
+                        |__client_id__|
+  1 | +… 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRI…
+                           |_________client_secret________|
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
   3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
 
@@ -345,11 +345,11 @@ secrets-engine-version: 3.14.159
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-                       |___client_id__|
-  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-                                         |_________client_secret_________|
-  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  1 | +FacebookAppKeys: 294*********573 / ce3f9f********************5e4371 -----BEGIN RSA PRIVATE KEY-----
+                        |__client_id__|
+  1 | +FacebookAppKeys: 294*********573 / ce3f9f********************5e4371 -----BEGIN RSA PRIVATE KEY-----
+                                          |_________client_secret________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
   3 | +****************************************************************
 
 >> Secret detected: RSA Private Key
@@ -359,14 +359,14 @@ secrets-engine-version: 3.14.159
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  1 | +FacebookAppKeys: 294*********573 / ce3f9f********************5e4371 -----BEGIN RSA PRIVATE KEY-----
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
   3 | +****************************************************************
   4 | +****************************************************************
   5 | +***********+****************************************************
   6 | +****************+***********************************************
   7 | +**********************+*****************************************
-  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  8 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
        
 
@@ -377,7 +377,7 @@ secrets-engine-version: 3.14.159
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
   7 | +**********************+*****************************************
-  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  8 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
                                             |_______________________________apikey______________________________|
 """
@@ -397,9 +397,9 @@ secrets-engine-version: 3.14.159
 
     | @@ -0,0 +1,29 @
   1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
-                       |___client_id__|
+                        |__client_id__|
   1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
-                                         |_________client_secret_________|
+                                          |_________client_secret________|
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
   3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
 
@@ -447,13 +447,13 @@ snapshots[
       | @@ -0,0 +1,29 @
     1 | +PrivateKeyRsa:
     2 | +- text: -----BEGIN RSA PRIVATE KEY-----
-    3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+    3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
     4 | +****************************************************************
     5 | +****************************************************************
     6 | +***********+****************************************************
     7 | +****************+***********************************************
     8 | +**********************+*****************************************
-    9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+    9 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
          |____________________________apikey____________________________|
 """
@@ -499,13 +499,13 @@ secrets-engine-version: 3.14.159
       | @@ -0,0 +1,29 @
     1 | +PrivateKeyRsa:
     2 | +- text: -----BEGIN RSA PRIVATE KEY-----
-    3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+    3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiE*****************************+******
     4 | +****************************************************************
     5 | +****************************************************************
     6 | +***********+****************************************************
     7 | +****************+***********************************************
     8 | +**********************+*****************************************
-    9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+    9 | +****+*****wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
          |____________________________apikey____________________________|
 """

--- a/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
+++ b/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
@@ -17,10 +17,10 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | Facebook = 294*********575 | ce3f9f********************5e4372;
-                 |___client_id__|
-  1 | Facebook = 294*********575 | ce3f9f********************5e4372;
-                                   |_________client_secret_________|
+  1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
+                  |___client_id__|
+  1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
+                                    |_________client_secret_________|
 """
 
 snapshots[
@@ -35,10 +35,10 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                 |___client_id__|
-  1 | Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                   |_________client_secret_________|
+  1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
+                  |___client_id__|
+  1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
+                                    |_________client_secret_________|
 """
 
 snapshots[
@@ -55,10 +55,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | Facebook = 294*********575 | ce3f9f********************5e4372;
-                 |___client_id__|
-  1 | Facebook = 294*********575 | ce3f9f********************5e4372;
-                                   |_________client_secret_________|
+  1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
+                  |___client_id__|
+  1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
+                                    |_________client_secret_________|
 """
 
 snapshots[
@@ -75,10 +75,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                 |___client_id__|
-  1 | Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                   |_________client_secret_________|
+  1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
+                  |___client_id__|
+  1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
+                                    |_________client_secret_________|
 """
 
 snapshots[
@@ -93,9 +93,9 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f**************…
-                      |___client_id__|
-  1 | … = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
+  1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f*************…
+                       |___client_id__|
+  1 | +…= 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
                                                |_________client_secret_________|
 """
 
@@ -111,9 +111,9 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01df…
-                      |___client_id__|
-  1 | … = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
+  1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01d…
+                       |___client_id__|
+  1 | +…= 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
                                                |_________client_secret_________|
 """
 
@@ -131,10 +131,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
-                      |___client_id__|
-  1 | FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
-                                                           |_________client_secret_________|
+  1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
+                       |___client_id__|
+  1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
+                                                            |_________client_secret_________|
 """
 
 snapshots[
@@ -151,10 +151,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +1 @
-  1 | FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                      |___client_id__|
-  1 | FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                                                           |_________client_secret_________|
+  1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
+                       |___client_id__|
+  1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
+                                                            |_________client_secret_________|
 """
 
 snapshots[
@@ -169,10 +169,10 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +2 @
-  1 | FacebookAppId = 294*********575;
-                      |___client_id__|
-  2 | FacebookAppSecret = ce3f9f********************5e4372;
-                          |_________client_secret_________|
+  1 | +FacebookAppId = 294*********575;
+                       |__client_id__|
+  2 | +FacebookAppSecret = ce3f9f********************5e4372;
+                           |_________client_secret_________|
 """
 
 snapshots[
@@ -187,10 +187,10 @@ snapshots[
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +2 @
-  1 | FacebookAppId = 294790898041575;
-                      |___client_id__|
-  2 | FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                          |_________client_secret_________|
+  1 | +FacebookAppId = 294790898041575;
+                       |__client_id__|
+  2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
+                           |_________client_secret_________|
 """
 
 snapshots[
@@ -207,10 +207,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +2 @
-  1 | FacebookAppId = 294*********575;
-                      |___client_id__|
-  2 | FacebookAppSecret = ce3f9f********************5e4372;
-                          |_________client_secret_________|
+  1 | +FacebookAppId = 294*********575;
+                       |__client_id__|
+  2 | +FacebookAppSecret = ce3f9f********************5e4372;
+                           |_________client_secret_________|
 """
 
 snapshots[
@@ -227,10 +227,10 @@ secrets-engine-version: 3.14.159
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
 
     | @@ -0,0 +2 @
-  1 | FacebookAppId = 294790898041575;
-                      |___client_id__|
-  2 | FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
-                          |_________client_secret_________|
+  1 | +FacebookAppId = 294790898041575;
+                       |__client_id__|
+  2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
+                           |_________client_secret_________|
 """
 
 snapshots[
@@ -245,12 +245,12 @@ snapshots[
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----…
-                      |___client_id__|
-  1 | …:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRI…
-                          |_________client_secret_________|
-  2 | MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
-  3 | ****************************************************************
+  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 ----…
+                       |___client_id__|
+  1 | +…:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRI…
+                           |_________client_secret_________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  3 | +****************************************************************
 
 >> Secret detected: RSA Private Key
    Occurrences: 1
@@ -259,7 +259,7 @@ snapshots[
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | …**5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
+  1 | +…*5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
   3 | +****************************************************************
   4 | +****************************************************************
@@ -267,8 +267,8 @@ snapshots[
   6 | +****************+***********************************************
   7 | +**********************+*****************************************
   8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: SG._Yytrtvlj************************…
-      |_________________________________apikey_________________________________|
+  9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj***********************…
+       |_________________________________apikey________________________________|
 
 >> Secret detected: SendGrid Key
    Occurrences: 1
@@ -276,10 +276,10 @@ snapshots[
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
-  7 | **********************+*****************************************
-  8 | ****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | …-- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
-                 |_______________________________apikey______________________________|
+  7 | +**********************+*****************************************
+  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  9 | +…-- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
+                  |_______________________________apikey______________________________|
 """
 
 snapshots[
@@ -294,12 +294,12 @@ snapshots[
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----…
-                      |___client_id__|
-  1 | …: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRI…
-                          |_________client_secret_________|
-  2 | MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
-  3 | bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
+  1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 ----…
+                       |___client_id__|
+  1 | +…: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRI…
+                           |_________client_secret_________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
+  3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
 
 >> Secret detected: RSA Private Key
    Occurrences: 1
@@ -308,7 +308,7 @@ snapshots[
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | …041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
+  1 | +…41573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
   3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
   4 | +NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW
@@ -316,8 +316,8 @@ snapshots[
   6 | +22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
   8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: SG._YytrtvljkWqCrkMa3r5hw.yijiPf2qxr…
-      |_________________________________apikey_________________________________|
+  9 | +-----END RSA PRIVATE KEY----- token: SG._YytrtvljkWqCrkMa3r5hw.yijiPf2qx…
+       |_________________________________apikey________________________________|
 
 >> Secret detected: SendGrid Key
    Occurrences: 1
@@ -325,10 +325,10 @@ snapshots[
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
-  7 | bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
-  8 | RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | …-- token: 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
-                 |_______________________________apikey______________________________|
+  7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
+  8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  9 | +…-- token: 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
+                  |_______________________________apikey______________________________|
 """
 
 snapshots[
@@ -345,12 +345,12 @@ secrets-engine-version: 3.14.159
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-                      |___client_id__|
-  1 | FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
-                                        |_________client_secret_________|
-  2 | MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
-  3 | ****************************************************************
+  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
+                       |___client_id__|
+  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
+                                         |_________client_secret_________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
+  3 | +****************************************************************
 
 >> Secret detected: RSA Private Key
    Occurrences: 1
@@ -359,7 +359,7 @@ secrets-engine-version: 3.14.159
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
+  1 | +FacebookAppKeys:294*********5733 /ce3f9f********************5e43711 -----BEGIN RSA PRIVATE KEY-----
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
   3 | +****************************************************************
   4 | +****************************************************************
@@ -367,8 +367,8 @@ secrets-engine-version: 3.14.159
   6 | +****************+***********************************************
   7 | +**********************+*****************************************
   8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
-      
+  9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
+       
 
 >> Secret detected: SendGrid Key
    Occurrences: 1
@@ -376,10 +376,10 @@ secrets-engine-version: 3.14.159
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
-  7 | **********************+*****************************************
-  8 | ****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
-                                           |_______________________________apikey______________________________|
+  7 | +**********************+*****************************************
+  8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
+                                            |_______________________________apikey______________________________|
 """
 
 snapshots[
@@ -396,12 +396,12 @@ secrets-engine-version: 3.14.159
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
-                      |___client_id__|
-  1 | FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
-                                        |_________client_secret_________|
-  2 | MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
-  3 | bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
+  1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
+                       |___client_id__|
+  1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
+                                         |_________client_secret_________|
+  2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
+  3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
 
 >> Secret detected: RSA Private Key
    Occurrences: 1
@@ -410,7 +410,7 @@ secrets-engine-version: 3.14.159
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
     | @@ -0,0 +1,29 @
-  1 | FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
+  1 | +FacebookAppKeys: 294790898041573 / ce3f9f0362bbe5ab01dfc8ee565e4371 -----BEGIN RSA PRIVATE KEY-----
   2 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
   3 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
   4 | +NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW
@@ -418,8 +418,8 @@ secrets-engine-version: 3.14.159
   6 | +22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
   8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: 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
-      
+  9 | +-----END RSA PRIVATE KEY----- token: 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
+       
 
 >> Secret detected: SendGrid Key
    Occurrences: 1
@@ -427,10 +427,10 @@ secrets-engine-version: 3.14.159
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
 
-  7 | bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
-  8 | RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-  9 | -----END RSA PRIVATE KEY----- token: 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
-                                           |_______________________________apikey______________________________|
+  7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
+  8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
+  9 | +-----END RSA PRIVATE KEY----- token: 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
+                                            |_______________________________apikey______________________________|
 """
 
 snapshots[
@@ -445,8 +445,8 @@ snapshots[
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
       | @@ -0,0 +1,29 @
-    1 | PrivateKeyRsa:
-    2 | - text: -----BEGIN RSA PRIVATE KEY-----
+    1 | +PrivateKeyRsa:
+    2 | +- text: -----BEGIN RSA PRIVATE KEY-----
     3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
     4 | +****************************************************************
     5 | +****************************************************************
@@ -454,8 +454,8 @@ snapshots[
     7 | +****************+***********************************************
     8 | +**********************+*****************************************
     9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-   10 | -----END RSA PRIVATE KEY-----
-        |_____________________________apikey____________________________|
+   10 | +-----END RSA PRIVATE KEY-----
+         |____________________________apikey____________________________|
 """
 
 snapshots[
@@ -470,8 +470,8 @@ snapshots[
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
       | @@ -0,0 +1,29 @
-    1 | PrivateKeyRsa:
-    2 | - text: -----BEGIN RSA PRIVATE KEY-----
+    1 | +PrivateKeyRsa:
+    2 | +- text: -----BEGIN RSA PRIVATE KEY-----
     3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
     4 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
     5 | +NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW
@@ -479,8 +479,8 @@ snapshots[
     7 | +22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT
     8 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
     9 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-   10 | -----END RSA PRIVATE KEY-----
-        |_____________________________apikey____________________________|
+   10 | +-----END RSA PRIVATE KEY-----
+         |____________________________apikey____________________________|
 """
 
 snapshots[
@@ -497,8 +497,8 @@ secrets-engine-version: 3.14.159
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
       | @@ -0,0 +1,29 @
-    1 | PrivateKeyRsa:
-    2 | - text: -----BEGIN RSA PRIVATE KEY-----
+    1 | +PrivateKeyRsa:
+    2 | +- text: -----BEGIN RSA PRIVATE KEY-----
     3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZi******************************+******
     4 | +****************************************************************
     5 | +****************************************************************
@@ -506,8 +506,8 @@ secrets-engine-version: 3.14.159
     7 | +****************+***********************************************
     8 | +**********************+*****************************************
     9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
-   10 | -----END RSA PRIVATE KEY-----
-        |_____________________________apikey____________________________|
+   10 | +-----END RSA PRIVATE KEY-----
+         |____________________________apikey____________________________|
 """
 
 snapshots[
@@ -524,8 +524,8 @@ secrets-engine-version: 3.14.159
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
 
       | @@ -0,0 +1,29 @
-    1 | PrivateKeyRsa:
-    2 | - text: -----BEGIN RSA PRIVATE KEY-----
+    1 | +PrivateKeyRsa:
+    2 | +- text: -----BEGIN RSA PRIVATE KEY-----
     3 | +MIIBOgIBAAJBAIIRkYjxjE3KIZiEc8k4sWWGNsPYRNE0u0bl5oFVApPLm+uXQ/4l
     4 | +bKO9LFtMiVPy700oMWLScwAN5OAiqVLMvHUCAwEAAQJANLr8nmEWuV6t2hAwhK5I
     5 | +NNmBkEo4M/xFxEtl9J7LKbE2gtNrlCQiJlPP1EMhwAjDOzQcJ3lgFB28dkqH5rMW
@@ -533,8 +533,8 @@ secrets-engine-version: 3.14.159
     7 | +22tthkAvcN1s66lG+0DztOVJ4QLI2z8CIBPeDGwGpx8pdIicN/5LFuLWbyAcoZaT
     8 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
     9 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
-   10 | -----END RSA PRIVATE KEY-----
-        |_____________________________apikey____________________________|
+   10 | +-----END RSA PRIVATE KEY-----
+         |____________________________apikey____________________________|
 """
 
 snapshots[
@@ -549,8 +549,8 @@ snapshots[
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
 
     | @@ -0,0 +1 @
-  1 | github_token: 368ac3e**************************37ddf91
-                    |________________apikey________________|
+  1 | +github_token: 368ac3e**************************37ddf91
+                     |________________apikey________________|
 """
 
 snapshots[
@@ -565,8 +565,8 @@ snapshots[
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
 
     | @@ -0,0 +1 @
-  1 | github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
-                    |________________apikey________________|
+  1 | +github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
+                     |________________apikey________________|
 """
 
 snapshots[
@@ -583,8 +583,8 @@ secrets-engine-version: 3.14.159
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
 
     | @@ -0,0 +1 @
-  1 | github_token: 368ac3e**************************37ddf91
-                    |________________apikey________________|
+  1 | +github_token: 368ac3e**************************37ddf91
+                     |________________apikey________________|
 """
 
 snapshots[
@@ -601,6 +601,6 @@ secrets-engine-version: 3.14.159
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
 
     | @@ -0,0 +1 @
-  1 | github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
-                    |________________apikey________________|
+  1 | +github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
+                     |________________apikey________________|
 """

--- a/tests/unit/verticals/secret/test_censor_extended_matches.py
+++ b/tests/unit/verticals/secret/test_censor_extended_matches.py
@@ -1,0 +1,126 @@
+from pygitguardian.models import Match
+
+from ggshield.core.lines import Line, LineCategory, get_lines_from_content
+from ggshield.utils.git_shell import Filemode
+from ggshield.verticals.secret.extended_match import ExtendedMatch
+from tests.unit.conftest import _SINGLE_MOVE_PATCH
+
+
+def test_censor_match_for_a_patch():
+    """
+    GIVEN a match against a patch
+    AND its lines
+    WHEN ExtendedMatch.from_match()  and ext.censor() are called
+    THEN it contains the expected values
+    """
+
+    # When scanning a patch we send the content after the first "@@" of the patch
+    content = _SINGLE_MOVE_PATCH[_SINGLE_MOVE_PATCH.index("@@") :]
+    lines = get_lines_from_content(content, Filemode.MODIFY)
+    start = 40
+    end = 108
+    match = Match(
+        match=content[start : end + 1],
+        match_type="token",
+        index_start=start,
+        index_end=end,
+    )
+
+    ex_match = ExtendedMatch.from_match(match, lines, is_patch=True)
+    len_match = len(ex_match.match)
+    ex_match.censor()
+
+    assert len(ex_match.match) == len_match
+    assert (
+        ex_match.match
+        == "SG._Yytrtvlj******************************************-**rRJLGFLBLf0M"
+    )
+    assert ex_match.lines_before_secret == [
+        Line(
+            content="@@ -150 +150,2 @",
+            category=LineCategory.EMPTY,
+            pre_index=None,
+            post_index=None,
+        ),
+        Line(
+            content="something",
+            category=LineCategory.ADDITION,
+            pre_index=None,
+            post_index=150,
+        ),
+    ]
+    assert ex_match.lines_with_secret == [
+        Line(
+            content='sg_key = "SG._Yytrtvlj******************************************-**rRJLGFLBLf0M";',
+            category=None,
+            pre_index=150,
+            post_index=151,
+        )
+    ]
+
+
+PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE = """/*
+01234567890
+*/
+token1=ABCD token2=EFGH
+
+# Some more content
+# Even more content
+"""
+
+
+def test_censor_match_for_plain_content_multiple_on_one_line():
+    """
+    GIVEN some content
+    AND a match in it
+    WHEN ExtendedMatch.from_match() is called
+    THEN it contains the expected values
+    """
+    lines = get_lines_from_content(PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE, Filemode.FILE)
+    start1 = PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE.find("A")
+    # No + 1 here because in a Match object, index_end points to the last character of
+    # the match, not the character after it.
+    end1 = PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE.find("D")
+    match1 = Match(match="ABCD", match_type="token", index_start=start1, index_end=end1)
+    start2 = PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE.find("E")
+    end2 = PLAIN_CONTENT_MUTIPLE_ON_ONE_LINE.find("H")
+    match2 = Match(match="EFGH", match_type="token", index_start=start2, index_end=end2)
+
+    ex_match1 = ExtendedMatch.from_match(match1, lines, is_patch=False)
+    ex_match2 = ExtendedMatch.from_match(match2, lines, is_patch=False)
+    ex_match1.censor()
+    ex_match2.censor()
+
+    assert (
+        ex_match1.lines_before_secret
+        == ex_match2.lines_before_secret
+        == [
+            Line(
+                content="01234567890",
+                category=LineCategory.DATA,
+                pre_index=2,
+            ),
+            Line(content="*/", category=LineCategory.DATA, pre_index=3),
+        ]
+    )
+    assert (
+        ex_match1.lines_after_secret
+        == ex_match2.lines_after_secret
+        == [
+            Line(content="", category=LineCategory.DATA, pre_index=5),
+            Line(
+                content="# Some more content", category=LineCategory.DATA, pre_index=6
+            ),
+        ]
+    )
+    assert (
+        ex_match1.lines_with_secret
+        == ex_match2.lines_with_secret
+        == [
+            Line(
+                content="token1=A**D token2=E**H",
+                category=LineCategory.DATA,
+                pre_index=4,
+            ),
+        ]
+    )


### PR DESCRIPTION
## Context

After having worked on factorizing `make_matches` the new goal is to start storing context lines in the Extended Match and have the output entirely depend those line and no longer the `result.file.content`. 
In particular this means a way to censor Extended Match based on the lines and the indices in MatchSpan and no longer relying on censor content.

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

This MR is divided into several commits and test should pass after each commit (best reviewed by commit?). 

Several important change have been made:
- the `Line` class has been changed from a `NamedTuple` to a `SimpleNamespace` to be able to modify the line.content for censoring.
- The display patch hunk indication is no longer present in the patch output as it is not really part of the file and we do not display the patch symbols '+/-/ ' . This means some test secrets are considered shorter and the censoring (proportional to the length of the secret) is shorter as well (so some test in output test text have been changed accordingly).
- The '+' have been removed of multi line secret in patches as they where not present in single ligne secret nor in the first and last lines of the multiline secret.
- Some test in test output text had falty Match index end creating falty output, it has been cleanned up. 

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

Test pass and output is more coherent now ? I did my best to make it reviewable but it was quite tricky to work with...

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
