### PR TITLE
Add incident details option for json and sarif formats

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -231,11 +231,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.10"
         },
         "marshmallow": {
             "hashes": [
@@ -294,12 +294,9 @@
             "version": "==2.22"
         },
         "pygitguardian": {
-            "hashes": [
-                "sha256:1e965017a87337db72749a454359d13625850ce855b7dcbdac8e2cbdea3d102b",
-                "sha256:91f7c5454fcf7d337946f53c35d035e4979224bf45eba85ed82f9d3939c904fd"
-            ],
+            "git": "git+https://github.com/GitGuardian/py-gitguardian.git@dce0ec3326a52724822d0f1468d2039bd04d562b",
             "markers": "python_version >= '3.8'",
-            "version": "==1.16.0"
+            "ref": "dce0ec3326a52724822d0f1468d2039bd04d562b"
         },
         "pygments": {
             "hashes": [
@@ -402,11 +399,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308",
-                "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
+                "sha256:25af69c809d9334cd8e653d385277abeb5a102dca255954005a7092d282575ea",
+                "sha256:791ae94f04f78c880b5e614e560dd32d4b4af5d151bd9e7483e3377846caf90a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==74.1.2"
+            "version": "==75.0.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -425,11 +422,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         }
     },
     "develop": {
@@ -833,19 +830,19 @@
         },
         "identify": {
             "hashes": [
-                "sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf",
-                "sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0"
+                "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0",
+                "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.6.0"
+            "version": "==2.6.1"
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.10"
         },
         "import-linter": {
             "hashes": [
@@ -1416,11 +1413,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308",
-                "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
+                "sha256:25af69c809d9334cd8e653d385277abeb5a102dca255954005a7092d282575ea",
+                "sha256:791ae94f04f78c880b5e614e560dd32d4b4af5d151bd9e7483e3377846caf90a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==74.1.2"
+            "version": "==75.0.0"
         },
         "six": {
             "hashes": [
@@ -1464,11 +1461,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "vcrpy": {
             "hashes": [

--- a/changelog.d/20240906_141336_fnareoh_scrt_4693_ggshield_output_expose_incident_date_and_severity.md
+++ b/changelog.d/20240906_141336_fnareoh_scrt_4693_ggshield_output_expose_incident_date_and_severity.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `--with-incident-details` to output more information about known incidents (JSON and SARIF outputs only).

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -68,8 +68,10 @@ def precommit_cmd(
     output_handler = SecretTextOutputHandler(
         show_secrets=config.user_config.secret.show_secrets,
         verbose=verbose,
+        client=ctx_obj.client,
         output=None,
         ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
+        with_incident_details=config.user_config.secret.with_incident_details,
     )
     check_git_dir()
 

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -120,6 +120,13 @@ _banlist_detectors_option = click.option(
     metavar="DETECTOR",
 )
 
+_with_incident_details_option = click.option(
+    "--with-incident-details",
+    is_flag=True,
+    help="Display full details about the dashboard incident if one is found (JSON and SARIF formats only).",
+    callback=create_config_callback("secret", "with_incident_details"),
+)
+
 
 def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
     def decorator(cmd: AnyFunction) -> AnyFunction:
@@ -132,6 +139,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         _exclude_option(cmd)
         _ignore_known_secrets_option(cmd)
         _banlist_detectors_option(cmd)
+        _with_incident_details_option(cmd)
         return cmd
 
     return decorator
@@ -153,6 +161,8 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     return output_handler_cls(
         show_secrets=config.user_config.secret.show_secrets,
         verbose=config.user_config.verbose,
+        client=ctx_obj.client,
         output=ctx_obj.output,
         ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
+        with_incident_details=config.user_config.secret.with_incident_details,
     )

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -45,6 +45,7 @@ class SecretConfig(FilteredConfig):
     ignored_matches: List[IgnoredMatch] = field(default_factory=list)
     ignored_paths: Set[str] = field(default_factory=set)
     ignore_known_secrets: bool = False
+    with_incident_details: bool = False
     # if configuration key is left unset the dashboard's remediation message is used.
     prereceive_remediation_message: str = ""
 

--- a/ggshield/verticals/secret/output/schemas.py
+++ b/ggshield/verticals/secret/output/schemas.py
@@ -1,5 +1,5 @@
 from marshmallow import fields
-from pygitguardian.models import BaseSchema
+from pygitguardian.models import BaseSchema, SecretIncidentSchema
 
 from ggshield.verticals.secret.extended_match import ExtendedMatchSchema
 
@@ -12,6 +12,7 @@ class FlattenedPolicyBreak(BaseSchema):
     ignore_sha = fields.String(required=True)
     total_occurrences = fields.Integer(required=True)
     incident_url = fields.String(required=True, dump_default="")
+    incident_details = fields.Nested(SecretIncidentSchema)
     known_secret = fields.Bool(required=True, dump_default=False)
 
 

--- a/ggshield/verticals/secret/output/secret_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_output_handler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from pygitguardian import GGClient
 
 from ggshield.core.errors import ExitCode
 from ggshield.verticals.secret import SecretScanCollection
@@ -11,6 +12,7 @@ from ggshield.verticals.secret import SecretScanCollection
 class SecretOutputHandler(ABC):
     show_secrets: bool = False
     verbose: bool = False
+    client: Optional[GGClient] = None
     output: Optional[Path] = None
     use_stderr: bool = False
 
@@ -18,13 +20,17 @@ class SecretOutputHandler(ABC):
         self,
         show_secrets: bool,
         verbose: bool,
+        client: Optional[GGClient] = None,
         output: Optional[Path] = None,
         ignore_known_secrets: bool = False,
+        with_incident_details: bool = False,
     ):
         self.show_secrets = show_secrets
         self.verbose = verbose
+        self.client = client
         self.output = output
         self.ignore_known_secrets = ignore_known_secrets
+        self.with_incident_details = with_incident_details
 
     def process_scan(self, scan: SecretScanCollection) -> ExitCode:
         """Process a scan collection, write the report to :attr:`self.output`

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,8 @@ install_requires =
     marshmallow>=3.18.0,<3.19.0
     marshmallow-dataclass>=8.5.8,<8.6.0
     oauthlib>=3.2.1,<3.3.0
-    pygitguardian>=1.16.0,<1.17.0
+    # TODO: replace when the next pygitguardian release is out
+    pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@dce0ec3326a52724822d0f1468d2039bd04d562b
     pyjwt>=2.6.0,<2.7.0
     python-dotenv>=0.21.0,<0.22.0
     pyyaml>=6.0.1,<6.1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,7 +11,7 @@ import yaml
 from click.testing import CliRunner, Result
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pygitguardian import GGClient
-from pygitguardian.models import ScanResult
+from pygitguardian.models import ScanResult, SecretIncident
 from requests.utils import DEFAULT_CA_BUNDLE_PATH, extract_zipped_paths
 
 from ggshield.core.cache import Cache
@@ -702,3 +702,51 @@ def clear_cache():
     _get_git_path.cache_clear()
     _git_rev_parse_absolute.cache_clear()
     read_git_file.cache_clear()
+
+
+SECRET_INCIDENT_MOCK = SecretIncident.from_dict(
+    {
+        "id": 42,
+        "date": "2024-09-04T16:00:48.956235+00:00",
+        "detector": {
+            "name": "detector",
+            "display_name": "Detector",
+            "nature": "specific",
+            "family": "Api",
+            "detector_group_name": "detector_group",
+            "detector_group_display_name": "Detector Group",
+        },
+        "secret_hash": "NpQakTjuW7LlWWgeHOR5VewWfLbUtKn1bZ3EDrLLw7aMf26zyCrzdQOwnLqJOGTb",
+        "hmsl_hash": "0483663d03dc4ea2c2bfb73d0a4a8bc6f2035d911f3a7d210a16e8314413c29e",
+        "gitguardian_url": "https://dashboard.staging.gitguardian.tech/workspace/1/incidents/42",
+        "regression": False,
+        "status": "TRIGGERED",
+        "assignee_id": None,
+        "assignee_email": None,
+        "occurrences_count": 1,
+        "secret_presence": {
+            "files_requiring_code_fix": 1,
+            "files_pending_merge": 0,
+            "files_fixed": 0,
+            "outside_vcs": 0,
+            "removed_outside_vcs": 0,
+            "in_vcs": 1,
+            "removed_in_vcs": 0,
+        },
+        "ignore_reason": None,
+        "triggered_at": "2024-09-04T16:00:48.956235+00:00",
+        "ignored_at": None,
+        "ignorer_id": None,
+        "ignorer_api_token_id": None,
+        "resolver_id": None,
+        "resolver_api_token_id": None,
+        "secret_revoked": False,
+        "severity": "high",
+        "validity": "invalid",
+        "resolved_at": None,
+        "share_url": None,
+        "tags": [],
+        "feedback_list": [],
+        "occurrences": [],
+    }
+)


### PR DESCRIPTION
## Context

- Add `--with-incident-details` to output (json and sarif output only) more information about incident when the secret is already known by the gitguardian dashboard.


## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
