### PR TITLE
Add missing dependency

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -291,11 +291,11 @@ jobs:
               dpkg -i packages/*.deb
               ;;
             rockylinux*)
-              yum install -y git
+              yum install -y git-core
               rpm -i packages/*.rpm
               ;;
             opensuse*)
-              zypper install -y git
+              zypper install -y git-core
               rpm -i packages/*.rpm
               ;;
             clearlinux*)

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -46,12 +46,14 @@ jobs:
   build_os_packages:
     name: Build packages
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.os == 'ubuntu-22.04' && 'rockylinux/rockylinux:8.8' || null }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04
+            # When building on Linux we use a container to build using an old enough version
+            container: rockylinux/rockylinux:8
           - os: windows-2022
           - os: macos-13
             arch: x86_64
@@ -84,6 +86,9 @@ jobs:
       - name: Install Linux specific dependencies
         if: matrix.os == 'ubuntu-22.04'
         run: |
+          # Install latest security updates
+          yum update -y
+
           # Install necessary packages
           yum install -y \
             python3.9 \

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -268,6 +268,7 @@ jobs:
           - debian:stable
           - ubuntu:latest
           - rockylinux/rockylinux:8.8
+          - rockylinux/rockylinux:9
           - opensuse/leap
           # Test a distribution with no deb or rpm support
           - clearlinux:latest

--- a/changelog.d/20250107_114112_aurelien.gateau_add_missing_dependency.md
+++ b/changelog.d/20250107_114112_aurelien.gateau_add_missing_dependency.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installing ggshield from the release RPM on EL9 failed because of a missing library. This is now fixed (#1036).

--- a/scripts/build-os-packages/nfpm.yaml
+++ b/scripts/build-os-packages/nfpm.yaml
@@ -27,6 +27,13 @@ contents:
     dst: /usr/libexec/ggshield
     expand: true
 
+    # Required because our bundled Python binary still uses libcrypt.so.1, but
+    # some distributions ship with libcrypt.so.2 nowadays (see #1036).
+    # We copy libcrypt.so.1.1.0 and not libcrypt.so.1 because the later is a
+    # symlink to the former.
+  - src: /usr/lib64/libcrypt.so.1.1.0
+    dst: /usr/libexec/ggshield/_internal/libcrypt.so.1
+
   - src: README.md
     dst: /usr/share/doc/ggshield/README.md
 


### PR DESCRIPTION
## Context

The Python interpreter we bundle in our RPM package depends on libcrypt.so.1, but some distributions do not ship it anymore. This is why ggshield fails when it's installed using its RPM package on Red Hat Enterprise Linux 9 (See #1036).

## What has been done

- Update nfpm configuration to bundle the version of libcrypt we depend on.
- Update CI to test the RPM on RockyLinux 9 (more-or-less equivalent to RHEL 9).
- Build the RPM using rockylinux:8 instead of rockylinux:8.8 because the 8.8 Docker image does not receive security upgrades (we still test with 8.8 to ensure it works)

## Validation

- Start a rockylinux 9 container
- Install git
- Install ggshield from the RPM
- Run `ggshield --version` → with the released version it fails, with the version from the CI it works

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
