### PR TITLE
fix: handle ignored_paths in docker scan

### DIFF
--- a/changelog.d/20250226_170555_severine.bonnechere_fix_paths_exclusion_in_docker.md
+++ b/changelog.d/20250226_170555_severine.bonnechere_fix_paths_exclusion_in_docker.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix https://github.com/GitGuardian/ggshield/issues/548. `ggshield secret scan docker` now correctly handles ignored paths.

--- a/changelog.d/20250226_170555_severine.bonnechere_fix_paths_exclusion_in_docker.md
+++ b/changelog.d/20250226_170555_severine.bonnechere_fix_paths_exclusion_in_docker.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Fix https://github.com/GitGuardian/ggshield/issues/548. `ggshield secret scan docker` now correctly handles ignored paths.
+- `ggshield secret scan docker` now correctly handles ignored paths (#548).

--- a/ggshield/cmd/secret/scan/docker.py
+++ b/ggshield/cmd/secret/scan/docker.py
@@ -61,6 +61,7 @@ def docker_name_cmd(
             cache=ctx_obj.cache,
             secret_config=config.user_config.secret,
             scan_context=scan_context,
+            exclusion_regexes=ctx_obj.exclusion_regexes,
         )
 
         return output_handler.process_scan(scan)

--- a/ggshield/cmd/secret/scan/dockerarchive.py
+++ b/ggshield/cmd/secret/scan/dockerarchive.py
@@ -48,6 +48,7 @@ def docker_archive_cmd(
         cache=ctx_obj.cache,
         secret_config=config.user_config.secret,
         scan_context=scan_context,
+        exclusion_regexes=ctx_obj.exclusion_regexes,
     )
 
     return output_handler.process_scan(scan)

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -7,7 +8,11 @@ import click
 import pytest
 
 from ggshield.__main__ import cli
+from ggshield.cmd.secret.scan.secret_scan_common_options import (
+    IGNORED_DEFAULT_WILDCARDS,
+)
 from ggshield.core.errors import ExitCode
+from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.scan import StringScannable
 from ggshield.verticals.secret import SecretScanCollection
 from ggshield.verticals.secret.docker import DockerImage, LayerInfo, _validate_filepath
@@ -18,30 +23,37 @@ from tests.unit.conftest import (
     assert_invoke_exited_with,
     assert_invoke_ok,
     my_vcr,
+    write_text,
 )
 
 
 class TestDockerUtils:
     @pytest.mark.parametrize(
-        "filepath, valid",
+        "filepath, exclusion_regexes, valid",
         (
-            ["/usr/bin/secret.py", False],
-            ["usr/bin/secret.py", False],
-            ["/my/file/secret.py", True],
-            ["/my/file/usr/bin/secret.py", True],
-            ["/usr/share/nginx/secret.py", True],
-            ["/gems/secret.py", True],
-            ["/npm-bis/secret.py", True],
-            ["/banned/extension/secret.exe", False],
-            ["/banned/extension/secret.mng", False],
-            ["/banned/extension/secret.tar", False],
-            ["/banned/extension/secret.other", True],
+            ["/usr/bin/secret.py", set(), False],
+            ["usr/bin/secret.py", set(), False],
+            ["/my/file/secret.py", set(), True],
+            ["/my/file/usr/bin/secret.py", set(), True],
+            ["/usr/share/nginx/secret.py", set(), True],
+            ["/gems/secret.py", set(), True],
+            ["/npm-bis/secret.py", set(), True],
+            ["/banned/extension/secret.exe", set(), False],
+            ["/banned/extension/secret.mng", set(), False],
+            ["/banned/extension/secret.tar", set(), False],
+            ["/banned/extension/secret.other", set(), True],
+            [
+                "/banned/extension/secret.other",
+                {re.compile(r"secret")},
+                False,
+            ],
         ),
     )
-    def test_docker_filepath_validation(self, filepath, valid):
+    def test_docker_filepath_validation(self, filepath, exclusion_regexes, valid):
         assert (
             _validate_filepath(
                 filepath=filepath,
+                exclusion_regexes=exclusion_regexes,
             )
             is valid
         )
@@ -108,12 +120,14 @@ class TestDockerCMD:
         "image_path", [DOCKER_EXAMPLE_PATH, DOCKER__INCOMPLETE_MANIFEST_EXAMPLE_PATH]
     )
     @pytest.mark.parametrize("json_output", (False, True))
