### PR TITLE
feat(output): Only fail secret scans when the secret is introduced

### DIFF
--- a/changelog.d/20241129_155452_samuel.guillaume_spi_526_implement_deletion_commit_identification_in_ggshield.md
+++ b/changelog.d/20241129_155452_samuel.guillaume_spi_526_implement_deletion_commit_identification_in_ggshield.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- When scanning commits, ggshield will ignore by default secrets which are removed or contextual to the patch.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -28,6 +28,7 @@ class IgnoreReason(Enum):
     IGNORED_MATCH = "ignored_match"
     IGNORED_DETECTOR = "ignored_detector"
     KNOWN_SECRET = "known_secret"
+    NOT_INTRODUCED = "not_introduced"
 
 
 class Result:

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -7,7 +7,13 @@ from concurrent.futures import Future
 from typing import Dict, Iterable, List, Optional, Union
 
 from pygitguardian import GGClient
-from pygitguardian.models import APITokensResponse, Detail, MultiScanResult, TokenScope
+from pygitguardian.models import (
+    APITokensResponse,
+    Detail,
+    DiffKind,
+    MultiScanResult,
+    TokenScope,
+)
 
 from ggshield.core import ui
 from ggshield.core.cache import Cache
@@ -220,6 +226,11 @@ class SecretScanner:
                 )
                 if not scan_result.has_policy_breaks:
                     continue
+                result.apply_ignore_function(
+                    IgnoreReason.NOT_INTRODUCED,
+                    lambda policy_break: policy_break.diff_kind
+                    in {DiffKind.DELETION, DiffKind.CONTEXT},
+                )
                 result.apply_ignore_function(
                     IgnoreReason.IGNORED_MATCH,
                     lambda policy_break: is_in_ignored_matches(


### PR DESCRIPTION
## Context

Related to SPI-526 and will close  #1001

We want to only fail secret scans when the secret is introduced.  
New fields have been added to the API to automatically detect if the content is a diff and if the secret has been added, deleted or in the context. (https://github.com/GitGuardian/py-gitguardian/pull/122)

- Add `not_introduced` as an ignore reason
- Make use of `diff_kind` to ignore policy breaks

`diff_kind` can be `null` (outside of commit) or `ADDITION`/`DELETION`/`CONTEXT`. We want to keep only the policy breaks with `diff_kind`:
- `null` => outside of commits, when scanning files or docker layers
- `ADDITION` => introduced by a commit

In #1024, a `--all-secrets` option will allow user to display ignored secrets.

## Validation

- Create a repository
- Add a secret in commit A
- Edit the line below the secret in commit B
- Remove the secret in commit C

When scanning the repository with `main`: 3 policy breaks are found in commit A, B and C
When scanning with this PR: 1 policy break is found in commit A

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
