### PR TITLE
feat(cmd): make the exit-zero option apply to all errors

### DIFF
--- a/changelog.d/20250106_115429_jonathan.griffe_make_exit_zero_option_apply_to_all_errors.md
+++ b/changelog.d/20250106_115429_jonathan.griffe_make_exit_zero_option_apply_to_all_errors.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The `--exit-zero` option now applies to all errors.

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -46,10 +46,7 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> int:
     when exit_zero is enabled
     """
     ctx_obj = ContextObj.get(ctx)
-    if (
-        exit_code == ExitCode.SCAN_FOUND_PROBLEMS
-        and ctx_obj.config.user_config.exit_zero
-    ):
+    if ctx_obj.config.user_config.exit_zero:
         logger.debug("scan exit_code forced to 0")
         sys.exit(ExitCode.SUCCESS)
 


### PR DESCRIPTION
## Context

Some users try to use the --exit-zero option to bypass the ggshield prereceive hook, and avoid breaking their repo if GitGuardian is down. However, this option only applies when a secret has been found, and not for other errors.

## What has been done

Make the exit-zero option apply to all errors.

## Validation

Shut down internet access
Try to scan something with the --exit-zero option on.
The return code should be 0.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
