### PR TITLE
Remove urllib3<2 hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipenv==2023.12.1
           pipenv install --system --dev
-          # Hack: workaround urllib3 still being installed on windows-2022 builder
-          pip install --force-reinstall 'urllib3<2'
       - name: Install Windows dev dependencies
         if: matrix.os == 'windows-2022'
         run: |


### PR DESCRIPTION
Our CI included a workaround for a weird Windows-only failure with urllib3 and vcrpy. It seems it no longer happens so we can remove it.