### PR TITLE
Add default EU support for HMSL

### DIFF
--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -142,14 +142,15 @@ class Config:
     @property
     def saas_api_url(self) -> str:
         """
-        The GIM SaaS instance (used to get JWT tokens).
-        It is not configurable, but can be overridden with the
-        GITGUARDIAN_SAAS_URL environment variable for tests.
+        The GIM SaaS instance used to get JWT tokens.
+        This can be overridden with the GITGUARDIAN_SAAS_URL environment variable.
+        If the HMSL URL is different from the default, we derive the SaaS API from it.
+        Otherwise the SaaS API URL is actually the one derived from the dashboard
         """
-        if "api" in self.hmsl_url:  # case https://api.hasmysecretleaked.[...]
+        if self.hmsl_url != DEFAULT_HMSL_URL and "api" in self.hmsl_url:
             default_value = self.hmsl_url.replace("hasmysecretleaked", "gitguardian")
-        else:  # case https://hasmysecretleaked.[...]
-            default_value = self.hmsl_url.replace("hasmysecretleaked", "api")
+        else:
+            default_value = self.api_url
 
         return os.environ.get(
             "GITGUARDIAN_SAAS_URL",

--- a/tests/unit/verticals/hmsl/test_hmsl_utils.py
+++ b/tests/unit/verticals/hmsl/test_hmsl_utils.py
@@ -49,13 +49,31 @@ def test_hmsl_other_env_config_values(isolated_fs, hmsl_no_env_vars, monkeypatch
     WHEN getting HasMySecretLeaked config values
     THEN the values are correctly set
     """
+    # If the user defines a custom HMSL URL
     monkeypatch.setenv(
-        "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.secretdomain.net"
+        "GITGUARDIAN_HMSL_URL", "https://hasmysecretleaked.env.gitguardian.com"
+    )
+    # They are also expected to set a corresponding GitGuardian instance
+    monkeypatch.setenv("GITGUARDIAN_INSTANCE", "https://dashboard.env.gitguardian.com")
+    config = Config()
+    assert config.hmsl_url == "https://hasmysecretleaked.env.gitguardian.com"
+    assert config.hmsl_audience == "https://hasmysecretleaked.env.gitguardian.com"
+    assert config.saas_api_url == "https://api.env.gitguardian.com"
+
+
+def test_hmsl_region_specific_config_values(isolated_fs, hmsl_no_env_vars, monkeypatch):
+    """
+    GIVEN another SaaS environment
+    WHEN getting HasMySecretLeaked config values
+    THEN the values are correctly set
+    """
+    monkeypatch.setenv(
+        "GITGUARDIAN_INSTANCE", "https://dashboard.region3.gitguardian.com"
     )
     config = Config()
-    assert config.hmsl_url == "https://hasmysecretleaked.secretdomain.net"
-    assert config.hmsl_audience == "https://hasmysecretleaked.secretdomain.net"
-    assert config.saas_api_url == "https://api.secretdomain.net"
+    assert config.hmsl_url == "https://api.hasmysecretleaked.com"
+    assert config.hmsl_audience == "https://api.hasmysecretleaked.com"
+    assert config.saas_api_url == "https://api.region3.gitguardian.com"
 
 
 def test_no_token(isolated_fs, hmsl_no_env_vars):


### PR DESCRIPTION
## Summary

This MR teaches ggshield and HMSL how to support GitGuardian EU instance without special configurations.   

**Reminder:** ggshield gets a JWT from a GitGuardian dashboard to later be authorized to call an HMSL instance.

Before this MR, the GitGuardian instance targeted to get a JWT was derived from the HMSL_URL defined in the config if any.  This means that, unless you explicitly define it in your environment variable, you could never end up targeting the EU GitGuardian instance (there is no EU HMSL instance).

After this MR:  
- If a non-default HMSL_URL is defined with an env variable, we follow the user's logic, and we derive the GitGuardian dashboard URL from the HMSL URL.
- If not, we just use the dashboard URL defined by the user.

## Additional notes  
The logic is a bit complex here. Note that anyway, the user can override any of the concerned config values with environment variables.  