### PR TITLE
Improve RPM dependencies

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -254,3 +254,65 @@ jobs:
             packages/ggshield-*.zip
             packages/ggshield-*.rpm
             packages/ggshield_*.deb
+
+  # Run some basic tests, the goal is to verify the ggshield binary has all the
+  # libraries it needs to run
+  linux_package_smoke_tests:
+    needs: build_os_packages
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:stable
+          - ubuntu:latest
+          - rockylinux/rockylinux:8.8
+          - opensuse/leap
+          # Test a distribution with no deb or rpm support
+          - clearlinux:latest
+
+    steps:
+      - name: Download OS packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: os-packages-ubuntu-22.04
+          path: packages
+          merge-multiple: true
+
+      - name: Setup
+        # Install ggshield dependencies and the package itself
+        run: |
+          case "${{ matrix.image }}" in
+            debian:*|ubuntu:*)
+              apt update
+              apt install --no-install-recommends -y git
+              dpkg -i packages/*.deb
+              ;;
+            rockylinux*)
+              yum install -y git
+              rpm -i packages/*.rpm
+              ;;
+            opensuse*)
+              zypper install -y git
+              rpm -i packages/*.rpm
+              ;;
+            clearlinux*)
+              swupd bundle-add git
+
+              # Unpack ggshield in /usr/local/ggshield
+              pkg_dir=$PWD/packages
+              mkdir /usr/local/ggshield
+              cd /usr/local/ggshield
+              tar --strip-components 1 -xf $pkg_dir/*.tar.gz
+
+              # Add ggshield to $PATH
+              mkdir /usr/local/bin
+              ln -s $PWD/ggshield /usr/local/bin/ggshield
+              ;;
+          esac
+
+      - name: Smoke test
+        run: |
+          ggshield --version
+          ggshield --help

--- a/changelog.d/20241029_092310_aurelien.gateau_improve_rpm_dependencies.md
+++ b/changelog.d/20241029_092310_aurelien.gateau_improve_rpm_dependencies.md
@@ -1,0 +1,3 @@
+### Changed
+
+- RPM packages now depend on `git-core` instead of `git`, reducing the number of dependencies to install (#983).

--- a/scripts/build-os-packages/nfpm.yaml
+++ b/scripts/build-os-packages/nfpm.yaml
@@ -16,9 +16,6 @@ version: ${VERSION}
 version_schema: semver
 release: 1
 
-depends:
-  - git
-
 # Make sure files are not group-writable. lintian does not like that.
 umask: 0o022
 
@@ -38,6 +35,9 @@ contents:
     dst: /usr/share/doc/ggshield/LICENSE
 
 overrides:
+  rpm:
+    depends:
+      - git-core
   deb:
     depends:
       - libc6


### PR DESCRIPTION
## Context

This PR adds some smoke tests for our binary archives, and then make use of them to safely trim the dependencies of our RPM packages, fixing #983.

## What has been done

- Add smoke tests for:
  - debian:stable (deb based)
  - ubuntu:latest (deb based)
  - rockylinux/rockylinux:8.8 (rpm based)
  - opensuse/leap (rpm based)
  - clearlinux:latest (test the raw tar.gz)

- Adjust dependencies of RPM packages.

## Validation

Download the RPM from https://github.com/GitGuardian/ggshield/actions/runs/11569940273 (the RPM is inside the os-packages-ubuntu-22.04 artifact).

Start a rockylinux/rockylinux:8.8 container. The following command assumes $PWD contains code to scan and $GITGUARDIAN_API_KEY contains a valid API key (the `SUDO_UID` is a way to workaround the "dubious ownership" git error):

```
docker run -it --rm \
    -e GITGUARDIAN_API_KEY \
    -e SUDO_UID=$UID \
    -v$PWD:$PWD -w $PWD \
    rockylinux/rockylinux:8.8
```

Inside the container:

```
# Install git-core
yum install -y git-core

# Install ggshield
# (assumes the ggshield rpm is in $PWD)
rpm -i ggshield-1.32.2+c48d31d-1.x86_64.rpm

# Run a scan
ggshield secret scan path -ry .
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
