### PR TITLE
chore: make ignore reason human readable in text output

### DIFF
--- a/ggshield/core/cache.py
+++ b/ggshield/core/cache.py
@@ -2,12 +2,9 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from pygitguardian.models import PolicyBreak
-
 from ggshield.core import ui
 from ggshield.core.constants import CACHE_PATH
 from ggshield.core.errors import UnexpectedError
-from ggshield.core.filter import get_ignore_sha
 from ggshield.core.types import IgnoredMatch
 
 
@@ -74,18 +71,18 @@ class Cache:
     def purge(self) -> None:
         self.last_found_secrets = []
 
-    def add_found_policy_break(self, policy_break: PolicyBreak, filename: str) -> None:
-        if policy_break.is_secret:
-            ignore_sha = get_ignore_sha(policy_break)
-            if not any(
-                last_found.match == ignore_sha for last_found in self.last_found_secrets
-            ):
-                self.last_found_secrets.append(
-                    IgnoredMatch(
-                        name=f"{policy_break.break_type} - {filename}",
-                        match=get_ignore_sha(policy_break),
-                    )
+    def add_found_policy_break(
+        self, break_type: str, ignore_sha: str, filename: str
+    ) -> None:
+        if not any(
+            last_found.match == ignore_sha for last_found in self.last_found_secrets
+        ):
+            self.last_found_secrets.append(
+                IgnoredMatch(
+                    name=f"{break_type} - {filename}",
+                    match=ignore_sha,
                 )
+            )
 
 
 class ReadOnlyCache(Cache):

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 import operator
 import re
-from typing import Dict, Iterable, List, Pattern, Set
+from typing import Iterable, Pattern, Set
 
 from click import UsageError
 from pygitguardian.models import Match, PolicyBreak
@@ -58,20 +58,6 @@ def get_ignore_sha(policy_break: PolicyBreak) -> str:
     )
 
     return hashlib.sha256(hashable.encode("UTF-8")).hexdigest()
-
-
-def group_policy_breaks_by_ignore_sha(
-    policy_breaks: List[PolicyBreak],
-) -> Dict[str, List[PolicyBreak]]:
-    """
-    Group policy breaks by their ignore sha.
-    """
-    sha_dict: Dict[str, List[PolicyBreak]] = {}
-    for policy_break in policy_breaks:
-        ignore_sha = get_ignore_sha(policy_break)
-        sha_dict.setdefault(ignore_sha, []).append(policy_break)
-
-    return sha_dict
 
 
 def translate_user_pattern(pattern: str) -> str:

--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -26,7 +26,7 @@ STYLE: Dict[str, Dict[str, Any]] = {
     "warning": {"fg": "yellow"},
     "heading": {"fg": "green"},
     "incident_validity": {"fg": "bright_yellow", "bold": True},
-    "policy_break_type": {"fg": "bright_yellow", "bold": True},
+    "secret_type": {"fg": "bright_yellow", "bold": True},
     "occurrence_count": {"fg": "bright_yellow", "bold": True},
     "ignore_sha": {"fg": "bright_yellow", "bold": True},
     "iac_vulnerability_critical": {"fg": "red", "bold": True},

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -358,7 +358,7 @@ def docker_scan_archive(
                 ui.display_heading(f"Scanning layer {info.diff_id}")
                 with ui.create_scanner_ui(file_count) as scanner_ui:
                     layer_results = scanner.scan(files, scanner_ui=scanner_ui)
-                if not layer_results.has_policy_breaks:
+                if not layer_results.has_secrets:
                     layer_id_cache.add(layer_id)
                 results.extend(layer_results)
 

--- a/ggshield/verticals/secret/extended_match.py
+++ b/ggshield/verticals/secret/extended_match.py
@@ -140,3 +140,17 @@ class ExtendedMatch(Match):
                 f"post_line_end:{self.post_line_end}",
             ]
         )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, ExtendedMatch):
+            return False
+        return (
+            self.span == other.span
+            and self.lines_before_secret == other.lines_before_secret
+            and self.lines_with_secret == other.lines_with_secret
+            and self.lines_after_secret == other.lines_after_secret
+            and self.pre_line_start == other.pre_line_start
+            and self.pre_line_end == other.pre_line_end
+            and self.post_line_start == other.post_line_start
+            and self.post_line_end == other.post_line_end
+        )

--- a/ggshield/verticals/secret/output/schemas.py
+++ b/ggshield/verticals/secret/output/schemas.py
@@ -12,7 +12,7 @@ class IgnoreReasonSchema(BaseSchema):
 class FlattenedPolicyBreak(BaseSchema):
     policy = fields.String(required=True)
     occurrences = fields.List(fields.Nested(ExtendedMatchSchema), required=True)
-    break_type = fields.String(data_key="type", required=True)
+    detector = fields.String(data_key="type", required=True)
     validity = fields.String(required=False, allow_none=True)
     ignore_sha = fields.String(required=True)
     total_occurrences = fields.Integer(required=True)

--- a/ggshield/verticals/secret/output/schemas.py
+++ b/ggshield/verticals/secret/output/schemas.py
@@ -4,6 +4,11 @@ from pygitguardian.models import BaseSchema, SecretIncidentSchema
 from ggshield.verticals.secret.extended_match import ExtendedMatchSchema
 
 
+class IgnoreReasonSchema(BaseSchema):
+    kind = fields.String(required=True)
+    detail = fields.String()
+
+
 class FlattenedPolicyBreak(BaseSchema):
     policy = fields.String(required=True)
     occurrences = fields.List(fields.Nested(ExtendedMatchSchema), required=True)
@@ -14,6 +19,7 @@ class FlattenedPolicyBreak(BaseSchema):
     incident_url = fields.String(required=True, dump_default="")
     incident_details = fields.Nested(SecretIncidentSchema)
     known_secret = fields.Bool(required=True, dump_default=False)
+    ignore_reason = fields.Nested(IgnoreReasonSchema, dump_default=None)
 
 
 class JSONResultSchema(BaseSchema):

