### PR TITLE
chore(cmd): improve the exit-zero option help message

### DIFF
--- a/ggshield/cmd/utils/common_options.py
+++ b/ggshield/cmd/utils/common_options.py
@@ -160,7 +160,8 @@ exit_zero_option = click.option(
     default=None,
     envvar="GITGUARDIAN_EXIT_ZERO",
     help=(
-        "Always return a 0 (non-error) status code, even if incidents are found."
+        "Return a 0 (non-error) status code, even if incidents are found."
+        " An error status code will still be returned for other errors, such as connection errors."
         " This option can also be set with the `GITGUARDIAN_EXIT_ZERO` environment"
         " variable."
     ),


### PR DESCRIPTION
## Context

The help message for the `exit-zero` option can be slightly misleading, as one could understand that it will make the command exit with the 0 exit code, regardless of the error raised.

## What has been done

The `exit-zero` option help message was modified to make it clear it only applies when a secret is detected.
