### PR TITLE
chore(ci): lock pyfakefs <5.6.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,6 @@ vcrpy = ">=5.1.0"
 # support Python 3.8 anymore.
 voluptuous = "<0.15.0"
 
-pyfakefs = ">=5.2.0"
+pyfakefs = ">=5.2.0, < 5.6.0" # Pin because 5.6.0 currently (2024-07-15) does not work on Windows
 scriv = { version = "*", extras = ["toml"] }
 pyright = "==1.1.367"


### PR DESCRIPTION
## Context

The CI unit test on windows are[ currently broken](https://github.com/GitGuardian/ggshield/actions/runs/9874525991/job/27463370150) see also current MR like #931, I suspect it is coming from  pyfakefs 5.6.0, so I am constraining for now.