### PR TITLE
chore: adding a warning message about Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ documentation.
 
 `ggshield` works on macOS, Linux and Windows.
 
-It requires **Python 3.8 and newer** (except for standalone packages) and git.
+It requires **Python 3.8 or above** (except for standalone packages) and git.
+
+:warning: Python 3.8 is no longer supported by the Python Software Foundation since October, 14th 2024. GGShield will soon require Python 3.9 or above to run.
 
 Some commands require additional programs:
 

--- a/changelog.d/20241125_113845_severine.bonnechere_scrt_5123_before_next_ggshield_release.md
+++ b/changelog.d/20241125_113845_severine.bonnechere_scrt_5123_before_next_ggshield_release.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+Warning message: Python 3.8 is no longer supported by the Python Software Foundation since October, 14th 2024. GGShield will soon require Python 3.9 or above to run.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/changelog.d/20241125_113845_severine.bonnechere_scrt_5123_before_next_ggshield_release.md
+++ b/changelog.d/20241125_113845_severine.bonnechere_scrt_5123_before_next_ggshield_release.md
@@ -17,16 +17,12 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 -->
 
-### Changed
+<!-- ### Changed -->
 
-Warning message: Python 3.8 is no longer supported by the Python Software Foundation since October, 14th 2024. GGShield will soon require Python 3.9 or above to run.
-
-<!--
 ### Deprecated
 
-- A bullet item for the Deprecated category.
+- Added warning message about future removal of Python 3.8 support.
 
--->
 <!--
 ### Fixed
 

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -23,6 +23,7 @@ from ggshield.cmd.status import status_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.debug import setup_debug_mode
+from ggshield.cmd.utils.output_format import OutputFormat
 from ggshield.core import check_updates, ui
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
@@ -138,9 +139,14 @@ def _set_color(ctx: click.Context):
         ctx.color = True
 
 
-def _display_deprecation_message(cfg: Config) -> None:
-    for message in cfg.user_config.deprecation_messages:
+def _display_deprecation_message(ctx_obj: ContextObj) -> None:
+    for message in ctx_obj.config.user_config.deprecation_messages:
         ui.display_warning(message)
+    if sys.version_info < (3, 9) and ctx_obj.output_format is OutputFormat.TEXT:
+        ui.display_warning(
+            "Python 3.8 is no longer supported by the Python Software Foundation. "
+            "GGShield will soon require Python 3.9 or above to run."
+        )
 
 
 def _check_for_updates(check_for_updates: bool) -> None:
@@ -165,7 +171,7 @@ def before_exit(ctx: click.Context, exit_code: int, *args: Any, **kwargs: Any) -
     The argument exit_code is the result of the previously executed click command.
     """
     ctx_obj = ContextObj.get(ctx)
-    _display_deprecation_message(ctx_obj.config)
+    _display_deprecation_message(ctx_obj)
     _check_for_updates(ctx_obj.check_for_updates)
     sys.exit(exit_code)
 

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -23,7 +23,6 @@ from ggshield.cmd.status import status_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.debug import setup_debug_mode
-from ggshield.cmd.utils.output_format import OutputFormat
 from ggshield.core import check_updates, ui
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
@@ -139,10 +138,10 @@ def _set_color(ctx: click.Context):
         ctx.color = True
 
 
-def _display_deprecation_message(ctx_obj: ContextObj) -> None:
-    for message in ctx_obj.config.user_config.deprecation_messages:
+def _display_deprecation_message(cfg: Config) -> None:
+    for message in cfg.user_config.deprecation_messages:
         ui.display_warning(message)
-    if sys.version_info < (3, 9) and ctx_obj.output_format is OutputFormat.TEXT:
+    if sys.version_info < (3, 9):
         ui.display_warning(
             "Python 3.8 is no longer supported by the Python Software Foundation. "
             "GGShield will soon require Python 3.9 or above to run."
@@ -171,7 +170,7 @@ def before_exit(ctx: click.Context, exit_code: int, *args: Any, **kwargs: Any) -
     The argument exit_code is the result of the previously executed click command.
     """
     ctx_obj = ContextObj.get(ctx)
