### PR TITLE
Fix censor_string() behavior on short strings

### DIFF
--- a/changelog.d/20250506_160702_aurelien.gateau_fix_censor.md
+++ b/changelog.d/20250506_160702_aurelien.gateau_fix_censor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug in the way ggshield obfuscated secrets that caused a crash for short secrets (#1086).

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -114,6 +114,13 @@ def censor_string(text: str) -> str:
     :return: the text censored
     """
     len_match = len(text)
+
+    # Special cases for short lengths
+    if len_match <= 2:
+        return "*" * len_match
+    if len_match == 3:
+        return f"**{text[2]}"
+
     start_privy_len = min(math.ceil(len_match / 6), MAXIMUM_CENSOR_LENGTH)
     end_privy_len = len_match - min(math.ceil(len_match / 6), MAXIMUM_CENSOR_LENGTH)
 

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -121,16 +121,12 @@ def censor_string(text: str) -> str:
     if len_match == 3:
         return f"**{text[2]}"
 
-    start_privy_len = min(math.ceil(len_match / 6), MAXIMUM_CENSOR_LENGTH)
-    end_privy_len = len_match - min(math.ceil(len_match / 6), MAXIMUM_CENSOR_LENGTH)
+    censor_start = min(math.ceil(len_match / 6), MAXIMUM_CENSOR_LENGTH)
+    censor_end = len_match - censor_start
 
     censored = REGEX_MATCH_HIDE.sub("*", text)
 
-    return str(
-        text[:start_privy_len]
-        + censored[start_privy_len:end_privy_len]
-        + text[end_privy_len:]
-    )
+    return text[:censor_start] + censored[censor_start:censor_end] + text[censor_end:]
 
 
 def censor_match(match: Match) -> str:

--- a/tests/unit/core/test_filter.py
+++ b/tests/unit/core/test_filter.py
@@ -6,7 +6,7 @@ import pytest
 from pygitguardian.models import Match, PolicyBreak
 from snapshottest import Snapshot
 
-from ggshield.core.filter import censor_match, get_ignore_sha
+from ggshield.core.filter import censor_match, censor_string, get_ignore_sha
 from tests.unit.conftest import (
     _MULTILINE_SECRET,
     _MULTIPLE_SECRETS_SCAN_RESULT,
@@ -116,3 +116,18 @@ def test_censor_match(input_match: Match, expected_value: str) -> None:
     value = censor_match(input_match)
     assert len(value) == len(input_match.match)
     assert value == expected_value
+
+
+@pytest.mark.parametrize(
+    ["text", "expected"],
+    (
+        ("hello world", "he*** ***ld"),
+        ("abcd", "a**d"),
+        ("abc", "**c"),
+        ("ab", "**"),
+        ("a", "*"),
+    ),
+)
+def test_censor_string(text: str, expected: str) -> None:
+    censored = censor_string(text)
+    assert censored == expected


### PR DESCRIPTION
## Context
    
When called with a one-char string, censor_string() would return the same
char doubled (so `censor_string("a")` would return "aa").
    
The behavior was also not good on 2-char string: it would leave the string
unchanged, and on 3-char string it would hide only the middle char.
    
## What has been done

1st commit changes this behavior to make sure that:

- 1 & 2 char strings are fully censored
- 2 chars out of 3 are censored in a 3 char string

2nd commit simplifies the implementation.

## Validation

- Create a file containing a one-char match secret.
- Scan it with `ggshield secret scan path` → it should not crash.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
