### PR TITLE
agateau/refactor get files from path

### DIFF
--- a/ggshield/cmd/iac/scan/all.py
+++ b/ggshield/cmd/iac/scan/all.py
@@ -73,8 +73,6 @@ def iac_scan_all(
     paths = get_iac_files_from_path(
         path=directory,
         exclusion_regexes=ctx_obj.exclusion_regexes,
-        # bypass verbose here: we want to display only IaC files
-        verbose=False,
         # If the repository is a git repository, ignore untracked files
         ignore_git=False,
         ignore_git_staged=(scan_mode == ScanMode.PRE_PUSH_ALL),

--- a/ggshield/cmd/sca/scan/sca_scan_utils.py
+++ b/ggshield/cmd/sca/scan/sca_scan_utils.py
@@ -122,7 +122,6 @@ def get_sca_scan_all_filepaths(
     all_filepaths = get_all_files_from_sca_paths(
         path=directory,
         exclusion_regexes=exclusion_regexes,
-        verbose=verbose,
         # If the repository is a git repository, ignore untracked files
         ignore_git=True,
     )

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -13,6 +13,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.text_utils import display_heading
 from ggshield.utils.archive import safe_unpack
 from ggshield.utils.click import RealPath
 from ggshield.utils.files import ListFilesMode
@@ -35,6 +36,7 @@ def archive_cmd(
     """
     with tempfile.TemporaryDirectory(suffix="ggshield") as temp_dir:
         temp_path = Path(temp_dir)
+        display_heading("Unpacking archive")
         try:
             safe_unpack(path, extract_dir=temp_path)
         except Exception as exn:
@@ -50,6 +52,7 @@ def archive_cmd(
         )
         if verbose:
             print_file_list(files, binary_paths)
+        display_heading("Starting scan")
 
         with ctx_obj.ui.create_scanner_ui(len(files), verbose=verbose) as ui:
             scan_context = ScanContext(

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -12,7 +12,7 @@ from ggshield.cmd.secret.scan.ui_utils import print_file_list
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
-from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.scan.file import create_files_from_paths
 from ggshield.core.text_utils import display_heading
 from ggshield.utils.archive import safe_unpack
 from ggshield.utils.click import RealPath
@@ -45,7 +45,7 @@ def archive_cmd(
         ctx_obj = ContextObj.get(ctx)
         config = ctx_obj.config
         verbose = config.user_config.verbose
-        files, binary_paths = get_files_from_paths(
+        files, binary_paths = create_files_from_paths(
             paths=[temp_path],
             exclusion_regexes=ctx_obj.exclusion_regexes,
             list_files_mode=ListFilesMode.ALL,

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -8,6 +8,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.cmd.secret.scan.ui_utils import print_file_list
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
@@ -42,14 +43,13 @@ def archive_cmd(
         ctx_obj = ContextObj.get(ctx)
         config = ctx_obj.config
         verbose = config.user_config.verbose
-        files = get_files_from_paths(
+        files, binary_paths = get_files_from_paths(
             paths=[temp_path],
             exclusion_regexes=ctx_obj.exclusion_regexes,
-            yes=True,
-            display_scanned_files=verbose,
-            display_binary_files=verbose,
             list_files_mode=ListFilesMode.ALL,
         )
+        if verbose:
+            print_file_list(files, binary_paths)
 
         with ctx_obj.ui.create_scanner_ui(len(files), verbose=verbose) as ui:
             scan_context = ScanContext(

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -12,7 +12,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
-from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.scan.file import create_files_from_paths
 from ggshield.core.text_utils import display_heading
 from ggshield.utils.click import RealPath
 from ggshield.utils.files import ListFilesMode
@@ -55,7 +55,7 @@ def path_cmd(
                 " Use --recursive to scan directories."
             )
 
-    files, binary_paths = get_files_from_paths(
+    files, binary_paths = create_files_from_paths(
         paths=paths,
         exclusion_regexes=ctx_obj.exclusion_regexes,
         list_files_mode=(

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -46,6 +46,13 @@ def path_cmd(
     for path in paths:
         check_directory_not_ignored(path, ctx_obj.exclusion_regexes)
 
+    if not recursive:
+        if path := next((x for x in paths if x.is_dir()), None):
+            raise click.UsageError(
+                f"{click.format_filename(path)} is a directory."
+                " Use --recursive to scan directories."
+            )
+
     files = get_files_from_paths(
         paths=paths,
         exclusion_regexes=ctx_obj.exclusion_regexes,
@@ -53,11 +60,7 @@ def path_cmd(
         display_scanned_files=verbose,
         display_binary_files=verbose,
         list_files_mode=(
-            ListFilesMode.FILES_ONLY
-            if not recursive
-            else (
-                ListFilesMode.ALL_BUT_GITIGNORED if use_gitignore else ListFilesMode.ALL
-            )
+            ListFilesMode.ALL_BUT_GITIGNORED if use_gitignore else ListFilesMode.ALL
         ),
     )
     target = paths[0] if len(paths) == 1 else Path.cwd()

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -13,6 +13,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.text_utils import display_heading
 from ggshield.utils.click import RealPath
 from ggshield.utils.files import ListFilesMode
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -66,6 +67,8 @@ def path_cmd(
     if not yes:
         confirm_scan(files)
 
+    if verbose:
+        display_heading("Starting scan")
     target = paths[0] if len(paths) == 1 else Path.cwd()
     target_path = target if target.is_dir() else target.parent
     with ctx_obj.ui.create_scanner_ui(len(files), verbose=verbose) as scanner_ui:

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -15,7 +15,7 @@ from ggshield.cmd.secret.scan.ui_utils import print_file_list
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
-from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.scan.file import create_files_from_paths
 from ggshield.core.text_utils import display_heading
 from ggshield.utils.archive import safe_unpack
 from ggshield.utils.files import ListFilesMode
@@ -67,7 +67,7 @@ def get_files_from_package(
 
     exclusion_regexes.add(re.compile(re.escape(archive.name)))
 
-    return get_files_from_paths(
+    return create_files_from_paths(
         paths=[archive_dir],
         exclusion_regexes=exclusion_regexes,
         list_files_mode=ListFilesMode.ALL,

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -16,6 +16,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.text_utils import display_heading
 from ggshield.utils.archive import safe_unpack
 from ggshield.utils.files import ListFilesMode
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -35,7 +36,7 @@ def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     ]
 
     try:
-        click.echo("Downloading pip package... ", nl=False, err=True)
+        display_heading("Downloading package")
         subprocess.run(
             command,
             check=True,
@@ -43,7 +44,6 @@ def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
             stderr=sys.stderr,
             timeout=PYPI_DOWNLOAD_TIMEOUT,
         )
-        click.echo("OK", err=True)
 
     except subprocess.CalledProcessError:
         raise UnexpectedError(f'Failed to download "{package_name}"')
@@ -59,6 +59,7 @@ def get_files_from_package(
 ) -> Tuple[List[Scannable], List[Path]]:
     archive: Path = next(archive_dir.iterdir())
 
+    display_heading("Unpacking package")
     try:
         safe_unpack(archive, extract_dir=archive_dir)
     except Exception as exn:
@@ -110,6 +111,7 @@ def pypi_cmd(
         )
         if verbose:
             print_file_list(files, binary_paths)
+        display_heading("Starting scan")
 
         with ctx_obj.ui.create_scanner_ui(len(files), verbose=verbose) as ui:
             scan_context = ScanContext(

--- a/ggshield/cmd/secret/scan/ui_utils.py
+++ b/ggshield/cmd/secret/scan/ui_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import List
+
+from ggshield.core.scan import Scannable
+from ggshield.core.text_utils import display_heading, display_info
+
+
+def print_file_list(files: List[Scannable], binary_paths: List[Path]) -> None:
+    if binary_paths:
+        display_heading("Ignored binary files")
+        for path in binary_paths:
+            display_info(f"- {path}")
+    display_heading("Files to scan")
+    for f in files:
+        display_info(f"- {f.path}")

--- a/ggshield/core/scan/__init__.py
+++ b/ggshield/core/scan/__init__.py
@@ -1,12 +1,12 @@
 from .commit import Commit
-from .file import File, get_files_from_paths
+from .file import File, create_files_from_paths
 from .scan_context import ScanContext
 from .scan_mode import ScanMode
 from .scannable import DecodeError, Scannable, StringScannable
 
 
 __all__ = [
-    "get_files_from_paths",
+    "create_files_from_paths",
     "Commit",
     "DecodeError",
     "File",

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -46,14 +46,14 @@ class File(Scannable):
                 )
 
 
-def get_files_from_paths(
+def create_files_from_paths(
     paths: List[Path],
     exclusion_regexes: Set[Pattern[str]],
     list_files_mode: ListFilesMode = ListFilesMode.GIT_COMMITTED_OR_STAGED,
 ) -> Tuple[List[Scannable], List[Path]]:
     """
-    Returns a tuple of a list of scannables for the files, and a list of ignored binary
-    paths
+    Create File instances for `paths` and return them, as well as a list of the ignored
+    paths found in `paths`.
     """
     filepaths = list_files(
         paths,

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -1,12 +1,7 @@
 from pathlib import Path
 from typing import List, Pattern, Set, Tuple, Union
 
-from ggshield.utils.files import (
-    ListFilesMode,
-    get_filepaths,
-    is_path_binary,
-    url_for_path,
-)
+from ggshield.utils.files import ListFilesMode, is_path_binary, list_files, url_for_path
 
 from .scannable import Scannable
 
@@ -60,7 +55,7 @@ def get_files_from_paths(
     Returns a tuple of a list of scannables for the files, and a list of ignored binary
     paths
     """
-    filepaths = get_filepaths(
+    filepaths = list_files(
         paths,
         exclusion_regexes,
         list_files_mode=list_files_mode,

--- a/ggshield/core/scan/file.py
+++ b/ggshield/core/scan/file.py
@@ -5,7 +5,6 @@ import click
 
 from ggshield.utils.files import (
     ListFilesMode,
-    UnexpectedDirectoryError,
     get_filepaths,
     is_path_binary,
     url_for_path,
@@ -72,17 +71,11 @@ def get_files_from_paths(
     :param display_binary_files: Display all ignored binary files
     :param ignore_git: Ignore that the folder is a git repository
     """
-    try:
-        filepaths = get_filepaths(
-            paths,
-            exclusion_regexes,
-            list_files_mode=list_files_mode,
-        )
-    except UnexpectedDirectoryError as error:
-        raise click.UsageError(
-            f"{click.format_filename(error.path)} is a directory."
-            " Use --recursive to scan directories."
-        )
+    filepaths = get_filepaths(
+        paths,
+        exclusion_regexes,
+        list_files_mode=list_files_mode,
+    )
 
     files = list(generate_files_from_paths(filepaths, display_binary_files))
 

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -47,11 +47,9 @@ def get_filepaths(
     list_files_mode: ListFilesMode,
 ) -> Set[Path]:
     """
-    Retrieve the filepaths from the command.
+    Retrieve a set of the files inside `paths`.
 
-    :param paths: List of file/dir paths from the command
-    :param ignore_git: Ignore that the folder is a git repository
-    :raise: UnexpectedDirectoryError if directory is given without --recursive option
+    Note: only plain files are returned, not directories.
     """
     targets: Set[Path] = set()
     for path in paths:
@@ -72,7 +70,9 @@ def get_filepaths(
                 _targets = path.rglob(r"*")
 
             for file_path in _targets:
-                if not is_path_excluded(file_path, exclusion_regexes):
+                if not file_path.is_dir() and not is_path_excluded(
+                    file_path, exclusion_regexes
+                ):
                     targets.add(file_path)
     return targets
 

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -41,7 +41,7 @@ def is_path_excluded(
     return any(r.search(path_string) for r in exclusion_regexes)
 
 
-def get_filepaths(
+def list_files(
     paths: List[Path],
     exclusion_regexes: Set[Pattern[str]],
     list_files_mode: ListFilesMode,

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -16,25 +16,16 @@ class ListFilesMode(Enum):
     """
     Control `get_filepaths()` behavior:
 
-    - FILES_ONLY: list specified paths. Expect them to be plain files, raise an exception if one of them is not.
     - ALL: list all specified paths. If one of the path is a directory, list all its paths recursively.
     - ALL_BUT_GITIGNORED: like ALL, except those ignored by git (listed in .gitignore).
     - GIT_COMMITTED_OR_STAGED: list all committed files and all staged files.
     - GIT_COMMITTED: list only committed files.
     """
 
-    FILES_ONLY = auto()
     GIT_COMMITTED = auto()
     GIT_COMMITTED_OR_STAGED = auto()
     ALL_BUT_GITIGNORED = auto()
     ALL = auto()
-
-
-class UnexpectedDirectoryError(ValueError):
-    """Raise when a directory is used where it is not excepted"""
-
-    def __init__(self, path: Path):
-        self.path = path
 
 
 def is_path_excluded(
@@ -67,9 +58,6 @@ def get_filepaths(
         if path.is_file():
             targets.add(path)
         elif path.is_dir():
-            if list_files_mode == ListFilesMode.FILES_ONLY:
-                raise UnexpectedDirectoryError(path)
-
             _targets = set()
             if list_files_mode != ListFilesMode.ALL and is_git_dir(path):
                 target_filepaths = (

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -19,7 +19,6 @@ IAC_FILENAME_KEYWORDS = {"tfvars", "dockerfile"}
 def get_iac_files_from_path(
     path: Path,
     exclusion_regexes: Set[Pattern[str]],
-    verbose: bool,
     ignore_git: bool = False,
     ignore_git_staged: bool = False,
 ) -> List[Path]:

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -32,26 +32,20 @@ def get_iac_files_from_path(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
-    return [
-        x.path
-        for x in get_files_from_paths(
-            paths=[path],
-            exclusion_regexes=exclusion_regexes,
-            yes=True,
-            display_binary_files=verbose,
-            display_scanned_files=False,
-            list_files_mode=(
-                ListFilesMode.ALL
-                if ignore_git
-                else (
-                    ListFilesMode.GIT_COMMITTED
-                    if ignore_git_staged
-                    else ListFilesMode.GIT_COMMITTED_OR_STAGED
-                )
-            ),
-        )
-        if is_iac_file_path(x.path)
-    ]
+    files, _ = get_files_from_paths(
+        paths=[path],
+        exclusion_regexes=exclusion_regexes,
+        list_files_mode=(
+            ListFilesMode.ALL
+            if ignore_git
+            else (
+                ListFilesMode.GIT_COMMITTED
+                if ignore_git_staged
+                else ListFilesMode.GIT_COMMITTED_OR_STAGED
+            )
+        ),
+    )
+    return [x.path for x in files if is_iac_file_path(x.path)]
 
 
 def is_iac_file_path(path: Path) -> bool:

--- a/ggshield/verticals/iac/filter.py
+++ b/ggshield/verticals/iac/filter.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from typing import List, Pattern, Set
 
-from ggshield.core.scan.file import get_files_from_paths
-from ggshield.utils.files import ListFilesMode
+from ggshield.utils.files import ListFilesMode, is_path_binary, list_files
 
 
 IAC_EXTENSIONS = {
@@ -32,7 +31,7 @@ def get_iac_files_from_path(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files added to git are scanned
     """
-    files, _ = get_files_from_paths(
+    paths = list_files(
         paths=[path],
         exclusion_regexes=exclusion_regexes,
         list_files_mode=(
@@ -45,10 +44,12 @@ def get_iac_files_from_path(
             )
         ),
     )
-    return [x.path for x in files if is_iac_file_path(x.path)]
+    return [x for x in paths if is_iac_file_path(x)]
 
 
 def is_iac_file_path(path: Path) -> bool:
+    if is_path_binary(path):
+        return False
     if any(ext in IAC_EXTENSIONS for ext in path.suffixes):
         return True
     if any(path.name.endswith(iac_ext) for iac_ext in IAC_EXTENSIONS):

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -7,10 +7,14 @@ from pygitguardian.client import GGClient
 from pygitguardian.models import Detail
 
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
-from ggshield.core.scan.file import get_files_from_paths
 from ggshield.core.tar_utils import INDEX_REF
 from ggshield.core.text_utils import display_info
-from ggshield.utils.files import ListFilesMode, is_path_excluded
+from ggshield.utils.files import (
+    ListFilesMode,
+    is_path_binary,
+    is_path_excluded,
+    list_files,
+)
 from ggshield.utils.git_shell import get_filepaths_from_ref, get_staged_filepaths
 
 
@@ -48,14 +52,14 @@ def get_all_files_from_sca_paths(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files tracked by git are scanned
     """
-    files, _ = get_files_from_paths(
+    paths = list_files(
         paths=[path],
         exclusion_regexes=exclusion_regexes | SCA_EXCLUSION_REGEXES,
         list_files_mode=(
             ListFilesMode.ALL if ignore_git else ListFilesMode.GIT_COMMITTED_OR_STAGED
         ),
     )
-    return sorted(str(x.path.relative_to(path)) for x in files)
+    return sorted(str(x.relative_to(path)) for x in paths if not is_path_binary(x))
 
 
 def sca_files_from_git_repo(

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -48,23 +48,14 @@ def get_all_files_from_sca_paths(
     :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files tracked by git are scanned
     """
-    paths = [
-        x.path
-        for x in get_files_from_paths(
-            paths=[path],
-            exclusion_regexes=exclusion_regexes | SCA_EXCLUSION_REGEXES,
-            yes=True,
-            display_binary_files=verbose,
-            display_scanned_files=False,  # If True, this displays all files in the directory but we only want SCA files
-            list_files_mode=(
-                ListFilesMode.ALL
-                if ignore_git
-                else ListFilesMode.GIT_COMMITTED_OR_STAGED
-            ),
-        )
-    ]
-
-    return [str(x.relative_to(path)) for x in sorted(paths)]
+    files, _ = get_files_from_paths(
+        paths=[path],
+        exclusion_regexes=exclusion_regexes | SCA_EXCLUSION_REGEXES,
+        list_files_mode=(
+            ListFilesMode.ALL if ignore_git else ListFilesMode.GIT_COMMITTED_OR_STAGED
+        ),
+    )
+    return sorted(str(x.path.relative_to(path)) for x in files)
 
 
 def sca_files_from_git_repo(

--- a/ggshield/verticals/sca/file_selection.py
+++ b/ggshield/verticals/sca/file_selection.py
@@ -39,17 +39,13 @@ SCA_EXCLUSION_REGEXES = {
 
 
 def get_all_files_from_sca_paths(
-    path: Path,
-    exclusion_regexes: Set[Pattern[str]],
-    verbose: bool,
-    ignore_git: bool = False,
+    path: Path, exclusion_regexes: Set[Pattern[str]], ignore_git: bool = False
 ) -> List[str]:
     """
-    Create a Files object from a path, recursively, ignoring non SCA files
+    Recurse on `path` and return a list of SCA paths.
 
     :param path: path to scan
     :param exclusion_regexes: list of regexes, used to exclude some filepaths
-    :param verbose: Option that displays filepaths as they are scanned
     :param ignore_git: Ignore that the folder is a git repository. If False, only files tracked by git are scanned
     """
     paths = list_files(

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -70,19 +70,19 @@ class TestListPackageFiles:
     exclusion_regexes: Set[Pattern[str]] = {re.compile("i am a regex")}
 
     @pytest.mark.parametrize("extension", ["whl", "tar.gz"])
-    @patch("ggshield.cmd.secret.scan.pypi.get_files_from_paths")
+    @patch("ggshield.cmd.secret.scan.pypi.create_files_from_paths")
     @patch("ggshield.cmd.secret.scan.pypi.safe_unpack")
     def test_unpack_archive_format(
         self,
         safe_unpack_mock: Mock,
-        get_files_from_paths_mock: Mock,
+        create_files_from_paths_mock: Mock,
         extension: str,
         tmp_path,
     ):
         # TODO: rewrite this test: it tests implementation details instead of the
         # function outcome
         archive_path = tmp_path / f"{self.package_name}.{extension}"
-        get_files_from_paths_mock.return_value = ([], [])
+        create_files_from_paths_mock.return_value = ([], [])
 
         with patch.object(Path, "iterdir", return_value=iter([archive_path])):
             get_files_from_package(
@@ -101,7 +101,7 @@ class TestListPackageFiles:
                 re.compile(f"{self.package_name}.{extension}")
             )
 
-            get_files_from_paths_mock.assert_called_once_with(
+            create_files_from_paths_mock.assert_called_once_with(
                 paths=[tmp_path],
                 exclusion_regexes=expected_exclusion_regexes,
                 list_files_mode=ListFilesMode.ALL,

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -69,14 +69,7 @@ class TestListPackageFiles:
     package_name: str = "what-ever-non-existing"
     exclusion_regexes: Set[Pattern[str]] = {re.compile("i am a regex")}
 
-    @pytest.mark.parametrize(
-        "extension,verbose",
-        [
-            ("whl", True),
-            ("whl", False),
-            ("tar.gz", True),
-        ],
-    )
+    @pytest.mark.parametrize("extension", ["whl", "tar.gz"])
     @patch("ggshield.cmd.secret.scan.pypi.get_files_from_paths")
     @patch("ggshield.cmd.secret.scan.pypi.safe_unpack")
     def test_unpack_archive_format(
@@ -84,17 +77,18 @@ class TestListPackageFiles:
         safe_unpack_mock: Mock,
         get_files_from_paths_mock: Mock,
         extension: str,
-        verbose: bool,
         tmp_path,
     ):
+        # TODO: rewrite this test: it tests implementation details instead of the
+        # function outcome
         archive_path = tmp_path / f"{self.package_name}.{extension}"
+        get_files_from_paths_mock.return_value = ([], [])
 
         with patch.object(Path, "iterdir", return_value=iter([archive_path])):
             get_files_from_package(
                 archive_dir=tmp_path,
                 package_name=self.package_name,
                 exclusion_regexes=self.exclusion_regexes,
-                verbose=verbose,
             )
 
             safe_unpack_mock.assert_called_once_with(
@@ -110,8 +104,5 @@ class TestListPackageFiles:
             get_files_from_paths_mock.assert_called_once_with(
                 paths=[tmp_path],
                 exclusion_regexes=expected_exclusion_regexes,
-                yes=True,
-                display_scanned_files=verbose,
-                display_binary_files=verbose,
                 list_files_mode=ListFilesMode.ALL,
             )

--- a/tests/unit/core/scan/test_file.py
+++ b/tests/unit/core/scan/test_file.py
@@ -217,12 +217,12 @@ def test_file_path():
         ("zero-bytes-are-kept.txt", b"Zero\0byte", "Zero\0byte"),
     ],
 )
-def test_get_files_from_paths(
+def test_create_files_from_paths(
     tmp_path, filename: str, input_content: bytes, expected_content: str
 ):
     """
     GIVEN a file
-    WHEN calling get_files_from_paths() on it
+    WHEN calling create_files_from_paths() on it
     THEN it returns the expected File instance
     AND the content of the File instance is what is expected
     """

--- a/tests/unit/core/scan/test_file.py
+++ b/tests/unit/core/scan/test_file.py
@@ -6,7 +6,7 @@ import charset_normalizer
 import pytest
 
 from ggshield.core.scan import DecodeError, File
-from ggshield.core.scan.file import get_files_from_paths
+from ggshield.core.scan.file import create_files_from_paths
 from tests.conftest import is_windows
 
 
@@ -229,7 +229,7 @@ def test_get_files_from_paths(
     path = tmp_path / filename
     path.write_bytes(input_content)
 
-    files, _ = get_files_from_paths([path], exclusion_regexes=set())
+    files, _ = create_files_from_paths([path], exclusion_regexes=set())
 
     file = files[0]
     assert file.filename == str(path)

--- a/tests/unit/core/scan/test_file.py
+++ b/tests/unit/core/scan/test_file.py
@@ -6,7 +6,7 @@ import charset_normalizer
 import pytest
 
 from ggshield.core.scan import DecodeError, File
-from ggshield.core.scan.file import generate_files_from_paths
+from ggshield.core.scan.file import get_files_from_paths
 from tests.conftest import is_windows
 
 
@@ -217,19 +217,19 @@ def test_file_path():
         ("zero-bytes-are-kept.txt", b"Zero\0byte", "Zero\0byte"),
     ],
 )
-def test_generate_files_from_paths(
+def test_get_files_from_paths(
     tmp_path, filename: str, input_content: bytes, expected_content: str
 ):
     """
     GIVEN a file
-    WHEN calling generate_files_from_paths() on it
+    WHEN calling get_files_from_paths() on it
     THEN it returns the expected File instance
     AND the content of the File instance is what is expected
     """
     path = tmp_path / filename
     path.write_bytes(input_content)
 
-    files = list(generate_files_from_paths([path], display_binary_files=False))
+    files, _ = get_files_from_paths([path], exclusion_regexes=set())
 
     file = files[0]
     assert file.filename == str(path)

--- a/tests/unit/verticals/iac/test_filter.py
+++ b/tests/unit/verticals/iac/test_filter.py
@@ -31,7 +31,7 @@ def test_get_iac_files_from_path(tmp_path: Path):
     for filename in FILE_NAMES:
         (tmp_path / filename).write_text("something")
 
-    files = get_iac_files_from_path(tmp_path, set(), True)
+    files = get_iac_files_from_path(tmp_path, set())
     assert len(files) == 9
     assert tmp_path / "file1.txt" not in files
     assert tmp_path / "file2.json" in files
@@ -46,7 +46,7 @@ def test_get_iac_files_from_path_excluded(tmp_path: Path):
     for filename in FILE_NAMES:
         (tmp_path / filename).write_text("something")
 
-    files = get_iac_files_from_path(tmp_path, {re.compile(r"file2")}, True)
+    files = get_iac_files_from_path(tmp_path, {re.compile(r"file2")})
     assert len(files) == 8
     assert tmp_path / "file2.json" not in files
     assert tmp_path / "file3.yaml" in files
@@ -71,7 +71,7 @@ def test_get_iac_files_from_path_ignore_git(tmp_path: Path, ignore_git: bool):
     # included in the get_iac_files_from_path response
     assert (tmp_path / ".git").exists()
 
-    files = get_iac_files_from_path(tmp_path, set(), True, ignore_git)
+    files = get_iac_files_from_path(tmp_path, set(), ignore_git)
     if ignore_git:
         assert len(files) == 9
         assert tmp_path / "file2.json" in files

--- a/tests/unit/verticals/sca/test_file_selection.py
+++ b/tests/unit/verticals/sca/test_file_selection.py
@@ -64,27 +64,22 @@ def test_get_all_files_from_sca_paths(tmp_path):
     ("file_path", "expected"),
     [("front/file1.png", True), (".git/file2.png", False), ("file3.png", True)],
 )
-def test_get_ignored_files(tmp_path, capsysbinary, file_path, expected):
+def test_get_ignored_files(tmp_path, file_path, expected):
     """
     GIVEN a directory
     WHEN calling sca scan a directory
     THEN excluded directory are not inspected
     """
-    write_text(filename=str(tmp_path / file_path), content="")
+    binary_path = tmp_path / file_path
+    write_text(filename=str(binary_path), content="")
 
-    get_files_from_paths(
-        paths=[Path(tmp_path)],
+    _, binary_paths = get_files_from_paths(
+        paths=[tmp_path],
         exclusion_regexes=SCA_EXCLUSION_REGEXES,  # directories we don't want to traverse
-        yes=True,
-        display_binary_files=True,
-        display_scanned_files=False,
     )
 
-    captured = capsysbinary.readouterr()
-
-    # stderr shows us the ignored binary files
-    # (stderr should be empty if binary files are in directories we don't want to traverse)
-    assert (captured.err != bytes("", "utf-8")) is expected
+    expected_paths = [binary_path] if expected else []
+    assert binary_paths == expected_paths
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/verticals/sca/test_file_selection.py
+++ b/tests/unit/verticals/sca/test_file_selection.py
@@ -36,7 +36,7 @@ def test_get_all_files_from_sca_paths(tmp_path):
     for path in tmp_paths:
         write_text(filename=path, content="")
 
-    files = get_all_files_from_sca_paths(tmp_path, set(), True)
+    files = get_all_files_from_sca_paths(tmp_path, set())
     assert len(files) == 7
     assert Path(".venv/dockerfile.txt") not in [Path(filepath) for filepath in files]
     assert Path("backend/pyproject.toml") in [Path(filepath) for filepath in files]

--- a/tests/unit/verticals/sca/test_file_selection.py
+++ b/tests/unit/verticals/sca/test_file_selection.py
@@ -5,9 +5,7 @@ from typing import Set
 import pytest
 from pygitguardian import GGClient
 
-from ggshield.core.scan.file import get_files_from_paths
 from ggshield.verticals.sca.file_selection import (
-    SCA_EXCLUSION_REGEXES,
     get_all_files_from_sca_paths,
     sca_files_from_git_repo,
 )
@@ -58,28 +56,6 @@ def test_get_all_files_from_sca_paths(tmp_path):
             "front/yarn.lock",
         ]
     ]
-
-
-@pytest.mark.parametrize(
-    ("file_path", "expected"),
-    [("front/file1.png", True), (".git/file2.png", False), ("file3.png", True)],
-)
-def test_get_ignored_files(tmp_path, file_path, expected):
-    """
-    GIVEN a directory
-    WHEN calling sca scan a directory
-    THEN excluded directory are not inspected
-    """
-    binary_path = tmp_path / file_path
-    write_text(filename=str(binary_path), content="")
-
-    _, binary_paths = get_files_from_paths(
-        paths=[tmp_path],
-        exclusion_regexes=SCA_EXCLUSION_REGEXES,  # directories we don't want to traverse
-    )
-
-    expected_paths = [binary_path] if expected else []
-    assert binary_paths == expected_paths
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Context

`core.scan.file.get_files_from_path()` does too many things, and gets in the way of some cleaning I plan to do on ggshield UI. This PR reduces its scope.

## What has been done

`core.scan.file.get_files_from_path()` scope has been reduced. Most of the work is done in the 1st and 2nd commit. Look at their commit messages for details.

`iac scan` and `sca scan` no longer list skipped binary files. This has been discussed upfront and decided to be OK.

Output of `secret scan path`, `secret scan archive` and `secret scan pypi` is a bit nicer: it now makes use of headings:

![image](https://github.com/user-attachments/assets/0a52aa2b-9338-4e2f-9044-3f6ba01f4cab)


![image](https://github.com/user-attachments/assets/e4a1cc53-141f-4daf-9013-bbbd5b66fce0)


## Validation

Tests still pass. UI looks a bit nicer. Code is nicer.
