### PR TITLE
doc(sca): fix name of the command in action documentation

### DIFF
--- a/actions/sca/action.yml
+++ b/actions/sca/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: |
       Arguments to pass to `ggshield sca scan ci`.
 
-      [`ggshield iac sca ci` reference](https://docs.gitguardian.com/ggshield-docs/reference/sca/scan/ci).
+      [`ggshield sca scan ci` reference](https://docs.gitguardian.com/ggshield-docs/reference/sca/scan/ci).
     required: false
 branding:
   icon: 'shield'


### PR DESCRIPTION
## What has been done

- Change a typo made when creating the action from the IaC one, the wrong word was modified
## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
