### PR TITLE
fix(docker): add docker to the image so ggshield secret scan docker works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Keep image in sync with scripts/update-pipfile-lock/Dockerfile
 FROM python:3.10-slim as build
 
-LABEL maintainer="GitGuardian SRE Team <support@gitguardian.com>"
+LABEL maintainer="GitGuardian <support@gitguardian.com>"
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
@@ -15,9 +15,10 @@ WORKDIR /app
 RUN \
     apt-get update \
     && apt-get dist-upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends git openssh-client \
+    && apt-get install -y --no-install-recommends git openssh-client ca-certificates curl gnupg  \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*\
+    && curl -fsSL https://get.docker.com | sh
 
 RUN pip3 install pipenv==2023.12.1
 

--- a/changelog.d/20240628_101407_fnareoh_add_docker_to_docker_image.md
+++ b/changelog.d/20240628_101407_fnareoh_add_docker_to_docker_image.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The docker image now has docker installed, so `ggshield secret scan docker` can work properly.


### PR DESCRIPTION
## Context

Addresses #924, thanks a lot @cdupuis for raising the issue and providing a fix !

## What has been done

This MR adds docker to the image so the command `ggshield secret scan docker alpine` can download the image and works out of the box.

## Validation

 `ggshield secret scan docker alpine` works on the new image.

