### PR TITLE
chore(ci): add job to push new version to chocolatey

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -175,3 +175,23 @@ jobs:
           scripts/push-to-cloudsmith
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+  push_to_chocolatey:
+    needs: build_release_assets
+    name: Push to Chocolatey
+    runs-on: chocolatey/choco
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: os-packages-windows-2022
+          path: packages
+          merge-multiple: true
+
+      - name: Push to Chocolatey
+        run: |
+          scripts/push-to-chocolatey/push-to-chocolatey

--- a/changelog.d/20250408_150950_jonathan.griffe_add_ci_push_to_choco_job.md
+++ b/changelog.d/20250408_150950_jonathan.griffe_add_ci_push_to_choco_job.md
@@ -1,0 +1,3 @@
+### Added
+
+- GGShield is now available on Chocolatey (#934).

--- a/scripts/push-to-chocolatey/ggshield.nuspec
+++ b/scripts/push-to-chocolatey/ggshield.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ggshield</id>
+    <version>__VERSION__</version>
+    <owners>GitGuardian</owners>
+    <title>GGShield</title>
+    <authors>GitGuardian</authors>
+    <projectUrl>https://github.com/GitGuardian/ggshield</projectUrl>
+    <iconUrl>https://avatars.githubusercontent.com/u/27360172</iconUrl>
+    <licenseUrl>https://raw.githubusercontent.com/GitGuardian/ggshield/refs/heads/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/GitGuardian/ggshield</projectSourceUrl>
+    <docsUrl>https://docs.gitguardian.com/ggshield-docs/getting-started</docsUrl>
+    <tags>ggshield</tags>
+    <summary>ggshield is a CLI application that helps you detect secrets.</summary>
+    <description>
+ggshield is a CLI application that runs in your local environment or in a CI environment to help you detect more than 400+ types of secrets.
+
+ggshield is open source on GitHub and accessible [here](https://github.com/GitGuardian/ggshield).
+
+ggshield can run:
+
+- in your local environment to scan local files and repositories or as a pre-commit hook.
+- in a CI environment,
+- in a pre-receive hook, if you have a self-managed VCS instance
+
+Note: ggshield uses our public API through py-gitguardian to scan files. Only metadata such as call time, request size and scan mode is stored when launching a scan with ggshield, therefore secrets incidents will not be displayed on your dashboard and your files and secrets won't be stored.
+    </description>
+    <releaseNotes>https://raw.githubusercontent.com/GitGuardian/ggshield/refs/heads/main/CHANGELOG.md</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/scripts/push-to-chocolatey/push-to-chocolatey
+++ b/scripts/push-to-chocolatey/push-to-chocolatey
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+    echo $* >&2
+    exit 1
+}
+
+if [ -z "${CHOCOLATEY_API_KEY:-}" ] ; then
+    die '$CHOCOLATEY_API_KEY is not set'
+fi
+
+if ! command -v unzip > /dev/null ; then
+    apt update
+    apt install unzip
+fi
+
+zip_name=$(ls packages)
+unzip packages/$zip_name -d packages
+
+version=$(echo "$zip_name" | grep -oP '(?<=ggshield-)[0-9.]+')
+
+mkdir ggshield-package
+mkdir ggshield-package/tools
+
+mv packages/*/_internal ggshield-package/tools
+mv packages/*/ggshield.exe ggshield-package/tools
+cp scripts/push-to-chocolatey/ggshield.nuspec ggshield-package
+sed -i "s/__VERSION__/$version/" ggshield-package/ggshield.nuspec
+
+cd ggshield-package
+choco pack
+
+choco push ggshield.$version.nupkg --source https://push.chocolatey.org/ --api-key $CHOCOLATEY_API_KEY


### PR DESCRIPTION
## What has been done

A job was added to automatically publish new ggshield versions on chocolatey.
This MR also introduces the ggshield.nuspec used for the ggshield chocolatey package.

## Validation

- Test the push-to-chocolatey script
- Download the nupkg and install it on a windows VM with "choco install ggshield -source ."