### PR TITLE
fix(with-incident-details): Ensure the token has the correct scope

### DIFF
--- a/changelog.d/20241120_160018_salome.voltz_scrt_4913_ggshield_with_incident_details_does_not_tell_about_required.md
+++ b/changelog.d/20241120_160018_salome.voltz_scrt_4913_ggshield_with_incident_details_does_not_tell_about_required.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- When `ggshield secret scan` is called with `--with-incident-details` and the token does not have the required scopes, the command fails and an error message is printed.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -126,6 +126,7 @@ _banlist_detectors_option = click.option(
     metavar="DETECTOR",
 )
 
+
 _with_incident_details_option = click.option(
     "--with-incident-details",
     is_flag=True,
@@ -134,7 +135,7 @@ _with_incident_details_option = click.option(
     # If the option is placed early in the command line, the value may be overridden
     # later on with False if no default is defined.
     default=None,
-    help="Display full details about the dashboard incident if one is found (JSON and SARIF formats only).",
+    help="""Display full details about the dashboard incident if one is found (JSON and SARIF formats only). Requires the 'incidents:read' scope.""",  # noqa
     callback=create_config_callback("secret", "with_incident_details"),
 )
 

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -7,12 +7,13 @@ import logging
 import platform
 import traceback
 from enum import IntEnum
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import click
 from marshmallow import ValidationError
-from pygitguardian.models import Detail
+from pygitguardian.models import Detail, TokenScope
 
+from ggshield.core.text_utils import pluralize
 from ggshield.utils.git_shell import GitError, InvalidGitRefError
 
 
@@ -64,6 +65,19 @@ class ParseError(_ExitError):
 
     def __init__(self, message: str):
         super().__init__(ExitCode.UNEXPECTED_ERROR, message)
+
+
+class MissingScopesError(_ExitError):
+    """
+    Token does not have the required scope
+    """
+
+    def __init__(self, token_scopes: List[TokenScope]):
+        scopes_list = ", ".join([scope.value for scope in token_scopes])
+        super().__init__(
+            ExitCode.UNEXPECTED_ERROR,
+            f"Token is missing the required {pluralize('scope', len(token_scopes))} {scopes_list} to perform this operation.",  # noqa
+        )
 
 
 class AuthError(_ExitError):

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "standalone", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:86c46c5cb62145e14a5a9de0bc34e98b22ede9b8b447a1ff881eb8c32a157535"
+content_hash = "sha256:b1963577318c9838275196f2080a6d7df233e1f7b23821a5b6ecdb0312866f87"
 
 [[metadata.targets]]
 requires_python = ">=3.8.1"
@@ -1473,6 +1473,9 @@ files = [
 name = "pygitguardian"
 version = "1.17.0"
 requires_python = ">=3.8"
+git = "https://github.com/GitGuardian/py-gitguardian.git"
+ref = "41d034799683d7b6c1fd4e7131f9a740c4d9851d"
+revision = "41d034799683d7b6c1fd4e7131f9a740c4d9851d"
 summary = "Python Wrapper for GitGuardian's API -- Scan security policy breaks everywhere"
 groups = ["default"]
 dependencies = [
@@ -1481,10 +1484,6 @@ dependencies = [
     "requests<3,>=2",
     "setuptools>=70.1.0",
     "typing-extensions",
-]
-files = [
-    {file = "pygitguardian-1.17.0-py3-none-any.whl", hash = "sha256:ddfe97312d21133fd50848a532560397b5342587420c5207701efa83c630b3a2"},
-    {file = "pygitguardian-1.17.0.tar.gz", hash = "sha256:17ef91e7fe954f7b8d91f39c0097ba49b07e77b5ee9d0596adad256a9d4ab71e"},
 ]
 
 [[package]]
@@ -2104,7 +2103,7 @@ files = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "1.1.0"
-summary = "The Cranelift compiler for the `wasmer` package (to compile WebAssembly module)"
+summary = "Python extension to run WebAssembly binaries"
 groups = ["tests"]
 files = [
     {file = "wasmer_compiler_cranelift-1.1.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:9869910179f39696a020edc5689f7759257ac1cce569a7a0fcf340c59788baad"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "marshmallow~=3.18.0",
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
-    "pygitguardian~=1.17.0",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@41d034799683d7b6c1fd4e7131f9a740c4d9851d",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -103,6 +103,21 @@ _MULTIPLE_SECRETS_SCAN_RESULT = ScanResult.SCHEMA.load(
     }
 )
 
+API_TOKENS_RESPONSE_SCAN_SCOPES = {
+    "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
+    "name": "myTokenName",
+    "workspace_id": 42,
+    "type": "personal_access_token",
+    "status": "revoked",
+    "created_at": "2023-05-20T12:40:55.662949Z",
+    "last_used_at": "2023-05-24T12:40:55.662949Z",
+    "expire_at": None,
+    "revoked_at": "2023-05-27T12:40:55.662949Z",
+    "member_id": 22015,
+    "creator_id": 22015,
+    "scopes": ["scan"],
+}
+
 # This long token is a test token, always reported as an uncheckable secret
 GG_TEST_TOKEN = (
     "8a784aab7090f6a4ba3b9f7a6594e2e727007a26590b58ed314e4b9ed4536479sRZlRup3xvtMVfiHWA"


### PR DESCRIPTION
## Context

ggshield 1.32.0 can now return the details of an incident when a scan is run with the --with-incident-details option. For this feature to work, the token used to authenticate with the API must have the 'incidents:read' scope. This is currently not documented and if the token does not have the required scope, the flag will be silently ignored.

## What has been done

Ensure the token has the required scope before running a command with `--with-incident-details` flag. This MR goes with https://github.com/GitGuardian/py-gitguardian/pull/126


## PR check list

- [X] As much as possible, the changes include tests (unit and/or functional)
- [X] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
