### PR TITLE
Add a test secret as environment variable to hide it from the dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ GITGUARDIAN_INSTANCE=https://dashboard.gitguardian.com/
 # it unless the default value does not work for you
 #TEST_UNKNOWN_SECRET=
 # Set this to a single match secret unknown by your dashboard with a valid status
-# This is required to run functional test on an instance with a ggshield repo integrated
+# This is required to run functional tests on an account monitoring ggshield repository,
+# where the token in conftest.py has been ignored
 TEST_GG_VALID_TOKEN=
 TEST_GG_VALID_TOKEN_IGNORE_SHA=

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ GITGUARDIAN_INSTANCE=https://dashboard.gitguardian.com/
 # TEST_KNOWN_SECRET, this one has a default value, so you do not have to set
 # it unless the default value does not work for you
 #TEST_UNKNOWN_SECRET=
+# Set this to a single match secret unknown by your dashboard with a valid status
+# This is required to run functional test on an instance with a ggshield repo integrated
+TEST_GG_VALID_TOKEN=
+TEST_GG_VALID_TOKEN_IGNORE_SHA=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,11 @@ ROOT_DIR = Path(__file__).parent.parent
 JSON_SCHEMAS_DIR = ROOT_DIR / "doc/schemas"
 
 # This is a test token, it is always reported as a valid secret
-GG_VALID_TOKEN = "ggtt-v-12345azert"  # ggignore
-GG_VALID_TOKEN_IGNORE_SHA = (
-    "56c126cef75e3d17c3de32dac60bab688ecc384a054c2c85b688c1dd7ac4eefd"
+# Use your own value if needed
+GG_VALID_TOKEN = os.getenv("TEST_GG_VALID_TOKEN", "ggtt-v-12345azert")  # ggignore
+GG_VALID_TOKEN_IGNORE_SHA = os.getenv(
+    "TEST_GG_VALID_TOKEN_IGNORE_SHA",
+    "56c126cef75e3d17c3de32dac60bab688ecc384a054c2c85b688c1dd7ac4eefd",
 )
 
 # This secret must be a secret known by the dashboard running functional tests


### PR DESCRIPTION
## Context

We cannot run the functional tests on an instance monitoring the repo because the GG_VALID_SECRET has been marked as ignored which means it is ignored when scanning (see documentation).

## What has been done
- Add the ability to override the value with the .env so that we can have a secret not known by the dashboard

BEWARE: I did not modify the environment variables yet in the ggshield repo.

## Validation

- functional tests should run with an account monitoring ggshield

