### PR TITLE
Add signed standalone binaries for Windows

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -154,6 +154,43 @@ jobs:
           MACOS_P12_PASSWORD: ${{ secrets.MACOS_P12_PASSWORD }}
           MACOS_API_KEY_FILE: ${{ secrets.MACOS_API_KEY_FILE }}
 
+      - name: Setup Windows environment
+        if: startsWith(matrix.os, 'windows-') && inputs.release_mode
+        shell: bash
+        run: |
+          signtool_install_dir="/c/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64"
+          smctl_install_dir="/c/Program Files/DigiCert/DigiCert Keylocker Tools"
+
+          # Add signtool dir to $PATH
+          if [ ! -x "$signtool_install_dir/signtool.exe" ] ; then
+            echo "signtool.exe is not in '$signtool_install_dir'"
+            exit 1
+          fi
+          echo "$signtool_install_dir" >> $GITHUB_PATH
+
+          # Add smctl dir to $PATH
+          # Don't test if smctl is there: it is installed by the next step
+          echo "$smctl_install_dir" >> $GITHUB_PATH
+
+          # Create our certificate file
+          cert_file="$TMPDIR/cert.p12"
+          echo "${{ secrets.SM_CLIENT_CERT_FILE }}" | base64 --decode > "$cert_file"
+
+          # Add secrets to env
+          cat >> $GITHUB_ENV <<EOF
+          WINDOWS_CERT_FINGERPRINT=${{ secrets.WINDOWS_CERT_FINGERPRINT }}
+          SM_API_KEY=${{ secrets.SM_API_KEY }}
+          SM_HOST=${{ secrets.SM_HOST }}
+          SM_CLIENT_CERT_FILE=$cert_file
+          SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          EOF
+
+      - name: Install Windows dependencies
+        if: startsWith(matrix.os, 'windows-') && inputs.release_mode
+        shell: bash
+        run: |
+          scripts/build-os-packages/install-keylockertools
+
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -79,6 +79,7 @@ jobs:
             packages/ggshield-*.pkg \
             packages/ggshield_*.deb \
             packages/ggshield-*.rpm \
+            packages/ggshield-*.zip \
             packages/ggshield-*.gz
 
   push_to_docker_hub:

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ test-secret-files.json
 
 # cache
 .cache_ggshield
+*.msi

--- a/changelog.d/20240613_171809_aurelien.gateau_sign_windows_binaries.md
+++ b/changelog.d/20240613_171809_aurelien.gateau_sign_windows_binaries.md
@@ -1,0 +1,3 @@
+### Added
+
+- GGShield is now available as a standalone executable on Windows.

