### PR TITLE
Post release fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           pdm sync
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ documentation.
 
 It requires **Python 3.8 or above** (except for standalone packages) and git.
 
-:warning: Python 3.8 is no longer supported by the Python Software Foundation since October, 14th 2024. GGShield will soon require Python 3.9 or above to run.
+⚠️ Python 3.8 is no longer supported by the Python Software Foundation since October, 14th 2024. GGShield will soon require Python 3.9 or above to run.
 
 Some commands require additional programs:
 


### PR DESCRIPTION
## What has been done

This are small post-release fixes:

- Update the actions/cache action to v4.
- Fix pypi.org README because pypi does not render `:warning:`:

![image](https://github.com/user-attachments/assets/00208eba-f741-4652-b8c5-ef2f4d2f144d)

Changes won't be visible until the next release though.