--- a/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
@@ -17,7 +17,7 @@ def format_secret(secret: Secret) -> str:
         f'{x.match_type}: "{censor_match(x)}"' for x in secret.matches
     )
     validity = translate_validity(secret.validity)
-    return f"{secret.break_type} (Validity: {validity}, {match_str})"
+    return f"{secret.detector} (Validity: {validity}, {match_str})"
 
 
 class SecretGitLabWebUIOutputHandler(SecretOutputHandler):

--- a/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
@@ -1,13 +1,11 @@
-from pygitguardian.models import PolicyBreak
-
 from ggshield.core.filter import censor_match
 from ggshield.core.text_utils import pluralize, translate_validity
 
-from ..secret_scan_collection import SecretScanCollection
+from ..secret_scan_collection import Secret, SecretScanCollection
 from .secret_output_handler import SecretOutputHandler
 
 
-def format_policy_break(policy_break: PolicyBreak) -> str:
+def format_policy_break(policy_break: Secret) -> str:
     """Returns a string with the policy name, validity and a comma-separated,
     double-quoted, censored version of all `policy_break` matches.
 

--- a/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_gitlab_webui_output_handler.py
@@ -5,19 +5,19 @@ from ..secret_scan_collection import Secret, SecretScanCollection
 from .secret_output_handler import SecretOutputHandler
 
 
-def format_policy_break(policy_break: Secret) -> str:
+def format_secret(secret: Secret) -> str:
     """Returns a string with the policy name, validity and a comma-separated,
-    double-quoted, censored version of all `policy_break` matches.
+    double-quoted, censored version of all `secret` matches.
 
     Looks like this:
 
     PayPal OAuth2 Keys (Validity: Valid, id="aa*******bb", secret="cc******dd")
     """
     match_str = ", ".join(
-        f'{x.match_type}: "{censor_match(x)}"' for x in policy_break.matches
+        f'{x.match_type}: "{censor_match(x)}"' for x in secret.matches
     )
-    validity = translate_validity(policy_break.validity)
-    return f"{policy_break.break_type} (Validity: {validity}, {match_str})"
+    validity = translate_validity(secret.validity)
+    return f"{secret.break_type} (Validity: {validity}, {match_str})"
 
 
 class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
@@ -33,21 +33,17 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
     def _process_scan_impl(self, scan: SecretScanCollection) -> str:
         results = scan.get_all_results()
 
-        policy_breaks_to_report = [
-            policy_break for result in results for policy_break in result.policy_breaks
-        ]
+        secrets_to_report = [secret for result in results for secret in result.secrets]
 
         # If no secrets or no new secrets were found
-        if len(policy_breaks_to_report) == 0:
+        if len(secrets_to_report) == 0:
             return ""
 
         # Use a set to ensure we do not report duplicate incidents.
         # (can happen when the secret is present in both the old and the new version of
         # the document)
-        formatted_policy_breaks = {
-            format_policy_break(x) for x in policy_breaks_to_report
-        }
-        break_count = len(formatted_policy_breaks)
+        formatted_secrets = {format_secret(x) for x in secrets_to_report}
+        break_count = len(formatted_secrets)
 
         if self.ignore_known_secrets:
             summary_str = f"{break_count} new {pluralize('incident', break_count)}"
@@ -58,7 +54,7 @@ class SecretGitLabWebUIOutputHandler(SecretOutputHandler):
         # do this because of a bug in GitLab Web IDE which causes newline characters to
         # be shown as "<br>"
         # https://gitlab.com/gitlab-org/gitlab/-/issues/350349
-        breaks_str = ", ".join(formatted_policy_breaks)
+        breaks_str = ", ".join(formatted_secrets)
 
         return (
             f"GL-HOOK-ERR: ggshield found {summary_str} in these changes: {breaks_str}."

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, Dict, List, cast
 
 from pygitguardian.client import VERSIONS
@@ -131,6 +132,11 @@ class SecretJSONOutputHandler(SecretOutputHandler):
             details = incident_details.get(policy_breaks[0].incident_url)
             if details is not None:
                 flattened_dict["incident_details"] = details
+
+        if policy_breaks[0].ignore_reason is not None:
+            flattened_dict["ignore_reason"] = dataclasses.asdict(
+                policy_breaks[0].ignore_reason
+            )
 
         for policy_break in policy_breaks:
             flattened_dict["occurrences"].extend(

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -80,15 +80,15 @@ class SecretJSONOutputHandler(SecretOutputHandler):
             "total_occurrences": 0,
             "total_incidents": 0,
         }
-        sha_dict = group_secrets_by_ignore_sha(result.policy_breaks)
+        sha_dict = group_secrets_by_ignore_sha(result.secrets)
         result_dict["total_incidents"] = len(sha_dict)
 
         if not self.show_secrets:
             result.censor()
 
-        for ignore_sha, policy_breaks in sha_dict.items():
-            flattened_dict = self.serialized_policy_break(
-                ignore_sha, policy_breaks, incident_details
+        for ignore_sha, secrets in sha_dict.items():
+            flattened_dict = self.serialized_secret(
+                ignore_sha, secrets, incident_details
             )
             result_dict["incidents"].append(flattened_dict)
             result_dict["total_occurrences"] += flattened_dict["total_occurrences"]
@@ -108,54 +108,52 @@ class SecretJSONOutputHandler(SecretOutputHandler):
         }
         return error_dict
 
-    def serialized_policy_break(
+    def serialized_secret(
         self,
         ignore_sha: str,
-        policy_breaks: List[Secret],
+        secrets: List[Secret],
         incident_details: Dict[str, SecretIncident],
     ) -> Dict[str, Any]:
         flattened_dict: Dict[str, Any] = {
             "occurrences": [],
             "ignore_sha": ignore_sha,
-            "policy": policy_breaks[0].policy,
-            "break_type": policy_breaks[0].break_type,
-            "total_occurrences": len(policy_breaks),
+            "policy": secrets[0].policy,
+            "break_type": secrets[0].break_type,
+            "total_occurrences": len(secrets),
         }
 
-        if policy_breaks[0].validity:
-            flattened_dict["validity"] = policy_breaks[0].validity
+        if secrets[0].validity:
+            flattened_dict["validity"] = secrets[0].validity
 
-        if policy_breaks[0].known_secret:
-            flattened_dict["known_secret"] = policy_breaks[0].known_secret
-            flattened_dict["incident_url"] = policy_breaks[0].incident_url
-            assert policy_breaks[0].incident_url
-            details = incident_details.get(policy_breaks[0].incident_url)
+        if secrets[0].known_secret:
+            flattened_dict["known_secret"] = secrets[0].known_secret
+            flattened_dict["incident_url"] = secrets[0].incident_url
+            assert secrets[0].incident_url
+            details = incident_details.get(secrets[0].incident_url)
             if details is not None:
                 flattened_dict["incident_details"] = details
 
-        if policy_breaks[0].ignore_reason is not None:
+        if secrets[0].ignore_reason is not None:
             flattened_dict["ignore_reason"] = dataclasses.asdict(
-                policy_breaks[0].ignore_reason
+                secrets[0].ignore_reason
             )
 
-        for policy_break in policy_breaks:
-            flattened_dict["occurrences"].extend(
-                self.serialize_policy_break_matches(policy_break)
-            )
+        for secret in secrets:
+            flattened_dict["occurrences"].extend(self.serialize_secret_matches(secret))
 
         return flattened_dict
 
-    def serialize_policy_break_matches(
+    def serialize_secret_matches(
         self,
-        policy_break: Secret,
+        secret: Secret,
     ) -> List[Dict[str, Any]]:
         """