--- a/doc/dev/os-packages.md
+++ b/doc/dev/os-packages.md
@@ -32,6 +32,10 @@ flowchart TD
 
 We use [PyInstaller](https://pyinstaller.org) to generate `ggshield` standalone executable.
 
+## Signing
+
+MacOS and Windows archives are signed, but `build-os-packages` must be called with the `--sign` option to sign binaries because: signing requires access to secrets not available for PR from forks.
+
 ## macOS-specific information
 
 For macOS, we produce a .pkg archive. The advantage of this file is that it can be installed by double-clicking on it or by using `sudo installer -pkg path/to/ggshield.pkg -target /`, and `ggshield` is immediately usable after install, without the need to alter `$PATH`.
@@ -40,18 +44,9 @@ For macOS, we produce a .pkg archive. The advantage of this file is that it can 
 
 The .pkg itself installs `ggshield` files in `/opt/gitguardian/ggshield-$version` and a `ggshield` symbolic link in `/usr/local/bin/ggshield`.
 
-### Signing & notarizing
+### Setting up signing
 
-The .pkg archive used for releases is signed. Signing the archive is required to ensure macOS Gatekeeper security system does not block `ggshield` when users try to run it.
-
-#### Setting up signing
-
-`build-standalone-exe` won't sign binaries unless it's called with `--sign`. This is because:
-
-- signing requires access to secrets not available for PR from forks.
-- signing (and especially notarizing) can take a long time.
-
-When called with `--sign`, `build-standalone-exe` expects the following environment variables to be set:
+When called with `--sign`, `build-os-packages` expects the following environment variables to be set:
 
 - `$MACOS_P12_FILE`: Path to a signing certificate. You can export one from Xcode by following [Apple documentation][apple-signing-certificate].
 - `$MACOS_P12_PASSWORD_FILE`: Path containing the password protecting the signing certificate. Xcode will ask for it when exporting it.
@@ -62,7 +57,7 @@ Attention: these 3 files should be treated as secrets (even if `$MACOS_P12_FILE`
 [apple-signing-certificate]: https://help.apple.com/xcode/mac/current/#/dev154b28f09
 [rcodesign-api-key]: https://gregoryszorc.com/docs/apple-codesign/0.27.0/apple_codesign_getting_started.html#obtaining-an-app-store-connect-api-key
 
-#### Signing implementation details
+### Signing implementation details
 
 Although PyInstaller supports signing, it did not work at the time we tried it, so we use [rcodesign][] to do so.
 
@@ -71,3 +66,33 @@ Although PyInstaller supports signing, it did not work at the time we tried it, 
 For Gatekeeper to accept the app, the executable and all the dynamic libraries must be signed, as well as the .pkg archive itself. Signing the executable and the libraries is done by the `sign` step, whereas signing the .pkg archive is done by the `create_archive` step.
 
 [rcodesign]: https://gregoryszorc.com/docs/apple-codesign/
+
+## Windows specific information
+
+### Signing
+
+We use [DigiCert](https://www.digicert.com) to sign `ggshield` Windows binaries.
+
+#### Environment variables
+
+On Windows, `build-os-packages` expects a number of environment variables to be set:
+
+- `$WINDOWS_CERT_FINGERPRINT`: the thumbprint of the certificate.
+- `$SM_API_KEY`: DigiCert API token.
+- `$SM_HOST`: the host to use for DigiCert.
+- `$SM_CLIENT_CERT_FILE`: the path to the signing user authentication certificate.
+- `$SM_CLIENT_CERT_PASSWORD`: the password protecting the signing user authentication certificate.
+- `$PATH`: `$PATH` must contain the path to:
+  - the `signtool.exe` tool, from Microsoft
+  - the `smctl.exe` tool, provided by DigiCert. Its default installation path is `C:\Program Files\DigiCert\DigiCert Keylocker Tools`.
+
+#### Installing DigiCert tools
+
+Downloading and installing DigiCert tools can be done with `scripts/build-os-packages/install-keylocker-tools`.
+
+Note 1: `$SM_API_KEY` must be set to a valid API token: it is required to be able to download the tools.
+Note 2: `install-keylocker-tools` expects `$PATH` to already contain the installation path of `smctl.exe`.
+
+#### Building signed binaries
+
+Once all environment variables are set and DigiCert tools are installed, one can build signed Windows binaries using `build-os-packages --sign`.

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -20,15 +20,6 @@ DO_SIGN=0
 # - 1: generate it using `git describe`
 USE_GIT_VERSION=0
 
-MACOS_P12_FILE=${MACOS_P12_FILE:-}
-MACOS_P12_PASSWORD_FILE=${MACOS_P12_PASSWORD_FILE:-}
-
-# Path to a file used by rcodesign for notarizing.
-# Follow the instructions from
-# https://gregoryszorc.com/docs/apple-codesign/0.27.0/apple_codesign_getting_started.html#apple-codesign-app-store-connect-api-key
-# to generate one.
-MACOS_API_KEY_FILE=${MACOS_API_KEY_FILE:-}
-
 # Colors
 C_RED="\e[31;1m"
 C_GREEN="\e[32;1m"
@@ -45,6 +36,15 @@ info() {
 die() {
     printf "$C_RED%s$C_RESET\n" "$PROGNAME: [ERROR] $*" >&2
     exit 1
+}
+
+check_var() {
+    local name="$1"
+    set +u
+    if [ -z "${!name}" ] ; then
+        die "\$$name must be set"
+    fi
+    set -u
 }
 
 usage() {
@@ -113,10 +113,6 @@ init_system_vars() {
         EXE_EXT=""
         HUMAN_OS=macOS
         TARGET="$arch-apple-darwin"
-        if [ "$DO_SIGN" -eq 1 ] ; then
-            REQUIREMENTS="$REQUIREMENTS rcodesign"
-            DEFAULT_STEPS="$DEFAULT_STEPS notarize"
-        fi
         INSTALL_PREFIX=opt/gitguardian/ggshield-$VERSION
         ;;
     MINGW*|MSYS*)
@@ -129,6 +125,26 @@ init_system_vars() {
         ;;
     esac
     ARCHIVE_DIR_NAME=ggshield-$VERSION-$TARGET
+}
+
+load_os_specific_code() {
+    case "$HUMAN_OS" in
+    macOS)
+        . "$SCRIPT_DIR/macos-functions.bash"
+        ;;
+    *)
+        ;;
+    esac
+}
+
+add_os_specific_sign_requirements() {
+    case "$HUMAN_OS" in
+    macOS)
+        macos_add_sign_dependencies
+        ;;
+    *)
+        ;;
+    esac
 }
 
 step_req() {
@@ -208,39 +224,19 @@ step_copy_files() {
     esac
 }
 
-sign_file() {
-    if [ -z "$MACOS_P12_FILE" ] ; then
-        die "\$MACOS_P12_FILE must be set to sign"
-    fi
-    local file
-    file="$1"
-    info "- Signing $file"
-    rcodesign sign \
-        --p12-file "$MACOS_P12_FILE" \
-        --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
-        --code-signature-flags runtime \
-        --for-notarization \
-        "$file"
-}
-
-list_files_to_sign() {
-    local archive_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
-    echo "$archive_dir/$INSTALL_PREFIX/ggshield"
-    find "$archive_dir" -name '*.so' -o -name '*.dylib'
-}
-
 step_sign() {
-    if [ "$HUMAN_OS" != "macOS" ] ; then
-        info "Signing not supported on $HUMAN_OS, skipping step"
-        return
-    fi
     if [ "$DO_SIGN" -eq 0 ] ; then
         info "Skipping signing step"
         return
     fi
-    list_files_to_sign | while read path ; do
-        sign_file "$path"
-    done
+    case "$HUMAN_OS" in
+    macOS)
+        macos_sign
+        ;;
+    *)
+        info "Signing not supported on $HUMAN_OS, skipping step"
+        ;;
+    esac
 }
 
 step_test() {
@@ -289,7 +285,7 @@ step_create_archive() {
         popd
 
         if [ "$DO_SIGN" -eq 1 ] ; then
-            sign_file "$archive_path"
+            macos_sign_file "$archive_path"
         fi
         ;;
     Windows)
@@ -300,17 +296,6 @@ step_create_archive() {
         ;;
     esac
     info "Archive created in $archive_path"
-}
-
-step_notarize() {
-    if [ "$DO_SIGN" -eq 0 ] ; then
-        info "Skipping notarize step"
-    fi
-    info "Notarizing"
-    rcodesign notary-submit \
-        --api-key-file "$MACOS_API_KEY_FILE" \
-        --staple \
-        "$PACKAGES_DIR/$ARCHIVE_DIR_NAME.pkg"
 }
 
 steps=""
@@ -338,6 +323,7 @@ done
 cd "$ROOT_DIR"
 read_version
 init_system_vars
+load_os_specific_code
 
 if [ -z "$steps" ] ; then
     steps=$DEFAULT_STEPS

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -132,6 +132,9 @@ load_os_specific_code() {
     macOS)
         . "$SCRIPT_DIR/macos-functions.bash"
         ;;
+    Windows)
+        . "$SCRIPT_DIR/windows-functions.bash"
+        ;;
     *)
         ;;
     esac
