### PR TITLE
chore: move VERIFICATION.txt to tools package folder

### DIFF
--- a/scripts/push-to-chocolatey/push-to-chocolatey
+++ b/scripts/push-to-chocolatey/push-to-chocolatey
@@ -26,7 +26,7 @@ mkdir ggshield-package/tools
 mv packages/*/_internal ggshield-package/tools
 mv packages/*/ggshield.exe ggshield-package/tools
 cp scripts/push-to-chocolatey/ggshield.nuspec ggshield-package
-cp scripts/push-to-chocolatey/VERIFICATION.txt ggshield-package
+cp scripts/push-to-chocolatey/VERIFICATION.txt ggshield-package/tools
 sed -i "s/__VERSION__/$version/" ggshield-package/ggshield.nuspec
 
 cd ggshield-package


### PR DESCRIPTION
## Context

According to the documentation, VERIFICATION.txt should be in the tools folder of the package.
Moving it there also makes it included in the package since all files in "tools" are included.
