### PR TITLE
Do not require git

### DIFF
--- a/changelog.d/20250515_155151_aurelien.gateau_dont_require_git.md
+++ b/changelog.d/20250515_155151_aurelien.gateau_dont_require_git.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield` no longer crashes when it can't find git.

--- a/ggshield/core/env_utils.py
+++ b/ggshield/core/env_utils.py
@@ -6,7 +6,7 @@ from typing import Optional, Set
 from dotenv import dotenv_values, load_dotenv
 
 from ggshield.core import ui
-from ggshield.utils.git_shell import get_git_root, is_git_dir
+from ggshield.utils.git_shell import get_git_root, is_git_available, is_git_dir
 from ggshield.utils.os import getenv_bool
 
 
@@ -37,7 +37,7 @@ def _find_dot_env() -> Optional[Path]:
         return env
 
     # If we are in a git checkout, look for a .env at the root of the checkout
-    if is_git_dir(os.getcwd()):
+    if is_git_available() and is_git_dir(os.getcwd()):
         env = get_git_root() / ".env"
         if env.is_file():
             return env

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -14,7 +14,7 @@ from marshmallow import ValidationError
 from pygitguardian.models import Detail, TokenScope
 
 from ggshield.core.text_utils import pluralize
-from ggshield.utils.git_shell import GitError, InvalidGitRefError
+from ggshield.utils.git_shell import InvalidGitRefError
 
 
 logger = logging.getLogger(__name__)
@@ -193,7 +193,7 @@ def handle_exception(exc: Exception) -> int:
             " To workaround that, try setting the PYTHONUTF8 environment variable to 1."
         )
 
-    if not isinstance(exc, (click.ClickException, GitError)):
+    if not isinstance(exc, click.ClickException):
         click.echo()
         if ui.is_verbose():
             traceback.print_exc()

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -59,6 +59,14 @@ class Filemode(Enum):
     UNKNOWN = "unknown"
 
 
+def is_git_available() -> bool:
+    try:
+        _get_git_path()
+        return True
+    except GitExecutableNotFound:
+        return False
+
+
 @lru_cache(None)
 def _get_git_path() -> str:
     git_path = which("git")
@@ -362,11 +370,11 @@ def get_last_commit_sha_of_branch(branch_name: str) -> Optional[str]:
 def get_repository_url_from_path(wd: Path) -> Optional[str]:
     """
     Returns one of the repository remote urls. Returns None if no remote are found,
-    or the directory is not a repository.
+    or the directory is not a repository or we don't have git so we can't know if the
+    directory is a repository.
     """
-    remotes_raw: List[str] = []
     try:
-        if not is_git_dir(wd):
+        if not is_git_available() or not is_git_dir(wd):
             return None
         remotes_raw = git(["remote", "-v"], cwd=wd).splitlines()
     except (subprocess.CalledProcessError, OSError):

--- a/tests/unit/utils/test_git_shell.py
+++ b/tests/unit/utils/test_git_shell.py
@@ -10,6 +10,7 @@ import pytest
 
 from ggshield.core.tar_utils import tar_from_ref_and_filepaths
 from ggshield.utils.git_shell import (
+    GitExecutableNotFound,
     InvalidGitRefError,
     NotAGitDirectory,
     check_git_dir,
@@ -22,6 +23,7 @@ from ggshield.utils.git_shell import (
     get_staged_filepaths,
     git,
     git_ls_unstaged,
+    is_git_available,
     is_git_dir,
     is_valid_git_commit_ref,
     simplify_git_url,
@@ -45,6 +47,12 @@ def _create_repository_with_remote(
     local_repo = Repository.create(repository_path, bare=True)
     _add_remote(local_repo, repository_name, remote_name)
     return local_repo
+
+
+@patch("ggshield.utils.git_shell._get_git_path")
+def test_is_git_available(_get_git_path_mock):
+    _get_git_path_mock.side_effect = GitExecutableNotFound()
+    assert not is_git_available()
 
 
 def test_git_shell():


### PR DESCRIPTION
## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

When running on a machine where git is not in $PATH, ggshield would crash because there are a few places that tries to use git at startup. This is annoying because there are valid situations (such being installed inside a Docker image) where git is not available but we would like to use non-git-related scan commands such as `secret scan path`.

## What has been done

- Add a test that tries to run `secret scan path` when git is not available
- Fix all crashes so that the test pass
<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

- Install ggshield in a Docker image that does not have git installed.
- Try to scan a path, it should not crash.
<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