@@ -141,6 +144,9 @@ add_os_specific_sign_requirements() {
     case "$HUMAN_OS" in
     macOS)
         macos_add_sign_dependencies
+        ;;
+    Windows)
+        windows_add_sign_dependencies
         ;;
     *)
         ;;
@@ -233,6 +239,9 @@ step_sign() {
     macOS)
         macos_sign
         ;;
+    Windows)
+        windows_sign
+        ;;
     *)
         info "Signing not supported on $HUMAN_OS, skipping step"
         ;;
@@ -324,6 +333,9 @@ cd "$ROOT_DIR"
 read_version
 init_system_vars
 load_os_specific_code
+if [ "$DO_SIGN" -eq 1 ] ; then
+    add_os_specific_sign_requirements
+fi
 
 if [ -z "$steps" ] ; then
     steps=$DEFAULT_STEPS

--- a/scripts/build-os-packages/install-keylockertools
+++ b/scripts/build-os-packages/install-keylockertools
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOWNLOAD_URL=https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download
+KEYLOCKER_TOOLS_MSI_PATH=Keylockertools-windows-x64.msi
+
+if command -v smctl.exe > /dev/null ; then
+    echo "Skipping installation of Keylockertools, smctl is already there"
+else
+    curl \
+        -H "x-api-key:$SM_API_KEY" \
+        -o "$KEYLOCKER_TOOLS_MSI_PATH" \
+        --continue-at - \
+        "$DOWNLOAD_URL"
+
+    # double '/' so that Git Bash does not turn them into paths
+    msiexec //passive //i "$KEYLOCKER_TOOLS_MSI_PATH"
+fi
+
+if ! command -v smctl.exe > /dev/null ; then
+    echo "smctl.exe not found after installation. Make sure its installation dir is in \$PATH"
+    exit 1
+fi
+
+set -x # Log commands before running them
+smksp_registrar list
+smctl keypair ls
+certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+
+# Synchronize certificates with Windows certificate store
+smctl windows certsync
+
+smctl healthcheck --tools

