### PR TITLE
Fix ggshield error with emojis in file name

### DIFF
--- a/changelog.d/20250306_155222_severine.bonnechere_scrt_5358_ggshield_error_with_emojis_in_file_name.md
+++ b/changelog.d/20250306_155222_severine.bonnechere_scrt_5358_ggshield_error_with_emojis_in_file_name.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Files with emojis in their name are now handled properly.

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -204,7 +204,7 @@ def git(
     try:
         logger.debug("command=%s timeout=%d", command, timeout)
         result = subprocess.run(
-            [_get_git_path()] + ["-c", "core.quotePath=false"] + command,
+            [_get_git_path(), "-c", "core.quotePath=false"] + command,
             check=check,
             capture_output=True,
             timeout=timeout,

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -204,7 +204,7 @@ def git(
     try:
         logger.debug("command=%s timeout=%d", command, timeout)
         result = subprocess.run(
-            [_get_git_path()] + command,
+            [_get_git_path()] + ["-c", "core.quotePath=false"] + command,
             check=check,
             capture_output=True,
             timeout=timeout,

--- a/tests/unit/cassettes/test_emoji_filename.yaml
+++ b/tests/unit/cassettes/test_emoji_filename.yaml
@@ -1,0 +1,157 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.20.0 (Darwin;py3.11.10) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/metadata
+    response:
+      body:
+        string:
+          '{"version":"v2.163.0","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"on_premise__default_sso_config_force_sso":null,"onboarding__segmentation_v1_enabled":true,"general__maximum_payload_size":26214400,"general__mutual_tls_mode":"disabled","general__signup_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576},"remediation_messages":{"pre_commit":">
+          How to remediate\n\n  Since the secret was detected before the commit was
+          made:\n  1. replace the secret with its reference (e.g. environment variable).\n  2.
+          commit again.\n\n> [Apply with caution] If you want to bypass ggshield (false
+          positive or other reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield
+          git commit -m \"<your message>\"\n    ","pre_push":"> How to remediate\n\n  Since
+          the secret was detected before the push BUT after the commit, you need to:\n  1.
+          rewrite the git history making sure to replace the secret with its reference
+          (e.g. environment variable).\n  2. push again.\n\n  To prevent having to rewrite
+          git history in the future, setup ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [Apply with caution] If you want to bypass ggshield (false positive or other
+          reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield-push
+          git push","pre_receive":"> How to remediate\n\n  A pre-receive hook set server
+          side prevented you from pushing secrets.\n\n  Since the secret was detected
+          during the push BUT after the commit, you need to:\n  1. rewrite the git history
+          making sure to replace the secret with its reference (e.g. environment variable).\n  2.
+          push again.\n\n  To prevent having to rewrite git history in the future, setup
+          ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [Apply with caution] If you want to bypass ggshield (false positive or other
+          reason), run:\n\n    git push -o breakglass"}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '2198'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 06 Mar 2025 16:36:14 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding,Cookie
+        x-app-version:
+          - v2.163.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '36'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.133.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "commit://staged/my_\ud83d\ude0a_emoji_file.txt", "document":
+        "@@ -1 +1 @@\n-Initial content\n\\ No newline at end of file\n+Modified content\n\\
+        No newline at end of file"}]'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '188'
+        Content-Type:
+          - application/json
+        GGShield-Command-Id:
+          - c59543a5-978d-4b24-99e0-8c748921a2ac
+        GGShield-Command-Path:
+          - cli secret scan pre-commit
+        GGShield-OS-Name:
+          - darwin
+        GGShield-OS-Version:
+          - 'Darwin Kernel Version 24.3.0: Thu Jan  2 20:23:36 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T8112'
+        GGShield-Python-Version:
+          - 3.11.10
+        GGShield-Version:
+          - 1.37.0
+        User-Agent:
+          - pygitguardian/1.20.0 (Darwin;py3.11.10) ggshield
+        mode:
+          - pre_commit
+        scan_options:
+          - '{"show_secrets": false, "ignored_detectors_count": 0, "ignored_matches_count":
+            0, "ignored_paths_count": 14, "ignore_known_secrets": false, "with_incident_details":
+            false, "has_prereceive_remediation_message": false, "all_secrets": false}'
+      method: POST
+      uri: https://api.gitguardian.com/v1/multiscan?all_secrets=True
+    response:
+      body:
+        string: '[{"policy_break_count":0,"policies":["Secrets detection"],"policy_breaks":[],"is_diff":true}]'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '93'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 06 Mar 2025 16:36:15 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.163.0
+        x-content-type-options:
+          - nosniff
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '70'
+        x-frame-options:
+          - DENY
+          - SAMEORIGIN
+        x-secrets-engine-version:
+          - 2.133.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/scan/test_precommit.py
+++ b/tests/unit/cmd/scan/test_precommit.py
@@ -3,12 +3,15 @@ from pathlib import Path
 
 import pytest
 
+from ggshield.__main__ import cli
 from ggshield.cmd.secret.scan.precommit import (
     check_is_merge_with_conflict,
     check_is_merge_without_conflict,
     get_merge_branch_from_reflog,
 )
+from ggshield.utils.os import cd
 from tests.repository import Repository
+from tests.unit.conftest import assert_invoke_ok, my_vcr
 
 
 def test_is_merge_not_merge(tmp_path):
@@ -98,3 +101,30 @@ def test_get_merge_branch_from_reflog(monkeypatch):
     monkeypatch.setenv("GIT_REFLOG_ACTION", "merge master")  # Simulate merge
     assert check_is_merge_without_conflict()
     assert get_merge_branch_from_reflog() == "master"
+
+
+@my_vcr.use_cassette("test_emoji_filename")
+def test_precommit_with_emoji_filename(tmp_path, cli_fs_runner):
+    """
+    GIVEN a repository with a staged diff on a file with an emoji in its name
+    WHEN the precommit command is run
+    THEN it executes successfully
+    """
+    # Set up repository
+    repo = Repository.create(tmp_path, initial_branch="main")
+
+    # Create a file with emoji in the name
+    emoji_file = tmp_path / "my_😊_emoji_file.txt"
+    emoji_file.write_text("Initial content")
+    repo.add(".")
+    repo.create_commit("Initial commit with emoji file")
+
+    # Modify the file and stage the changes
+    emoji_file.write_text("Modified content")
+    repo.add(".")
+
+    # Run the precommit command
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
+    # Verify the command executed successfully
+    assert_invoke_ok(result)

--- a/tests/unit/cmd/scan/test_precommit.py
+++ b/tests/unit/cmd/scan/test_precommit.py
@@ -111,7 +111,7 @@ def test_precommit_with_emoji_filename(tmp_path, cli_fs_runner):
     THEN it executes successfully
     """
     # Set up repository
-    repo = Repository.create(tmp_path, initial_branch="main")
+    repo = Repository.create(tmp_path)
 
     # Create a file with emoji in the name
     emoji_file = tmp_path / "my_😊_emoji_file.txt"


### PR DESCRIPTION
## Context

Today, when running `ggshield secret scan pre-commit` on a patch modifying a file which has an emoji in its name, the command fails and raises an error.

## What has been done

Surprisingly, the issue is coming from the git command itself. The header and content are not encoded the same in the output of below command (cf screenshot).

![image](https://github.com/user-attachments/assets/aadaef98-e6fc-4fdb-8f01-57a0b6b9ea48)

We can see that
- in the header the emoji is there
- in the diff part, the emoji was replaced by its utf-8 octal representation (`\360\237\230\212`).

In ggshield internals, we encode both header and content in utf-8. But the emoji in the header is getting encoding by an utf-8 byte (hexadecimal) representation: `\xf0\x9f\x98\x8a`. At some point we check filenames against each other and this is were the issue arises.

From what I understood, octal-representation occurs in some Unix/Linux environments or older programming languages, this is probably why git uses it.

Anyway, proposed fix rely on [core.quotePath](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath) param. See related info on the doc link.

Using this param fixes the issue:
![image](https://github.com/user-attachments/assets/abfb8866-e7d9-4981-8041-3a54ca111363)

## Validation
- commit a file with an emoji in its name
- edit some content in the file
- stage it (git add)
- run `ggshield secret scan pre-commit`

Before: fails, after: works fine.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
