### PR TITLE
Fix with-incident-details option

### DIFF
--- a/changelog.d/20241107_194448_pierrelalanne_fix_with_incident_details_option.md
+++ b/changelog.d/20241107_194448_pierrelalanne_fix_with_incident_details_option.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- We add a default value None to the click option `with-incident-details` to fix the behavior of the option.
+<!--
+
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -95,6 +95,10 @@ _exclude_option = click.option(
 _ignore_known_secrets_option = click.option(
     "--ignore-known-secrets",
     is_flag=True,
+    # The default value **must** be set to None.
+    # Each command or subcommand calls create_config_callback to gather option values.
+    # If the option is placed early in the command line, the value may be overridden
+    # later on with False if no default is defined.
     default=None,
     help="Ignore secrets already known by GitGuardian dashboard.",
     callback=create_config_callback("secret", "ignore_known_secrets"),
@@ -124,6 +128,11 @@ _banlist_detectors_option = click.option(
 _with_incident_details_option = click.option(
     "--with-incident-details",
     is_flag=True,
+    # The default value **must** be set to None.
+    # Each command or subcommand calls create_config_callback to gather option values.
+    # If the option is placed early in the command line, the value may be overridden
+    # later on with False if no default is defined.
+    default=None,
     help="Display full details about the dashboard incident if one is found (JSON and SARIF formats only).",
     callback=create_config_callback("secret", "with_incident_details"),
 )


### PR DESCRIPTION
## The Fix
If no default value is defined for the option `with-incident-details`, the behavior of ggshield can be misleading and actually bugged.
Indeed, each command or subcommand uses the decorator "add_secret_scan_common_options" to
collect values of several command options. This lets the user place the option --with-incident-details
at several level in the command line.

If they do so, the command or subcommand that does not have the flag will set the value to False
which can prevent the option from working correctly. For instance:
`ggshield secret scan --with-incident-details path dummy.py` => The option is set to False in the end because the path subcommand does not have the option defined.
`ggshield secret scan path --with-incident-details dummy.py` => The optiton is set to True, because defined in the path subcommand.

We make the option default to None. This does not override the value defined earlier in the command line.

## Remarks
1. Let me know if the comment or the commit is too verbose.