### PR TITLE
chore: don't update GitGuardian/homebrew-tap/ anymore

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -124,34 +124,6 @@ jobs:
           tag_with_ref: true
           tags: latest
 
-  push_to_tap:
-    needs: push_to_pypi
-    name: Push to GitGuardian taps
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    steps:
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Checkout Homebrew-tap
-        uses: actions/checkout@v4
-        with:
-          repository: GitGuardian/homebrew-tap
-          token: ${{ secrets.PAT_GITHUB }}
-
-      - name: Update Homebrew-tap
-        run: |
-          version=${GITHUB_REF/refs\/tags\/v/}
-
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
-          scripts/update-ggshield --commit "$version"
-
-          git push
-
   push_to_cloudsmith:
     needs: build_release_assets
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Context

See https://github.com/GitGuardian/homebrew-tap/pull/8.

## What has been done

Remove CI job updating ggshield formula on https://github.com/GitGuardian/homebrew-tap.

## Validation

Not really possible to validate locally.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