-        Serialize policy_break matches. The method uses MatchSpan to get the start and
+        Serialize secret matches. The method uses MatchSpan to get the start and
         end index of the match.
         Returns a list of matches.
         """
         matches_list: List[Dict[str, Any]] = []
-        for match in policy_break.matches:
+        for match in secret.matches:
             assert isinstance(match, ExtendedMatch)
 
             match_dict: Dict[str, Any] = {

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -1,12 +1,17 @@
 from typing import Any, Dict, List, cast
 
 from pygitguardian.client import VERSIONS
-from pygitguardian.models import PolicyBreak, SecretIncident
+from pygitguardian.models import SecretIncident
 
-from ggshield.core.filter import group_policy_breaks_by_ignore_sha
 from ggshield.verticals.secret.extended_match import ExtendedMatch
 
-from ..secret_scan_collection import Error, Result, SecretScanCollection
+from ..secret_scan_collection import (
+    Error,
+    Result,
+    Secret,
+    SecretScanCollection,
+    group_secrets_by_ignore_sha,
+)
 from .schemas import JSONScanCollectionSchema
 from .secret_output_handler import SecretOutputHandler
 
@@ -74,7 +79,7 @@ class SecretJSONOutputHandler(SecretOutputHandler):
             "total_occurrences": 0,
             "total_incidents": 0,
         }
-        sha_dict = group_policy_breaks_by_ignore_sha(result.policy_breaks)
+        sha_dict = group_secrets_by_ignore_sha(result.policy_breaks)
         result_dict["total_incidents"] = len(sha_dict)
 
         if not self.show_secrets:
@@ -105,7 +110,7 @@ class SecretJSONOutputHandler(SecretOutputHandler):
     def serialized_policy_break(
         self,
         ignore_sha: str,
-        policy_breaks: List[PolicyBreak],
+        policy_breaks: List[Secret],
         incident_details: Dict[str, SecretIncident],
     ) -> Dict[str, Any]:
         flattened_dict: Dict[str, Any] = {
@@ -136,7 +141,7 @@ class SecretJSONOutputHandler(SecretOutputHandler):
 
     def serialize_policy_break_matches(
         self,
-        policy_break: PolicyBreak,
+        policy_break: Secret,
     ) -> List[Dict[str, Any]]:
         """
         Serialize policy_break matches. The method uses MatchSpan to get the start and

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -118,7 +118,7 @@ class SecretJSONOutputHandler(SecretOutputHandler):
             "occurrences": [],
             "ignore_sha": ignore_sha,
             "policy": secrets[0].policy,
-            "break_type": secrets[0].break_type,
+            "detector": secrets[0].detector,
             "total_occurrences": len(secrets),
         }
 

--- a/ggshield/verticals/secret/output/secret_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_output_handler.py
@@ -56,6 +56,6 @@ class SecretOutputHandler(ABC):
         raise NotImplementedError()
 
     def _get_exit_code(self, scan: SecretScanCollection) -> ExitCode:
-        if scan.total_policy_breaks_count > 0:
+        if scan.total_secrets_count > 0:
             return ExitCode.SCAN_FOUND_PROBLEMS
         return ExitCode.SUCCESS

--- a/ggshield/verticals/secret/output/secret_sarif_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_sarif_output_handler.py
@@ -76,12 +76,12 @@ def _create_sarif_result_dict(
         f"- [{m.match_type}]({id})" for id, m in enumerate(secret.matches)
     )
     extended_matches = cast(List[ExtendedMatch], secret.matches)
