### PR TITLE
Logging improvements

### DIFF
--- a/ggshield/cmd/utils/debug.py
+++ b/ggshield/cmd/utils/debug.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import pygitguardian
 
+import ggshield
 from ggshield.core import ui
 from ggshield.core.ui import log_utils
 
@@ -32,4 +33,5 @@ def setup_debug_mode(*, filename: Optional[str] = None) -> None:
     logging.getLogger("charset_normalizer").setLevel(logging.WARNING)
 
     logger.debug("args=%s", sys.argv)
+    logger.debug("ggshield=%s", ggshield.__version__)
     logger.debug("py-gitguardian=%s", pygitguardian.__version__)

--- a/ggshield/core/scan/scannable.py
+++ b/ggshield/core/scan/scannable.py
@@ -159,6 +159,7 @@ class Scannable(ABC):
         if charset_match is None:
             raise DecodeError
 
+        logger.debug('filename="%s" charset=%s', fp.name, charset_match.encoding)
         if charset_match.encoding in {"utf_8", "ascii"}:
             # Shortcut: the content is already in UTF-8 (or ASCII, which is a subset of
             # utf-8), no need to decode anything
@@ -167,6 +168,7 @@ class Scannable(ABC):
         # We can't know if the file is longer without reading its content, do it now
         fp.seek(0, SEEK_SET)
         content, utf8_encoded_size = Scannable._decode_bytes(fp.read(), charset_match)
+        logger.debug('filename="%s" utf8_encoded_size=%d', fp.name, utf8_encoded_size)
         if utf8_encoded_size > max_utf8_encoded_size:
             return True, None, utf8_encoded_size
         else:

--- a/ggshield/verticals/secret/repo.py
+++ b/ggshield/verticals/secret/repo.py
@@ -1,4 +1,6 @@
 import itertools
+import logging
+import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, List, Pattern, Set
@@ -21,6 +23,9 @@ from ggshield.utils.os import cd
 from .output import SecretOutputHandler
 from .secret_scan_collection import Results, SecretScanCollection
 from .secret_scanner import SecretScanner
+
+
+logger = logging.getLogger(__name__)
 
 
 # We add a maximal value to avoid silently consuming all threads on powerful machines
@@ -80,6 +85,13 @@ def scan_commits_content(
     except QuotaLimitReachedError:
         raise
     except Exception as exc:
+        logger.error(
+            "Exception raised during scan. commits=%s type(exception)=%s exception=%s trace=%s",
+            commits,
+            type(exc),
+            exc,
+            traceback.format_exc(),
+        )
         results = Results.from_exception(exc)
     finally:
         progress_callback(len(commits))

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -93,7 +93,9 @@ class Results:
     @staticmethod
     def from_exception(exc: Exception) -> "Results":
         """Create a Results representing a failure"""
-        error = Error(files=[], description=str(exc))
+        exc_class_name = exc.__class__.__name__
+        description = f"{exc_class_name}: {str(exc) or '-'}"
+        error = Error(files=[], description=description)
         return Results(results=[], errors=[error])
 
     def extend(self, others: "Results") -> None:

--- a/tests/unit/verticals/secret/test_secret_scan_collection.py
+++ b/tests/unit/verticals/secret/test_secret_scan_collection.py
@@ -1,0 +1,21 @@
+from ggshield.verticals.secret import Results
+
+
+class MyException(Exception):
+    pass
+
+
+def test_results_from_exception():
+    """
+    GIVEN an exception
+    WHEN creating a Results from it
+    THEN it contains the right content
+    """
+    exc = MyException("Hello")
+    results = Results.from_exception(exc)
+
+    assert len(results.errors) == 1
+    error = results.errors[0]
+    assert error.description == "MyException: Hello"
+
+    assert results.results == []


### PR DESCRIPTION
## Context

This MR improves our logging, to help diagnose problems:

- Log ggshield version (in addition to logging py-gitguardian version)
- Log details about detected file encodings
- Improve logging for errors during scan

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
