### PR TITLE
Add malicious severity option for SCA scans

### DIFF
--- a/actions-unstable/sca/action.yml
+++ b/actions-unstable/sca/action.yml
@@ -11,7 +11,7 @@ inputs:
                                         are found. The env var GITGUARDIAN_EXIT_ZERO can also be used
                                         to set this option.
         --minimum-severity              [LOW|MEDIUM|HIGH|CRITICAL|MALICIOUS]
-                                        Minimum severity of the policies
+                                        Minimum severity of the vulnerabilities.
         --ignore-path, --ipa PATH       Do not scan the specified paths.
     required: false
 branding:

--- a/changelog.d/20240709_183759_florian.perucki_sca_malicious_minimum_severity.md
+++ b/changelog.d/20240709_183759_florian.perucki_sca_malicious_minimum_severity.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- `ggshield sca scan ci` and `ggshield sca scan all` now support the `MALICIOUS` value for `--minimum-severity`
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/iac/scan/iac_scan_common_options.py
+++ b/ggshield/cmd/iac/scan/iac_scan_common_options.py
@@ -20,7 +20,7 @@ from ggshield.cmd.utils.common_options import (
     exit_zero_option,
     ignore_path_option,
     json_option,
-    minimum_severity_option,
+    minimum_severity_option_iac,
     text_json_format_option,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
@@ -59,7 +59,7 @@ def add_iac_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
         exit_zero_option(cmd)
-        minimum_severity_option(cmd)
+        minimum_severity_option_iac(cmd)
         _ignore_policy_option(cmd)
         ignore_path_option(cmd)
         json_option(cmd)

--- a/ggshield/cmd/sca/scan/scan_common_options.py
+++ b/ggshield/cmd/sca/scan/scan_common_options.py
@@ -21,7 +21,7 @@ from ggshield.cmd.utils.common_options import (
     exit_zero_option,
     ignore_path_option,
     json_option,
-    minimum_severity_option,
+    minimum_severity_option_sca,
     text_json_format_option,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
@@ -49,7 +49,7 @@ def add_sca_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
         add_common_options()(cmd)
         exit_zero_option(cmd)
-        minimum_severity_option(cmd)
+        minimum_severity_option_sca(cmd)
         ignore_path_option(cmd)
         json_option(cmd)
         text_json_format_option(cmd)

--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -158,12 +158,21 @@ exit_zero_option = click.option(
 )
 
 
-minimum_severity_option = click.option(
+minimum_severity_option_iac = click.option(
     "--minimum-severity",
     "minimum_severity",
     type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL")),
     help="Minimum severity of the policies.",
 )
+
+
+minimum_severity_option_sca = click.option(
+    "--minimum-severity",
+    "minimum_severity",
+    type=click.Choice(("LOW", "MEDIUM", "HIGH", "CRITICAL", "MALICIOUS")),
+    help="Minimum severity of the vulnerabilities.",
+)
+
 
 ignore_path_option = click.option(
     "--ignore-path",


### PR DESCRIPTION
## Context

Malicious vulnerabilities support was introduced in #889 but the CLI severity argument for SCA was not updated.

## What has been done

Add support for `--minimum-severity MALICIOUS`, only for SCA scans

## Validation

- ` pipenv run ggshield sca scan ci -h` should display MALICIOUS in the possible values of `--minimum-severity`
- ` pipenv run ggshield sca scan all -h` should display MALICIOUS in the possible values of `--minimum-severity`
- ` pipenv run ggshield iac scan ci -h` should NOT display MALICIOUS in the possible values of `--minimum-severity`
- ` pipenv run ggshield iac scan all -h` should NOT display MALICIOUS in the possible values of `--minimum-severity`

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [X] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
