### PR TITLE
pre-commit: fix deprecated stages

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   name: ggshield (pre-commit)
   entry: ggshield
   description: Runs ggshield to detect hardcoded secrets.
-  stages: [commit]
+  stages: [pre-commit]
   args: ['secret', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
@@ -12,7 +12,7 @@
   name: ggshield-iac (pre-commit)
   entry: ggshield
   description: Runs ggshield Infra as Code Security to detect IaC vulnerabilities.
-  stages: [commit]
+  stages: [pre-commit]
   args: ['iac', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
@@ -21,7 +21,7 @@
   name: ggshield-sca (pre-commit)
   entry: ggshield
   description: Runs ggshield Software Composition Analysis to detect vulnerabilities introduced by dependencies.
-  stages: [commit]
+  stages: [pre-commit]
   args: ['sca', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
@@ -38,7 +38,7 @@
   entry: ggshield
   description: Runs ggshield to detect hardcoded secrets.
   args: ['secret', 'scan', 'pre-push']
-  stages: [push]
+  stages: [pre-push]
   language: python
   pass_filenames: false
 
@@ -47,7 +47,7 @@
   entry: ggshield
   description: Runs ggshield Infra as Code Security to detect IaC vulnerabilities.
   args: ['iac', 'scan', 'pre-push']
-  stages: [push]
+  stages: [pre-push]
   language: python
   pass_filenames: false
 
@@ -56,7 +56,7 @@
   entry: ggshield
   description: Runs ggshield Software Composition Analysis to detect vulnerabilities introduced by dependencies.
   args: ['sca', 'scan', 'pre-push']
-  stages: [push]
+  stages: [pre-push]
   language: python
   pass_filenames: false
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   args: ['secret', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: ggshield-iac
   name: ggshield-iac (pre-commit)
@@ -16,6 +17,7 @@
   args: ['iac', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: ggshield-sca
   name: ggshield-sca (pre-commit)
@@ -25,6 +27,7 @@
   args: ['sca', 'scan', 'pre-commit']
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: docker-ggshield
   name: ggshield (pre-commit,docker)
@@ -41,6 +44,7 @@
   stages: [pre-push]
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: ggshield-iac-push
   name: ggshield-iac (pre-push)
@@ -50,6 +54,7 @@
   stages: [pre-push]
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: ggshield-sca-push
   name: ggshield-sca (pre-push)
@@ -59,6 +64,7 @@
   stages: [pre-push]
   language: python
   pass_filenames: false
+  minimum_pre_commit_version: 3.2.0
 
 - id: docker-ggshield-push
   name: ggshield (pre-push,docker)


### PR DESCRIPTION
## Context

Fix deprecated pre-commit stages.
Fix #980

## Validation

* Create a minimal pre-commit config (see below)
* Run `pre-commit run --all-files`
* No warning should appear.

Minimal config:
```yaml
repos:
  - repo: https://github.com/gitguardian/ggshield
    rev: v1.34.0 # update this version
    hooks:
      - id: ggshield
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

❓ Does this require a changelog entry? I'd be tempted to say no but I don't know your policies.
