### PR TITLE
fix: force utf-8 to fix visual studio failure to print error messages

### DIFF
--- a/changelog.d/20250107_183611_aurelien.gateau_fix_windows_encoding.md
+++ b/changelog.d/20250107_183611_aurelien.gateau_fix_windows_encoding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix Visual Studio not being able to show error messages from ggshield pre-commit (#170).


### PR DESCRIPTION
## Context

When a Python program runs on Windows and its stdout or stderr is redirected to a file, the encoding changes from UTF-8 to the default OS encoding. This causes problems when Visual Studio tries to show pre-commit errors if they contain non-ASCII UTF-8 characters such as the ellipsis `…` (see #170).

## What has been done

Following a suggestion from @mherzberg (thanks!), force stdout and stderr to always be UTf-8.

## Validation

- Install Visual Studio
- Setup a repository using ggshield as a pre-commit hook
- Leak a secret in a very long line (so that ggshield uses the ellipsis to crop it)
- Try to commit

Without the fix, Visual Studio says it can't decode the output of the pre-commit hook.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
