### PR TITLE
fix(scan): instantiate client after computing options

### DIFF
--- a/changelog.d/20241112_170752_jonathan.griffe_fix_secret_scan_option.md
+++ b/changelog.d/20241112_170752_jonathan.griffe_fix_secret_scan_option.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Take into account the `--allow-self-signed` option at all levels in `ggshield secret scan` commands

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -21,7 +21,6 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
-from ggshield.core.client import create_client_from_config
 
 
 @click.group(
@@ -70,7 +69,6 @@ def scan_group_impl(ctx: click.Context) -> int:
     """Implementation for scan_group(). Must be a separate function so that its code can
     be reused from the deprecated `cmd.scan` package."""
     ctx_obj = ContextObj.get(ctx)
-    ctx_obj.client = create_client_from_config(ctx_obj.config)
     return_code = 0
 
     config = ctx_obj.config

--- a/ggshield/cmd/secret/scan/archive.py
+++ b/ggshield/cmd/secret/scan/archive.py
@@ -11,6 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.secret.scan.ui_utils import print_file_list
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.scan.file import create_files_from_paths
@@ -43,6 +44,7 @@ def archive_cmd(
             raise UnexpectedError(f'Failed to unpack "{path}" archive: {exn}')
 
         ctx_obj = ContextObj.get(ctx)
+        ctx_obj.client = create_client_from_config(ctx_obj.config)
         config = ctx_obj.config
         files, binary_paths = create_files_from_paths(
             paths=[temp_path],

--- a/ggshield/cmd/secret/scan/changes.py
+++ b/ggshield/cmd/secret/scan/changes.py
@@ -10,6 +10,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.core.text_utils import pluralize
 from ggshield.utils.git_shell import (
@@ -29,6 +30,7 @@ def changes_cmd(ctx: click.Context, **kwargs: Any) -> int:
     Scan the set of changes between the default branch and the current HEAD, including staged changes.
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     check_git_dir()
 

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -13,6 +13,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
+from ggshield.core.client import create_client_from_config
 from ggshield.core.git_hooks.ci import collect_commit_range_from_ci_env
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import check_git_dir
@@ -28,6 +29,7 @@ def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     Scan the set of pushed commits that triggered the CI pipeline.
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     check_git_dir()
     if not (os.getenv("CI") or os.getenv("JENKINS_HOME") or os.getenv("BUILD_BUILDID")):

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -10,6 +10,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.verticals.secret.docker import docker_save_to_tmp, docker_scan_archive
 
@@ -42,6 +43,7 @@ def docker_name_cmd(
 
     with tempfile.TemporaryDirectory(suffix="ggshield") as temporary_dir:
         ctx_obj = ContextObj.get(ctx)
+        ctx_obj.client = create_client_from_config(ctx_obj.config)
         config = ctx_obj.config
         output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -9,6 +9,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.click import RealPath
 from ggshield.verticals.secret.docker import docker_scan_archive
@@ -32,6 +33,7 @@ def docker_archive_cmd(
     Hidden command `ggshield secret scan docker-archive`
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/secret/scan/docset.py
+++ b/ggshield/cmd/secret/scan/docset.py
@@ -10,6 +10,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode, Scannable, StringScannable
 from ggshield.core.ui.ggshield_ui import GGShieldProgress
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -62,6 +63,7 @@ def docset_cmd(
     [1]: https://docs.gitguardian.com/ggshield-docs/integrations/other-data-sources/other-data-sources
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     output_handler = create_output_handler(ctx)
     with ui.create_progress(len(files)) as progress:

--- a/ggshield/cmd/secret/scan/path.py
+++ b/ggshield/cmd/secret/scan/path.py
@@ -12,6 +12,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.files import check_directory_not_ignored
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import create_files_from_paths
 from ggshield.utils.click import RealPath
@@ -42,6 +43,7 @@ def path_cmd(
     """
     ctx_obj = ContextObj.get(ctx)
     config = ctx_obj.config
+    ctx_obj.client = create_client_from_config(config)
     output_handler = create_output_handler(ctx)
 
     for path in paths:

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -12,6 +12,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import Commit, ScanContext, ScanMode
 from ggshield.utils.git_shell import check_git_dir, git
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
@@ -59,6 +60,7 @@ def precommit_cmd(
     Scan as a pre-commit hook all changes that have been staged in a git repository.
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
 
     if check_user_requested_skip():

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -12,6 +12,7 @@ from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.git_hooks.prepush import collect_commits_refs
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import (
@@ -36,6 +37,7 @@ def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> i
     Scan as a pre-push git hook all commits that are about to be pushed.
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
 
     if check_user_requested_skip():

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -15,6 +15,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
+from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.errors import handle_exception
 from ggshield.core.git_hooks.prereceive import (
@@ -86,6 +87,7 @@ def prereceive_cmd(
     Scan as a pre-receive git hook all commits about to enter the remote git repository.
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     output_handler = create_output_handler(ctx)
     if os.getenv("GL_PROTOCOL") == "web":

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -14,6 +14,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.secret.scan.ui_utils import print_file_list
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.scan import ScanContext, ScanMode, Scannable
 from ggshield.core.scan.file import create_files_from_paths
@@ -96,6 +97,7 @@ def pypi_cmd(
     [1]: https://pip.pypa.io/en/stable/topics/configuration/
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     output_handler = create_output_handler(ctx)
 

--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -11,6 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 from ggshield.cmd.utils.common_decorators import exception_wrapper
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import get_list_commit_SHA
 from ggshield.verticals.secret.repo import scan_commit_range
@@ -34,6 +35,7 @@ def range_cmd(
     Example: `ggshield secret scan commit-range HEAD~1...`
     """
     ctx_obj = ContextObj.get(ctx)
+    ctx_obj.client = create_client_from_config(ctx_obj.config)
     config = ctx_obj.config
     commit_list = get_list_commit_SHA(commit_range)
     if not commit_list:

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -11,6 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     create_output_handler,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import git
 from ggshield.verticals.secret.repo import scan_repo_path
@@ -38,7 +39,7 @@ def repo_cmd(
     ctx_obj = ContextObj.get(ctx)
     config = ctx_obj.config
     cache = ctx_obj.cache
-    client = ctx_obj.client
+    ctx_obj.client = create_client_from_config(config)
 
     scan_context = ScanContext(
         scan_mode=ScanMode.REPO,
@@ -49,7 +50,7 @@ def repo_cmd(
     if path.is_dir():
         scan_context.target_path = path
         return scan_repo_path(
-            client=client,
+            client=ctx_obj.client,
             cache=cache,
             output_handler=create_output_handler(ctx),
             exclusion_regexes=ctx_obj.exclusion_regexes,
@@ -63,7 +64,7 @@ def repo_cmd(
             git(["clone", "--mirror", repository, tmpdirname])
             scan_context.target_path = Path(tmpdirname)
             return scan_repo_path(
-                client=client,
+                client=ctx_obj.client,
                 cache=cache,
                 output_handler=create_output_handler(ctx),
                 exclusion_regexes=ctx_obj.exclusion_regexes,

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -233,6 +233,18 @@ secret:
             _, kwargs = client_mock.call_args
             assert kwargs["base_uri"] == "https://dashboard.my-instance.com/exposed"
 
+    @pytest.mark.parametrize("position", [0, 1, 2, 3, 4])
+    def test_ssl_verify(self, cli_fs_runner, position):
+        self.create_files()
+
+        cmd = ["secret", "scan", "path", "file1"]
+        cmd.insert(position, "--allow-self-signed")
+
+        with patch("ggshield.core.client.GGClient") as client_mock:
+            cli_fs_runner.invoke(cli, cmd)
+            _, kwargs = client_mock.call_args
+            assert kwargs["session"].verify is False
+
 
 class TestScanDirectory:
     """


### PR DESCRIPTION
## Context

The `--allow-self-signed` option can theoretically be placed at any level in all `ggshield secret scan` commands, but in practice does not work when passed at the last level (ex: `ggshield secret scan path --allow-self-signed`). This is due to the GGClient being instantiated before taking into account higher level options.


## What has been done

This MR makes the GGClient be instantiated in the command function to fix this issue.

## Validation

Set up a proxy, for example with mitmproxy. To verify that it works, run `ggshield secret scan path <file>`, this should return a certificate error.
Run `ggshield secret scan path <file> --allow-self-signed`. It should succeed.


## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
