### PR TITLE
refactor: remove the scannable from the result class

### DIFF
--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -86,8 +86,8 @@ def remove_results_from_ignore_detectors(
 
 def get_ignore_sha(policy_break: PolicyBreak) -> str:
     hashable = "".join(
-        [
-            f"{match.match},{match.match_type}"
+        [  # for retro compatibility use content_match if it exists (Extended Match) and for Match use match
+            f"{getattr(match, 'content_match', None) or match.match},{match.match_type}"
             for match in sorted(
                 policy_break.matches, key=operator.attrgetter("match_type")
             )

--- a/ggshield/verticals/secret/extended_match.py
+++ b/ggshield/verticals/secret/extended_match.py
@@ -45,6 +45,7 @@ class ExtendedMatch(Match):
     def __init__(
         self,
         span: MatchSpan,
+        content_match: str,
         lines_before_secret: List[Line],
         lines_with_secret: List[Line],
         lines_after_secret: List[Line],
@@ -55,6 +56,7 @@ class ExtendedMatch(Match):
         **kwargs: Any,
     ):
         self.span = span
+        self.content_match = content_match
         self.lines_before_secret = lines_before_secret
         self.lines_with_secret = lines_with_secret
         self.lines_after_secret = lines_after_secret
@@ -97,8 +99,14 @@ class ExtendedMatch(Match):
         else:
             stripped_match = match.match
         return cls(
-            span=span,
             match=stripped_match,
+            content_match=match.match,  # for backward compatibility
+            # content_match still contails the patch symbols and is used
+            # to get the policy breaks shas
+            index_start=match.index_start,
+            index_end=match.index_end,
+            span=span,
+            stripped_match=stripped_match,
             lines_before_secret=lines[
                 max(
                     span.line_index_start - NB_CONTEXT_LINES + 1, 0
@@ -110,8 +118,6 @@ class ExtendedMatch(Match):
                 + 1 : min(span.line_index_end + NB_CONTEXT_LINES, len(lines))
             ],
             match_type=match.match_type,
-            index_start=span.column_index_start,
-            index_end=span.column_index_end,
             line_start=line_index_start,
             line_end=line_index_end,
             pre_line_start=start_line.pre_index,

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -53,7 +53,7 @@ class SecretJSONOutputHandler(SecretOutputHandler):
 
     def process_result(self, result: Result) -> Dict[str, Any]:
         result_dict: Dict[str, Any] = {
-            "filename": result.file.path,
+            "filename": result.filepath,
             "mode": result.filemode.name,
             "incidents": [],
             "total_occurrences": 0,
@@ -61,7 +61,6 @@ class SecretJSONOutputHandler(SecretOutputHandler):
         }
         sha_dict = leak_dictionary_by_ignore_sha(result.scan.policy_breaks)
         result_dict["total_incidents"] = len(sha_dict)
-        result.enrich_matches()
 
         if not self.show_secrets:
             result.censor()

--- a/ggshield/verticals/secret/output/secret_text_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_text_output_handler.py
@@ -1,5 +1,4 @@
 import shutil
-from copy import deepcopy
 from io import StringIO
 from typing import Dict, List, Optional, Tuple
 
@@ -100,13 +99,8 @@ class SecretTextOutputHandler(SecretOutputHandler):
         """
         result_buf = StringIO()
 
-        # policy breaks and matches are modified in the functions leak_dictionary_by_ignore_sha and censor_content.
-        # Previously process_result was executed only once, so it did not create any issue.
-        # In the future we could rework those functions such that they do not change what is in the result.
-        result = Result(file=result.file, scan=deepcopy(result.scan))
         sha_dict = leak_dictionary_by_ignore_sha(result.scan.policy_breaks)
 
-        result.enrich_matches()
         if not self.show_secrets:
             result.censor()
 

--- a/ggshield/verticals/secret/repo.py
+++ b/ggshield/verticals/secret/repo.py
@@ -93,7 +93,7 @@ def scan_commits_content(
         for commit in commits:
             commit_scanned_callback(commit)
 
-    result_for_urls = {result.file.url: result for result in results.results}
+    result_for_urls = {result.file_url: result for result in results.results}
     scans = []
     for commit in commits:
         results_for_commit_files = [

--- a/tests/unit/core/test_match_span.py
+++ b/tests/unit/core/test_match_span.py
@@ -5,7 +5,6 @@ import pytest
 from pygitguardian import GGClient
 
 from ggshield.core.cache import Cache
-from ggshield.core.lines import get_lines_from_content
 from ggshield.core.match_span import MatchSpan
 from ggshield.core.scan import Commit, ScanContext, ScanMode, StringScannable
 from ggshield.verticals.secret import SecretScanner
@@ -92,17 +91,12 @@ def test_from_span(
         results = scanner.scan(files, scanner_ui=Mock())
         result = results.results[0]
 
-    lines = get_lines_from_content(
-        content=result.content,
-        filemode=result.filemode,
-    )
     matches = [
         match
         for policy_break in result.scan.policy_breaks
         for match in policy_break.matches
     ]
     for expected_span, match in zip(expected_spans, matches):
-        span = MatchSpan.from_match(match, lines, is_patch=is_patch)
-        assert span == expected_span
+        assert match.span == expected_span
 
     assert len(expected_spans) == len(matches)

--- a/tests/unit/verticals/secret/test_extended_match.py
+++ b/tests/unit/verticals/secret/test_extended_match.py
@@ -36,8 +36,8 @@ def test_from_match_for_plain_content():
     assert ex_match.line_end == 3
     # ExtendedMatch.from_match() "hijacks" index_start and index_end: they become
     # 0-based *columns*, and index_end points to the character *after* the match :/
-    assert ex_match.index_start == 6
-    assert ex_match.index_end == 10
+    assert ex_match.span.column_index_start == 6
+    assert ex_match.span.column_index_end == 10
     assert ex_match.lines_before_secret == [
         Line(content="01234567890", category=LineCategory.DATA, pre_index=2),
         Line(content="*/", category=LineCategory.DATA, pre_index=3),
@@ -75,8 +75,8 @@ def test_from_match_for_a_patch():
 
     assert ex_match.line_start == 150
     assert ex_match.line_end == 150
-    assert ex_match.index_start == 10
-    assert ex_match.index_end == 79
+    assert ex_match.span.column_index_start == 10
+    assert ex_match.span.column_index_end == 79
     assert ex_match.lines_before_secret == [
         Line(
             content="@@ -150 +150,2 @",

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -10,7 +10,7 @@ from ggshield.core.scan.commit_information import CommitInformation
 from ggshield.core.scan.commit_utils import CommitScannable
 from ggshield.verticals.secret import Result, Results
 from ggshield.verticals.secret.repo import get_commits_by_batch, scan_commits_content
-from tests.unit.conftest import TWO_POLICY_BREAKS
+from tests.unit.conftest import _ONE_LINE_AND_MULTILINE_PATCH_CONTENT, TWO_POLICY_BREAKS
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
     THEN the total number of policy breaks is 4
     """
     path = Path("filename")
-    content = "content"
+    content = _ONE_LINE_AND_MULTILINE_PATCH_CONTENT
     commit_1_files = [CommitScannable("some_sha_1", path, content)]
     commit_1 = Commit(
         sha="some_sha_1",
@@ -159,9 +159,15 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
     THEN the files and policy breaks are associated with the correct commits
     """
     sha1 = "some_sha_1"
-    file1_1 = CommitScannable(sha1, Path("filename1"), "document1")
-    file1_2 = CommitScannable(sha1, Path("filename2"), "document2")
-    file1_3 = CommitScannable(sha1, Path("filename3"), "document3")
+    file1_1 = CommitScannable(
+        sha1, Path("filename1"), _ONE_LINE_AND_MULTILINE_PATCH_CONTENT + "document1"
+    )
+    file1_2 = CommitScannable(
+        sha1, Path("filename2"), _ONE_LINE_AND_MULTILINE_PATCH_CONTENT + "document2"
+    )
+    file1_3 = CommitScannable(
+        sha1, Path("filename3"), _ONE_LINE_AND_MULTILINE_PATCH_CONTENT + "document3"
+    )
     file1_list = [file1_1, file1_2, file1_3]
 
     commit_1 = Commit(
@@ -176,8 +182,12 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
     )
 
     sha2 = "some_sha_2"
-    file2_1 = CommitScannable(sha2, Path("filename2"), "document2")
-    file2_2 = CommitScannable(sha2, Path("filename3"), "document3")
+    file2_1 = CommitScannable(
+        sha2, Path("filename2"), _ONE_LINE_AND_MULTILINE_PATCH_CONTENT + "document2"
+    )
+    file2_2 = CommitScannable(
+        sha2, Path("filename3"), _ONE_LINE_AND_MULTILINE_PATCH_CONTENT + "document3"
+    )
     file2_list = [file2_1, file2_2]
 
     commit_2 = Commit(


### PR DESCRIPTION
This the last commit of the work on refactoring Result, ExtendedMatch and output handlers to avoid saving the scannable. We remove the scannable from the Result class but to still preserve the same policy break sha, I have added content_match to the Extended match which still has patch symbols.

## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
