### PR TITLE
Fix functional tests

### DIFF
--- a/tests/functional/secret/test_scan_path.py
+++ b/tests/functional/secret/test_scan_path.py
@@ -43,6 +43,7 @@ def test_scan_path(tmp_path: Path, show_secrets: bool) -> None:
 def test_scan_path_dot_git(tmp_path: Path, show_secrets: bool) -> None:
     # GIVEN a secret
     test_file = tmp_path / ".git" / "config"
+    test_file.parent.mkdir()
     test_file.write_text(f"SECRET='{GG_VALID_TOKEN}'")
 
     # WHEN ggshield scans it

--- a/tests/functional/secret/test_scan_path.py
+++ b/tests/functional/secret/test_scan_path.py
@@ -17,10 +17,12 @@ from tests.functional.utils import (
 )
 
 
+@pytest.mark.parametrize("path", ("config.py", ".git/config"))
 @pytest.mark.parametrize("show_secrets", (True, False))
-def test_scan_path(tmp_path: Path, show_secrets: bool) -> None:
+def test_scan_path(tmp_path: Path, path: str, show_secrets: bool) -> None:
     # GIVEN a secret
-    test_file = tmp_path / "config.py"
+    test_file = tmp_path / path
+    test_file.parent.mkdir(exist_ok=True, parents=True)
     test_file.write_text(f"SECRET='{GG_VALID_TOKEN}'")
 
     # WHEN ggshield scans it
@@ -32,30 +34,7 @@ def test_scan_path(tmp_path: Path, show_secrets: bool) -> None:
     # THEN the output contains the context and the expected ignore sha
     assert "SECRET=" in result.stdout
     assert GG_VALID_TOKEN_IGNORE_SHA in result.stdout
-    # and the secrets shown only with --show-secrets
-    if show_secrets:
-        assert GG_VALID_TOKEN in result.stdout
-    else:
-        assert recreate_censored_string(GG_VALID_TOKEN) in result.stdout
-
-
-@pytest.mark.parametrize("show_secrets", (True, False))
-def test_scan_path_dot_git(tmp_path: Path, show_secrets: bool) -> None:
-    # GIVEN a secret
-    test_file = tmp_path / ".git" / "config"
-    test_file.parent.mkdir()
-    test_file.write_text(f"SECRET='{GG_VALID_TOKEN}'")
-
-    # WHEN ggshield scans it
-    args = ["path", str(test_file)]
-    if show_secrets:
-        args.append("--show-secrets")
-    result = run_ggshield_scan(*args, cwd=tmp_path, expected_code=1)
-
-    # THEN the output contains the context and the expected ignore sha
-    assert "SECRET=" in result.stdout
-    assert GG_VALID_TOKEN_IGNORE_SHA in result.stdout
-    # and the secrets shown only with --show-secrets
+    # AND the secrets are shown only with --show-secrets
     if show_secrets:
         assert GG_VALID_TOKEN in result.stdout
     else:


### PR DESCRIPTION
## Context

I merged a PR which came from a fork. In this conditions functional tests are skipped (they can't be run because they don't have access to secrets). This broke `main` because there was a small bug in a test added by the PR.

## What has been done

Fix the test, and actually merge it with an existing one.

## Validation

Tests pass!

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
