### PR TITLE
fix(ci): grant access to the correct environment variables for tests

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -219,6 +219,9 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
           TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
+          TEST_GG_VALID_TOKEN: ${{ secrets.TEST_GG_VALID_TOKEN }}
+          TEST_GG_VALID_TOKEN_IGNORE_SHA: ${{ secrets.TEST_GG_VALID_TOKEN_IGNORE_SHA }}
+          TEST_UNKNOWN_SECRET: ${{ secrets.TEST_UNKNOWN_SECRET }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
           TEST_KNOWN_SECRET: ${{ secrets.TEST_KNOWN_SECRET }}
+          TEST_GG_VALID_TOKEN: ${{ secrets.TEST_GG_VALID_TOKEN }}
+          TEST_GG_VALID_TOKEN_IGNORE_SHA: ${{ secrets.TEST_GG_VALID_TOKEN_IGNORE_SHA }}
+          TEST_UNKNOWN_SECRET: ${{ secrets.TEST_UNKNOWN_SECRET }}
 
   build_os_packages:
     uses: ./.github/workflows/build_release_assets.yml


### PR DESCRIPTION
## Context

I changed the values used in CI so that it uses env variable but forgot to grant access to these in the job. 

## What has been done

Checked occurrences of other env variables and add the new ones at the same place

## Validation

All jobs are green during the next release
