### PR TITLE
feat(api-status): add api key and instance sources to the api-status command output

### DIFF
--- a/changelog.d/20241113_152802_jonathan.griffe_improve_api_status_output_info.md
+++ b/changelog.d/20241113_152802_jonathan.griffe_improve_api_status_output_info.md
@@ -1,0 +1,3 @@
+### Added
+
+- The `api-status` command now returns the sources of both the api-key and instance used.

--- a/doc/schemas/api-status.json
+++ b/doc/schemas/api-status.json
@@ -13,6 +13,14 @@
       "format": "uri",
       "description": "URL of the GitGuardian instance"
     },
+    "instance_source": {
+      "enum": ["CMD_OPTION", "DOTENV", "ENV_VAR", "USER_CONFIG", "DEFAULT"],
+      "description": "Source the instance was read from"
+    },
+    "api_key_source": {
+      "enum": ["DOTENV", "ENV_VAR", "USER_CONFIG"],
+      "description": "Source the API key was read from"
+    },
     "detail": {
       "type": "string",
       "description": "Human-readable version of the status"

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -107,7 +107,7 @@ def cli(
     if allow_self_signed:
         user_config.allow_self_signed = allow_self_signed
 
-    load_dot_env()
+    ctx_obj.config._dotenv_vars = load_dot_env()
 
     _set_color(ctx)
 

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -24,7 +24,7 @@ from ggshield.core.text_utils import STYLE, format_text
 @add_common_options()
 @click.pass_context
 def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
-    """Show API status and version."""
+    """Show API status and version, along with API key and instance sources."""
     ctx_obj = ContextObj.get(ctx)
     client = create_client_from_config(ctx_obj.config)
     response: HealthCheckResponse = client.health_check()
@@ -32,17 +32,23 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
     if not isinstance(response, HealthCheckResponse):
         raise UnexpectedError("Unexpected health check response")
 
+    instance, instance_source = ctx_obj.config.get_instance_name_and_source()
+    _, api_key_source = ctx_obj.config.get_api_key_and_source()
     if ctx_obj.use_json:
         json_output = response.to_dict()
-        json_output["instance"] = client.base_uri
+        json_output["instance"] = instance
+        json_output["instance_source"] = instance_source.name
+        json_output["api_key_source"] = api_key_source.name
         click.echo(json.dumps(json_output))
     else:
         click.echo(
-            f"{format_text('API URL:', STYLE['key'])} {client.base_uri}\n"
+            f"{format_text('API URL:', STYLE['key'])} {instance}\n"
             f"{format_text('Status:', STYLE['key'])} {format_healthcheck_status(response)}\n"
             f"{format_text('App version:', STYLE['key'])} {response.app_version or 'Unknown'}\n"
             f"{format_text('Secrets engine version:', STYLE['key'])} "
-            f"{response.secrets_engine_version or 'Unknown'}\n"
+            f"{response.secrets_engine_version or 'Unknown'}\n\n"
+            f"{format_text('Instance source:', STYLE['key'])} {instance_source.value}\n"
+            f"{format_text('API key source:', STYLE['key'])} {api_key_source.value}\n"
         )
 
     return 0

--- a/tests/unit/core/test_env_utils.py
+++ b/tests/unit/core/test_env_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from ggshield.core.env_utils import load_dot_env
+from ggshield.core.env_utils import TRACKED_ENV_VARS, load_dot_env
 from ggshield.utils.os import cd
 
 
@@ -84,3 +84,18 @@ def test_load_dot_env_loads_git_root_env(
     with cd(sub1_sub2_dir):
         load_dot_env()
         load_dotenv_mock.assert_called_once_with(git_root_dotenv, override=True)
+
+
+@pytest.mark.parametrize("env_var", TRACKED_ENV_VARS)
+def test_load_dot_env_returns_set_vars(env_var, tmp_path, monkeypatch):
+    """
+    GIVEN an env var that is set, and also set with the same value in the .env
+    WHEN load_dot_env() is called
+    THEN it returns the env var
+    """
+    monkeypatch.setenv(env_var, "value")
+    (tmp_path / ".env").write_text(f"{env_var}=value")
+    with cd(tmp_path):
+        set_variables = load_dot_env()
+
+    assert set_variables == {env_var}


### PR DESCRIPTION
## Context

There are a lot of ways for ggshield users to set authentication credentials. When these credentials are invalid, it can be difficult to search where they were set. When multiple sources are set, it can also be complicated to find the source that was used.

## What has been done

This MR makes the api-status command return the source of the instance and API key used.

## Validation

Run `ggshield api-status` and verify that the sources are the correct ones.
Repeat for all possible api key and instance locations.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
