### PR TITLE
fix: secret scan pre-commit crashing on big merges

### DIFF
--- a/changelog.d/20250110_162407_salome.voltz_scrt_5247_ggshield_crashed_on_windows_because_of_git_command_too_long.md
+++ b/changelog.d/20250110_162407_salome.voltz_scrt_5247_ggshield_crashed_on_windows_because_of_git_command_too_long.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix `secret scan pre-commit` crashing on big merges (#1032).


### PR DESCRIPTION
## Context

`ggshield secret scan pre-commit` crashes on Windows when committing a merge with many long file names with `[WinError 206] The filename or extension is too long`. 
This happens because ggshield is building a git command that is longer than the maximum path length on Windows. (see #1032 ).

## What has been done

Functions that execute git commands on all files in a merge were updated to process files in batches, respecting the limit defined by `MAX_FILES_PER_GIT_COMMAND`.

## Validation

On Windows:
- Runs the script provided in the issue description. ggshield should crash
- Test with the updated ggshield version. ggshield should proceed as expected.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.