### PR TITLE
Fix RPM packages not working on RHEL 8.8

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -42,6 +42,7 @@ jobs:
   build_os_packages:
     name: Build packages
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.os == 'ubuntu-22.04' && 'rockylinux/rockylinux:8.8' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -64,11 +65,43 @@ jobs:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.10 (Windows 1/2)
+        if: matrix.os == 'windows-2022'
         uses: actions/setup-python@v5
-        if: "!startsWith(matrix.os, 'macos-')"
         with:
           python-version: '3.10'
+
+      - name: Set up Python 3.10 (Windows 2/2)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        run: |
+          echo PYTHON_CMD=python >> $GITHUB_ENV
+
+      - name: Install Linux specific dependencies
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          # Install necessary packages
+          yum install -y \
+            python3.9 \
+            git-core \
+            findutils
+
+          echo PYTHON_CMD=/usr/bin/python3.9 >> $GITHUB_ENV
+
+          # Install NFPM
+          NFPM_VERSION=2.36.1
+          NFPM_CHECKSUM=9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
+
+          scripts/download \
+            https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz \
+            nfpm.tar.gz \
+            $NFPM_CHECKSUM
+
+          tar xf nfpm.tar.gz nfpm
+          cp nfpm /usr/local/bin
+
+          # Avoid "dubious permission" git error
+          git config --global --add safe.directory '*'
 
       - name: Install macOS specific dependencies
         if: startsWith(matrix.os, 'macos-')
@@ -92,6 +125,7 @@ jobs:
 
           # Make Python available
           echo PATH=$PWD/python/bin:$PATH >> $GITHUB_ENV
+          echo PYTHON_CMD=$PWD/python/bin/python >> $GITHUB_ENV
 
           # Install rcodesign
           RCODESIGN_VERSION=0.27.0
@@ -109,8 +143,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade \
+          $PYTHON_CMD -m pip install --upgrade pip
+          $PYTHON_CMD -m pip install --upgrade \
             pipenv==2023.12.1
 
           pipenv install --dev
@@ -118,19 +152,6 @@ jobs:
         env:
           # Disable lock otherwise Windows-only dependencies like colorama are not installed
           PIPENV_SKIP_LOCK: 1
-
-      - name: Install Linux specific dependencies
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          NFPM_VERSION=2.36.1
-          NFPM_CHECKSUM=05c17a1e09c470807b149fdd7bcd8f600eea044f459fc3ce81aa230103c0baf5
-
-          scripts/download \
-            https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_amd64.deb \
-            nfpm.deb \
-            $NFPM_CHECKSUM
-
-          sudo dpkg -i nfpm.deb
 
       - name: Prepare macOS secrets
         if: startsWith(matrix.os, 'macos-') && inputs.release_mode

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -111,9 +111,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade \
-            pipenv==2023.12.1 \
-            pyinstaller==6.7.0
-          pipenv install --system --dev
+            pipenv==2023.12.1
+
+          pipenv install --dev
+          pipenv run pip install pyinstaller==6.7.0
         env:
           # Disable lock otherwise Windows-only dependencies like colorama are not installed
           PIPENV_SKIP_LOCK: 1
@@ -199,7 +200,9 @@ jobs:
           else
             args="--git-version"
           fi
-          scripts/build-os-packages/build-os-packages $args
+          # Run the script with `bash -c` because `pipenv run` does not
+          # automatically do it on Windows
+          pipenv run bash -c "scripts/build-os-packages/build-os-packages $args"
 
       - name: Override base Docker image used for functional tests on Windows
         if: matrix.os == 'windows-2022'
@@ -214,7 +217,7 @@ jobs:
         # See note about steps requiring the GITGUARDIAN_API at the top of this file
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
-          scripts/build-os-packages/build-os-packages functests
+          pipenv run bash -c "scripts/build-os-packages/build-os-packages functests"
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -100,9 +100,6 @@ jobs:
           tar xf nfpm.tar.gz nfpm
           cp nfpm /usr/local/bin
 
