### PR TITLE
Handle trailing content in multi-parent hunk header

### DIFF
--- a/changelog.d/20241213_184336_severine.bonnechere_handle_multi_parent_hunk_header.md
+++ b/changelog.d/20241213_184336_severine.bonnechere_handle_multi_parent_hunk_header.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Handle trailing content in multi-parent hunk header.

--- a/ggshield/core/scan/commit_utils.py
+++ b/ggshield/core/scan/commit_utils.py
@@ -40,7 +40,7 @@ OLD_NAME_RX = re.compile(r"^--- a/(.*?)\t?$", flags=re.MULTILINE)
 NEW_NAME_RX = re.compile(r"^\+\+\+ b/(.*?)\t?$", flags=re.MULTILINE)
 
 MULTI_PARENT_HUNK_HEADER_RX = re.compile(
-    r"^(?P<at>@@+) (?P<from>-\d+(?:,\d+)?) .* (?P<to>\+\d+(?:,\d+)?) @@+$"
+    r"^(?P<at>@@+) (?P<from>-\d+(?:,\d+)?) .* (?P<to>\+\d+(?:,\d+)?) @@+(?P<trailing_content>.+)?"
 )
 
 
@@ -352,11 +352,14 @@ def process_multi_parent_hunk_header(header: str) -> Tuple[str, int]:
 
     from_ = match.group("from")
     to = match.group("to")
+    new_hunk_header = f"@@ {from_} {to} @@"
+    if match.group("trailing_content"):
+        new_hunk_header += f"{match.group('trailing_content')}"
 
     # Parent count is the number of '@' at the beginning of the header, minus 1
     parent_count = len(match.group("at")) - 1
 
-    return f"@@ {from_} {to} @@", parent_count
+    return new_hunk_header, parent_count
 
 
 def get_file_sha_in_ref(

--- a/tests/unit/core/scan/test_commit_utils.py
+++ b/tests/unit/core/scan/test_commit_utils.py
@@ -97,6 +97,21 @@ def test_patch_file_info_from_string(
  To get interesting indices.
 """,  # noqa:W293
         ),
+        (
+            """
+@@@ -1,1 -1,1 +1,2 @@@ I'm on the hunk header
+- baz
+ -bar
+++hello
+++world
+""",
+            """
+@@ -1,1 +1,2 @@ I'm on the hunk header
+-baz
++hello
++world
+""",
+        ),
     ],
 )
 def test_convert_multi_parent_diff(diff: str, expected: str):


### PR DESCRIPTION
## Context

When running a scan on a multi-parent commit with a hunk header with a trailing content, parsing of the header would fail and raise a `PatchParseError`.

This PR relates to https://github.com/GitGuardian/ggshield/pull/1022.

## What has been done
Handle trailing content in the regex used to parse multi-parent hunk header.

## Validation
- Using previous version, on this repo
```bash
ggshield secret scan commit-range eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f^..eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f
Error: Could not parse patch (sha: eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f): Failed to parse multi-parent hunk header '@@@ -23,37 -22,21 +23,52 @@@ from ggshield.core.types import Ignored'
Error: Could not parse patch (sha: eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f): Failed to parse multi-parent hunk header '@@@ -23,37 -22,21 +23,52 @@@ from ggshield.core.types import Ignored'
Error: Could not parse patch (sha: eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f): Failed to parse multi-parent hunk header '@@@ -23,37 -22,21 +23,52 @@@ from ggshield.core.types import Ignored'
Error: Could not parse patch (sha: eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f): Failed to parse multi-parent hunk header '@@@ -23,37 -22,21 +23,52 @@@ from ggshield.core.types import Ignored'
Error: Could not parse patch (sha: eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f): Failed to parse multi-parent hunk header '@@@ -23,37 -22,21 +23,52 @@@ from ggshield.core.types import Ignored'
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5 / 5

No secrets have been found
```
- On this branch
```bash
ggshield secret scan commit-range eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f^..eb052f92b8bdaf0b32b9de1f1bc8c9493496c50f
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5 / 5

No secrets have been found
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