-    _display_deprecation_message(ctx_obj)
+    _display_deprecation_message(ctx_obj.config)
     _check_for_updates(ctx_obj.check_for_updates)
     sys.exit(exit_code)
 

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, Tuple
 from unittest.mock import Mock
 
@@ -79,6 +80,12 @@ class TestAuthLogout:
             expected_output += (
                 "Your personal access token has been removed "
                 "from your configuration.\n"
+            )
+
+        if sys.version_info < (3, 9):
+            expected_output += (
+                "Warning: Python 3.8 is no longer supported by the Python Software Foundation. "
+                "GGShield will soon require Python 3.9 or above to run.\n"
             )
 
         assert output == expected_output

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -75,7 +76,14 @@ class TestDockerCMD:
             ["-v", "secret", "scan", "docker", "ggshield-non-existant"],
         )
         assert_invoke_ok(result)
-        assert result.output == ""
+
+        expected_output = ""
+        if sys.version_info < (3, 9):
+            expected_output += (
+                "Warning: Python 3.8 is no longer supported by the Python Software Foundation. "
+                "GGShield will soon require Python 3.9 or above to run.\n"
+            )
+        assert result.output == expected_output
 
     @patch("ggshield.cmd.secret.scan.docker.docker_save_to_tmp")
     @patch("ggshield.cmd.secret.scan.docker.docker_scan_archive")

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -132,6 +132,7 @@ class TestConfigList:
     @staticmethod
     def run_cmd(cli_fs_runner, json: bool = False) -> Tuple[bool, str]:
         cmd = ["config", "list", "--json"] if json else ["config", "list"]
+        cli_fs_runner.mix_stderr = False if json else True
         result = cli_fs_runner.invoke(cli, cmd, color=False, catch_exceptions=False)
         return result.exit_code, result.output
 

--- a/tests/unit/cmd/test_status.py
+++ b/tests/unit/cmd/test_status.py
@@ -16,6 +16,7 @@ from tests.unit.conftest import assert_invoke_ok, my_vcr
 def test_quota(cli_fs_runner, quota_json_schema):
     with my_vcr.use_cassette("quota"):
         cmd = ["quota", "--json"]
+        cli_fs_runner.mix_stderr = False
         result = cli_fs_runner.invoke(cli, cmd, color=False)
         assert_invoke_ok(result)
 
@@ -28,6 +29,7 @@ def test_quota(cli_fs_runner, quota_json_schema):
 def test_api_status(cli_fs_runner, api_status_json_schema):
     with my_vcr.use_cassette("test_health_check"):
         cmd = ["api-status", "--json"]
+        cli_fs_runner.mix_stderr = False
         result = cli_fs_runner.invoke(cli, cmd, color=False)
         assert_invoke_ok(result)
 
@@ -71,6 +73,7 @@ def test_api_status_sources(_, hs_mock, cli_fs_runner, tmp_path, monkeypatch):
     def get_api_status(env, instance=None):
         with cd(tmp_path):
             cmd = ["api-status", "--json"]
+            cli_fs_runner.mix_stderr = False
             if instance:
                 cmd.extend(["--instance", instance])
             result = cli_fs_runner.invoke(cli, cmd, color=False, env=env)


### PR DESCRIPTION
Python 3.8 is no longer supported by the Python Software Foundation. Thus, GGShield will soon require Python 3.9 and above to run.

In this PR we add a deprecation warning message to warn Python 3.8 users about future deprecation.

Output example:
```
$ ggshield api-status
API URL: https://dashboard.gitguardian.com
Status: healthy
App version: v2.119.0
Secrets engine version: 2.126.0

Instance source: default
API key source: user config

Warning: Python 3.8 is no longer supported by the Python Software Foundation. GGShield will soon require Python 3.9 or above to run.
```