### PR TITLE
Reword error messages in honeytoken command

### DIFF
--- a/ggshield/cmd/honeytoken/create.py
+++ b/ggshield/cmd/honeytoken/create.py
@@ -80,7 +80,11 @@ def create_cmd(
     if not isinstance(response, (Detail, HoneytokenResponse)):
         raise UnexpectedError("Unexpected honeytoken response")
 
-    if isinstance(response, Detail) and response.status_code == 403:
+    if (
+        isinstance(response, Detail)
+        and response.status_code == 403
+        and "allowlist" not in response.detail
+    ):
         raise UnexpectedError(
             """ggshield does not have permissions to create honeytokens on your workspace. Make sure that:
 

--- a/ggshield/cmd/honeytoken/create_with_context.py
+++ b/ggshield/cmd/honeytoken/create_with_context.py
@@ -117,7 +117,11 @@ def create_with_context_cmd(
     if not isinstance(response, (Detail, HoneytokenWithContextResponse)):
         raise UnexpectedError("Unexpected honeytoken response")
 
-    if isinstance(response, Detail) and response.status_code == 403:
+    if (
+        isinstance(response, Detail)
+        and response.status_code == 403
+        and "allowlist" not in response.detail
+    ):
         raise UnexpectedError(
             """ggshield does not have permissions to create honeytokens on your workspace. Make sure that:
 


### PR DESCRIPTION
## Context

The message from 403 errors in honeytoken commands is not used and replaced by a static one in order to explain how to access to the honeytoken feature, but if the error come from a rejection by IP allow list rules, this message is pointless.

## What has been done

If the error message from API is about the allowlist, then it is displayed instead of the static error message.

