### PR TITLE
feat(cmd): add the instance option to more commands

### DIFF
--- a/changelog.d/20241112_172503_jonathan.griffe_expand_instance_option.md
+++ b/changelog.d/20241112_172503_jonathan.griffe_expand_instance_option.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added the `--instance` option to allow using a different instance to all `secret scan` commands as well as the `api-status` and `quota` commands.

--- a/ggshield/cmd/quota.py
+++ b/ggshield/cmd/quota.py
@@ -7,6 +7,7 @@ from pygitguardian.models import Detail, Quota, QuotaResponse
 
 from ggshield.cmd.utils.common_options import (
     add_common_options,
+    instance_option,
     json_option,
     text_json_format_option,
 )
@@ -19,6 +20,7 @@ from ggshield.core.errors import UnexpectedError
 @click.command()
 @text_json_format_option
 @json_option
+@instance_option
 @add_common_options()
 @click.pass_context
 def quota_cmd(ctx: click.Context, **kwargs: Any) -> int:

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -9,6 +9,7 @@ from ggshield.cmd.utils.common_options import (
     create_ctx_callback,
     exit_zero_option,
     get_config_from_context,
+    instance_option,
     json_option,
     text_json_sarif_format_option,
 )
@@ -150,6 +151,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         _ignore_known_secrets_option(cmd)
         _banlist_detectors_option(cmd)
         _with_incident_details_option(cmd)
+        instance_option(cmd)
         return cmd
 
     return decorator

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -7,6 +7,7 @@ from pygitguardian.models import HealthCheckResponse
 
 from ggshield.cmd.utils.common_options import (
     add_common_options,
+    instance_option,
     json_option,
     text_json_format_option,
 )
@@ -19,6 +20,7 @@ from ggshield.core.text_utils import STYLE, format_text
 @click.command()
 @text_json_format_option
 @json_option
+@instance_option
 @add_common_options()
 @click.pass_context
 def status_cmd(ctx: click.Context, **kwargs: Any) -> int:

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -216,6 +216,23 @@ secret:
         assert "An ignored file or directory cannot be scanned." in result.stdout
         scan_mock.assert_not_called()
 
+    def test_instance_option(self, cli_fs_runner):
+        """
+        GIVEN an instance url
+        WHEN running the path command and passing the instance url as option
+        THEN the call resulting from the command is made to the instance url
+        """
+        self.create_files()
+
+        uri = "https://dashboard.my-instance.com"
+
+        with patch("ggshield.core.client.GGClient") as client_mock:
+            cli_fs_runner.invoke(
+                cli, ["secret", "scan", "--instance", uri, "path", "file1"]
+            )
+            _, kwargs = client_mock.call_args
+            assert kwargs["base_uri"] == "https://dashboard.my-instance.com/exposed"
+
 
 class TestScanDirectory:
     """

--- a/tests/unit/cmd/test_status.py
+++ b/tests/unit/cmd/test_status.py
@@ -55,3 +55,19 @@ def test_ssl_verify(cli_fs_runner, verify):
         cli_fs_runner.invoke(cli, cmd)
         _, kwargs = client_mock.call_args
         assert kwargs["session"].verify == verify
+
+
+@pytest.mark.parametrize("command", ["api-status", "quota"])
+def test_instance_option(cli_fs_runner, command):
+    """
+    GIVEN an instance url
+    WHEN running a command and passing the instance url as option
+    THEN the call resulting from the command is made to the instance url
+    """
+
+    uri = "https://dashboard.my-instance.com"
+
+    with mock.patch("ggshield.core.client.GGClient") as client_mock:
+        cli_fs_runner.invoke(cli, [command, "--instance", uri])
+        _, kwargs = client_mock.call_args
+        assert kwargs["base_uri"] == "https://dashboard.my-instance.com/exposed"


### PR DESCRIPTION
## Context

Currently, we can login to a specific instance by using the --instance option.
We want to also be able to use a specific instance for other commands

## What has been done

The `--instance` option has been added to all `secret scan` command, as well as `api-status` and `quota` commands

## Validation

Use commands specified above using the `--instance` with a non default instance and an API KEY for the instance in the `.env`. Verify that the command succeeds.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
