### PR TITLE
fix: make API urls from GitGuardian work with GGShield

### DIFF
--- a/changelog.d/20250108_124709_severine.bonnechere_handle_product_doc_api_urls.md
+++ b/changelog.d/20250108_124709_severine.bonnechere_handle_product_doc_api_urls.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `--instance` param now handles input https://api.eu1.gitguardian.com/v1 or https://api.gitguardian.com/v1.

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional, Set, Tuple
@@ -94,10 +95,10 @@ class Config:
         - the default instance
         """
         if self._cmdline_instance_name:
-            if (
-                "api" in self._cmdline_instance_name
-                and "gitguardian" in self._cmdline_instance_name
-            ):
+            if re.match(
+                r"^https:\/\/api(\.[a-z0-9]+)?\.gitguardian\.com",
+                self._cmdline_instance_name,
+            ) or re.match(r"/exposed/?$", self._cmdline_instance_name):
                 return (
                     api_to_dashboard_url(self._cmdline_instance_name),
                     ConfigSource.CMD_OPTION,

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -86,6 +86,7 @@ class Config:
         The instance name (defaulting to URL) of the selected instance
         priority order is:
         - set from the command line (by setting cmdline_instance_name)
+          - in case the user set the api url instead of dashboard url, we replace it
         - GITGUARDIAN_INSTANCE env var
         - GITGUARDIAN_API_URL env var
         - in local user config (in user_config.dashboard_url)
@@ -93,6 +94,14 @@ class Config:
         - the default instance
         """
         if self._cmdline_instance_name:
+            if (
+                "api" in self._cmdline_instance_name
+                and "gitguardian" in self._cmdline_instance_name
+            ):
+                return (
+                    api_to_dashboard_url(self._cmdline_instance_name),
+                    ConfigSource.CMD_OPTION,
+                )
             return self._cmdline_instance_name, ConfigSource.CMD_OPTION
 
         try:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -148,6 +148,36 @@ class TestAuthLoginToken:
         self._request_mock.assert_all_requests_happened()
 
     @pytest.mark.parametrize(
+        ("cmd_line_instance", "expected_instance"),
+        [
+            ("https://api.gitguardian.com/v1", "https://dashboard.gitguardian.com"),
+            (
+                "https://api.eu1.gitguardian.com/v1",
+                "https://dashboard.eu1.gitguardian.com",
+            ),
+        ],
+    )
+    def test_api_instance_url(
+        self, cmd_line_instance, expected_instance, cli_fs_runner
+    ):
+        """
+        GIVEN a valid API token and an instance URL matching GitGuardian API urls
+        WHEN running the login command
+        THEN it succeeds
+        """
+        token = "mysupertoken"
+        cmd = ["auth", "login", "--method=token", f"--instance={cmd_line_instance}"]
+        self._request_mock.add_GET(TOKEN_ENDPOINT, VALID_TOKEN_RESPONSE)
+        result = cli_fs_runner.invoke(cli, cmd, color=False, input=token + "\n")
+        config = Config()
+        config_instance_urls = [
+            instance_config.url for instance_config in config.auth_config.instances
+        ]
+        assert_invoke_ok(result)
+        assert expected_instance in config_instance_urls
+        self._request_mock.assert_all_requests_happened()
+
+    @pytest.mark.parametrize(
         ("instance", "suggests"),
         (
             ("", False),
@@ -966,3 +996,22 @@ class TestAuthLoginWeb:
         exit_code, output = self.run_cmd(cli_fs_runner)
         assert exit_code == ExitCode.USAGE_ERROR, output
         self._webbrowser_open_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "instance_url",
+        [
+            "https://api.gitguardian.com/v1",
+            "https://api.eu1.gitguardian.com/v1",
+        ],
+    )
+    def test_api_instance_url(self, instance_url, cli_fs_runner, monkeypatch):
+        """
+        GIVEN an instance URL matching GitGuardian API urls
+        WHEN running the login command
+        THEN it succeeds
+        """
+        monkeypatch.setenv("GITGUARDIAN_INSTANCE", instance_url)
+        self.prepare_mocks(monkeypatch)
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+        self._webbrowser_open_mock.assert_called()

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -151,9 +151,18 @@ class TestAuthLoginToken:
         ("cmd_line_instance", "expected_instance"),
         [
             ("https://api.gitguardian.com/v1", "https://dashboard.gitguardian.com"),
+            ("https://api.gitguardian.com", "https://dashboard.gitguardian.com"),
             (
                 "https://api.eu1.gitguardian.com/v1",
                 "https://dashboard.eu1.gitguardian.com",
+            ),
+            (
+                "https://gitguardian.mycorp.local/exposed/",
+                "https://gitguardian.mycorp.local",
+            ),
+            (
+                "https://gitguardian.mycorp.local/exposed",
+                "https://gitguardian.mycorp.local",
             ),
         ],
     )
@@ -1002,6 +1011,7 @@ class TestAuthLoginWeb:
         [
             "https://api.gitguardian.com/v1",
             "https://api.eu1.gitguardian.com/v1",
+            "https://gitguardian.mycorp.local/exposed/",
         ],
     )
     def test_api_instance_url(self, instance_url, cli_fs_runner, monkeypatch):


### PR DESCRIPTION
## Context

See https://github.com/GitGuardian/gitguardian-vscode/pull/67

## What has been done

When running `ggshield cmd --instance ${INSTANCE}`, if `INSTANCE` matches any of the URLs mentioned https://api.eu1.gitguardian.com/docs, it is replaced by the relevant URL.

## Validation
### Validate with GGShield
- Checkout this branch
- Run any `ggshield` command having the `--instance` option available with `--instance https://api.gitguardian.com/v1` or `--instance https://api.eu1.gitguardian.com/v1`
- Command should work the same as if you put `--instance https://dashboard.gitguardian.com/` or `--instance https://dashboard.eu1.gitguardian.com/`


### Validate with VSCode Extension
- Checkout this branch
- Checkout `main` at https://github.com/GitGuardian/gitguardian-vscode
- Replace [this line](https://github.com/GitGuardian/gitguardian-vscode/blob/816b609fba6dc09617216b2e3c9f22d14a9a3c83/src/lib/ggshield-configuration-utils.ts#L21) with path to ggshield in your local repo
- Launch the extension in debug mode
- Set extension API url param to https://api.gitguardian.com/v1 or https://api.eu1.gitguardian.com/v1
- Reload window
- You should have logged in perfectly
- You can try adding a secret in a file: when saving it the extension will warn you

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
