### PR TITLE
Add an option to ignore secrets which are removed by the scanned commit

### DIFF
--- a/changelog.d/20240606_111932_samuel.guillaume.md
+++ b/changelog.d/20240606_111932_samuel.guillaume.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Add option `--ignore-removed-secrets` to ignore secrets which are removed by the scanned commit.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -96,6 +96,14 @@ _ignore_known_secrets_option = click.option(
     callback=create_config_callback("secret", "ignore_known_secrets"),
 )
 
+_ignore_removed_secrets_option = click.option(
+    "--ignore-removed-secrets",
+    is_flag=True,
+    default=None,
+    help="Ignore secrets which are removed by the scanned commit.",
+    callback=create_config_callback("secret", "ignore_removed_secrets"),
+)
+
 
 def _banlist_detectors_callback(
     ctx: click.Context, param: click.Parameter, value: Optional[List[str]]
@@ -127,6 +135,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         exit_zero_option(cmd)
         _exclude_option(cmd)
         _ignore_known_secrets_option(cmd)
+        _ignore_removed_secrets_option(cmd)
         _banlist_detectors_option(cmd)
         return cmd
 
@@ -146,4 +155,5 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
         verbose=config.user_config.verbose,
         output=ctx_obj.output,
         ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
+        ignore_removed_secrets=config.user_config.secret.ignore_removed_secrets,
     )

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -45,6 +45,7 @@ class SecretConfig(FilteredConfig):
     ignored_matches: List[IgnoredMatch] = field(default_factory=list)
     ignored_paths: Set[str] = field(default_factory=set)
     ignore_known_secrets: bool = False
+    ignore_removed_secrets: bool = False
     prereceive_remediation_message: str = """A pre-receive hook set server side prevented you from pushing secrets.
 Since the secret was detected during the push BUT after the commit, you need to:
 1. rewrite the git history making sure to replace the secret with its reference (e.g. environment variable).

--- a/ggshield/verticals/secret/output/secret_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_output_handler.py
@@ -20,11 +20,13 @@ class SecretOutputHandler(ABC):
         verbose: bool,
         output: Optional[Path] = None,
         ignore_known_secrets: bool = False,
+        ignore_removed_secrets: bool = True,
     ):
         self.show_secrets = show_secrets
         self.verbose = verbose
         self.output = output
         self.ignore_known_secrets = ignore_known_secrets
+        self.ignore_removed_secrets = ignore_removed_secrets
 
     def process_scan(self, scan: SecretScanCollection) -> ExitCode:
         """Process a scan collection, write the report to :attr:`self.output`
@@ -32,6 +34,9 @@ class SecretOutputHandler(ABC):
         :param scan: The scan collection to process
         :return: The exit code
         """
+        if self.ignore_removed_secrets:
+            scan = scan.without_removed_secrets()
+
         text = self._process_scan_impl(scan)
         if self.output:
             self.output.write_text(text)


### PR DESCRIPTION
## Context

Add an option to ignore secrets which are removed by the scanned commit.  
The goal of this PR is to create a way to accept secrets which are being remediated. If a dev is removing a secret from their code, but not rewriting the git history, GGShield will prevent them (pre-commit, pre-push or pre-receive) from committing and pushing the secret remediation.

This optional option will allow users to accept secrets in commits when they are removed, either on a deleted line or in a deleted file.

## What has been done

- Add `--ignore-removed-secrets` via the decorator `add_secret_scan_common_options`
- Add an equivalent field to `SecretConfig` named `ignore_removed_secrets`

## Validation

Create a repository, add then remove a secret:
```
git init
echo "ggtt-v-7faxcu9ak6" > secret.txt
git add secret.txt
git commit -m "add secret"
echo "remove" > secret.txt
git add secret.txt
git commit -m "remove secret"
```
Then verify that scanning the repository raises two incidents and only one with `--ignore-removed-secrets` 
```
$ ggshield secret scan repo . --json | jq .total_incidents
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2 / 2
2
```
```
$ ggshield secret scan repo . --json --ignore-removed-secrets | jq .total_incidents
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2 / 2
1
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

