### PR TITLE
Unblock push of the unstable Docker images

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4c275ab5e30b5d81f8648a63f5f235967f66832bd7955e4fe7d749e02990aff7"
+            "sha256": "eee3fdd1152c4453c9df0b39525a676809b86c988b6f153419ee62c845a7966f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -261,11 +261,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
         },
         "platformdirs": {
             "hashes": [
@@ -371,11 +371,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
         },
         "rich": {
             "hashes": [
@@ -387,11 +387,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a",
-                "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.12.1"
+            "version": "==4.12.2"
         },
         "typing-inspect": {
             "hashes": [
@@ -402,11 +402,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         }
     },
     "develop": {
@@ -650,20 +650,20 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f",
-                "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"
+                "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8",
+                "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.14.0"
+            "version": "==3.15.1"
         },
         "flake8": {
             "hashes": [
-                "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132",
-                "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"
+                "sha256:2e416edcc62471a64cea09353f4e7bdba32aeb079b6e360554c659a122b1bc6a",
+                "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.8.1'",
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "flake8-isort": {
             "hashes": [
@@ -683,82 +683,110 @@
         },
         "grimp": {
             "hashes": [
-                "sha256:02f58a0afa5fa06f6f98bad28a5e1a33c9e32b2c8281df7069f932dc56719335",
-                "sha256:038779ebb05509de9c418555e5d7b8857f90d7a095baf0f4e0ec261fcfae22ba",
-                "sha256:05a2f1f3a2e69fae9469c89f48c516cab862403256c5441b524784c74ac43f0d",
-                "sha256:05feca9c9f20f0b227a747a3300c49628cafc852e7f63f476f6adcfc2a81421a",
-                "sha256:0690fdde12d5224b7787e3aea14cb9579569e9cb503ce4334eb19fb5e224901a",
-                "sha256:085119de62cf07ece8e80cb4a55fa0883d3cefa35f05d7025f0c98abece51119",
-                "sha256:08d7b6f63b3ad2e18956508500fbff840ec0fa0e789b629bec29966df3686f2f",
-                "sha256:090b545afc14d090d5f15570cde2e5ce46700787f364130afcc12d4f2d8c8c26",
-                "sha256:0e24b4a9cbe4be686508e103d4520cd3af0200c7743f1ffafcfc1fd2d130efbf",
-                "sha256:132e0714bbd0fa2ddd8a66483ca0cdf3b2a1a9a01ad0b7b6da470fb4692b1a87",
-                "sha256:15013ae12d2b5659d5f55f98941acc8da0172151b21ef29fa6e4f355266594b9",
-                "sha256:192e00612e0ff4d6262f1080f71459997a1ab2efac4343e0630415e3e320d688",
-                "sha256:1bb65430aa58f81bece95927bb87c092a34f5c8295fe8dc81c312764a6a709f1",
-                "sha256:217320c5851df9b761d6195884e28f0f82b562237776b092b0e216ff5c57f5d1",
-                "sha256:232af9c0a9bf14b3588df5f4b857e38b77cd7e829ec664b191e057e113e1b695",
-                "sha256:284bd64133f562e617645ec35355365d56303fd7fa607ebdd144c04cbf335b02",
-                "sha256:2c746d6894cd6ed836377977343add3b591b17529d06b8e6904ce264e40fd395",
-                "sha256:2e173ec37da134f48c48d85f6b57f72a22a5abdba69bfae2516f0c5aea5aba88",
-                "sha256:3419aace4bb2cfb2e08c03951c9412c9097a5dcc8bdbc65dbdf88d673cda898b",
-                "sha256:34833ac76c5f23e523aab9701d2b6c051d1fdef330b53a569cb316ed6cac8c93",
-                "sha256:36404520c1b02b6f5a12f4da738f64a9c1559fc026e9a68a64eff408b1642158",
-                "sha256:37fe23a595f26ea91022a9166b8b7353f788686d650705d30ead2c8ef88da17d",
-                "sha256:3855540cbb952a74a70786f32774cfbaccf45fa3b268a7ef7bf969bd6b80de95",
-                "sha256:414f0d2c772df180a287ddf8897c28e6bf71b597de6363fc3e5ff2456a168a5a",
-                "sha256:436931ba7d4644b5b55f84d92c12d18365d3ec94f8e4b4ee874d12f5b961c30c",
-                "sha256:474be3c8f1b5b79611421b75f035ccfe176355e139624503b19510147edf9566",
-                "sha256:4b8fb16982fe646a682b8bf7cdd4d6db1812c1e54583c7821d0e7d197895c2bd",
-                "sha256:4bb53fd3994e9bb2ba57f68eeb1c8dc25713ee46908b590e323a163c65dd2046",
-                "sha256:4e72e0c8f56bd54e8e61bd7ed34bf62ca0821aa32536564241334be7704da739",
-                "sha256:5054e0f5d8b19970881f060c879e5fd69045b9f45c0c51afd0314268db21c02f",
-                "sha256:523c33702a0544d9ebd000217b375534d9291a40fefc7d8da7317f2f74041fd9",
-                "sha256:55332ec2cca39d7604b9a1f08c63eabaf965008b8bed0fdc80d684383cb5e194",
-                "sha256:5ba0d863b10c6b612486e2d1b97539894c7f3f71fd67ef126b2c77eb9c027d5c",
-                "sha256:5ec7e7475a3616b1bec14d852784fa2e3829a4331fd2309a055f1e75ba5a4f50",
-                "sha256:6107b1d242ffb4e577527e7a66583d68c119944694139790f926566857dddc18",
-                "sha256:6f17a817f9410e10bbcccb021dd160c08f8ee2b3d8e546f358603bba0e16a4f4",
-                "sha256:72a3daf117d997712938e57763a95ae6e5d703b001ca46908b44884b220005b1",
-                "sha256:7342d444caa2f0e49efb6f30d550ab77acffa6ec53efaafff9ea6023578fa720",
-                "sha256:7462e673623e905c358275900550a7b605b0a89bfbc671602dc150bea0afd4bd",
-                "sha256:7c0d2793022efa837f3cad413dd70e11496e3511570c5bb78c0e667813196e75",
-                "sha256:7c19629f6164363b20690ff09480051d85a6ed99501e7208c2ac8a1b85cee75d",
-                "sha256:7ea0c58cceab6c75452a6ab9617698b3ece2eb20938d91419ec3ed35d7ab3be5",
-                "sha256:83acb48ed49c123111cb098cae39625bfbf454524f6f89182cc0a3b6860a63cd",
-                "sha256:8493e03a968507ac7212c0571ef2ab5094f950370a37db2c98b3a73b965b6db9",
-                "sha256:8ad66be05a325c80655861bcbe6b86e50a890ca17ebb00b9c8d23d38f89485dd",
-                "sha256:8eb1fd52f6251f90b246d43038a421fde21cc3d4b16c99646753086a9749ce7f",
-                "sha256:9021541c5155ae454da3bfa639e8ca01965d6adbaf6f46808a0d6782a6dc072d",
-                "sha256:a4b7edeb5745ae47a20989fd488bfee49970429898cb3952b7c284ec136f3f00",
-                "sha256:ab50b3684210032aee6665c924b1b49ef7a044cc64761fb1173d967b9995fb68",
-                "sha256:adf032c8f5014da61aba7689e05831843b4e8c5209c2792a5fb8acd7a01ece5d",
-                "sha256:b0726e943fccaa60f823675a236e413cafb4526cafadec334903b1b217c317ed",
-                "sha256:b092dc245981a672570ae7c772e99f81f10efc11bbe6d3bca3e8ed1ac83c586d",
-                "sha256:b34c5c891669b5691894649554c91f118925132d892a660847c7b4f8b8cfc023",
-                "sha256:b6502ca836895eb56f1363d808d00c7571ccaca170dca9bf8e92dc44ca00aa5c",
-                "sha256:b8f18e4c913019bcfcaf3396e64cdfc76890ec942b420ee3c025094f16560288",
-                "sha256:bf10209fc39edfa95a3409a4a4921a9370414e8e6b38672494e7e01f437a2b1f",
-                "sha256:c4a86f86b7e0f0d81da587f01f30fa04a9f087de76e40c1fe790cb5525b2e2de",
-                "sha256:c4cf735df220895e8a10d3e61e4d9a5d5a483464a27086f677798936dd3dcc73",
-                "sha256:c657c1cbabe9534cfbf6e0d9c7b0743f7b656a30763243a336366a59c06c4f48",
-                "sha256:ca3828d1d151eb960fa7106cacf89ac8f41f316a954f64023610efa2c891e349",
-                "sha256:cad714ca909eefc9fcc189c3fdefbc012cae7e4d4d4bb2f9496e98da87a27136",
-                "sha256:d4e88f311db803773a98799bf90046fae88790dbac954763e4907e0e88fb7cbe",
-                "sha256:d999fa016aff0cdbddc3375538cd7b8acf76112d5760ef0b21a1be6866278628",
-                "sha256:dba38c70c58f5b9dd9f72ffd996858cf4f1e4862d32d76efe51a42975cd130bd",
-                "sha256:e0bc593f9eda9ec056bf6d9309542e44215440f8512586b3ba4267d41d5833e7",
-                "sha256:e133d5adc1093fe66ef58b8cdc4a96b7928678e1624c1cf47a33231e1953df8d",
-                "sha256:e537464745084bc4e2c1786dd3848b895a66a62e7205532c7c28224e7550496f",
-                "sha256:eacf611157e61c4140382a1893479664a33b158b08f605f1ea63cabe996b7cf0",
-                "sha256:f39eadd5b74119355a871f98b904e7e0b25a5eba06fda315c097962acef61841",
-                "sha256:f4c80ae001b4bbe5b50f2c6a532553ef099e7b62bc08b3a7df4446346ad62eaf",
-                "sha256:f9887a8ddbd3e3ccb2d21fec98f4ab1b311baff25013d21486abb9f63b1d0bae",
-                "sha256:fd1a7d82a3d4529561d3fb152797d66b0e63823c8b875662fc7c7d7231752c42",
-                "sha256:ff9e87f38c6a31d7aa16f8cc93efe8a5ba3195ea8f9260eceed2b56395965276"
+                "sha256:0185f7a676403ff8eb0cd772b1a7d30a79b3fd490718f7b26037a40c608dc1ba",
+                "sha256:048b138a744e5f0c97a53427b7f6ccd02b6dfe683b040b3dbfdf558a3760ebd7",
+                "sha256:049fe46ad180bf35437469905345c8281ffb126c4dfc7cd6a126cd26d9a2bb58",
+                "sha256:086e879dbb482aa6c7f55b4608bf635cee4f01bf0a8774308410531e6f22d6c7",
+                "sha256:099617459d81e21a455303fe4a0d696956c2b0bbb8690ebd806647c1f423aaeb",
+                "sha256:0fa8541f51b1aa75ca53589a609c8a0e5d1567abda12d688421f5ab371529ce7",
+                "sha256:14235c6bf375f2858979418cc78cd5b8273d8207bb264fcb1a232410f01ba1b1",
+                "sha256:20dddc49109058d5635038f9b69d75b69fd740febdb26018cf6f2b6026da6cc7",
+                "sha256:21a335e3dcb74bfcc928ef6eec08c8bed836b492ac81dd08ca1199bb55659097",
+                "sha256:23ddd88c101c464e9977e8fbdc3e8b068a2e90f47e308c4eaf6feac5ce873061",
+                "sha256:282b0b6d461af9194a86c6c4950a2efa5a2205efbfa22d3f685b326187dde5b4",
+                "sha256:28b8e77d88c2fa101289dada95c10906ebabdc8f8d75d529df95686d8ac39280",
+                "sha256:28f18fae9e45da0126d396e77740a0b22b6cc05147c8e2ed01a3028952917399",
+                "sha256:2b8acddab24f9f0cc7a95f0e775a39d57bd0938e5ac9a9b5c94c01a3b6db2067",
+                "sha256:2d35114966b1ea10104fb7cfc1a7df9729dc4d7f1e4b7ac4f129cdbea0c3d14f",
+                "sha256:2e9745072cc7ffd806948685c9b02904dbf7094596747642f202b9f2935ad520",
+                "sha256:34842b3dca54d5cfac22380d4c2fe02b8880dc41fb9300d52a8c24d1185c178a",
+                "sha256:354e5201a190fae37423d4d8a1b3ce10fdeb0d75c6de0dfda2bc9d8c49c832ff",
+                "sha256:36ee0c707b60b359aace1f0c1f519be3b7e75d2f3bbdd7283e9026aa3cb6562c",
+                "sha256:391d76cd15de278cda693b60446641774266c9f93e1688c92b46f76909d3ee79",
+                "sha256:3b474acb40ff17b0a740c510ab63a49ababe62316403135dacfa0a42d7be5e2b",
+                "sha256:3d6dfd86413a79c936508bb75f2e59e5ee0b076d5dfc08b60a827edfe5889ada",
+                "sha256:415f6192d67379852291e04ce151dc91f49cc69dc14740bc3e2737707718ed4b",
+                "sha256:4219adfdf212e77d31fd43bde018200b42a54be95fddfcf13388bddb91ca15be",
+                "sha256:45c783477e8d82e3e40321e9c77276bb29b2d65fe09b6c7696b6179ffd291021",
+                "sha256:47080077af734fa9409c092317a99401e0eae2dc6f3ae97515f63379fd847f63",
+                "sha256:47bb45ec3f697eb0b3e3d28750ef27691e618068a1f1b6f00f4a6ded182e5713",
+                "sha256:49a8cebfeff2e1fbfa5e14b0e9f5d5f8db6c1ad6aed8a4524cf54b78657e6bc1",
+                "sha256:4fdd9a30cc60c94e27f29207f14ec1268a9b5198d739eef51c87d1679dde2e7e",
+                "sha256:52dea0611dbad57e1b58a663066a6218a0846e4b6d43e7325e97811803715a6b",
+                "sha256:590e85a4bfe58fd4de0384eaccdf545ef7145cbbcaf4f8c52a134100e94db2b9",
+                "sha256:5a395f959ec7936f015e5c834d551ea5b9e1b8217d2e9001ddbb80e46dfff822",
+                "sha256:620f4a68a6fe8799b9378f6399e1603a25c35d5e291a6ee01b6f20cc868d8680",
+                "sha256:646679d42f6c7ac0cd341870e4e420556c0e64d7c52a9434a82c4e764bf0929d",
+                "sha256:691e006fc28e86529309ea630f4854ce39fab013f56029644f8eb6b1c87e88a6",
+                "sha256:69fea066125d5339ce025136e1081facf68015d46320020ede7d4ac8b7284df9",
+                "sha256:6cf059072c557ebe07339e6f0fd4d47be57784c8c85013456177fbb7cf366b13",
+                "sha256:6e01ddd07d054fa827ad9901d84a490ded6edd203ad07bbb77e1c9e82617e4c8",
+                "sha256:6e060c76a40ac8510b109443a38de90308c8ef41d9b081b3410d72acbbaaea77",
+                "sha256:6e6a554929ea71369d8ebefb1610593d839abd5a4a92dcedda374969d7c9df86",
+                "sha256:6f3cdc853bad614198a3e34214b8db5043957bfbb140d8521e6e76f6ae7954ca",
+                "sha256:70d9f9c5fe7b186c2bd3f2229badd1b970c5d0c62a6a0e02725157d31143daf5",
+                "sha256:7135308594fbeba645205ee7077c89648e9f6dffac5ad4e3eadda4654cb74d38",
+                "sha256:7197607ff9f06f34ebbf61b494dace076efc6057f720c5c5e6bb309149d495c3",
+                "sha256:72da9eefbd21cf52eecfa9d3c3bbf75caf2d2545bf5cc27c09b5b0949f1ad826",
+                "sha256:785a4b08ff077f1799aa4bfe5b7e7e8f3a55371fb848c00ed99ff300142768a0",
+                "sha256:7a33be44cd833d7c108fd2ee856cae33164870a4a176ec995781fd8bdd63ec7d",
+                "sha256:7bbe0a996c323cb2f89f097a0f30d478964f001d84a67b948e9c460abd54fac8",
+                "sha256:7ca330c047e520d9b86b9436005fe126e8945f4e5d6471dd14f12eca0f41350d",
+                "sha256:7f7ea5b91e232b5cf298e0fc0158d79feedb158cefb84da608c6dc3a0febc6f6",
+                "sha256:805ab4bc78d9942aff583151d212d2f1fb1cd009491864b627690f6f4be3d86a",
+                "sha256:8248cc63e3c5fb7aef3cec71b4132cc4668f40b8b76c51b275c95a16e4c1b7d1",
+                "sha256:883f9048e9523e381721c83df69b68a51fdcbeed37f8a3f89be47f594ec906b3",
+                "sha256:8cff6a9b1c8f44ba9f42862be8c484be74fc748b954e643aa6ab93a5cf2d0b0e",
+                "sha256:8d4b144190e9774cdf0b20c2a5673e0fc3f5d104f813d21c7ee327249d860dd4",
+                "sha256:8ef3293a0f7f645c123189b6f017dcef98a7471608d9d3150f74be953f13b6b9",
+                "sha256:8f983b67471ff7d64d0a2ae9580768b863cb71dce3fc27f428f72bac8519ea97",
+                "sha256:8fd6b12baca6d673a1f13efb60090c6b69844e5d8bab932f029ad1cd26c43129",
+                "sha256:90f907788aad83e444c4e3809a8a68c6aa1035033f01994acc7d3c4e8371bddd",
+                "sha256:916586e1dc087ec446e77f5f63aefabeaaa62cab55f3cde064bd5685acc8c118",
+                "sha256:94129847bebc48f50fac771179da555af0c4bda71868171373afb0d343dce766",
+                "sha256:97ec6e0111d921815e24bc10d0cca2e4e252ccf64b66a907310e402bbd7f3c85",
+                "sha256:9a28ec4df3faab3acfdebe0c354889a4b77da40840bfe5f1d422e1efc3d4cb18",
+                "sha256:9b69bc145b095542258f1a8c934084557356c54efc6f11c66ca1b476c308ea26",
+                "sha256:9b759491c147d8a935d43bd1657922b41a798454125888504fa108c0499fa666",
+                "sha256:9bd67c31f914d3040481772eaa31a6da9adf7867429681258d866de9ee385063",
+                "sha256:9f84072c59738da90cf74e3ff638727e02210ba5b5e0b584450726f38ee86ef9",
+                "sha256:a65467d222ba3d8e32895f9a0abe3473c1936138abf008916554d6913477d210",
+                "sha256:aa647e85fdda49e693487b44bc8360b6c9431cbc7cd3aaff007c3d8261f3d42c",
+                "sha256:ac43fc1b6862991951a8657a22b693f40b4a3b9be7a9848d6b752234cdb9b2e0",
+                "sha256:aec933d3e156f7e0091db8ce9fc7d05c8bfbec05efe2c469042ed9587738ba28",
+                "sha256:b1ac4b644ab6ec10f742e5d21764a212be63f2edd2f55c1418486a670cbc756c",
+                "sha256:b4071a27074d7bc2ee23a5e5d9760be1ea25ea57519e454718da6f83f4038397",
+                "sha256:b50f373836ea96aaef2271edb361f326f06d167fd82a603da1f569a6ddc0986e",
+                "sha256:bb6a422547602d1045c621baaa58e12752bc365d8da74edce13dd93cc354a298",
+                "sha256:bcdf272f2284c27992cfd3f74757cc7398759fe193e4418e147f9c7f77d12c5b",
+                "sha256:bdfd90286ee32a3106a13c2ed2208c3f0a26c1c0477654c6daa7213c4bcea363",
+                "sha256:c56225e015a707737b55830f21730034139668d4164709d682e61be359be5e43",
+                "sha256:c79d3081a1f62ee7b16f74ef074b933688ae170c9fe7f46f42c78726147529d3",
+                "sha256:c7feb64a196c4904d5d388a231382dfe9d248665cdc82169a6f62b1ecd918940",
+                "sha256:c918e8cc3898aea5b1fd8d2a12aa23dc9021565ab0a543788f0c75292b86ad5d",
+                "sha256:caef602bfda3fcb3e9e344605e742412b1027c6f5e89e40c57b2847ac847973c",
+                "sha256:cb1b9ffe23185d00ccace2bc56c1b73a5a52fb724d1f3dfba4ed66a8997bff92",
+                "sha256:cd7fae24434962b780d179967c31dafd9417e8660bb56c6286b3e4b7cbe97191",
+                "sha256:cf4f4bfea5c384349e59b4eb31e09d92853bdc1fb097e3b3707da2a05ac469cb",
+                "sha256:d655cf9bb9be978ed89236472f978f84a1dddd6119dfcef02b614fb7a1760fcf",
+                "sha256:d95571888d6397810d10cba18c79a8ec879a6541eebe19ae79bfe529e9098462",
+                "sha256:d9b8329cf523a95bb458d5a0099983732669144f0bd4757d8260a3e8ed9fdb49",
+                "sha256:df94ec1283e653a97890c390847e5077195b235f3f1b699bab0f8c22b8b45877",
+                "sha256:e1c845dc492629510edbd473a19f7559d21c5bd39e44dfdb51c03012cad1f21c",
+                "sha256:e229a06a24696f117b7a3a1c39bdb589b76d087b4145eba3eb38a83ff58a153e",
+                "sha256:e2eb2fe0876b116dfc9b7ab59bacb8d27b440fb5b098e24002d9f19e33d5915a",
+                "sha256:ec0119d3925901d04a63bc28ddc8fdfa0c40eecb7d8cbd4ffbf1e7e74336fde9",
+                "sha256:ed0e319e2b3f613f7e650364a6f583c086a6263c8f99c32f7711f69c9c101198",
+                "sha256:ef507c9e09fb70dc3c92c41a84f33d66c47cfdb99b6851195b82eb857adedab3",
+                "sha256:efd825f5133d02b0f43bc631b4a3d647547fc8beea1ac3e67e0b26d73cc2fe14",
+                "sha256:f512c0062af1fc79d2b49f2e13eb91878f4ea072137bcf711eef2c4c9480a9e2",
+                "sha256:f5da111cf6c7ac34a8f525d42042c3e3d1c57ed2bb25a0378945cef471f6c00c",
+                "sha256:f764c8d284bcca2b2a16a659e5203bcfe6ad8240b2da0aba519c744f319bd4d4",
+                "sha256:fd62a1eb7798ddd62a16ab9087802adec18bc0de85aa34c7cb1cef6ba16bbe54",
+                "sha256:ff88f8797d2ae378fcef28f3771b6bf34afda2900436cd7d8c2764f9887a55a7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.2"
+            "version": "==3.3"
         },
         "identify": {
             "hashes": [
@@ -1030,11 +1058,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
         },
         "pathspec": {
             "hashes": [
@@ -1071,11 +1099,11 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f",
-                "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"
+                "sha256:442f950141b4f43df752dd303511ffded3a04c2b6fb7f65980574f0c31e6e79c",
+                "sha256:949a39f6b86c3e1515ba1787c2022131d165a8ad271b11370a8819aa070269e4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.1"
+            "version": "==2.12.0"
         },
         "pyfakefs": {
             "hashes": [
@@ -1096,12 +1124,12 @@
         },
         "pyright": {
             "hashes": [
-                "sha256:1aeed72d5563e97461cb9d17847bfa918f7ec0cf79912bb3d2432fbe014daa23",
-                "sha256:95fa963337e2cfd4900601197d0f866d8c51732dea6c0bb12f962f92a79c77e3"
+                "sha256:89de6502ae02f1552d0c4df4b46867887a419849f379db617695ef9308cf01eb",
+                "sha256:b1e5522ceb246ee6bc293a43d6d0162719d6467c1f1e9b81cee741aa11cdacbd"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==1.1.313"
+            "version": "==1.1.367"
         },
         "pytest": {
             "hashes": [
@@ -1205,11 +1233,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
         },
         "rpds-py": {
             "hashes": [
@@ -1377,19 +1405,19 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a",
-                "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==4.12.1"
+            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "vcrpy": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ install_requires =
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1
-    requests>=2.31.0,<2.32.0
-    urllib3>=2.2.1,<2.3.0
+    requests>=2.32.0,<2.33.0
+    urllib3>=2.2.2,<2.3.0
     rich>=12.5.1,<12.6.0
 include_package_data = True
 


### PR DESCRIPTION
## Context

The version of requests and urllib3 we depend on contained security issues. Those issues [were spotted](https://github.com/GitGuardian/ggshield/actions/runs/9566657039/job/26372468817) by `ggshield sca scan` when running on main, preventing the push of the unstable Docker images.

## What has been done

Update dependencies.

## Validation

- CI still pass.
- Cross fingers that once this is merged in main, it triggers the push of the images.