-    message = f"Secret detected: {secret.break_type}.\nMatches: {matches_str}"
-    markdown_message = f"Secret detected: {secret.break_type}\nMatches:\n{matches_li}"
+    message = f"Secret detected: {secret.detector}.\nMatches: {matches_str}"
+    markdown_message = f"Secret detected: {secret.detector}\nMatches:\n{matches_li}"
 
     # Create dict
     dct = {
-        "ruleId": secret.break_type,
+        "ruleId": secret.detector,
         "level": "error",
         "message": {
             "text": message,

--- a/ggshield/verticals/secret/output/secret_sarif_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_sarif_output_handler.py
@@ -2,14 +2,13 @@ import json
 from typing import Any, Dict, Iterable, List, cast
 
 from pygitguardian.client import VERSIONS
-from pygitguardian.models import PolicyBreak, SecretIncident
+from pygitguardian.models import SecretIncident
 
 from ggshield import __version__ as ggshield_version
-from ggshield.core.filter import get_ignore_sha
 from ggshield.core.match_span import MatchSpan
 
 from ..extended_match import ExtendedMatch
-from ..secret_scan_collection import Result, SecretScanCollection
+from ..secret_scan_collection import Result, Secret, SecretScanCollection
 from .secret_output_handler import SecretOutputHandler
 
 
@@ -66,7 +65,7 @@ def _create_sarif_results(
 
 def _create_sarif_result_dict(
     url: str,
-    policy_break: PolicyBreak,
+    policy_break: Secret,
     incident_details: Dict[str, SecretIncident],
 ) -> Dict[str, Any]:
     # Prepare message with links to the related location for each match
@@ -98,7 +97,7 @@ def _create_sarif_result_dict(
             for id, m in enumerate(extended_matches)
         ],
         "partialFingerprints": {
-            "secret/v1": get_ignore_sha(policy_break),
+            "secret/v1": policy_break.get_ignore_sha(),
         },
     }
     if policy_break.incident_url:

--- a/ggshield/verticals/secret/output/secret_text_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_text_output_handler.py
@@ -297,7 +297,7 @@ def secret_header(
     )
 
     start_line = format_text(">>", STYLE["detector_line_start"])
-    secret_type = format_text(secret.break_type, STYLE["secret_type"])
+    secret_type = format_text(secret.detector, STYLE["secret_type"])
     number_occurrences = format_text(str(len(secrets)), STYLE["occurrence_count"])
     ignore_sha = format_text(ignore_sha, STYLE["ignore_sha"])
 

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -83,7 +83,7 @@ class Secret:
     Named Secret since we are dropping other kind of policy breaks.
     """
 
-    break_type: str
+    detector: str
     validity: str
     known_secret: bool
     incident_url: Optional[str]
@@ -186,7 +186,7 @@ class Result:
                 validity=policy_break.validity,
                 known_secret=policy_break.known_secret,
                 incident_url=policy_break.incident_url,
-                break_type=policy_break.break_type,
+                detector=policy_break.break_type,
                 matches=[
                     ExtendedMatch.from_match(match, lines, result.is_on_patch)
                     for match in policy_break.matches

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -40,6 +40,9 @@ class IgnoreKind(str, Enum):
     NOT_INTRODUCED = "Secret was not in added in commit"
     BACKEND_EXCLUDED = "Excluded by dashboard"
 
+    def __str__(self):
+        return self.name.lower()
+
 
 @dataclass(frozen=True)
 class IgnoreReason:

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -99,10 +99,6 @@ class Secret:
     def is_ignored(self) -> bool:
         return self.ignore_reason is not None
 
-    @property
-    def is_secret(self) -> bool:
-        return True
-
     def get_ignore_sha(self) -> str:
         hashable = "".join(
             [

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -138,21 +138,21 @@ class Result:
     filemode: Filemode
     path: Path
     url: str
-    policy_breaks: List[Secret]
-    ignored_policy_breaks_count_by_kind: Counter[IgnoreKind]
+    secrets: List[Secret]
+    ignored_secrets_count_by_kind: Counter[IgnoreKind]
 
     @property
     def is_on_patch(self) -> bool:
         return self.filemode != Filemode.FILE
 
     def censor(self) -> None:
-        for policy_break in self.policy_breaks:
-            for extended_match in policy_break.matches:
+        for secret in self.secrets:
+            for extended_match in secret.matches:
                 cast(ExtendedMatch, extended_match).censor()
 
     @property
-    def has_policy_breaks(self) -> bool:
-        return len(self.policy_breaks) > 0
+    def has_secrets(self) -> bool:
+        return len(self.secrets) > 0
 
     @classmethod
     def from_scan_result(
@@ -164,14 +164,14 @@ class Result:
         """
 
         to_keep: List[Tuple[PolicyBreak, Optional[IgnoreReason]]] = []
-        ignored_policy_breaks_count_by_kind = Counter()
+        ignored_secrets_count_by_kind = Counter()
         for policy_break in scan_result.policy_breaks:
             ignore_reason = compute_ignore_reason(policy_break, secret_config)
             if ignore_reason is not None:
                 if secret_config.all_secrets:
                     to_keep.append((policy_break, ignore_reason))
                 else:
-                    ignored_policy_breaks_count_by_kind[ignore_reason.kind] += 1
+                    ignored_secrets_count_by_kind[ignore_reason.kind] += 1
             else:
                 to_keep.append((policy_break, None))
 
@@ -180,8 +180,8 @@ class Result:
             filemode=file.filemode,
             path=file.path,
             url=file.url,
-            policy_breaks=[],
-            ignored_policy_breaks_count_by_kind=ignored_policy_breaks_count_by_kind,
+            secrets=[],
+            ignored_secrets_count_by_kind=ignored_secrets_count_by_kind,
         )
 
         lines = get_lines_from_content(file.content, file.filemode)
@@ -201,7 +201,7 @@ class Result:
             for policy_break, ignore_reason in to_keep
         ]
 
-        result.policy_breaks = secrets
+        result.secrets = secrets
         return result
 
 
@@ -237,8 +237,8 @@ class Results:
         self.errors.extend(others.errors)
 
     @property
-    def has_policy_breaks(self) -> bool:
-        return any(x.has_policy_breaks for x in self.results)
+    def has_secrets(self) -> bool:
+        return any(x.has_secrets for x in self.results)
 
 
 class SecretScanCollection:
@@ -265,8 +265,8 @@ class SecretScanCollection:
         self.optional_header = optional_header
         self.extra_info = extra_info
 