+    @pytest.mark.parametrize("ignore_secret_file", (True, False))
     def test_docker_scan_archive(
         self,
         docker_image_open_mock: Mock,
         cli_fs_runner: click.testing.CliRunner,
         image_path: Path,
         json_output: bool,
+        ignore_secret_file: bool,
     ):
         assert image_path.exists()
 
@@ -131,7 +145,9 @@ class TestDockerCMD:
             scannable = StringScannable(
                 content=UNCHECKED_SECRET_PATCH, url="file_secret"
             )
-            docker_image.get_layer_scannables.return_value = [scannable]
+            docker_image.get_layer_scannables.return_value = (
+                [scannable] if not ignore_secret_file else []
+            )
 
             return docker_image
 
@@ -142,6 +158,15 @@ class TestDockerCMD:
         with my_vcr.use_cassette("test_scan_file_secret"):
             json_arg = ["--json"] if json_output else []
             cli_fs_runner.mix_stderr = False
+            if ignore_secret_file:
+                config = """
+version: 2
+secret:
+    ignored_paths:
+        - "file_secret"
+
+"""
+                write_text(Path(".gitguardian.yaml"), config)
             result = cli_fs_runner.invoke(
                 cli,
                 [
@@ -153,12 +178,31 @@ class TestDockerCMD:
                     str(image_path),
                 ],
             )
-            assert_invoke_exited_with(result, ExitCode.SCAN_FOUND_PROBLEMS)
+            assert_invoke_exited_with(
+                result,
+                (
+                    ExitCode.SCAN_FOUND_PROBLEMS
+                    if not ignore_secret_file
+                    else ExitCode.SUCCESS
+                ),
+            )
             docker_image_open_mock.assert_called_once_with(image_path)
-            docker_image.get_layer_scannables.assert_called_once_with(layer_info)
+            docker_image.get_layer_scannables.assert_called_once_with(
+                layer_info,
+                init_exclusion_regexes(
+                    IGNORED_DEFAULT_WILDCARDS
+                    + (["file_secret"] if ignore_secret_file else [])
+                ),
+            )
 
             if json_output:
                 output = json.loads(result.output)
-                assert len(output["entities_with_incidents"]) == 1
+                if not ignore_secret_file:
+                    assert len(output["entities_with_incidents"]) == 1
+                else:
+                    assert output["total_incidents"] == 0
             else:
-                assert "file_secret: 1 secret detected" in result.output
+                if not ignore_secret_file:
+                    assert "file_secret: 1 secret detected" in result.output
+                else:
+                    assert "No secrets have been found" in result.output

--- a/tests/unit/verticals/secret/test_scan_docker.py
+++ b/tests/unit/verticals/secret/test_scan_docker.py
@@ -94,7 +94,7 @@ class TestDockerScan:
 
             # Fill layer_ids and layer_files
             for info in image.layer_infos:
-                if files := list(image.get_layer_scannables(info)):
+                if files := list(image.get_layer_scannables(info, set())):
                     layer_ids.append(info.diff_id)
                     layer_files.append(files)
 


### PR DESCRIPTION
## Context

Fix https://github.com/GitGuardian/ggshield/issues/548

When a `.gitguardian.yaml` file was present with an `ignored_paths` entry, it wouldn't be taken into account.

## What has been done

- Paths to exclude are retrieved in the cli `_exclude_callback` function (see [here](https://github.com/GitGuardian/ggshield/blob/61c5bf3103eb490c9bb91f526b273e3408b72254/ggshield/cmd/secret/scan/secret_scan_common_options.py#L71)). They are then available in `ctx_obj.exclusion_regexes`. These `exclusion_regexes` are now passed as an option to the main function `docker_scan_archive` and then properly handled.
- Note that this fix consists in plugging the whole `_exclude_callback` feature in docker scanning: it means that other patterns such as `IGNORED_DEFAULT_WILDCARDS` are now applied too.

## Validation
- Create a minimalist Dockerfile. In `secret_to_find.txt` and `secret_not_to_find.txt` put secrets detected by ggshield (they can be the same secret).
```
FROM alpine

COPY secret_to_find.txt /secret_to_find.txt
COPY secret_not_to_find.txt /secret_not_to_find.txt
```
- Build the image: `docker build -t my-image .`
- Create a `.gitguardian.yaml` file:
```
version: 2

secret:
  ignored_paths:
    - 'secret_not_to_find.txt'
```
- Run `ggshield secret scan docker my-image`

**Before this PR**: both secrets are found.

**After this PR**: only secret in `secret_to_find.txt` is found.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
