### PR TITLE
Mmillet/sca 1670 refactor ggshield scan ci commands

### DIFF
--- a/changelog.d/20240604_115221_mathias.millet_sca_1670_refactor_ggshield_scan_ci_commands.md
+++ b/changelog.d/20240604_115221_mathias.millet_sca_1670_refactor_ggshield_scan_ci_commands.md
@@ -1,0 +1,37 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+### Removed
+
+- The `--all` option for the `sca scan ci` and `iac scan ci` commands.
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- The `sca scan ci` and `iac scan ci` behaviour has changed. They are expected to run in merge-request CI pipelines only, and will compute the diff exactly associated with the merge request.
+
+### Deprecated
+
+- Running `sca scan ci` or `iac scan ci` outside of a merge request CI pipeline is now deprecated.
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -115,6 +115,19 @@ class APIKeyCheckError(AuthError):
         super().__init__(instance, message)
 
 
+class NotAMergeRequestError(_ExitError):
+    """
+    Raised when the command is not run in a Merge Request, while
+    it expects it to.
+    """
+
+    def __init__(self):
+        super().__init__(
+            ExitCode.USAGE_ERROR,
+            "This command expects to be run from a merge request.",
+        )
+
+
 def format_validation_error(exc: ValidationError) -> str:
     """
     Take a Marshmallow ValidationError and turn it into a more user-friendly message

--- a/ggshield/core/git_hooks/ci/get_scan_ci_parameters.py
+++ b/ggshield/core/git_hooks/ci/get_scan_ci_parameters.py
@@ -1,0 +1,112 @@
+import os
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
+
+import click
+
+from ggshield.core.errors import NotAMergeRequestError, UnexpectedError
+from ggshield.utils.git_shell import get_commits_not_in_branch, get_remotes
+
+from .supported_ci import SupportedCI
+
+
+def travis_scan_ci_args() -> Tuple[str, str]:
+    if "TRAVIS_PULL_REQUEST" not in os.environ:
+        raise NotAMergeRequestError()
+    try:
+        commit_range = os.environ["TRAVIS_COMMIT_RANGE"]
+        first_commit, last_commit = commit_range.split("..")
+        return last_commit, first_commit + "~1"
+    except Exception as exc:
+        raise UnexpectedError("Failed to extract scan ci arguments for travis") from exc
+
+
+# Note: this does not exist (yet ?) for CircleCI, see
+# https://circleci.canny.io/config/p/provide-env-variable-for-branch-name-targeted-by-pull-request
+CI_TARGET_BRANCH_ASSOC: Dict[SupportedCI, str] = {
+    SupportedCI.GITHUB: "GITHUB_BASE_REF",
+    SupportedCI.GITLAB: "CI_MERGE_REQUEST_TARGET_BRANCH_NAME",
+    SupportedCI.JENKINS: "CHANGE_TARGET",
+    SupportedCI.AZURE: "SYSTEM_PULLREQUEST_TARGETBRANCHNAME",
+    SupportedCI.BITBUCKET: "BITBUCKET_PR_DESTINATION_BRANCH",
+    SupportedCI.DRONE: "DRONE_COMMIT_BRANCH",
+}
+
+
+def get_scan_ci_parameters(
+    current_ci: SupportedCI,
+    wd: Optional[Union[str, Path]] = None,
+    verbose: bool = False,
+) -> Union[Tuple[str, str], None]:
+    """
+    Function used to gather current commit and reference commit, for the SCA/IaC scan
+    ci commands.
+    Return:
+      - a tuple (current_commit, reference commit) in the nominal case
+      - or None if the MR has no associated commits
+        (i.e. the mr branch has no new commit compared to the target branch)
+
+    Note: this function will not work (i.e. probably raise) if the git directory is a shallow clone
+    """
+    if verbose:
+        click.echo(
+            f"\tIdentified current ci as {current_ci.value}",
+            err=True,
+        )
+
+    if current_ci == SupportedCI.TRAVIS:
+        return travis_scan_ci_args()
+
+    remotes = get_remotes(wd=wd)
+    if len(remotes) == 0:
+        # note: this should not happen in practice, esp. in a CI job
+        if verbose:
+            click.echo(
+                "\tNo remote found.",
+                err=True,
+            )
+        remote_prefix = ""
+    else:
+        if verbose:
+            click.echo(
+                f"\tUsing first remote {remotes[0]}.",
+                err=True,
+            )
+        remote_prefix = f"{remotes[0]}/"
+
+    target_branch_var = CI_TARGET_BRANCH_ASSOC.get(current_ci)
+    if not target_branch_var:
+        raise UnexpectedError(f"Using scan ci is not supported for {current_ci.value}.")
+
+    if not os.getenv(target_branch_var):
+        raise NotAMergeRequestError()
+    target_branch = remote_prefix + os.environ[target_branch_var]
+
+    mr_tip = "HEAD"
+    if current_ci == SupportedCI.GITHUB:
+        # - GitHub pipelines are all merge results
+        # - GITHUB_BASE_REF and GITHUB_HEAD_REF are always set together
+        #   "when the event that triggers a workflow run is either pull_request or pull_request_target"
+        mr_tip = remote_prefix + os.environ["GITHUB_HEAD_REF"]
+    if current_ci == SupportedCI.GITLAB:
+        # Handles gitlab's MR, whether merge results pipelines are enabled or not
+        mr_tip = remote_prefix + os.environ["CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"]
+
+    mr_commits = get_commits_not_in_branch(
+        current_tip=mr_tip, target_branch=target_branch, wd=wd
+    )
+    if len(mr_commits) == 0:
+        return None
+
+    current_commit = mr_commits[0]
+    reference_commit = mr_commits[-1] + "~1"
+    if verbose:
+        click.echo(
+            (
+                f"\tIdentified current commit as {current_commit}\n"
+                f"\tIdentified reference commit as {reference_commit}"
+            ),
+            err=True,
+        )
+
+    return current_commit, reference_commit

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -509,3 +509,16 @@ def get_default_branch(wd: Optional[Union[str, Path]] = None) -> str:
         return git(["config", "init.defaultBranch"], cwd=wd).strip()
 
     return default_branch
+
+
+def get_commits_not_in_branch(
+    target_branch: str, current_tip: str = "HEAD", wd: Optional[Union[str, Path]] = None
+) -> List[str]:
+    """
+    This function lists commits, starting from `current_tip`, that do not belong to `target_branch`.
+    It is used to list commits associated with a merge request
+    Commits are returned in descending order (most recent commit first)
+    """
+    cmd = ["log", current_tip, "--not", target_branch, "--format=%H"]
+    output = git(cmd, cwd=wd)
+    return output.splitlines()

--- a/tests/functional/iac/test_iac_scan_ci.py
+++ b/tests/functional/iac/test_iac_scan_ci.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import pytest
 
-from ggshield.utils.git_shell import EMPTY_SHA
 from tests.conftest import IAC_SINGLE_VULNERABILITY
 from tests.functional.utils import run_ggshield_iac_scan
 from tests.repository import Repository
@@ -12,23 +11,28 @@ from tests.repository import Repository
 @pytest.mark.parametrize(
     "scan_arg,file_content,expected_code,expected_output",
     [
-        (None, "Nothing to see here", 0, "No new incident"),
+        (None, "Nothing to see here", 0, "No incidents have been found"),
         (None, IAC_SINGLE_VULNERABILITY, 1, "[+] 1 new incident detected (HIGH: 1)"),
-        ("--all", "Nothing to see here", 0, "No incidents have been found"),
-        ("--all", IAC_SINGLE_VULNERABILITY, 1, "1 incident detected"),
     ],
 )
-def test_ci_diff_no_vuln(
+def test_scan_ci(
     tmp_path: Path,
     scan_arg: Optional[str],
     file_content: str,
     expected_code: int,
     expected_output: str,
 ) -> None:
+    """
+    GIVEN a repository, with a branch containing changes
+    WHEN scanning it with ci
+    THEN the changes are scanned
+    """
     # GIVEN a repository
     repository = Repository.create(tmp_path)
-    initial_sha = repository.create_commit()
+    repository.create_commit()
+    repository.create_commit()
 
+    repository.create_branch("mr_branch")
     # AND a commit containing a file with or without a vulnerability
     test_file = tmp_path / "test_file.tf"
     test_file.write_text(file_content)
@@ -43,11 +47,16 @@ def test_ci_diff_no_vuln(
     args = ["ci"]
     if scan_arg is not None:
         args.append(scan_arg)
+    args.append("--verbose")
     result = run_ggshield_iac_scan(
         *args,
         cwd=tmp_path,
         expected_code=expected_code,
-        env={"GITLAB_CI": "1", "CI_COMMIT_BEFORE_SHA": initial_sha},
+        env={
+            "GITLAB_CI": "1",
+            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "main",
+            "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME": "mr_branch",
+        },
     )
 
     # THEN a vulnerability should be found if and only if
@@ -59,82 +68,13 @@ def test_ci_diff_no_vuln(
     assert expected_output in result.stdout
 
 
-def test_gitlab_previous_commit_sha_for_merged_results_pipelines(
-    tmp_path: Path,
-) -> None:
-    # GIVEN a remote repository
-    remote_repository = Repository.create(tmp_path / "remote", bare=True)
-    # AND a local clone with a first vulnerability
-    local_tmp_path = tmp_path / "local"
-    repository = Repository.clone(remote_repository.path, local_tmp_path)
-    ignored_file = local_tmp_path / "ignored_file.tf"
-    ignored_file.write_text(IAC_SINGLE_VULNERABILITY)
-    repository.add(ignored_file)
-    repository.create_commit()
-    repository.push()
-
-    # AND a new commit containing another file with a vulnerability
-    scanned_file = local_tmp_path / "scanned_file.tf"
-    scanned_file.write_text(IAC_SINGLE_VULNERABILITY)
-    repository.add(scanned_file)
-    last_sha = repository.create_commit()
-
-    # WHEN scanning it with the local last commit as CI_COMMIT_BEFORE_SHA var
-    # to emulate Gitlab "merged results pipelines" behaviour
-    args = ["ci"]
-    result = run_ggshield_iac_scan(
-        *args,
-        cwd=local_tmp_path,
-        expected_code=1,
-        env={
-            "GITLAB_CI": "1",
-            "CI_COMMIT_BEFORE_SHA": last_sha,
-            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "main",
-        },
-    )
-
-    # THEN the scan should be run on the expected commit
-    assert "ignored_file.tf" not in result.stdout
-    assert "scanned_file.tf" in result.stdout
-    assert "[+] 1 new incident detected (HIGH: 1)" in result.stdout
-
-
-def test_gitlab_new_branch(tmp_path: Path) -> None:
-    # GIVEN a remote repository
-    remote_repository = Repository.create(tmp_path / "remote", bare=True)
-    # AND a local clone with a vulnerability on the same branch
-    repository = Repository.clone(remote_repository.path, tmp_path / "local")
-    ignored_file = repository.path / "ignored_file.tf"
-    ignored_file.write_text(IAC_SINGLE_VULNERABILITY)
-    repository.add(ignored_file)
-    repository.create_commit()
-    repository.push()
-    # AND another vulnerability on another branch
-    repository.create_branch("branch2")
-    scanned_file = repository.path / "scanned_file.tf"
-    scanned_file.write_text(IAC_SINGLE_VULNERABILITY)
-    repository.add(scanned_file)
-    repository.create_commit()
-
-    # WHEN scanning in CI on a push pipeline for a new branch
-    result = run_ggshield_iac_scan(
-        "ci",
-        cwd=repository.path,
-        expected_code=1,
-        env={
-            "GITLAB_CI": "1",
-            "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
-            "CI_COMMIT_BRANCH": "branch2",
-        },
-    )
-
-    # THEN the scan should be run on the expected commit
-    assert "ignored_file.tf" not in result.stdout
-    assert "scanned_file.tf" in result.stdout
-    assert "[+] 1 new incident detected (HIGH: 1)" in result.stdout
-
-
 def test_gitlab_new_empty_branch(tmp_path: Path) -> None:
+    """
+    GIVEN a repository, with a branch containing no new commit
+    WHEN scanning it with scan ci
+    THEN the scan is skipped
+    """
+
     # GIVEN a remote repository
     remote_repository = Repository.create(tmp_path / "remote", bare=True)
     # AND a local clone with a vulnerability on the same branch
@@ -146,18 +86,21 @@ def test_gitlab_new_empty_branch(tmp_path: Path) -> None:
     repository.push()
     # AND another branch with no new commits
     repository.create_branch("branch2")
+    repository.push("--set-upstream", "origin", "branch2")
 
     # WHEN scanning in CI on a push pipeline for a new branch
     result = run_ggshield_iac_scan(
         "ci",
+        "--verbose",
         cwd=repository.path,
         expected_code=0,
         env={
             "GITLAB_CI": "1",
-            "CI_COMMIT_BEFORE_SHA": EMPTY_SHA,
-            "CI_COMMIT_BRANCH": "branch2",
+            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "main",
+            "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME": "branch2",
         },
     )
 
     # THEN the scan should be skipped
-    assert "> No IaC files changed. Skipping." in result.stdout
+    assert result.stdout == ""
+    assert "No commit found in merge request, skipping scan." in result.stderr

--- a/tests/unit/cmd/sca/test_ci.py
+++ b/tests/unit/cmd/sca/test_ci.py
@@ -1,144 +1,83 @@
+from pathlib import Path
 from unittest.mock import Mock, patch
 
-import click
-from pygitguardian.sca_models import ComputeSCAFilesResult, SCAScanDiffOutput
+from click.testing import CliRunner
+from pygitguardian.sca_models import SCAScanAllOutput, SCAScanDiffOutput
 
 from ggshield.__main__ import cli
-from ggshield.core.errors import ExitCode
-from ggshield.utils.git_shell import EMPTY_SHA, get_list_commit_SHA
-from ggshield.utils.os import cd
+from ggshield.core.errors import ExitCode, NotAMergeRequestError
+from ggshield.core.scan.scan_mode import ScanMode
+from tests.repository import Repository
 
 
-@patch("pygitguardian.GGClient.scan_diff")
+@patch("ggshield.cmd.sca.scan.ci.sca_scan_diff", return_value=SCAScanDiffOutput())
 @patch(
-    "ggshield.cmd.sca.scan.sca_scan_utils.sca_files_from_git_repo", return_value=set()
+    "ggshield.cmd.sca.scan.ci.get_scan_ci_parameters",
 )
-@patch("ggshield.cmd.sca.scan.ci.get_current_and_previous_state_from_ci_env")
-def test_sca_scan_ci_no_commit(
-    get_current_and_previous_state_from_ci_env_mock: Mock,
-    sca_files_from_git_repo_mock: Mock,
-    scan_diff_mock: Mock,
-    cli_fs_runner: click.testing.CliRunner,
+def test_sca_scan_ci_mr_env(
+    get_scan_ci_parameters_mock: Mock,
+    sca_scan_diff_mock: Mock,
     monkeypatch,
+    tmp_path: Path,
 ):
     """