-        self.total_policy_breaks_count = sum(
-            len(result.policy_breaks) for result in self.get_all_results()
+        self.total_secrets_count = sum(
+            len(result.secrets) for result in self.get_all_results()
         )
 
     @property
@@ -287,8 +287,8 @@ class SecretScanCollection:
     def get_incident_details(self, client: GGClient) -> Dict[str, SecretIncident]:
         incident_details: dict[str, SecretIncident] = {}
         for result in self.get_all_results():
-            for policy_break in result.policy_breaks:
-                url = policy_break.incident_url
+            for secret in result.secrets:
+                url = secret.incident_url
                 if url and url not in incident_details:
                     incident_id = int(url.split("/")[-1])
                     resp = client.retrieve_secret_incident(

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -216,7 +216,7 @@ class SecretScanner:
                 result = Result.from_scan_result(file, scan_result, self.secret_config)
                 for secret in result.secrets:
                     self.cache.add_found_policy_break(
-                        secret.break_type,
+                        secret.detector,
                         secret.get_ignore_sha(),
                         file.filename,
                     )

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -214,10 +214,10 @@ class SecretScanner:
             assert isinstance(scan, MultiScanResult)
             for file, scan_result in zip(chunk, scan.scan_results):
                 result = Result.from_scan_result(file, scan_result, self.secret_config)
-                for policy_break in result.policy_breaks:
+                for secret in result.secrets:
                     self.cache.add_found_policy_break(
-                        policy_break.break_type,
-                        policy_break.get_ignore_sha(),
+                        secret.break_type,
+                        secret.get_ignore_sha(),
                         file.filename,
                     )
                 results.append(result)

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -215,7 +215,11 @@ class SecretScanner:
             for file, scan_result in zip(chunk, scan.scan_results):
                 result = Result.from_scan_result(file, scan_result, self.secret_config)
                 for policy_break in result.policy_breaks:
-                    self.cache.add_found_policy_break(policy_break, file.filename)
+                    self.cache.add_found_policy_break(
+                        policy_break.break_type,
+                        policy_break.get_ignore_sha(),
+                        file.filename,
+                    )
                 results.append(result)
 
         self.cache.save()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,6 +6,7 @@ from pygitguardian.models import Match, PolicyBreak, ScanResult
 
 from ggshield.core.scan.scannable import StringScannable
 from ggshield.utils.git_shell import Filemode
+from ggshield.verticals.secret.secret_scan_collection import Secret
 from tests.factory_constants import DETECTOR_NAMES, MATCH_NAMES
 
 
@@ -87,3 +88,16 @@ class ScanResultFactory(factory.Factory):
     policy_breaks = []
     policies = ["Secrets detection"]
     is_diff = False
+
+
+class SecretFactory(factory.Factory):
+    class Meta:
+        model = Secret
+
+    detector = factory.lazy_attribute(lambda obj: random.choice(DETECTOR_NAMES))
+    validity = "valid"
+    known_secret = True
+    incident_url = None
+    matches = []
+    ignore_reason = None
+    diff_kind = None

--- a/tests/unit/cmd/test_ignore.py
+++ b/tests/unit/cmd/test_ignore.py
@@ -9,6 +9,7 @@ from ggshield.cmd.secret.ignore import ignore_last_found
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
 from ggshield.core.errors import ExitCode
+from ggshield.core.filter import get_ignore_sha
 from ggshield.core.scan import Commit, ScanContext, ScanMode
 from ggshield.core.types import IgnoredMatch
 from ggshield.verticals.secret import SecretScanner
@@ -212,26 +213,14 @@ def test_do_not_duplicate_last_found_secrets(client, isolated_fs):
     )
     cache = Cache()
 
-    cache.add_found_policy_break(policy_break, "a")
-    cache.add_found_policy_break(policy_break, "b")
+    cache.add_found_policy_break(
+        policy_break.break_type, get_ignore_sha(policy_break), "a"
+    )
+    cache.add_found_policy_break(
+        policy_break.break_type, get_ignore_sha(policy_break), "b"
+    )
 
     assert len(cache.last_found_secrets) == 1
-
-
-def test_do_not_add_policy_breaks_to_last_found(client, isolated_fs):
-    """
-    GIVEN 1 policy breaks on different files with the same ignore sha
-    WHEN add_found_policy_break is called
-    THEN only one element should be added
-    """
-    policy_break = PolicyBreak(
-        "a", "gitignore", None, [Match("apikey", "apikey", 0, 0, 0, 0)]
-    )
-    cache = Cache()
-
-    cache.add_found_policy_break(policy_break, "a")
-
-    assert len(cache.last_found_secrets) == 0
 
 
 def test_ignore_last_found_preserve_previous_config(client, isolated_fs):

--- a/tests/unit/cmd/test_ignore.py
+++ b/tests/unit/cmd/test_ignore.py
@@ -149,7 +149,7 @@ def test_cache_catches_nothing(client, isolated_fs):
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
 
-        assert sum(len(result.policy_breaks) for result in results.results) == 0
+        assert sum(len(result.secrets) for result in results.results) == 0
         assert config.user_config.secret.ignored_matches == FOUND_SECRETS
         assert cache.last_found_secrets == []
 

--- a/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
+++ b/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
@@ -4,11 +4,11 @@ from ggshield.core.config.user_config import SecretConfig
 from ggshield.verticals.secret import Results, SecretScanCollection
 from ggshield.verticals.secret.output.secret_gitlab_webui_output_handler import (
     SecretGitLabWebUIOutputHandler,
-    format_policy_break,
+    format_secret,
 )
 
 
-def test_format_policy_break():
+def test_format_secret():
     policy = PolicyBreak(
         "PayPal",
         "Secrets detection",
@@ -18,7 +18,7 @@ def test_format_policy_break():
             Match("abcdefghijk", "client_secret", line_start=456),
         ],
     )
-    out = format_policy_break(policy)
+    out = format_secret(policy)
 
     assert policy.break_type in out
     assert "Validity: Valid" in out

