### PR TITLE
chore: add txt extension to license in chocolatey package

### DIFF
--- a/scripts/push-to-chocolatey/push-to-chocolatey
+++ b/scripts/push-to-chocolatey/push-to-chocolatey
@@ -27,7 +27,7 @@ mv packages/*/_internal ggshield-package/tools
 mv packages/*/ggshield.exe ggshield-package/tools
 cp scripts/push-to-chocolatey/ggshield.nuspec ggshield-package
 cp scripts/push-to-chocolatey/VERIFICATION.txt ggshield-package/tools
-cp LICENSE ggshield-package/tools
+cp LICENSE ggshield-package/tools/LICENSE.txt
 sed -i "s/__VERSION__/$version/" ggshield-package/ggshield.nuspec
 
 cd ggshield-package


### PR DESCRIPTION
## Context

To be able to preview the license in the chocolatey community repository, the license must have a .txt extension.

## What has been done

In the chocolatey package build script, when copying the LICENSE into the package, add a .txt extension