### PR TITLE
Unflakify test_text_output.py::test_leak_message()

### DIFF
--- a/tests/unit/verticals/secret/output/test_sarif_output.py
+++ b/tests/unit/verticals/secret/output/test_sarif_output.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from typing import Any, Dict, TypedDict
 from unittest import mock
 
@@ -166,6 +167,7 @@ def test_sarif_output_for_flat_scan_with_secrets(
     WHEN SecretSARIFOutputHandler runs on it
     THEN it outputs a SARIF document pointing to the secrets
     """
+    scan_result = deepcopy(scan_result)
     client_mock = mock.Mock(spec=GGClient)
     client_mock.retrieve_secret_incident.return_value = SECRET_INCIDENT_MOCK
 


### PR DESCRIPTION
## Context

test_leak_message() would sometimes fail because of a policy break fixture having its known_secret field set to True.

This was caused by test_sarif_output_for_flat_scan_with_secrets() modifying its test data, which comes from conftest.py.

## What has been done

Make the test copy its test data before modifying it to fix that.

## Validation

Tests pass.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
