### PR TITLE
Post-release fixes

### DIFF
--- a/scripts/hmsl/hashicorp_vault.py
+++ b/scripts/hmsl/hashicorp_vault.py
@@ -15,6 +15,8 @@ CONTAINER_NAME = "hashicorp-vault-ggshield"
 ROOT_TOKEN = "my_vault_token"
 RESTRICTED_TOKEN = "restricted_token"
 
+READY_TRIES = 20
+
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -29,8 +31,7 @@ def wait_for_server_to_be_ready() -> None:
 
     If timeout elapsed, a RuntimeError is raised.
     """
-    tries = 0
-    while tries < 10:
+    for tries in range(READY_TRIES):
         check_cmd_ret = subprocess.run(
             [
                 "docker",
@@ -46,11 +47,12 @@ def wait_for_server_to_be_ready() -> None:
 
         if "(healthy)" in json_status["Status"]:
             logger.debug("Server is healthy")
-            return True
+            return
 
-        logger.debug("Server not healthy yet, waiting...")
+        logger.debug(
+            "Server not healthy yet, waiting... (%d / %d)", tries + 1, READY_TRIES
+        )
         time.sleep(0.500)
-        tries += 1
 
     raise RuntimeError("Hashicorp Vault server is not ready")
 

--- a/tests/functional/secret/test_scan_prereceive.py
+++ b/tests/functional/secret/test_scan_prereceive.py
@@ -1,8 +1,6 @@
 import logging
-import os
 from pathlib import Path
 from subprocess import CalledProcessError
-from unittest.mock import patch
 
 import pytest
 
@@ -106,7 +104,7 @@ def test_scan_prereceive_push_force(tmp_path: Path) -> None:
 
 
 def test_scan_prereceive_timeout(
-    tmp_path: Path, slow_gitguardian_api: str, caplog
+    tmp_path: Path, monkeypatch, slow_gitguardian_api: str, caplog
 ) -> None:
     # GIVEN a remote repository
     remote_repo = Repository.create(tmp_path / "remote", bare=True)
@@ -128,9 +126,9 @@ def test_scan_prereceive_timeout(
 
     # WHEN I try to push
     # THEN the hook timeouts and allows the push
-    with patch.dict(
-        os.environ, {**os.environ, "GITGUARDIAN_API_URL": slow_gitguardian_api}
-    ), caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING):
+        monkeypatch.setenv("GITGUARDIAN_API_URL", slow_gitguardian_api)
+        monkeypatch.delenv("GITGUARDIAN_INSTANCE", raising=False)
         local_repo.push()
 
     # AND the error message contains timeout message


### PR DESCRIPTION
## Context

This PR fixes two issues I hit during the release:
- The test vault server taking too long to start
- Some tests failing if `$GITGUARDIAN_INSTANCE` is set

## What has been done

- Increase timeout for the Vault server (also, turn that `while` loop into a `for`!)
- monkeypatch GITGUARDIAN_INSTANCE

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
