### PR TITLE
chore: pass secret config around instead of discrete args

### DIFF
--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -64,8 +64,7 @@ def archive_cmd(
                 client=ctx_obj.client,
                 cache=ctx_obj.cache,
                 scan_context=scan_context,
-                ignored_matches=config.user_config.secret.ignored_matches,
-                ignored_detectors=config.user_config.secret.ignored_detectors,
+                secret_config=config.user_config.secret,
             )
             results = scanner.scan(files, scanner_ui=scanner_ui)
 

--- a/ggshield/cmd/secret/scan/changes.py
+++ b/ggshield/cmd/secret/scan/changes.py
@@ -52,9 +52,7 @@ def changes_cmd(ctx: click.Context, **kwargs: Any) -> int:
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
         exclusion_regexes=ctx_obj.exclusion_regexes,
-        matches_ignore=config.user_config.secret.ignored_matches,
+        secret_config=config.user_config.secret,
         scan_context=scan_context,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
         verbose=config.user_config.verbose,
-        include_staged=True,
     )

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -51,7 +51,6 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
         exclusion_regexes=ctx_obj.exclusion_regexes,
-        matches_ignore=config.user_config.secret.ignored_matches,
+        secret_config=config.user_config.secret,
         scan_context=scan_context,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
     )

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -57,9 +57,8 @@ def docker_name_cmd(
             archive_path=archive,
             client=ctx_obj.client,
             cache=ctx_obj.cache,
-            matches_ignore=config.user_config.secret.ignored_matches,
+            secret_config=config.user_config.secret,
             scan_context=scan_context,
-            ignored_detectors=config.user_config.secret.ignored_detectors,
             verbose=config.user_config.verbose,
         )
 

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -44,9 +44,8 @@ def docker_archive_cmd(
         archive_path=archive,
         client=ctx_obj.client,
         cache=ctx_obj.cache,
-        matches_ignore=config.user_config.secret.ignored_matches,
+        secret_config=config.user_config.secret,
         scan_context=scan_context,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
     )
 
     return output_handler.process_scan(scan)

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -76,9 +76,8 @@ def docset_cmd(
         scanner = SecretScanner(
             client=ctx_obj.client,
             cache=ctx_obj.cache,
-            ignored_matches=config.user_config.secret.ignored_matches,
+            secret_config=config.user_config.secret,
             scan_context=scan_context,
-            ignored_detectors=config.user_config.secret.ignored_detectors,
         )
         scans = create_scans_from_docset_files(
             scanner=scanner,

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -81,9 +81,8 @@ def path_cmd(
         scanner = SecretScanner(
             client=ctx_obj.client,
             cache=ctx_obj.cache,
-            ignored_matches=config.user_config.secret.ignored_matches,
             scan_context=scan_context,
-            ignored_detectors=config.user_config.secret.ignored_detectors,
+            secret_config=config.user_config.secret,
         )
         results = scanner.scan(files, scanner_ui=scanner_ui)
     scan = SecretScanCollection(

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -66,12 +66,10 @@ def precommit_cmd(
         return 0
 
     output_handler = SecretTextOutputHandler(
-        show_secrets=config.user_config.secret.show_secrets,
         verbose=verbose,
         client=ctx_obj.client,
         output=None,
-        ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
-        with_incident_details=config.user_config.secret.with_incident_details,
+        secret_config=config.user_config.secret,
     )
     check_git_dir()
 
@@ -94,8 +92,7 @@ def precommit_cmd(
         client=ctx_obj.client,
         cache=ctx_obj.cache,
         scan_context=scan_context,
-        ignored_matches=config.user_config.secret.ignored_matches,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
+        secret_config=config.user_config.secret,
     )
     with ui.create_scanner_ui(len(commit.urls), verbose=verbose) as scanner_ui:
         results = scanner.scan(commit.get_files(), scanner_ui)

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -98,9 +98,8 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
         exclusion_regexes=ctx_obj.exclusion_regexes,
-        matches_ignore=config.user_config.secret.ignored_matches,
+        secret_config=config.user_config.secret,
         scan_context=scan_context,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
     )
     if return_code:
         click.echo(

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -55,9 +55,8 @@ def _execute_prereceive(
             commit_list=commit_list,
             output_handler=output_handler,
             exclusion_regexes=exclusion_regexes,
-            matches_ignore=config.user_config.secret.ignored_matches,
+            secret_config=config.user_config.secret,
             scan_context=scan_context,
-            ignored_detectors=config.user_config.secret.ignored_detectors,
         )
         if return_code:
             click.echo(
@@ -95,8 +94,7 @@ def prereceive_cmd(
     if os.getenv("GL_PROTOCOL") == "web":
         # We are inside GitLab web UI
         output_handler = SecretGitLabWebUIOutputHandler(
-            show_secrets=config.user_config.secret.show_secrets,
-            ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
+            secret_config=config.user_config.secret
         )
 
     if get_breakglass_option():

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -94,7 +94,7 @@ def prereceive_cmd(
     if os.getenv("GL_PROTOCOL") == "web":
         # We are inside GitLab web UI
         output_handler = SecretGitLabWebUIOutputHandler(
-            secret_config=config.user_config.secret
+            secret_config=config.user_config.secret, verbose=False
         )
 
     if get_breakglass_option():

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -122,9 +122,8 @@ def pypi_cmd(
             scanner = SecretScanner(
                 client=ctx_obj.client,
                 cache=ctx_obj.cache,
-                ignored_matches=config.user_config.secret.ignored_matches,
+                secret_config=config.user_config.secret,
                 scan_context=scan_context,
-                ignored_detectors=config.user_config.secret.ignored_detectors,
             )
             results = scanner.scan(files, scanner_ui=scanner_ui)
         scan = SecretScanCollection(id=package_name, type="path_scan", results=results)

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -52,8 +52,7 @@ def range_cmd(
         commit_list=commit_list,
         output_handler=create_output_handler(ctx),
         exclusion_regexes=ctx_obj.exclusion_regexes,
-        matches_ignore=config.user_config.secret.ignored_matches,
+        secret_config=config.user_config.secret,
         scan_context=scan_context,
-        ignored_detectors=config.user_config.secret.ignored_detectors,
         verbose=config.user_config.verbose,
     )

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -159,10 +159,8 @@ def create_output_handler(ctx: click.Context) -> SecretOutputHandler:
     output_handler_cls = OUTPUT_HANDLER_CLASSES[ctx_obj.output_format]
     config = ctx_obj.config
     return output_handler_cls(
-        show_secrets=config.user_config.secret.show_secrets,
         verbose=config.user_config.verbose,
         client=ctx_obj.client,
         output=ctx_obj.output,
-        ignore_known_secrets=config.user_config.secret.ignore_known_secrets,
-        with_incident_details=config.user_config.secret.with_incident_details,
+        secret_config=config.user_config.secret,
     )

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -5,18 +5,18 @@ import tarfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Generator, Iterable, List, Optional, Set
+from typing import Any, Dict, Generator, Iterable, List
 
 from click import UsageError
 from pygitguardian import GGClient
 
 from ggshield.core import ui
 from ggshield.core.cache import Cache
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.dirs import get_cache_dir
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, Scannable, StringScannable
 from ggshield.core.scan.id_cache import IDCache
-from ggshield.core.types import IgnoredMatch
 from ggshield.utils.files import is_path_binary
 
 from .secret_scan_collection import SecretScanCollection
@@ -325,17 +325,15 @@ def docker_scan_archive(
     archive_path: Path,
     client: GGClient,
     cache: Cache,
-    matches_ignore: Iterable[IgnoredMatch],
+    secret_config: SecretConfig,
     scan_context: ScanContext,
-    ignored_detectors: Optional[Set[str]] = None,
     verbose: bool = False,
 ) -> SecretScanCollection:
     scanner = SecretScanner(
         client=client,
         cache=cache,
         scan_context=scan_context,
-        ignored_matches=matches_ignore,
-        ignored_detectors=ignored_detectors,
+        secret_config=secret_config,
     )
     secrets_engine_version = client.secrets_engine_version
     assert secrets_engine_version is not None

--- a/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from pygitguardian.models import PolicyBreak
 
 from ggshield.core.filter import censor_match
@@ -33,13 +31,6 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
     """
 
     use_stderr = True
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(
-            *args,
-            **kwargs,
-            verbose=False,
-        )
 
     def _process_scan_impl(self, scan: SecretScanCollection) -> str:
         results = list(scan.get_all_results())

--- a/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pygitguardian.models import PolicyBreak
 
 from ggshield.core.filter import censor_match
@@ -32,13 +34,11 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
 
     use_stderr = True
 
-    def __init__(
-        self, show_secrets: bool = False, ignore_known_secrets: bool = False
-    ) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(
-            show_secrets=show_secrets,
+            *args,
+            **kwargs,
             verbose=False,
-            ignore_known_secrets=ignore_known_secrets,
         )
 
     def _process_scan_impl(self, scan: SecretScanCollection) -> str:

--- a/ggshield/verticals/secret/output/secret_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_output_handler.py
@@ -5,12 +5,12 @@ from typing import Optional
 import click
 from pygitguardian import GGClient
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.errors import ExitCode
 from ggshield.verticals.secret import SecretScanCollection
 
 
 class SecretOutputHandler(ABC):
-    show_secrets: bool = False
     verbose: bool = False
     client: Optional[GGClient] = None
     output: Optional[Path] = None
@@ -18,19 +18,17 @@ class SecretOutputHandler(ABC):
 
     def __init__(
         self,
-        show_secrets: bool,
         verbose: bool,
+        secret_config: SecretConfig,
         client: Optional[GGClient] = None,
         output: Optional[Path] = None,
-        ignore_known_secrets: bool = False,
-        with_incident_details: bool = False,
     ):
-        self.show_secrets = show_secrets
+        self.show_secrets = secret_config.show_secrets
         self.verbose = verbose
         self.client = client
         self.output = output
-        self.ignore_known_secrets = ignore_known_secrets
-        self.with_incident_details = with_incident_details
+        self.ignore_known_secrets = secret_config.ignore_known_secrets
+        self.with_incident_details = secret_config.with_incident_details
 
     def process_scan(self, scan: SecretScanCollection) -> ExitCode:
         """Process a scan collection, write the report to :attr:`self.output`

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -4,7 +4,7 @@ import os
 import sys
 from ast import literal_eval
 from concurrent.futures import Future
-from typing import Dict, Iterable, List, Optional, Set, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, MultiScanResult
@@ -12,6 +12,7 @@ from pygitguardian.models import Detail, MultiScanResult
 from ggshield.core import ui
 from ggshield.core.cache import Cache
 from ggshield.core.client import check_client_api_key
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import handle_api_error
 from ggshield.core.filter import (
@@ -20,7 +21,6 @@ from ggshield.core.filter import (
 )
 from ggshield.core.scan import DecodeError, ScanContext, Scannable
 from ggshield.core.text_utils import pluralize
-from ggshield.core.types import IgnoredMatch
 from ggshield.core.ui.scanner_ui import ScannerUI
 
 from .secret_scan_collection import Error, Result, Results
@@ -50,8 +50,7 @@ class SecretScanner:
         client: GGClient,
         cache: Cache,
         scan_context: ScanContext,
-        ignored_matches: Optional[Iterable[IgnoredMatch]] = None,
-        ignored_detectors: Optional[Set[str]] = None,
+        secret_config: SecretConfig,
         check_api_key: Optional[bool] = True,
     ):
         if check_api_key:
@@ -59,8 +58,8 @@ class SecretScanner:
 
         self.client = client
         self.cache = cache
-        self.ignored_matches = ignored_matches or []
-        self.ignored_detectors = ignored_detectors
+        self.ignored_matches = secret_config.ignored_matches or []
+        self.ignored_detectors = secret_config.ignored_detectors
         self.headers = scan_context.get_http_headers()
         self.command_id = scan_context.command_id
 

--- a/tests/unit/cmd/scan/test_prepush.py
+++ b/tests/unit/cmd/scan/test_prepush.py
@@ -163,13 +163,12 @@ class TestPrepush:
             commit_list=shas,
             output_handler=ANY,
             exclusion_regexes=ANY,
-            matches_ignore=ANY,
             scan_context=ScanContext(
                 scan_mode=ScanMode.PRE_PUSH,
                 command_path="cli secret scan pre-push",
                 target_path=local_repo.path,
             ),
-            ignored_detectors=set(),
+            secret_config=ANY,
         )
         assert_invoke_ok(result)
         assert "Commits to scan: 20" in result.output
@@ -351,9 +350,8 @@ class TestPrepush:
             commit_list=shas,
             output_handler=ANY,
             exclusion_regexes=ANY,
-            matches_ignore=ANY,
             scan_context=ANY,
-            ignored_detectors=set(),
+            secret_config=ANY,
         )
 
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
@@ -391,9 +389,8 @@ class TestPrepush:
             commit_list=shas,
             output_handler=ANY,
             exclusion_regexes=ANY,
-            matches_ignore=ANY,
             scan_context=ANY,
-            ignored_detectors=set(),
+            secret_config=ANY,
         )
 
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -311,9 +311,8 @@ class TestPreReceive:
             commit_list=shas,
             output_handler=ANY,
             exclusion_regexes=ANY,
-            matches_ignore=ANY,
             scan_context=ANY,
-            ignored_detectors=set(),
+            secret_config=ANY,
         )
 
     @patch("ggshield.cmd.secret.scan.prereceive.scan_commit_range")

--- a/tests/unit/cmd/test_ignore.py
+++ b/tests/unit/cmd/test_ignore.py
@@ -103,11 +103,11 @@ def test_cache_catches_last_found_secrets(client, isolated_fs):
         scanner = SecretScanner(
             client=client,
             cache=cache,
-            ignored_matches=config.user_config.secret.ignored_matches,
             scan_context=ScanContext(
                 scan_mode=ScanMode.COMMIT_RANGE,
                 command_path="external",
             ),
+            secret_config=config.user_config.secret,
         )
         scanner.scan(commit.get_files(), scanner_ui=Mock())
     assert config.user_config.secret.ignored_matches == list()
@@ -140,11 +140,11 @@ def test_cache_catches_nothing(client, isolated_fs):
         scanner = SecretScanner(
             client=client,
             cache=cache,
-            ignored_matches=config.user_config.secret.ignored_matches,
             scan_context=ScanContext(
                 scan_mode=ScanMode.COMMIT_RANGE,
                 command_path="external",
             ),
+            secret_config=config.user_config.secret,
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
 

--- a/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
+++ b/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
@@ -43,7 +43,9 @@ def test_gitlab_web_ui_output_no_secrets(ignore_known_secrets):
     secret_config = SecretConfig(
         show_secrets=True, ignore_known_secrets=ignore_known_secrets
     )
-    output_handler = SecretGitLabWebUIOutputHandler(secret_config=secret_config)
+    output_handler = SecretGitLabWebUIOutputHandler(
+        secret_config=secret_config, verbose=False
+    )
     scan = SecretScanCollection(
         id="scan",
         type="test",
@@ -103,7 +105,9 @@ def test_gitlab_web_ui_output_ignore_known_secrets(secrets_types, ignore_known_s
     secret_config = SecretConfig(
         show_secrets=True, ignore_known_secrets=ignore_known_secrets
     )
-    output_handler = SecretGitLabWebUIOutputHandler(secret_config=secret_config)
+    output_handler = SecretGitLabWebUIOutputHandler(
+        secret_config=secret_config, verbose=False
+    )
     output = output_handler._process_scan_impl(
         SecretScanCollection(
             id="outer_scan",

--- a/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
+++ b/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import pytest
 from pygitguardian.models import Match, PolicyBreak
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import StringScannable
 from ggshield.verticals.secret import Result, Results, SecretScanCollection
 from ggshield.verticals.secret.output.secret_gitlab_webui_output_handler import (
@@ -39,9 +40,10 @@ def test_gitlab_web_ui_output_no_secrets(ignore_known_secrets):
     WHEN GitLabWebUIOutputHandler manipulates the corresponding scan
     THEN the error message is empty as expected and the status code is zero
     """
-    output_handler = SecretGitLabWebUIOutputHandler(
+    secret_config = SecretConfig(
         show_secrets=True, ignore_known_secrets=ignore_known_secrets
     )
+    output_handler = SecretGitLabWebUIOutputHandler(secret_config=secret_config)
     scan = SecretScanCollection(
         id="scan",
         type="test",
@@ -98,9 +100,10 @@ def test_gitlab_web_ui_output_ignore_known_secrets(secrets_types, ignore_known_s
             f"https://dashboard.gitguardian.com/workspace/1/incidents/{index}"
         )
 
-    output_handler = SecretGitLabWebUIOutputHandler(
+    secret_config = SecretConfig(
         show_secrets=True, ignore_known_secrets=ignore_known_secrets
     )
+    output_handler = SecretGitLabWebUIOutputHandler(secret_config=secret_config)
     output = output_handler._process_scan_impl(
         SecretScanCollection(
             id="outer_scan",

--- a/tests/unit/verticals/secret/output/test_sarif_output.py
+++ b/tests/unit/verticals/secret/output/test_sarif_output.py
@@ -9,6 +9,7 @@ from pytest_voluptuous import S
 from voluptuous import Optional as VOptional
 from voluptuous import validators
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import Commit
 from ggshield.verticals.secret import Result, Results, SecretScanCollection
 from ggshield.verticals.secret.output import SecretSARIFOutputHandler
@@ -122,7 +123,9 @@ def test_sarif_output_no_secrets(init_secrets_engine_version):
     THEN it outputs an empty SARIF document
     """
     scan = SecretScanCollection(id="path", type="test", results=Results())
-    handler = SecretSARIFOutputHandler(verbose=True, show_secrets=False)
+    handler = SecretSARIFOutputHandler(
+        verbose=True, secret_config=SecretConfig(show_secrets=False)
+    )
     output = handler._process_scan_impl(scan)
     dct = json.loads(output)
 
@@ -166,11 +169,12 @@ def test_sarif_output_for_flat_scan_with_secrets(
     client_mock = mock.Mock(spec=GGClient)
     client_mock.retrieve_secret_incident.return_value = SECRET_INCIDENT_MOCK
 
-    handler = SecretSARIFOutputHandler(
-        verbose=True,
+    secret_config = SecretConfig(
         show_secrets=False,
-        client=client_mock,
         with_incident_details=with_incident_details,
+    )
+    handler = SecretSARIFOutputHandler(
+        verbose=True, secret_config=secret_config, client=client_mock
     )
 
     commit = Commit.from_patch(patch)
@@ -231,7 +235,9 @@ def test_sarif_output_for_nested_scan(init_secrets_engine_version):
     WHEN SecretSARIFOutputHandler runs on it
     THEN it outputs a SARIF document pointing to the secrets
     """
-    handler = SecretSARIFOutputHandler(verbose=True, show_secrets=False)
+    handler = SecretSARIFOutputHandler(
+        verbose=True, secret_config=SecretConfig(show_secrets=False)
+    )
 
     nested_scans = []
     contents = []

--- a/tests/unit/verticals/secret/output/test_text_output.py
+++ b/tests/unit/verticals/secret/output/test_text_output.py
@@ -4,6 +4,7 @@ from unittest import mock
 import click
 import pytest
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.filter import group_policy_breaks_by_ignore_sha
 from ggshield.core.scan import StringScannable
 from ggshield.utils.git_shell import Filemode
@@ -117,8 +118,9 @@ def test_leak_message(result_input, snapshot, show_secrets, verbose):
     ) as VERSIONS:
         VERSIONS.secrets_engine_version = "3.14.159"
 
+        secret_config = SecretConfig(show_secrets=show_secrets)
         output_handler = SecretTextOutputHandler(
-            show_secrets=show_secrets, verbose=verbose
+            secret_config=secret_config, verbose=verbose
         )
 
         # _process_scan_impl() modifies its SecretScanCollection arg(!), so make a copy of it
@@ -224,8 +226,11 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
     WHEN generating text output
     THEN if ignore_known_secrets is used, do not show known secret (unless the verbose mode)
     """
+    secret_config = SecretConfig(
+        show_secrets=True, ignore_known_secrets=ignore_known_secrets
+    )
     output_handler = SecretTextOutputHandler(
-        show_secrets=True, verbose=verbose, ignore_known_secrets=ignore_known_secrets
+        secret_config=secret_config, verbose=verbose
     )
 
     result: Result = Result(
@@ -296,9 +301,10 @@ def test_ignore_known_secrets_exit_code(ignore_known_secrets, secrets_types):
     WHEN checking for the exit code
     THEN the exit code is 1 when the new secrets are present, and 0 otherwise
     """
-    output_handler = SecretTextOutputHandler(
-        show_secrets=True, verbose=False, ignore_known_secrets=ignore_known_secrets
+    secret_config = SecretConfig(
+        show_secrets=True, ignore_known_secrets=ignore_known_secrets
     )
+    output_handler = SecretTextOutputHandler(secret_config=secret_config, verbose=False)
 
     result: Result = Result(
         StringScannable(

--- a/tests/unit/verticals/secret/test_scan.py
+++ b/tests/unit/verticals/secret/test_scan.py
@@ -7,6 +7,7 @@ from pygitguardian.models import MultiScanResult, ScanResult
 
 from ggshield import __version__
 from ggshield.core.cache import Cache
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import Commit, ScanContext, ScanMode
 from ggshield.utils.os import cd, get_os_info
 from ggshield.verticals.secret import SecretScanner
@@ -47,6 +48,7 @@ def test_request_headers(scan_mock: Mock, client):
                 command_path=ctx.command_path,
             ),
             check_api_key=False,
+            secret_config=SecretConfig(),
         )
         scanner.scan(c.get_files(), scanner_ui=Mock())
     scan_mock.assert_called_with(

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import Commit
 from ggshield.core.scan.commit_information import CommitInformation
 from ggshield.core.scan.commit_utils import CommitScannable
@@ -136,10 +137,10 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
         commits=[commit_1, commit_2],
         client=MagicMock(),
         cache=MagicMock(),
-        matches_ignore=[],
         scan_context=MagicMock(),
         progress_callback=(lambda advance: None),
         commit_scanned_callback=(lambda commit: None),
+        secret_config=SecretConfig(),
     )
 
     assert len(scan_collection.scans) == 2
@@ -225,10 +226,10 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
         commits=[commit_1, commit_2],
         client=MagicMock(),
         cache=MagicMock(),
-        matches_ignore=[],
         scan_context=MagicMock(),
         progress_callback=(lambda advance: None),
         commit_scanned_callback=(lambda commit: None),
+        secret_config=SecretConfig(),
     )
 
     assert len(scan_collection.scans) == 2

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -5,6 +5,7 @@ import click
 import pytest
 from pygitguardian.models import Detail
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.errors import ExitCode, QuotaLimitReachedError
 from ggshield.core.scan import (
     Commit,
@@ -90,6 +91,7 @@ def test_scan_patch(client, cache, name: str, input_patch: str, expected: Expect
                 scan_mode=ScanMode.PATH,
                 command_path="external",
             ),
+            secret_config=SecretConfig(),
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
         for result in results.results:
@@ -143,6 +145,7 @@ def test_scanner_skips_unscannable_files(client, fs, cache, unscannable_type: st
             command_path="external",
         ),
         check_api_key=False,
+        secret_config=SecretConfig(),
     )
     scanner.scan([mock], scanner_ui=scanner_ui)
 
@@ -229,6 +232,7 @@ index 7601807,5716ca5..8c27e55
                 scan_mode=ScanMode.PATH,
                 command_path="external",
             ),
+            secret_config=SecretConfig(),
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
         scan = results.results[0].scan


### PR DESCRIPTION

## What has been done

Refactor how secret scan parameters are passed around: pass the SecretConfig around, instead of discrete args (both to the scanner, and in output handlers).

## Validation

There should be no functional change.
