### PR TITLE
Replace stray print() call with ui.display_info()

### DIFF
--- a/ggshield/core/ui/plain_text/plain_text_scanner_ui.py
+++ b/ggshield/core/ui/plain_text/plain_text_scanner_ui.py
@@ -1,8 +1,8 @@
-import sys
 from typing import Any, Sequence
 
 from typing_extensions import Self
 
+from ggshield.core import ui
 from ggshield.core.scan import Scannable
 from ggshield.core.ui.scanner_ui import ScannerUI
 
@@ -17,7 +17,7 @@ class PlainTextScannerUI(ScannerUI):
 
     def on_skipped(self, scannable: Scannable, reason: str) -> None:
         if reason:
-            print(f"Skipped {scannable.url}: {reason}", file=sys.stderr)
+            ui.display_info(f"Skipped {scannable.url}: {reason}")
 
     def __enter__(self) -> Self:
         return self


### PR DESCRIPTION
## Context

Micro-PR to fix a stray `print` I found while working on another PR.

## Validation

Scan a file to skip, forcing ggshield to use the text UI.

Before:

```console
$ ggshield secret scan path --debug /boot/initrd.img 2>&1 | tee
...
2024-11-14 10:45:13 337171:337171 [D] root:140 max_doc_size=1048576
2024-11-14 10:45:13 337171:337171 [D] root:141 max_docs=20
Skipped file:///boot/initrd.img: content is over 1,048,576 bytes
...
```

After:

```console
$ ggshield secret scan path --debug /boot/initrd.img 2>&1 | tee
...
2024-11-14 10:45:28 337290:337290 [D] root:140 max_doc_size=1048576
2024-11-14 10:45:28 337290:337290 [D] root:141 max_docs=20
2024-11-14 10:45:28 337290:337290 [I] Skipped file:///boot/initrd.img: content is over 1,048,576 bytes
```

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
