### PR TITLE
Fix output handling of merge commits

### DIFF
--- a/tests/unit/cassettes/test_scan_merge_commit.yaml
+++ b/tests/unit/cassettes/test_scan_merge_commit.yaml
@@ -1,0 +1,161 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.16.0 (Linux;py3.10.12)
+      method: GET
+      uri: https://api.gitguardian.com/v1/metadata
+    response:
+      body:
+        string:
+          '{"version":"v2.97.2","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"onboarding__segmentation_v1_enabled":true,"general__maximum_payload_size":26214400,"general__mutual_tls_mode":"disabled","general__signup_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576},"remediation_messages":{"pre_commit":">
+          How to remediate\n\n  Since the secret was detected before the commit was
+          made:\n  1. replace the secret with its reference (e.g. environment variable).\n  2.
+          commit again.\n\n> [To apply with caution] If you want to bypass ggshield
+          (false positive or other reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield
+          git commit -m \"<your message\"","pre_push":"> How to remediate\n\n  Since
+          the secret was detected before the push BUT after the commit, you need to:\n  1.
+          rewrite the git history making sure to replace the secret with its reference
+          (e.g. environment variable).\n  2. push again.\n\n  To prevent having to rewrite
+          git history in the future, setup ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [To apply with caution] If you want to bypass ggshield (false positive or
+          other reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield-push
+          git push","pre_receive":"> How to remediate\n\n  A pre-receive hook set server
+          side prevented you from pushing secrets.\n\n  Since the secret was detected
+          during the push BUT after the commit, you need to:\n  1. rewrite the git history
+          making sure to replace the secret with its reference (e.g. environment variable).\n  2.
+          push again.\n\n  To prevent having to rewrite git history in the future, setup
+          ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [To apply with caution] If you want to bypass ggshield (false positive or
+          other reason), run:\n\n    git push -o breakglass"}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '2151'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Mon, 23 Sep 2024 09:40:00 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.97.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '34'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 2.0.0
+        x-sca-last-vuln-fetch:
+          - '2024-09-23T09:06:36.704467+00:00'
+        x-secrets-engine-version:
+          - 2.120.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '[{"filename": "commit://patch/f", "document": "@@ -1,1 +1,2 @@\n-baz\n+username=owly\n+password=368ac3edf9e850d1c0ff9d6c526496f8237ddf91"}]'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '139'
+        Content-Type:
+          - application/json
+        GGShield-Command-Id:
+          - c3344cdf-dcee-4fe4-8d64-3fc69f95d2d5
+        GGShield-Command-Path:
+          - external
+        GGShield-OS-Name:
+          - ubuntu
+        GGShield-OS-Version:
+          - '22.04'
+        GGShield-Python-Version:
+          - 3.10.12
+        GGShield-Version:
+          - 1.31.0
+        User-Agent:
+          - pygitguardian/1.16.0 (Linux;py3.10.12)
+        mode:
+          - path
+      method: POST
+      uri: https://api.gitguardian.com/v1/multiscan?ignore_known_secrets=True
+    response:
+      body:
+        string:
+          '[{"policy_break_count":1,"policies":["File extensions","Filenames","Secrets
+          detection"],"policy_breaks":[{"type":"Username Password","policy":"Secrets
+          detection","matches":[{"type":"username","match":"owly","index_start":31,"index_end":34,"line_start":3,"line_end":3},{"type":"password","match":"368ac3edf9e850d1c0ff9d6c526496f8237ddf91","index_start":46,"index_end":85,"line_start":4,"line_end":4}],"incident_url":"","known_secret":false,"validity":"no_checker"}]}]'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '466'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Mon, 23 Sep 2024 09:40:01 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.97.2
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '87'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-sca-engine-version:
+          - 2.0.0
+        x-sca-last-vuln-fetch:
+          - '2024-09-23T09:06:36.704467+00:00'
+        x-secrets-engine-version:
+          - 2.120.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/core/scan/test_commit.py
+++ b/tests/unit/core/scan/test_commit.py
@@ -404,14 +404,16 @@ def test_from_sha_gets_right_content_for_conflicts(tmp_path):
     assert len(files) == 1
     content = files[0].content
 
-    # Content contains the old line,
-    assert "--Hello" in content
-    # the new line from main,
-    assert "- Hello from main" in content
-    # the new line from b1,
-    assert " -Hello from b1" in content
-    # and the result of the conflict resolution
-    assert "++Solve conflict" in content
+    # Content has been turned into a single-parent diff
+    assert (
+        content
+        == """
+@@ -1,2 +1,1 @@
+-Hello
+-Hello from main
++Solve conflict
+""".strip()
+    )
 
 
 def test_from_sha_files_matches_content(tmp_path):


### PR DESCRIPTION
## Context

GGShield output handlers currently do not support multi-parent commits. When they try to output them, they fail with list index errors:

```
$ ggshield secret scan commit-range HEAD^..
Error: list index out of range
Error: list index out of range
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2 / 2

No secrets have been found
```

This only happens in the `main` branch, not in the current release.

## What has been done

Workaround this by post-processing the diff to turn it into a single-parent commit.

## Validation

Using the same repository as in "Context":

```
$ ggshield secret scan commit-range HEAD^..
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 2 / 2

commit ca68e177596982fa38f181aa9944340a359748d2
Author: Aurelien Gateau <aurelien.gateau@gitguardian.com>
Date: Thu Sep 5 18:39:58 2024 +0200

> commit://ca68e177596982fa38f181aa9944340a359748d2/f: 1 incident detected

>> Secret detected: Username Password
   Validity: No Checker
   Occurrences: 1
   Known by GitGuardian dashboard: NO
   Incident URL: N/A
   Secret SHA: b90d21fc2d768dd94ff5fe69afec948ce10dfd53dc56303b5c688db9f40bfcb3

    | @@ -1,1 +1,2 @@
1   | -baz
...
  1 | +username=billybob
                |_username_|
  2 | +password=R34R_cZFFFrzfrzArz
                |____password____|
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

(skip-changelog because this bug is not in the current release)

<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
