### PR TITLE
Use allow-self-signed in auth login command

### DIFF
--- a/changelog.d/20240606_114213_james.sinclair_auth_login_allow_self_signed.md
+++ b/changelog.d/20240606_114213_james.sinclair_auth_login_allow_self_signed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The `ggshield auth login` command now respects the `--allow-self-signed` flag.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -189,7 +189,11 @@ def token_login(config: Config, instance: Optional[str]) -> None:
         raise UnexpectedError("No API token was provided.")
 
     # enforce using the token (and not use config default)
-    client = create_client(api_key=token, api_url=config.api_url)
+    client = create_client(
+        api_key=token,
+        api_url=config.api_url,
+        allow_self_signed=config.user_config.allow_self_signed,
+    )
     try:
         response = client.get(endpoint="token")
     except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
## Context

The `ggshield auth login` command isn't using the `--allow-self-hosted` flag.

## What has been done

Passing `allow_self_hosted` to the `create_client` function--as we're already doing for `auth logout`.

## Validation

Without the fix, trying run `ggshield auth login --allow-self-signed` against a GitGuardian instance using an untrusted certificate or being routed through a TLS bump proxy will result in an error:

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='hostname.example.com', port=443): Max retries exceeded with url: /exposed/v1/token (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1007)')))
```

With the fix the certificate error won't appear.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

