### PR TITLE
Make `scan docker` scan files in /usr/src/app

### DIFF
--- a/changelog.d/20250514_134109_aurelien.gateau_docker_scan_usr_src_app.md
+++ b/changelog.d/20250514_134109_aurelien.gateau_docker_scan_usr_src_app.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ggshield secret scan docker` now scans files in `/usr/src/app`.

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from ggshield.core.scan import ScanContext
 
 FILEPATH_BANLIST = [
-    r"^/?usr/(?!share/nginx)",
+    r"^/?usr/(?!share/nginx|src/app)",
     r"^/?lib/",
     r"^/?share/",
     r"^/?bin/",

--- a/tests/unit/cmd/scan/test_docker.py
+++ b/tests/unit/cmd/scan/test_docker.py
@@ -35,6 +35,7 @@ class TestDockerUtils:
             ["/my/file/secret.py", set(), True],
             ["/my/file/usr/bin/secret.py", set(), True],
             ["/usr/share/nginx/secret.py", set(), True],
+            ["/usr/src/app/secret.py", set(), True],
             ["/gems/secret.py", set(), True],
             ["/npm-bis/secret.py", set(), True],
             ["/banned/extension/secret.exe", set(), False],


### PR DESCRIPTION
## Context

`/usr/src/app` is often used to store the containerized app, so we should scan it.


<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

Tune the file ban list to ensure we scan the wanted directory.
<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

- Put a secret in a file called config.py
- Create a Dockerfile with this content:
```
FROM scratch

COPY config.py /usr/src/app
```
- Build an image for it: `docker build -t ggshield-src-app .`
- Scan it with ggshield: `ggshield secret scan docker ggshield-src-app` → it finds the secret
<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
