### PR TITLE
fix(precommit): handle filenames with spaces in Commit.from_merge

### DIFF
--- a/changelog.d/20241028_113440_jonathan.griffe_fix_precommit_git_merge_filename_with_spaces.md
+++ b/changelog.d/20241028_113440_jonathan.griffe_fix_precommit_git_merge_filename_with_spaces.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The ggshield pre-commit hook no longer crashes when merging files with spaces in their names (#991).

--- a/ggshield/core/scan/commit_utils.py
+++ b/ggshield/core/scan/commit_utils.py
@@ -369,7 +369,7 @@ def get_file_sha_in_ref(
     """
     output = git(["ls-tree", "-z", ref] + files, cwd=cwd)
     for line in output.split("\0")[:-1]:
-        _, _, sha, path = line.split()
+        _, _, sha, path = line.split(maxsplit=3)
         yield (path, sha)
 
 
@@ -381,7 +381,7 @@ def get_file_sha_stage(
     """
     output = git(["ls-files", "--stage", "-z"] + files, cwd=cwd)
     for line in output.split("\0")[:-1]:
-        _, sha, _, path = line.split()
+        _, sha, _, path = line.split(maxsplit=3)
         yield (path, sha)
 
 


### PR DESCRIPTION
## Context

When using `git merge` with a file which has a space in its name, the command fails with the error : 
- ValueError: too many values to unpack (expected 4)

## What has been done

Since the path is at the end of the parsed line (whose other components do not include spaces), we can simple add `maxsplit=3` as an argument to split.

## Validation

- Make a repo
- Create a file with a space in its name in a first branch
- In another branch, create the same file with a different content
- In a branch run `git merge <other_branch>`
- Resolve the conflict and run `git merge --continue`
If there is no error, it means the bug is fixed.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