--- a/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
+++ b/tests/unit/verticals/secret/output/test_gitlab_webui_output.py
@@ -1,4 +1,4 @@
-from pygitguardian.models import Match, PolicyBreak
+from pygitguardian.models import Match
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.verticals.secret import Results, SecretScanCollection
@@ -6,23 +6,21 @@ from ggshield.verticals.secret.output.secret_gitlab_webui_output_handler import 
     SecretGitLabWebUIOutputHandler,
     format_secret,
 )
+from tests.factories import SecretFactory
 
 
 def test_format_secret():
-    policy = PolicyBreak(
-        "PayPal",
-        "Secrets detection",
-        "valid",
-        [
+    secret = SecretFactory(
+        matches=[
             Match("AZERTYUIOP", "client_id", line_start=123),
             Match("abcdefghijk", "client_secret", line_start=456),
         ],
     )
-    out = format_secret(policy)
+    out = format_secret(secret)
 
-    assert policy.break_type in out
+    assert secret.detector in out
     assert "Validity: Valid" in out
-    for match in policy.matches:
+    for match in secret.matches:
         assert match.match_type in out
         # match value itself must be obfuscated
         assert match.match not in out

--- a/tests/unit/verticals/secret/output/test_json_output.py
+++ b/tests/unit/verticals/secret/output/test_json_output.py
@@ -13,7 +13,6 @@ from voluptuous import Optional as VOptional
 from voluptuous import Required, validators
 
 from ggshield.core.config.user_config import SecretConfig
-from ggshield.core.filter import group_policy_breaks_by_ignore_sha
 from ggshield.core.scan import Commit, ScanContext, ScanMode, StringScannable
 from ggshield.core.scan.file import File
 from ggshield.utils.git_shell import Filemode
@@ -27,6 +26,7 @@ from ggshield.verticals.secret.output import (
     SecretJSONOutputHandler,
     SecretOutputHandler,
 )
+from ggshield.verticals.secret.secret_scan_collection import group_secrets_by_ignore_sha
 from tests.unit.conftest import (
     _MULTILINE_SECRET_FILE,
     _MULTIPLE_SECRETS_PATCH,
@@ -425,7 +425,7 @@ def test_json_output_for_patch(
         assert all(
             ignore_sha in json_flat_results
             for result in results.results
-            for ignore_sha in group_policy_breaks_by_ignore_sha(result.policy_breaks)
+            for ignore_sha in group_secrets_by_ignore_sha(result.policy_breaks)
         )
 
 

--- a/tests/unit/verticals/secret/output/test_json_output.py
+++ b/tests/unit/verticals/secret/output/test_json_output.py
@@ -99,7 +99,7 @@ SCHEMA_WITH_INCIDENTS = S(
                         "incidents": validators.All(
                             [
                                 {
-                                    "break_type": str,
+                                    "detector": str,
                                     "policy": str,
                                     "total_occurrences": validators.All(int, min=1),
                                     Required("incident_url"): validators.Match(
@@ -509,14 +509,14 @@ def test_ignore_known_secrets(verbose, ignore_known_secrets, secrets_types):
     incident_for_secret_type = {incident["type"]: incident for incident in incidents}
 
     for secret in known_secrets:
-        assert incident_for_secret_type[secret.break_type]["known_secret"]
-        assert incident_for_secret_type[secret.break_type]["incident_url"].startswith(
+        assert incident_for_secret_type[secret.detector]["known_secret"]
+        assert incident_for_secret_type[secret.detector]["incident_url"].startswith(
             "https://dashboard.gitguardian.com/workspace/1/incidents/"
         )
 
     for secret in new_secrets:
-        assert not incident_for_secret_type[secret.break_type]["known_secret"]
-        assert not incident_for_secret_type[secret.break_type]["incident_url"]
+        assert not incident_for_secret_type[secret.detector]["known_secret"]
+        assert not incident_for_secret_type[secret.detector]["incident_url"]
 
 
 @pytest.mark.parametrize("with_incident_details", [True, False])

--- a/tests/unit/verticals/secret/output/test_sarif_output.py
+++ b/tests/unit/verticals/secret/output/test_sarif_output.py
@@ -264,17 +264,15 @@ def test_sarif_output_for_nested_scan(init_secrets_engine_version):
 
     assert SCHEMA_WITH_INCIDENTS == json_dict
 
-    # Create a flat list of policy breaks
-    policy_breaks = sum((s.results.results[0].policy_breaks for s in scan.scans), [])
+    # Create a flat list of secrets
+    secrets = sum((s.results.results[0].secrets for s in scan.scans), [])
 
     # Check each found secret is correctly represented
     sarif_results = json_dict["runs"][0]["results"]
-    for content, sarif_result, policy_break in zip(
-        contents, sarif_results, policy_breaks
-    ):
-        check_sarif_result(sarif_result, content, policy_break)
+    for content, sarif_result, secret in zip(contents, sarif_results, secrets):
+        check_sarif_result(sarif_result, content, secret)
 
-    assert len(sarif_results) == len(policy_breaks)
+    assert len(sarif_results) == len(secrets)
 
 
 def check_sarif_result(

--- a/tests/unit/verticals/secret/output/test_text_output.py
+++ b/tests/unit/verticals/secret/output/test_text_output.py
@@ -5,7 +5,6 @@ import click
 import pytest
 
 from ggshield.core.config.user_config import SecretConfig
-from ggshield.core.filter import group_policy_breaks_by_ignore_sha
 from ggshield.core.scan import StringScannable
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.secret import Result, Results, SecretScanCollection
@@ -13,6 +12,7 @@ from ggshield.verticals.secret.output import SecretTextOutputHandler
 from ggshield.verticals.secret.output.secret_text_output_handler import (
     format_line_count_break,
 )
+from ggshield.verticals.secret.secret_scan_collection import group_secrets_by_ignore_sha
 from tests.unit.conftest import (
     _MULTI_SECRET_ONE_LINE_PATCH,
     _MULTI_SECRET_ONE_LINE_PATCH_OVERLAY,
@@ -148,7 +148,7 @@ def test_leak_message(result_input, snapshot, show_secrets, verbose):
     # all ignore sha should be in the output
     assert all(
         ignore_sha in output
-        for ignore_sha in group_policy_breaks_by_ignore_sha(result_input.policy_breaks)
+        for ignore_sha in group_secrets_by_ignore_sha(result_input.policy_breaks)
     )
 
 

--- a/tests/unit/verticals/secret/output/test_text_output.py
+++ b/tests/unit/verticals/secret/output/test_text_output.py
@@ -161,7 +161,7 @@ def assert_policies_displayed(output, verbose, ignore_known_secrets, secrets):
     for secret in secrets:
         if not ignore_known_secrets or verbose:
             # All secrets are displayed no matter if they're known or not
-            assert f"Secret detected: {secret.break_type}" in output
+            assert f"Secret detected: {secret.detector}" in output
             if secret.known_secret:
                 assert "Known by GitGuardian dashboard: YES" in output
                 assert (
@@ -172,7 +172,7 @@ def assert_policies_displayed(output, verbose, ignore_known_secrets, secrets):
                 assert "Incident URL: N/A" in output
         else:
             if secret.known_secret:
-                assert f"Secret detected: {secret.break_type}" not in output
+                assert f"Secret detected: {secret.detector}" not in output
 
     if ignore_known_secrets:
         secrets_number = sum(1 for x in secrets if not x.known_secret)

--- a/tests/unit/verticals/secret/output/test_text_output.py
+++ b/tests/unit/verticals/secret/output/test_text_output.py
@@ -153,16 +153,16 @@ def test_leak_message(result_input, snapshot, show_secrets, verbose):
     # all ignore sha should be in the output
     assert all(
         ignore_sha in output
-        for ignore_sha in group_secrets_by_ignore_sha(result_input.policy_breaks)
+        for ignore_sha in group_secrets_by_ignore_sha(result_input.secrets)
     )
 
 
-def assert_policies_displayed(output, verbose, ignore_known_secrets, policy_breaks):
-    for policy_break in policy_breaks:
+def assert_policies_displayed(output, verbose, ignore_known_secrets, secrets):
+    for secret in secrets:
         if not ignore_known_secrets or verbose:
             # All secrets are displayed no matter if they're known or not
-            assert f"Secret detected: {policy_break.break_type}" in output
-            if policy_break.known_secret:
+            assert f"Secret detected: {secret.break_type}" in output
+            if secret.known_secret:
                 assert "Known by GitGuardian dashboard: YES" in output
                 assert (
                     "https://dashboard.gitguardian.com/workspace/1/incidents/" in output
@@ -171,13 +171,13 @@ def assert_policies_displayed(output, verbose, ignore_known_secrets, policy_brea
                 assert "Known by GitGuardian dashboard: NO" in output
                 assert "Incident URL: N/A" in output
         else:
-            if policy_break.known_secret:
-                assert f"Secret detected: {policy_break.break_type}" not in output
+            if secret.known_secret:
+                assert f"Secret detected: {secret.break_type}" not in output
 
     if ignore_known_secrets:
-        secrets_number = sum(1 for x in policy_breaks if not x.known_secret)
+        secrets_number = sum(1 for x in secrets if not x.known_secret)
     else:
-        secrets_number = len(policy_breaks)
+        secrets_number = len(secrets)
 
     if secrets_number:
         assert (

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -147,10 +147,10 @@ def test_scan_2_commits_same_content(secret_scanner_mock):
 
     assert len(scan_collection.scans) == 2
 
-    all_policy_breaks_count = sum(
-        len(result.policy_breaks) for result in scan_collection.get_all_results()
+    all_secrets_count = sum(
+        len(result.secrets) for result in scan_collection.get_all_results()
     )
-    assert all_policy_breaks_count == 4
+    assert all_secrets_count == 4
 
 
 @patch("ggshield.verticals.secret.repo.SecretScanner")

--- a/tests/unit/verticals/secret/test_secret_scan_collection.py
+++ b/tests/unit/verticals/secret/test_secret_scan_collection.py
@@ -96,7 +96,7 @@ def test_create_result_removes_ignored_matches(
             ignored_matches=[IgnoredMatch(name="", match=x) for x in ignores]
         ),
     )
-    assert len(result.policy_breaks) == final_len
+    assert len(result.secrets) == final_len
 
 
 @pytest.mark.parametrize("all_secrets", (True, False))
@@ -125,13 +125,13 @@ def test_create_result_removes_ignored_matches_bis(all_secrets):
         scannable, ScanResultFactory(policy_breaks=policy_breaks), config
     )
     if all_secrets:
-        assert len(result.policy_breaks) == 2
-        assert result.policy_breaks[0].is_ignored is True
-        assert result.policy_breaks[1].is_ignored is False
+        assert len(result.secrets) == 2
+        assert result.secrets[0].is_ignored is True
+        assert result.secrets[1].is_ignored is False
     else:
-        assert len(result.policy_breaks) == 1
-        assert result.policy_breaks[0].is_ignored is False
-        assert result.ignored_policy_breaks_count_by_kind[IgnoreKind.IGNORED_MATCH] == 1
+        assert len(result.secrets) == 1
+        assert result.secrets[0].is_ignored is False
+        assert result.ignored_secrets_count_by_kind[IgnoreKind.IGNORED_MATCH] == 1
 
 
 class TestComputeIgnoreReason:

--- a/tests/unit/verticals/secret/test_secret_scan_collection.py
+++ b/tests/unit/verticals/secret/test_secret_scan_collection.py
@@ -9,6 +9,7 @@ from ggshield.core.scan import StringScannable
 from ggshield.core.types import IgnoredMatch
 from ggshield.verticals.secret import Results
 from ggshield.verticals.secret.secret_scan_collection import (
+    IgnoreKind,
     IgnoreReason,
     Result,
     compute_ignore_reason,
@@ -125,15 +126,12 @@ def test_create_result_removes_ignored_matches_bis(all_secrets):
     )
     if all_secrets:
         assert len(result.policy_breaks) == 2
-        assert result.policy_breaks[0].is_excluded is True
-        assert result.policy_breaks[1].is_excluded is False
+        assert result.policy_breaks[0].is_ignored is True
+        assert result.policy_breaks[1].is_ignored is False
     else:
         assert len(result.policy_breaks) == 1
-        assert result.policy_breaks[0].is_excluded is False
-        assert (
-            result.ignored_policy_breaks_count_by_reason[IgnoreReason.IGNORED_MATCH]
-            == 1
-        )
+        assert result.policy_breaks[0].is_ignored is False
+        assert result.ignored_policy_breaks_count_by_kind[IgnoreKind.IGNORED_MATCH] == 1
 
 
 class TestComputeIgnoreReason:
@@ -146,7 +144,9 @@ class TestComputeIgnoreReason:
         policy_break = PolicyBreakFactory(
             is_excluded=True, exclude_reason="BACKEND_REASON"
         )
-        assert "BACKEND_REASON" in compute_ignore_reason(policy_break, SecretConfig())
+        assert compute_ignore_reason(policy_break, SecretConfig()) == IgnoreReason(
+            IgnoreKind.BACKEND_EXCLUDED, "BACKEND_REASON"
+        )
 
     def test_ignore_ignored_match(self):
         """

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -115,14 +115,12 @@ def test_scan_patch(client, cache, name: str, input_patch: str, expected: Expect
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
         for result in results.results:
-            if result.policy_breaks:
-                assert len(result.policy_breaks[0].matches) == expected.matches
+            if result.secrets:
+                assert len(result.secrets[0].matches) == expected.matches
                 if expected.first_match:
-                    assert (
-                        result.policy_breaks[0].matches[0].match == expected.first_match
-                    )
+                    assert result.secrets[0].matches[0].match == expected.first_match
             else:
-                assert result.policy_breaks == []
+                assert result.secrets == []
 
             if expected.want:
                 assert result.filename == expected.want["filename"]
@@ -253,10 +251,10 @@ index 7601807,5716ca5..8c27e55
             secret_config=SecretConfig(),
         )
         results = scanner.scan(commit.get_files(), scanner_ui=Mock())
-        policy_breaks = results.results[0].policy_breaks
-        assert len(policy_breaks) == 1
+        secrets = results.results[0].secrets
+        assert len(secrets) == 1
 
-        matches = {m.match_type: m.match for m in policy_breaks[0].matches}
+        matches = {m.match_type: m.match for m in secrets[0].matches}
         assert matches["username"] == "owly"
         assert matches["password"] == _SIMPLE_SECRET_TOKEN
 
@@ -401,11 +399,11 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
     results = scanner.scan([scannable], scanner_ui=Mock())
 
     if ignore_known_secrets:
-        assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+        assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
             "unknown"
         ]
     else:
-        assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+        assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
             "known",
             "unknown",
         ]
@@ -487,6 +485,6 @@ def test_all_secrets_is_used(scan_mock: Mock, client):
         secret_config=SecretConfig(),
     )
     results = scanner.scan([scannable], scanner_ui=Mock())
-    assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+    assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
         "not-excluded"
     ]

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -349,7 +349,7 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
     """
     scannable = StringScannable(url="localhost", content="known\nunknown")
     known_secret = PolicyBreak(
-        break_type="a",
+        break_type="known",
         policy="Secrets detection",
         validity="valid",
         known_secret=True,
@@ -365,7 +365,7 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
         ],
     )
     unknown_secret = PolicyBreak(
-        break_type="a",
+        break_type="unknown",
         policy="Secrets detection",
         validity="valid",
         known_secret=False,
@@ -401,9 +401,14 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
     results = scanner.scan([scannable], scanner_ui=Mock())
 
     if ignore_known_secrets:
-        assert results.results[0].policy_breaks == [unknown_secret]
+        assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+            "unknown"
+        ]
     else:
-        assert results.results[0].policy_breaks == [known_secret, unknown_secret]
+        assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+            "known",
+            "unknown",
+        ]
 
 
 @patch("pygitguardian.GGClient.multi_content_scan")
@@ -482,4 +487,6 @@ def test_all_secrets_is_used(scan_mock: Mock, client):
         secret_config=SecretConfig(),
     )
     results = scanner.scan([scannable], scanner_ui=Mock())
-    assert results.results[0].policy_breaks == [secret]
+    assert [pbreak.break_type for pbreak in results.results[0].policy_breaks] == [
+        "not-excluded"
+    ]

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -399,11 +399,9 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
     results = scanner.scan([scannable], scanner_ui=Mock())
 
     if ignore_known_secrets:
-        assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
-            "unknown"
-        ]
+        assert [pbreak.detector for pbreak in results.results[0].secrets] == ["unknown"]
     else:
-        assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
+        assert [pbreak.detector for pbreak in results.results[0].secrets] == [
             "known",
             "unknown",
         ]
@@ -485,6 +483,6 @@ def test_all_secrets_is_used(scan_mock: Mock, client):
         secret_config=SecretConfig(),
     )
     results = scanner.scan([scannable], scanner_ui=Mock())
-    assert [pbreak.break_type for pbreak in results.results[0].secrets] == [
+    assert [pbreak.detector for pbreak in results.results[0].secrets] == [
         "not-excluded"
     ]


### PR DESCRIPTION
## Context

Following https://github.com/GitGuardian/ggshield/pull/1024 ,

-  ~~small~~ fix to make ignore reasons human readable.
- add ignore reason to json output schema


## Validation

Perform scans with ignored secrets (either from config or  backend), with the `--all-secrets` options.

Ensure the output contains ignore info (both for text and json output)
<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

Note: skipping changelog as it was included in previous MR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
