### PR TITLE
feat: add --no-mirror option

### DIFF
--- a/changelog.d/20241030_095506_guillaume.valadon_git_clone_mirror.md
+++ b/changelog.d/20241030_095506_guillaume.valadon_git_clone_mirror.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ggshield secret scan repo` now uses `git clone --mirror` to retrive more git objects

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -60,7 +60,7 @@ def repo_cmd(
 
     if REGEX_GIT_URL.match(repository):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            git(["clone", repository, tmpdirname])
+            git(["clone", "--mirror", repository, tmpdirname])
             scan_context.target_path = Path(tmpdirname)
             return scan_repo_path(
                 client=client,


### PR DESCRIPTION
## Context

Cloning a repository with `git clone --mirror` may retrieve more git objects, and lead to more secrets being detected.

## What has been done

By default ggshield now used `--mirror`. A new command line option could be used to disable this feature.

## Validation

Clone `https://github.com/nightwatchcybersecurity/gb_testrepo_delete?tab=readme-ov-file`with and without the new option.
