### PR TITLE
fix(naming): rename option to skip merge files

### DIFF
--- a/changelog.d/20240819_162411_fnareoh_scrt_4759_optimize_files_to_scan_on_merge_commits.md
+++ b/changelog.d/20240819_162411_fnareoh_scrt_4759_optimize_files_to_scan_on_merge_commits.md
@@ -1,5 +1,5 @@
 ### Added
 
-- The command `ggshield secret scan pre-commit` has a new flag `--merge-skip-unchanged`. It is off by default, if activated,
+- The command `ggshield secret scan pre-commit` has a new flag `--skip-unchanged-merge-files`. It is off by default, if activated,
   in the case of merge commit, it skips the scan of files that were not modified by merge. This is done for efficiency
   but is less secure.

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -40,8 +40,7 @@ def check_is_merge_with_conflict(cwd: Path) -> bool:
 
 @click.command()
 @click.option(
-    "--merge-skip-unchanged",
-    "-m",
+    "--skip-unchanged-merge-files",
     is_flag=True,
     help="When scanning a merge commit, skip files that were not modified by the merge"
     " (assumes the merged commits are secret free).",
@@ -52,7 +51,7 @@ def check_is_merge_with_conflict(cwd: Path) -> bool:
 @exception_wrapper
 def precommit_cmd(
     ctx: click.Context,
-    merge_skip_unchanged: bool,
+    skip_unchanged_merge_files: bool,
     precommit_args: List[str],
     **kwargs: Any,
 ) -> int:  # pragma: no cover
@@ -81,9 +80,9 @@ def precommit_cmd(
     )
 
     # Get the commit object
-    if merge_skip_unchanged and check_is_merge_with_conflict(Path.cwd()):
+    if skip_unchanged_merge_files and check_is_merge_with_conflict(Path.cwd()):
         commit = Commit.from_merge(ctx_obj.exclusion_regexes)
-    elif merge_skip_unchanged and check_is_merge_without_conflict():
+    elif skip_unchanged_merge_files and check_is_merge_without_conflict():
         merge_branch = get_merge_branch_from_reflog()
         commit = Commit.from_merge(ctx_obj.exclusion_regexes, merge_branch)
     else:

--- a/tests/functional/utils_create_merge_repo.py
+++ b/tests/functional/utils_create_merge_repo.py
@@ -178,13 +178,13 @@ def generate_repo_with_merge_commit(
         cwd=repo.path,
     )
     if merge_skip_unchanged:
-        # rewrite the git hook file to add the option --merge-skip-unchanged
+        # rewrite the git hook file to add the option --skip-unchanged-merge-files
         hook_path = Path(
             f"{root_dir}/.git/hooks/pre-commit",
         )
         with open(hook_path, "r") as f:
             hook = f.read()
-        hook = hook.replace(r"pre-commit", r"pre-commit --merge-skip-unchanged")
+        hook = hook.replace(r"pre-commit", r"pre-commit --skip-unchanged-merge-files")
         with open(hook_path, "w") as f:
             f.write(hook)
 


### PR DESCRIPTION
## Context

I failed and forgot to push my changes to the naming  :facepalm:

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
