### PR TITLE
fix: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@GitGuardian/ggshield-admins
+* @GitGuardian/ggshield-admins


### PR DESCRIPTION
This time I checked the [doc](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)