### PR TITLE
chore: adding ggshield-admins team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@GitGuardian/ggshield-admins


### PR DESCRIPTION
Adding team as codeowners of the repo, to then add a branch protection rule on `main` requesting a review from codeowners.