### PR TITLE
Use system certificates

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -54,6 +54,8 @@ jobs:
           - os: ubuntu-22.04
             # When building on Linux we use a container to build using an old enough version
             container: rockylinux/rockylinux:8
+            sha256sum:
+              python: e8d7ed8c6f8c6f85cd083d5051cafd8c6c01d09eca340d1da74d0c00ff1cb897
           - os: windows-2022
           - os: macos-13
             arch: x86_64
@@ -91,11 +93,22 @@ jobs:
 
           # Install necessary packages
           yum install -y \
-            python3.9 \
             git-core \
             findutils
 
-          echo PYTHON_CMD=/usr/bin/python3.9 >> $GITHUB_ENV
+          # Install Python 3.10 (we can't use the one from setup-python@v5: it requires a more recent version of libc)
+          PYTHON_VERSION=3.10.16
+          PYTHON_BUILD=20250317
+          scripts/download \
+            https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz \
+            python.tar.gz \
+            ${{ matrix.sha256sum.python }}
+
+          tar xf python.tar.gz
+
+          # Make Python available
+          echo PATH=$PWD/python/bin:$PATH >> $GITHUB_ENV
+          echo PYTHON_CMD=$PWD/python/bin/python >> $GITHUB_ENV
 
           # Install NFPM
           NFPM_VERSION=2.36.1

--- a/changelog.d/20250321_152657_aurelien.gateau_support_host_certs.md
+++ b/changelog.d/20250321_152657_aurelien.gateau_support_host_certs.md
@@ -1,0 +1,3 @@
+### Added
+
+- ggshield now uses the system certificates instead of the bundled ones. Note that this only works with Python >= 3.10 (#1067).

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -179,6 +179,17 @@ def force_utf8_output():
         out.reconfigure(encoding="utf-8")
 
 
+def setup_truststore():
+    """Use the system certificates instead of the ones bundled by certifi"""
+    if sys.version_info < (3, 10):
+        # truststore requires Python 3.10
+        return
+
+    import truststore
+
+    truststore.inject_into_ssl()
+
+
 def main(args: Optional[List[str]] = None) -> Any:
     """
     Wrapper around cli.main() to handle the GITGUARDIAN_CRASH_LOG variable.
@@ -196,6 +207,7 @@ def main(args: Optional[List[str]] = None) -> Any:
         ui.set_ui(RichGGShieldUI())
 
     force_utf8_output()
+    setup_truststore()
 
     show_crash_log = getenv_bool("GITGUARDIAN_CRASH_LOG")
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "standalone", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:7bf5b6ed96fe8e05e0e70e51d58373e9a53273632c5a1f419deb4104454a368a"
+content_hash = "sha256:d28146ab5c332796d72134c95254e9352a7eec1259f09bd2abd71d445656533e"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -2210,6 +2210,18 @@ groups = ["dev"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.1"
+requires_python = ">=3.10"
+summary = "Verify certificates using native system trust stores"
+groups = ["default"]
+marker = "python_version >= \"3.10\""
+files = [
+    {file = "truststore-0.10.1-py3-none-any.whl", hash = "sha256:b64e6025a409a43ebdd2807b0c41c8bff49ea7ae6550b5087ac6df6619352d4c"},
+    {file = "truststore-0.10.1.tar.gz", hash = "sha256:eda021616b59021812e800fa0a071e51b266721bef3ce092db8a699e21c63539"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "rich~=12.5.1",
     "typing-extensions~=4.12.2",
     "urllib3~=2.2.2",
+    "truststore>=0.10.1; python_version >= \"3.10\"",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Context

This PR makes ggshield use the system certificates instead of the bundled ones.

Fixes #1067.

## What has been done

Integrate [truststore](https://pypi.org/project/truststore/) and use it. Note that this only works with Python >= 3.10.

The 2nd commit changes the CI so that the Linux standalone installer uses Python 3.10 instead of 3.9.

## Validation

I tested this using `mitmproxy`:
- Install it (`pipx install mitmproxy` for example)
- Follow [the documentation](https://docs.mitmproxy.org/stable/overview-getting-started/) to generate and install its certificate
- Tell ggshield to use the proxy (`export https_proxy=http://localhost:8080`)
- Run `ggshield api-status` using the main branch → it crashes with SSL errors
- Run `ggshield api-status` using this branch → it does not crash and you can see the exchange in mitmproxy UI

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