-    GIVEN a repository with no commits
-    WHEN `sca scan ci` is called without --all
-    THEN no scan has been triggered and the scan is successful
+    GIVEN a CI env for a Merge Request
+    WHEN `sca scan ci` is called
+    THEN sca_scan_diff is called with expected parameters
+    THEN the command does not fail
     """
+    cli_runner = CliRunner()
+    with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+        local_repo = Repository.create(tmp_path)
+        ref_commit = local_repo.create_commit()
+        cur_commit = local_repo.create_commit()
+        get_scan_ci_parameters_mock.return_value = (cur_commit, ref_commit)
 
-    monkeypatch.setenv("CI", "1")
-    monkeypatch.setenv("GITHUB_ACTIONS", "1")
-    get_current_and_previous_state_from_ci_env_mock.return_value = (
-        "HEAD",
-        None,
-    )
+        monkeypatch.setenv("GITLAB_CI", "true")
 
-    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
+        result = cli_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
 
-    scan_diff_mock.assert_not_called()
-    assert result.exit_code == ExitCode.SUCCESS
-    assert "No file to scan." in result.stdout
-    assert "No SCA vulnerability has been added." in result.stdout
+        sca_scan_diff_mock.assert_called_once()
+        assert set(
+            {
+                "current_ref": cur_commit,
+                "previous_ref": ref_commit,
+                "ci_mode": "GITLAB",
+                "scan_mode": "ci_diff/GITLAB",
+            }.items()
+        ) <= set(sca_scan_diff_mock.call_args.kwargs.items())
+        assert result.exit_code == ExitCode.SUCCESS
 
 
-@patch("pygitguardian.GGClient.scan_diff")
-@patch("ggshield.cmd.sca.scan.ci.get_current_and_previous_state_from_ci_env")
-def test_sca_scan_ci_same_commit(
-    get_current_and_previous_state_from_ci_env_mock: Mock,
-    scan_diff_mock: Mock,
-    cli_fs_runner: click.testing.CliRunner,
+@patch("ggshield.cmd.sca.scan.ci.sca_scan_all", return_value=SCAScanAllOutput())
+@patch(
+    "ggshield.cmd.sca.scan.ci.get_scan_ci_parameters",
+)
+def test_sca_scan_ci_non_mr_env(
+    get_scan_ci_parameters_mock: Mock,
+    sca_scan_all_mock: Mock,
     monkeypatch,
+    tmp_path: Path,
 ):
     """
