### PR TITLE
Fix `ggshield install -m global`

### DIFF
--- a/changelog.d/20241010_171735_aurelien.gateau_fix_install_global.md
+++ b/changelog.d/20241010_171735_aurelien.gateau_fix_install_global.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a regression introduced in ggshield 1.32.1, which made `ggshield install -m global` crash (#972).

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from platformdirs import user_cache_dir, user_config_dir
+from platformdirs import user_cache_dir, user_config_dir, user_data_dir
 
 from ggshield.utils.git_shell import NotAGitDirectory, get_git_root
 
@@ -32,6 +32,16 @@ def get_cache_dir() -> Path:
         return Path(os.environ["GG_CACHE_DIR"])
     except KeyError:
         return Path(user_cache_dir(appname=APPNAME, appauthor=APPAUTHOR))
+
+
+def get_data_dir() -> Path:
+    try:
+        # See tests/conftest.py for details
+        return Path(os.environ["GG_DATA_DIR"])
+    except KeyError:
+        return Path(
+            user_data_dir(appname=APPNAME, appauthor=APPAUTHOR)
+        )  # pragma: no cover
 
 
 def get_project_root_dir(path: Path) -> Path:

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -186,6 +186,7 @@ def git(
     check: bool = True,
     cwd: Optional[Union[str, Path]] = None,
     log_stderr: bool = True,
+    ignore_git_config: bool = True,
 ) -> str:
     """Calls git with the given arguments, returns stdout as a string"""
     env = os.environ.copy()
@@ -193,8 +194,9 @@ def git(
     env["LANG"] = "C"
     # Ensure git behavior is not affected by the user git configuration, but give us a
     # way to set some configuration (useful for safe.directory)
-    env["GIT_CONFIG_GLOBAL"] = os.getenv("GG_GIT_CONFIG", "")
-    env["GIT_CONFIG_SYSTEM"] = ""
+    if ignore_git_config:
+        env["GIT_CONFIG_GLOBAL"] = os.getenv("GG_GIT_CONFIG", "")
+        env["GIT_CONFIG_SYSTEM"] = ""
 
     if cwd is None:
         cwd = Path.cwd()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def do_not_use_real_user_dirs(monkeypatch, tmp_path):
     """
     monkeypatch.setenv("GG_CONFIG_DIR", str(tmp_path / "config"))
     monkeypatch.setenv("GG_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("GG_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("GG_USER_HOME_DIR", str(tmp_path / "home"))
 
 

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
-from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from ggshield.__main__ import cli
+from ggshield.cmd.install import get_default_global_hook_dir_path
 from ggshield.core.errors import ExitCode
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
@@ -18,15 +18,6 @@ ggshield secret scan pre-commit "$@"
 SAMPLE_PRE_PUSH = """#!/bin/sh
 ggshield secret scan pre-push "$@"
 """
-
-
-@pytest.fixture(scope="class")
-def mockHookDirPath():
-    with mock.patch(
-        "ggshield.cmd.install.get_global_hook_dir_path",
-        return_value=Path("global/hooks"),
-    ):
-        yield
 
 
 class TestInstallLocal:
@@ -187,45 +178,84 @@ class TestInstallLocal:
         assert_invoke_ok(result)
 
 
-class TestInstallGlobal:
-    def test_global_exist_is_dir(self, cli_fs_runner, mockHookDirPath):
-        global_hook_path = Path("global/hooks/pre-commit")
-        global_hook_path.mkdir(parents=True)
+@pytest.fixture()
+def custom_global_git_config_path(tmp_path, monkeypatch):
+    config_path = tmp_path / "global-git-config"
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config_path))
+    yield config_path
 
-        result = cli_fs_runner.invoke(cli, ["install", "-m", "global"])
+
+class TestInstallGlobal:
+    """
+    These tests use the cli_runner fixture and not the cli_fs_runner one. The reason for
+    this is they execute git commands and git commands are not run in the fake
+    filesystem created by cli_fs_runner so the fake filesystem is useless here.
+    """
+
+    def test_global_exist_is_dir(
+        self, cli_runner: CliRunner, custom_global_git_config_path: Path
+    ):
+        global_pre_commit_hook_path = get_default_global_hook_dir_path() / "pre-commit"
+        global_pre_commit_hook_path.mkdir(parents=True)
+
+        result = cli_runner.invoke(cli, ["install", "-m", "global"])
         assert_invoke_exited_with(result, ExitCode.USAGE_ERROR)
         assert result.exception
 
-    def test_global_not_exist(self, cli_fs_runner, mockHookDirPath):
-        global_hook_path = Path("global/hooks/pre-commit")
-        assert not global_hook_path.exists()
+    def test_global_not_exist(self, cli_runner, custom_global_git_config_path: Path):
+        global_pre_commit_hook_path = get_default_global_hook_dir_path() / "pre-commit"
+        assert not global_pre_commit_hook_path.exists()
 
-        result = cli_fs_runner.invoke(cli, ["install", "-m", "global"])
-        assert global_hook_path.is_file()
+        result = cli_runner.invoke(cli, ["install", "-m", "global"])
+        assert global_pre_commit_hook_path.is_file()
         assert_invoke_ok(result)
-        assert f"pre-commit successfully added in {global_hook_path}" in result.output
+        assert (
+            f"pre-commit successfully added in {global_pre_commit_hook_path}"
+            in result.output
+        )
+
+    def test_install_custom_global_hook_dir(
+        self, cli_runner: CliRunner, tmp_path: Path, custom_global_git_config_path: Path
+    ):
+        """
+        GIVEN an existing global git config
+        AND a custom value for core.hooksPath in the global git config
+        WHEN `install -m global` is called
+        THEN it installs the hook in the custom core.hooksPath dir
+        """
+        custom_hooks_dir = tmp_path / "custom-hooks-dir"
+        custom_pre_commit_path = custom_hooks_dir / "pre-commit"
+        custom_global_git_config_path.write_text(
+            f"[core]\nhooksPath = {custom_hooks_dir.as_posix()}\n", encoding="utf-8"
+        )
+
+        result = cli_runner.invoke(cli, ["install", "-m", "global"])
+        assert_invoke_ok(result)
+        assert custom_pre_commit_path.is_file()
+        assert (
+            f"pre-commit successfully added in {custom_pre_commit_path}"
+            in result.output
+        )
 
     @pytest.mark.parametrize("hook_type", ["pre-push", "pre-commit"])
-    @patch("ggshield.cmd.install.get_global_hook_dir_path")
     def test_install_global(
         self,
-        get_global_hook_dir_path_mock: Mock,
         hook_type: str,
-        cli_fs_runner: CliRunner,
+        cli_runner: CliRunner,
+        custom_global_git_config_path: Path,
     ):
         """
         GIVEN None
         WHEN the command is run
         THEN it should create a pre-push git hook script in the global path
         """
-        global_hooks_dir = Path("global_hooks")
-        get_global_hook_dir_path_mock.return_value = global_hooks_dir
-        result = cli_fs_runner.invoke(
+
+        result = cli_runner.invoke(
             cli,
             ["install", "-m", "global", "-t", hook_type],
         )
 
-        hook_path = global_hooks_dir / hook_type
+        hook_path = get_default_global_hook_dir_path() / hook_type
         hook_str = hook_path.read_text()
         assert f"if [ -f .git/hooks/{hook_type} ]; then" in hook_str
         assert f"ggshield secret scan {hook_type}" in hook_str
@@ -233,23 +263,37 @@ class TestInstallGlobal:
         assert f"{hook_type} successfully added in {hook_path}\n" in result.output
         assert_invoke_ok(result)
 
-    def test_global_exist_not_force(self, cli_fs_runner, mockHookDirPath):
-        hook_path = Path("global/hooks/pre-commit")
+    def test_global_exist_not_force(
+        self, cli_runner: CliRunner, custom_global_git_config_path: Path
+    ):
+        """
+        GIVEN a global hook dir with an exising pre-commit script
+        WHEN install is called
+        THEN it fails
+        """
+        hook_path = get_default_global_hook_dir_path() / "pre-commit"
         hook_path.parent.mkdir(parents=True, exist_ok=True)
         hook_path.write_text("pre-commit file")
         assert hook_path.is_file()
 
-        result = cli_fs_runner.invoke(cli, ["install", "-m", "global"])
+        result = cli_runner.invoke(cli, ["install", "-m", "global"])
         assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
         assert result.exception
         assert f"Error: {hook_path} already exists." in result.output
 
-    def test_global_exist_force(self, cli_fs_runner, mockHookDirPath):
-        hook_path = Path("global/hooks/pre-commit")
+    def test_global_exist_force(
+        self, cli_runner: CliRunner, custom_global_git_config_path: Path
+    ):
+        """
+        GIVEN a global hook dir with an exising pre-commit script
+        WHEN install is called with -f
+        THEN it ignores the fact that the pre-commit script exists and succeeds
+        """
+        hook_path = get_default_global_hook_dir_path() / "pre-commit"
         hook_path.parent.mkdir(parents=True, exist_ok=True)
         hook_path.write_text("pre-commit file")
         assert hook_path.is_file()
 
-        result = cli_fs_runner.invoke(cli, ["install", "-m", "global", "-f"])
+        result = cli_runner.invoke(cli, ["install", "-m", "global", "-f"])
         assert_invoke_ok(result)
         assert f"pre-commit successfully added in {hook_path}" in result.output


### PR DESCRIPTION
## Context

The fix from 1.32.1 to ignore the user git configuration when running git commands broke `ggshield install -m global` because this command modifies the global git config so it must not ignore the user git configuration.

This is #972.

## What has been done

- Add a `ignore_git_config` optional argument to `git_shell.git()`, which defaults to True. Set it to False in calls from cmd.install.
- Make `install_global()` install the git hooks in a sub-directory of the dir returned by `get_data_dir()`, this is required to be able to have tests which fail in the situation of 1.32.1.
- Rework test_install to be able to reproduce the bug. Add more tests.

Best reviewed commit by commit.

## Validation

Run `ggshield install -m global`. It should not crash anymore.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
