### PR TITLE
fix(secret): fix the example of commit range given in commit-range cmd

### DIFF
--- a/ggshield/cmd/secret/scan/range.py
+++ b/ggshield/cmd/secret/scan/range.py
@@ -32,7 +32,7 @@ def range_cmd(
 
     Any git compatible commit range can be provided as an input.
 
-    Example: `ggshield secret scan commit-range HEAD~1...`
+    Example: `ggshield secret scan commit-range HEAD~1..HEAD`
     """
     ctx_obj = ContextObj.get(ctx)
     ctx_obj.client = create_client_from_config(ctx_obj.config)


### PR DESCRIPTION
## Context

One of our user rightfully reported that the example of commit range given in the `secret scan commit-range` command was invalid. 
This PR corrects it

## What has been done

Just corrected the example. It will also automatically update our documentation https://docs.gitguardian.com/ggshield-docs/reference/secret/scan/commit-range


## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

