### PR TITLE
Fix git parser

### DIFF
--- a/changelog.d/20240910_170441_aurelien.gateau_fix_git_parser.md
+++ b/changelog.d/20240910_170441_aurelien.gateau_fix_git_parser.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The git commit parser have been reworked, fixing cases where commands scanning commits would fail.

--- a/ggshield/core/scan/commit_information.py
+++ b/ggshield/core/scan/commit_information.py
@@ -30,7 +30,7 @@ class CommitInformation:
         Output format looks like this:
 
         ```
-        commit: $SHA
+        commit $SHA
         Author: $NAME <$EMAIL>
         Date: $DATE
 

--- a/tests/unit/core/scan/test_commit.py
+++ b/tests/unit/core/scan/test_commit.py
@@ -343,22 +343,18 @@ def scenario_type_change(repo: Repository) -> None:
             ),
             (
                 scenario_merge,
-                [
-                    ("longfile", Filemode.MODIFY),
-                    ("longfile", Filemode.MODIFY),
-                    ("longfile", Filemode.MODIFY),
-                ],
+                [],  # no conflict -> nothing to scan
             ),
             (
                 scenario_merge_with_changes,
                 [
-                    ("conflicted", Filemode.MODIFY),
                     ("conflicted", Filemode.MODIFY),
                 ],
             ),
             (
                 scenario_type_change,
                 [
+                    ("f2", Filemode.NEW),
                     ("f2", Filemode.NEW),
                 ],
             ),
@@ -390,6 +386,56 @@ def test_from_sha(
     assert paths_and_modes == [
         (Path(name), mode) for name, mode in expected_paths_and_modes
     ]
+
+
+def test_from_sha_gets_right_content_for_conflicts(tmp_path):
+    """
+    GIVEN a merge commit with a conflict, loaded with Commit.from_sha()
+    WHEN Commit.get_files() is called
+    THEN it returns the right content
+    """
+    repo = Repository.create(tmp_path)
+    scenario_merge_with_changes(repo)
+
+    sha = repo.get_top_sha()
+    commit = Commit.from_sha(sha, cwd=tmp_path)
+
+    files = list(commit.get_files())
+    assert len(files) == 1
+    content = files[0].content
+
+    # Content contains the old line,
+    assert "--Hello" in content
+    # the new line from main,
+    assert "- Hello from main" in content
+    # the new line from b1,
+    assert " -Hello from b1" in content
+    # and the result of the conflict resolution
+    assert "++Solve conflict" in content
+
+
+def test_from_sha_files_matches_content(tmp_path):
+    """
+    GIVEN a commit with many files
+    WHEN Commit.get_files() is called
+    THEN the reported file names match their expected content
+    """
+    repo = Repository.create(tmp_path)
+
+    for idx in range(50):
+        path = tmp_path / str(idx)
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(f"{idx}\n")
+        repo.add(path)
+    repo.create_commit()
+
+    sha = repo.get_top_sha()
+    commit = Commit.from_sha(sha, cwd=tmp_path)
+    files = list(commit.get_files())
+
+    for file in files:
+        last_line = file.content.splitlines()[-1]
+        assert last_line == f"+{file.path.name}"
 
 
 def test_from_staged(tmp_path):

--- a/tests/unit/core/scan/test_commit.py
+++ b/tests/unit/core/scan/test_commit.py
@@ -24,7 +24,7 @@ Date:   Fri Oct 18 13:20:00 2012 +0100
     + ":100644 100644 6546aef b41653f M\0data/utils/email_sender.py\0"
     + """\0diff --git a/ggshield/tests/cassettes/test_files_yes.yaml b/ggshield/tests/cassettes/test_files_yes.yaml
 deleted file mode 100644
-index 0000000..0000000
+index 1233aef..0000000
 --- a/ggshield/tests/cassettes/test_files_yes.yaml
 +++ /dev/null
 @@ -1,45 +0,0 @@
@@ -32,7 +32,7 @@ index 0000000..0000000
 
 diff --git a/tests/test_scannable.py b/tests/test_scannable.py
 new file mode 100644
-index 0000000..0000000
+index 0000000..19465ef
 --- /dev/null
 +++ b/tests/test_scannable.py
 @@ -0,0 +1,112 @@
@@ -44,7 +44,7 @@ new mode 100755
 
 diff --git a/.env b/.env
 new file mode 100644
-index 0000000..0000000
+index 0000000..12356ef
 --- /dev/null
 +++ b/.env
 @@ -0,0 +1,112 @@
@@ -56,7 +56,7 @@ rename from ggshield/tests/test_config.py
 rename to tests/test_config.py
 
 diff --git a/data/utils/email_sender.py b/data/utils/email_sender.py
-index 56dc0d42..fdf48995 100644
+index 6546aef..b41653f 100644
 --- a/data/utils/email_sender.py
 +++ b/data/utils/email_sender.py
 @@ -49,6 +49,7 @@ def send_email(config, subject, content, tos, seperate):


### PR DESCRIPTION
## Context

This PR fixes two problems:

Problem 1: sometimes the path for a diff is wrong. This is because `commit_utils.parse_patch()` assumes that the diffs are in the same order as the filenames in the commit header, which turns out to not always be true.

Problem 2: turning merge commits into individual commits by calling `git show` with the `-m` option does not work when fetching only some files inside the commit (which we do when scanning huge commits): it always return the changes from the first parent.

## What has been done

For problem 1: get the path name from the `+++ b/path` or `--- a/path` lines of the diff header.

For problem 2: maybe it would be possible to return the changes from the correct parents, but it felt simpler to stop using the `-m` option.

As a bonus, it simplifies `parse_patch()` because it can now assume that there is only one commit per patch.

## Validation

Tests still pass.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->