### PR TITLE
fix: enable core.longpaths on git commands

### DIFF
--- a/changelog.d/20250310_144245_severine.bonnechere_handle_longpaths.md
+++ b/changelog.d/20250310_144245_severine.bonnechere_handle_longpaths.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix ggshield crashing on Windows when doing big merges (#1032).

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -204,7 +204,8 @@ def git(
     try:
         logger.debug("command=%s timeout=%d", command, timeout)
         result = subprocess.run(
-            [_get_git_path(), "-c", "core.quotePath=false"] + command,
+            [_get_git_path(), "-c", "core.quotePath=false", "-c", "core.longpaths=true"]
+            + command,
             check=check,
             capture_output=True,
             timeout=timeout,

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import re
 import subprocess
 from enum import Enum
@@ -204,8 +205,15 @@ def git(
     try:
         logger.debug("command=%s timeout=%d", command, timeout)
         result = subprocess.run(
-            [_get_git_path(), "-c", "core.quotePath=false", "-c", "core.longpaths=true"]
-            + command,
+            (
+                [_get_git_path(), "-c", "core.quotePath=false"]
+                + (
+                    ["-c", "core.longpaths=true"]
+                    if platform.system() == "Windows"
+                    else []
+                )
+                + command
+            ),
             check=check,
             capture_output=True,
             timeout=timeout,


### PR DESCRIPTION
## Context

We have been informed of an issue with ggshield and longpaths on Windows in https://github.com/GitGuardian/ggshield/issues/1032.

## What has been done

As the issuer reported, setting `core.longpaths` to true fixes the issue.

ℹ️  Note that this option is only available on the [git-for-windows fork](https://github.com/search?q=repo%3Agit-for-windows%2Fgit%20longpaths&type=code). With the standard git cli, this option has no effect.

## Validation

It was not possible to replicate the encountered issue, but the issuer confirmed [it worked](https://github.com/GitGuardian/ggshield/issues/1032#issuecomment-2694550173) with their original case.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
