### PR TITLE
ci: use codecov action v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,11 +133,12 @@ jobs:
           coverage report --fail-under=80
           coverage xml
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Run functional tests


### PR DESCRIPTION
## Context
Jobs are failing for an obscure reason : see for instance https://github.com/GitGuardian/ggshield/actions/runs/10262514554/job/28392351544

Let's try a simple fix which is also good for tech debt.

## What has been done

 I changed the value

## Validation

Can you see the coverage in codecov ?

## PR check list