-    GIVEN the same commits in the two states in CI
-    WHEN `sca scan ci` is called without --all
-    THEN no scan has been triggered and the scan is successful
+    GIVEN a CI env not for a Merge Request
+    WHEN `sca scan ci` is called
+    THEN sca_scan_all is called with expected parameters
+    THEN the command does not fail
+    THEN a warning is logged
     """
-    monkeypatch.setenv("CI", "1")
-    monkeypatch.setenv("GITHUB_ACTIONS", "1")
-    get_current_and_previous_state_from_ci_env_mock.return_value = (
-        "abcdefg",
-        "abcdefg",
-    )
+    cli_runner = CliRunner(mix_stderr=False)
+    with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+        Repository.create(tmp_path)
+        get_scan_ci_parameters_mock.side_effect = NotAMergeRequestError
 
-    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
+        monkeypatch.setenv("GITLAB_CI", "true")
 
-    scan_diff_mock.assert_not_called()
-    assert result.exit_code == ExitCode.SUCCESS
-    assert "SCA scan diff comparing identical versions, scan skipped." in result.stdout
-    assert "No SCA vulnerability has been added." in result.stdout
+        result = cli_runner.invoke(cli, ["sca", "scan", "ci"], catch_exceptions=False)
 
-
-@patch("pygitguardian.GGClient.sca_scan_directory")
-@patch("ggshield.cmd.sca.scan.sca_scan_utils.get_sca_scan_all_filepaths")
-def test_sca_scan_all_no_files(
-    scan_filepaths_mock: Mock,
-    scan_directory_mock: Mock,
-    cli_fs_runner: click.testing.CliRunner,
-    monkeypatch,
-):
-    """
-    GIVEN there are no files to check
-    WHEN `sca scan ci` is called with --all
-    THEN no scan has been triggered, and the scan is successful
-    """
-    monkeypatch.setenv("CI", "1")
-    scan_filepaths_mock.return_value = ([], 200)
-
-    result = cli_fs_runner.invoke(cli, ["sca", "scan", "ci", "--all"])
-
-    scan_directory_mock.assert_not_called()
-    assert result.exit_code == ExitCode.SUCCESS
-    assert "No file to scan." in result.stdout
-    assert "No SCA vulnerability has been found." in result.stdout
-
-
-@patch("pygitguardian.GGClient.compute_sca_files")
-@patch("pygitguardian.GGClient.scan_diff")
-def test_sca_scan_ci_github_push_before_empty_sha(
-    scan_diff_mock: Mock,
-    compute_sca_files_mock: Mock,
-    cli_fs_runner: click.testing.CliRunner,
-    dummy_sca_repo,
-    monkeypatch,
-):
-    """
-    GIVEN an empty commit sha in a GITHUB_PUSH_BEFORE_SHA in CI
-    WHEN `sca scan ci` is called without --all
-    THEN no error is raised
-    THEN the last commit of the branch is scanned
-    """
-
-    # Set CI env variables
-    monkeypatch.setenv("CI", "1")
-    monkeypatch.setenv("GITHUB_ACTIONS", "1")
-    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
-    monkeypatch.setenv("GITHUB_PUSH_BEFORE_SHA", EMPTY_SHA)
-
-    # Mocks the two client calls
-    compute_sca_files_mock.return_value = ComputeSCAFilesResult(
-        sca_files=["Pipfile", "Pipfile.lock"]
-    )
-    scan_diff_mock.return_value = SCAScanDiffOutput(
-        scanned_files=[], added_vulns=[], removed_vulns=[]
-    )
-
-    # Run CI scan
-    with cd(str(dummy_sca_repo.path)):
-        # Set two commits on the current branch
-        dummy_sca_repo.git("checkout", "branch_with_vuln")
-        dummy_sca_repo.create_commit("first commit")
-        dummy_sca_repo.create_commit("second commit")
-
-        # Set GITHUB_SHA to current HEAD
-        head_sha = get_list_commit_SHA("HEAD", max_count=1)[0]
-        monkeypatch.setenv("GITHUB_SHA", head_sha)
-
-        result = cli_fs_runner.invoke(
-            cli, ["sca", "scan", "ci", "--verbose"], catch_exceptions=False
+        sca_scan_all_mock.assert_called_once()
+        assert set({"scan_mode": ScanMode.CI_ALL}.items()) <= set(
+            sca_scan_all_mock.call_args.kwargs.items()
         )
-
-    scan_diff_mock.assert_called_once()
-    assert result.exit_code == ExitCode.SUCCESS
-    assert "No SCA vulnerability has been added." in result.stdout
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "WARNING: " in result.stderr

--- a/tests/unit/core/git_hooks/ci/test_get_scan_ci_parameters.py
+++ b/tests/unit/core/git_hooks/ci/test_get_scan_ci_parameters.py
@@ -1,0 +1,125 @@
+import pytest
+
+from ggshield.core.errors import NotAMergeRequestError, UnexpectedError
+from ggshield.core.git_hooks.ci.get_scan_ci_parameters import (
+    CI_TARGET_BRANCH_ASSOC,
+    get_scan_ci_parameters,
+)
+from ggshield.core.git_hooks.ci.supported_ci import SupportedCI
+from tests.repository import Repository
+
+
+class TestGetScanCIParameters:
+
+    @pytest.fixture(autouse=True)
+    def git_repo(self, tmp_path):
+        repo = Repository.create(tmp_path)
+        repo.create_commit()
+
+        first_file_name = "first.py"
+
+        # add a commit
+        first_file = repo.path / first_file_name
+        first_content = "First file (included)"
+        first_file.write_text(first_content)
+        repo.add(first_file_name)
+        self.ref_commit = repo.create_commit()
+
+        repo.create_branch("mr_branch")
+        self.repo = repo
+
+    @pytest.mark.parametrize(
+        "ci",
+        (
+            SupportedCI.JENKINS,
+            SupportedCI.AZURE,
+            SupportedCI.BITBUCKET,
+            SupportedCI.DRONE,
+        ),
+    )
+    def test_regular_pipeline(self, ci, monkeypatch):
+        """
+        GIVEN a ci env
+        WHEN calling get_scan_ci_parameters
+        THEN the parameters are returned
+        """
+        repo = self.repo
+        monkeypatch.setenv(CI_TARGET_BRANCH_ASSOC[ci], "main")
+        first_commit = repo.create_commit()
+        last_commit = repo.create_commit()
+        params = get_scan_ci_parameters(ci, wd=repo.path, verbose=False)
+        assert params == (last_commit, f"{first_commit}~1")
+
+    def test_gitlab_ci(self, monkeypatch):
+        """
+        GIVEN a gitlab ci env
+        WHEN calling get_scan_ci_parameters
+        THEN the parameters are returned
+        """
+        repo = self.repo
+        monkeypatch.setenv(CI_TARGET_BRANCH_ASSOC[SupportedCI.GITLAB], "main")
+        monkeypatch.setenv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME", "mr_branch")
+        first_commit = repo.create_commit()
+        last_commit = repo.create_commit()
+        params = get_scan_ci_parameters(SupportedCI.GITLAB, wd=repo.path, verbose=False)
+        assert params == (last_commit, f"{first_commit}~1")
+
+    def test_github_ci(self, monkeypatch):
+        """
+        GIVEN a  github ci env
+        WHEN calling get_scan_ci_parameters
+        THEN the parameters are returned
+        """
+        repo = self.repo
+        monkeypatch.setenv(CI_TARGET_BRANCH_ASSOC[SupportedCI.GITHUB], "main")
+        monkeypatch.setenv("GITHUB_HEAD_REF", "mr_branch")
+        first_commit = repo.create_commit()
+        last_commit = repo.create_commit()
+
+        repo.create_branch("simulate_merge_commit")
+        repo.create_commit()
+        params = get_scan_ci_parameters(SupportedCI.GITHUB, wd=repo.path, verbose=False)
+        assert params == (last_commit, f"{first_commit}~1")
+
+    def test_travis_ci(self, monkeypatch):
+        """
+        GIVEN a travis ci env
+        WHEN calling get_scan_ci_parameters
+        THEN the parameters are returned
+        """
+        repo = self.repo
+        first_commit = repo.create_commit()
+        last_commit = repo.create_commit()
+        monkeypatch.setenv("TRAVIS_PULL_REQUEST", "1")
+        monkeypatch.setenv("TRAVIS_COMMIT_RANGE", f"{first_commit}..{last_commit}")
+        params = get_scan_ci_parameters(SupportedCI.TRAVIS, wd=repo.path, verbose=False)
+        assert params == (last_commit, f"{first_commit}~1")
+
+    @pytest.mark.parametrize(
+        "ci",
+        [ci for ci in SupportedCI if ci != SupportedCI.CIRCLECI],
+    )
+    def test_not_a_merge_request_error_is_raised(self, ci, monkeypatch):
+        """
+        GIVEN a ci (excluding CircleCI)
+        WHEN no merge-request related env var is set
+        THEN NotAMergeRequestError is raised
+        """
+        # we unset variables that may be set by the CI in which tests are run
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+        monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+        with pytest.raises(NotAMergeRequestError):
+            get_scan_ci_parameters(ci, wd=self.repo.path, verbose=False)
+
+    def test_circleci_not_supported(self):
+        """
+        GIVEN -
+        WHEN calling get scan_ci_parameters for circleci
+        THEN an UnexpectedError is raised
+        """
+        with pytest.raises(
+            UnexpectedError, match="Using scan ci is not supported for CIRCLECI"
+        ):
+            get_scan_ci_parameters(
+                SupportedCI.CIRCLECI, wd=self.repo.path, verbose=False
+            )

--- a/tests/unit/utils/test_git_shell.py
+++ b/tests/unit/utils/test_git_shell.py
@@ -12,6 +12,7 @@ from ggshield.utils.git_shell import (
     NotAGitDirectory,
     check_git_dir,
     check_git_ref,
+    get_commits_not_in_branch,
     get_default_branch,
     get_filepaths_from_ref,
     get_new_branch_ci_commits,
@@ -442,3 +443,44 @@ def test_git_ls_unstaged(tmp_path):
     # as relative to repo.path
     expected_paths = {x.relative_to(repo.path) for x in (repo_file, submodule_file)}
     assert {Path(x) for x in unstaged_files} == expected_paths
+
+
+class TestGetCommitsNotInBranch:
+    @pytest.fixture(autouse=True)
+    def setup_repo(self, tmp_path):
+        repo = Repository.create(tmp_path)
+        repo.create_commit()
+
+        first_file_name = "first.py"
+
+        # add a commit
+        first_file = repo.path / first_file_name
+        first_content = "First file (included)"
+        first_file.write_text(first_content)
+        repo.add(first_file_name)
+        repo.create_commit()
+
+        repo.create_branch("mr_branch")
+        self.repo = repo
+
+    def test_no_commit(self):
+        """
+        GIVEN a MR branch with no dedicated commit
+        WHEN calling get_commits_not_in_branch
+        THEN an empty list is returned
+        """
+        assert get_commits_not_in_branch("main", "mr_branch", wd=self.repo.path) == []
+
+    def test_some_commits(self):
+        """
+        GIVEN a MR branch with some commits
+        WHEN calling get_commits_not_in_branch
+        THEN the list of commits is returned, in descending order
+        """
+
+        sha1 = self.repo.create_commit()
+        sha2 = self.repo.create_commit()
+        assert get_commits_not_in_branch("main", "mr_branch", wd=self.repo.path) == [
+            sha2,
+            sha1,
+        ]


### PR DESCRIPTION
## Context

Refactor `sca scan ci` and  `iac scan ci`:  we want to 
- compute the range of commits associated with the merge request, and not the push event
- only allow the command to run in merge requests pipelines (for now, a fallback behaviour is kept, so that the command will perform a full scan if that is not the case).


## What has been done

Refactor the commands

## Validation

Run the commands in merge request pipelines, with verbose mode.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