-          # Avoid "dubious permission" git error
-          git config --global --add safe.directory '*'
-
       - name: Install macOS specific dependencies
         if: startsWith(matrix.os, 'macos-')
         run: |
@@ -219,7 +216,7 @@ jobs:
           if [ "${{ inputs.release_mode }}" = "true" ] ; then
             args="--sign"
           else
-            args="--git-version"
+            args="--suffix +${GITHUB_SHA:0:7}"
           fi
           # Run the script with `bash -c` because `pipenv run` does not
           # automatically do it on Windows

--- a/changelog.d/20241028_140533_aurelien.gateau_use_manylinux.md
+++ b/changelog.d/20241028_140533_aurelien.gateau_use_manylinux.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- RPM packages should now work correctly on RHEL 8.8 (#984).

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -15,10 +15,7 @@ REQUIREMENTS="pyinstaller"
 # Whether we want a signed binary or not
 DO_SIGN=0
 
-# Where to find the version:
-# - 0: read it from ggshield/__init__.py
-# - 1: generate it using `git describe`
-USE_GIT_VERSION=0
+VERSION_SUFFIX=""
 
 # Colors
 C_RED="\e[31;1m"
@@ -62,7 +59,7 @@ Default steps are: $DEFAULT_STEPS
 Options:
   -h, --help      Display this usage message and exit.
   --sign          Sign the binary, on supported OSes.
-  --git-version   Append "+COMMIT_SHA" to the version number.
+  --suffix SUFFIX Append "SUFFIX" to the version number.
 
 For more details, see doc/dev/os-packages.md.
 EOF
@@ -72,10 +69,8 @@ EOF
 
 read_version() {
     VERSION=$(grep -o "[0-9]*\.[0-9]*\.[0-9]*" "$ROOT_DIR/ggshield/__init__.py")
-    if [ "$USE_GIT_VERSION" -eq 1 ] ; then
-        local commit_sha
-        commit_sha=$(git rev-parse --short HEAD)
-        VERSION="$VERSION+$commit_sha"
+    if [ -n "$VERSION_SUFFIX" ] ; then
+        VERSION="${VERSION}${VERSION_SUFFIX}"
     fi
     info "VERSION=$VERSION"
 }
@@ -343,8 +338,9 @@ while [ $# -gt 0 ] ; do
     --sign)
         DO_SIGN=1
         ;;
-    --git-version)
-        USE_GIT_VERSION=1
+    --suffix)
+        VERSION_SUFFIX="$2"
+        shift
         ;;
     -*)
         usage "Unknown option '$1'"


### PR DESCRIPTION
## Context

Our RPM packages are built using GitHub Linux runner, which uses libc 2.35. This is too recent for RHEL 8.8, which uses libc 2.28.

## What has been done

This PR reworks the CI to build the RPM and deb packages inside a Rocky Linux 8.8 container.

## Validation

Download the RPM from https://github.com/GitGuardian/ggshield/actions/runs/11552704333 (the RPM is inside the os-packages-ubuntu-22.04 artifact).

Start a rockylinux/rockylinux:8.8 container. The following command assumes $PWD contains code to scan and $GITGUARDIAN_API_KEY contains a valid API key (the `SUDO_UID` is a way to workaround the "dubious ownership" git error):

```
docker run -it --rm \
    -e GITGUARDIAN_API_KEY \
    -e SUDO_UID=$UID \
    -v$PWD:$PWD -w $PWD \
    rockylinux/rockylinux:8.8
```

Inside the container:

```
# Install git
yum install -y git

# Install ggshield
# (assumes the ggshield rpm is in $PWD)
rpm -i ggshield-1.32.2+c48d31d-1.x86_64.rpm

# Run a scan
ggshield secret scan path -ry .
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