--- a/scripts/build-os-packages/macos-functions.bash
+++ b/scripts/build-os-packages/macos-functions.bash
@@ -1,0 +1,50 @@
+MACOS_P12_FILE=${MACOS_P12_FILE:-}
+MACOS_P12_PASSWORD_FILE=${MACOS_P12_PASSWORD_FILE:-}
+
+# Path to a file used by rcodesign for notarizing.
+# Follow the instructions from
+# https://gregoryszorc.com/docs/apple-codesign/0.27.0/apple_codesign_getting_started.html#apple-codesign-app-store-connect-api-key
+# to generate one.
+MACOS_API_KEY_FILE=${MACOS_API_KEY_FILE:-}
+
+macos_add_sign_dependencies() {
+    REQUIREMENTS="$REQUIREMENTS rcodesign"
+    DEFAULT_STEPS="$DEFAULT_STEPS notarize"
+}
+
+macos_sign() {
+    macos_list_files_to_sign | while read path ; do
+        macos_sign_file "$path"
+    done
+}
+
+macos_sign_file() {
+    check_var MACOS_P12_FILE
+
+    local file
+    file="$1"
+    info "- Signing $file"
+    rcodesign sign \
+        --p12-file "$MACOS_P12_FILE" \
+        --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
+        --code-signature-flags runtime \
+        --for-notarization \
+        "$file"
+}
+
+macos_list_files_to_sign() {
+    local archive_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
+    echo "$archive_dir/$INSTALL_PREFIX/ggshield"
+    find "$archive_dir" -name '*.so' -o -name '*.dylib'
+}
+
+step_notarize() {
+    if [ "$DO_SIGN" -eq 0 ] ; then
+        info "Skipping notarize step"
+    fi
+    info "Notarizing"
+    rcodesign notary-submit \
+        --api-key-file "$MACOS_API_KEY_FILE" \
+        --staple \
+        "$PACKAGES_DIR/$ARCHIVE_DIR_NAME.pkg"
+}

--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -1,0 +1,28 @@
+WINDOWS_CERT_FINGERPRINT=${WINDOWS_CERT_FINGERPRINT:-}
+
+windows_add_sign_dependencies() {
+    REQUIREMENTS="$REQUIREMENTS smctl signtool"
+}
+
+windows_sign() {
+    check_var WINDOWS_CERT_FINGERPRINT
+
+    # All the SM_* vars are required by smctl
+    check_var SM_API_KEY
+    check_var SM_HOST
+    check_var SM_CLIENT_CERT_FILE
+    check_var SM_CLIENT_CERT_PASSWORD
+
+    if [ ! -f "$SM_CLIENT_CERT_FILE" ] ; then
+        die "$SM_CLIENT_CERT_FILE does not exist"
+    fi
+
+    local archive_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
+    smctl sign \
+        --verbose \
+        --exit-non-zero-on-fail \
+        --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
+        --tool signtool \
+        --input "$archive_dir/$INSTALL_PREFIX/ggshield.exe"
+}
+


### PR DESCRIPTION
## Context

To make it easier to deploy GGShield on Windows, this PR makes the release process produce a signed standalone Windows binary, similar to the macOS one.

## What has been done

First commit refactors `scripts/build-os-packages/build-os-packages` to make room for Windows-specific signing code.

Second commit implements Windows signing code.

Third commit adds the signed binaries to the release assets.

## Validation

- Trigger the [Build release assets](https://github.com/GitGuardian/ggshield/actions/workflows/build_release_assets.yml) CI workflow on the `agateau/sign-windows-binaries` branch. Tick the "Release mode" check box.
- From a Windows machine:
    - Download the Windows asset.
    - Unpack it.
    - Double-click on `ggshield.exe`: no scary "Windows has prevented you from opening this file" popup should appear.
    - Right-click on `ggshield.exe`, select Properties. There should be a "Digital signatures" tabs like this:

![image](https://github.com/GitGuardian/ggshield/assets/91945295/e808903d-7984-4b15-b81c-81b7c5a9141e)

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
