### PR TITLE
fix(error): Catch error when merging two configs

### DIFF
--- a/ggshield/core/config/utils.py
+++ b/ggshield/core/config/utils.py
@@ -123,16 +123,19 @@ def update_dict_from_other(dct: Dict[str, Any], other: Dict[str, Any]) -> None:
     The merge happens in-place: `dct` is modified.
     """
     for key, value in other.items():
-        if value is None:
-            continue
-        if isinstance(value, list):
-            dct.setdefault(key, []).extend(value)
-        elif isinstance(value, set):
-            dct.setdefault(key, set()).update(value)
-        elif isinstance(value, dict):
-            update_dict_from_other(dct.setdefault(key, {}), value)
-        else:
-            dct[key] = value
+        try:
+            if value is None:
+                continue
+            if isinstance(value, list):
+                dct.setdefault(key, []).extend(value)
+            elif isinstance(value, set):
+                dct.setdefault(key, set()).update(value)
+            elif isinstance(value, dict):
+                update_dict_from_other(dct.setdefault(key, {}), value)
+            else:
+                dct[key] = value
+        except AttributeError:
+            raise UnexpectedError(f"Failed to load configuration on key '{key}'")
 
 
 def remove_common_dict_items(

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -613,3 +613,16 @@ class TestUserConfig:
         )
         config, _ = UserConfig.load(local_config_path)
         assert config.secret.ignore_known_secrets
+
+    def test_bad_local_config(self, local_config_path, global_config_path):
+        """
+        GIVEN a malformed .gitguardian.yaml, with a list of instance
+        WHEN loading the user condiguration
+        THEN an error is returned
+        """
+        write_yaml(global_config_path, {"instance": "https://test.gitguardian.com/"})
+        write_yaml(
+            local_config_path, {"instance": ["https://dashboard.gitguardian.com/"]}
+        )
+        with pytest.raises(UnexpectedError):
+            UserConfig.load()


### PR DESCRIPTION
## Context

GGshield was crashing when merging two badly formed user config. This was returning exit code 1 instead of 128. 

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
