### PR TITLE
feat: do not block pre-receive when server isn't responding (503)

### DIFF
--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -17,7 +17,7 @@ from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
-from ggshield.core.errors import handle_exception
+from ggshield.core.errors import ExitCode, handle_exception
 from ggshield.core.git_hooks.prereceive import (
     get_breakglass_option,
     get_prereceive_timeout,
@@ -136,6 +136,9 @@ def prereceive_cmd(
     if process.is_alive() or process.exitcode is None:
         ui.display_error("\nPre-receive hook took too long")
         process.kill()
+        return 0
+    if process.exitcode == ExitCode.SERVER_UNAVAILABLE:
+        ui.display_error("\nServer is not responding.")
         return 0
 
     return process.exitcode

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -8,7 +8,12 @@ from requests import Session
 
 from .config import Config
 from .constants import DEFAULT_INSTANCE_URL
-from .errors import APIKeyCheckError, UnexpectedError, UnknownInstanceError
+from .errors import (
+    APIKeyCheckError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    UnknownInstanceError,
+)
 from .ui.client_callbacks import ClientCallbacks
 
 
@@ -103,7 +108,11 @@ def check_client_api_key(client: GGClient) -> None:
         raise APIKeyCheckError(client.base_uri, "Invalid API key.")
     elif response.status_code == 404:
         raise UnexpectedError(
-            "The server returned a 404 error. Check your instance URL" " settings."
+            "The server returned a 404 error. Check your instance URL settings.",
+        )
+    elif response.status_code == 503:
+        raise ServiceUnavailableError(
+            message=f"Server is not responding.\nDetails: {response.detail}",
         )
     else:
         raise UnexpectedError(

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -33,6 +33,8 @@ class ExitCode(IntEnum):
     USAGE_ERROR = 2
     # auth subcommand failed
     AUTHENTICATION_ERROR = 3
+    # server is not responding
+    SERVER_UNAVAILABLE = 4
 
     # Add new exit codes here.
     # If you add a new exit code, make sure you also add it to the documentation.
@@ -131,6 +133,15 @@ class APIKeyCheckError(AuthError):
 
     def __init__(self, instance: str, message: str):
         super().__init__(instance, message)
+
+
+class ServiceUnavailableError(_ExitError):
+    """
+    Raised when the server is unavailable
+    """
+
+    def __init__(self, message: str):
+        super().__init__(ExitCode.SERVER_UNAVAILABLE, message)
 
 
 def format_validation_error(exc: ValidationError) -> str:

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -2,6 +2,7 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 from click.testing import CliRunner
+from requests import Response
 
 from ggshield.__main__ import cli
 from ggshield.core.config.user_config import SecretConfig
@@ -363,3 +364,35 @@ class TestPreReceive:
         )
         assert_invoke_ok(result)
         assert "Deletion event or nothing to scan.\n" in result.output
+
+    @patch("pygitguardian.client.GGClient.read_metadata")
+    def test_server_unavailable(
+        self,
+        read_metadata_mock: Mock,
+        tmp_path,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN a repo on which the command is ran
+        WHEN the server is not responding (503)
+        THEN it should return 0
+        AND display an error message
+        """
+        # Set up the mock to return a 503 response
+        response = Response()
+        response.status_code = 503
+        response.detail = "Service Temporarily Unavailable"
+        read_metadata_mock.return_value = response
+
+        # setting up repo to run the command
+        repo = create_pre_receive_repo(tmp_path)
+        old_sha = repo.get_top_sha()
+        shas = [repo.create_commit() for _ in range(3)]
+        with cd(repo.path):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "secret", "scan", "pre-receive"],
+                input=f"{old_sha} {shas[-1]} origin/main\n",
+            )
+        assert "Server is not responding" in result.output
+        assert_invoke_exited_with(result, 0)


### PR DESCRIPTION
## Context

Today, when running `ggshield secret scan pre-receive`, if GitGuardian server is temporarily unavailable (returns a response with 503 error code), an error is raised and the command returns `ExitCode.UNEXPECTED_ERROR`, which prevents all commit pushes to get through.

## What has been done

In this particular case, we now display an error in the UI but return 0, allowing for the pushes to proceed.

## Validation

Tested with the new test added to the suite.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
