### PR TITLE
feat: apply gitignore for file paths when using use-gitignore option

### DIFF
--- a/changelog.d/20241022_155052_jonathan.griffe_gitignore_paths.md
+++ b/changelog.d/20241022_155052_jonathan.griffe_gitignore_paths.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The --use-gitignore option now also applies to single files passed as argument.

--- a/ggshield/utils/files.py
+++ b/ggshield/utils/files.py
@@ -54,6 +54,12 @@ def list_files(
     targets: Set[Path] = set()
     for path in paths:
         if path.is_file():
+            if (
+                list_files_mode == ListFilesMode.ALL_BUT_GITIGNORED
+                and is_git_dir(path.parent)
+                and path.name not in git_ls_unstaged(path.parent) + git_ls(path.parent)
+            ):
+                continue
             targets.add(path)
         elif path.is_dir():
             _targets = set()

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -143,3 +143,23 @@ def test_get_ignored_files(tmp_path, file_path, expected):
 def test_url_for_path(path: PurePath, expected_url: str):
     url = url_for_path(path)
     assert url == expected_url
+
+
+def test_get_gitignored_files(tmp_path):
+    """
+    GIVEN a file, that is in the .gitignore
+    WHEN listing its content
+    THEN an empty set is returned
+    """
+    Repository.create(tmp_path)
+    file_full_path = tmp_path / "file.txt"
+    write_text(filename=str(tmp_path / ".gitignore"), content="file.txt")
+    write_text(filename=str(file_full_path), content="")
+
+    file_paths = list_files(
+        paths=[file_full_path],
+        exclusion_regexes=set(),
+        list_files_mode=ListFilesMode.ALL_BUT_GITIGNORED,
+    )
+
+    assert file_paths == set()


### PR DESCRIPTION
## Context

In the GitGuardian vscode extension, we want to be able to avoid scanning files that are in the .gitignore.

The secret scan path command has an `use-gitignore` option that could do this, however it currently only applies to directories scanned recursively and not single files.

This MR proposes to also apply it to single files, which would allow the use of this argument in the vscode extension to avoid scanning gitignored files. This would also match the behavior of ignored paths in the `.gitguardian.yaml` config, for which an error is raised if an ignored directory is passed to the secret scan path command.

## Validation

- In a repo, put a file in the `.gitignore`
- run `ggshield secret scan path --use-gitignore <your_file>`
No file should be scanned.
-->

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
