### PR TITLE
fix: make "Secret in Secrets Manager" more consistent

### DIFF
--- a/ggshield/core/text_utils.py
+++ b/ggshield/core/text_utils.py
@@ -54,6 +54,10 @@ def format_line_count(line_count: Union[int, None], padding: int) -> str:
     return " " * max(0, padding - len(str(line_count))) + str(line_count)
 
 
+def format_bool(value: bool) -> str:
+    return "YES" if value else "NO"
+
+
 _VALIDITY_TEXT_FOR_ID = {
     "unknown": "Unknown",
     # cannot_check is the old ID for secrets for which there are no checkers

--- a/ggshield/verticals/secret/output/secret_sarif_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_sarif_output_handler.py
@@ -6,6 +6,7 @@ from pygitguardian.models import SecretIncident
 
 from ggshield import __version__ as ggshield_version
 from ggshield.core.match_span import MatchSpan
+from ggshield.core.text_utils import format_bool
 
 from ..extended_match import ExtendedMatch
 from ..secret_scan_collection import Result, Secret, SecretScanCollection
@@ -83,7 +84,7 @@ def _create_sarif_result_dict(
         markdown_message = f"Secret detected: [{secret.detector_display_name}]({secret.documentation_url})"
     else:
         markdown_message = f"Secret detected: {secret.detector_display_name}"
-    markdown_message += f"\nSecret in Secrets Manager: {secret.is_vaulted}"
+    markdown_message += f"\nSecret in Secrets Manager: {format_bool(secret.is_vaulted)}"
     markdown_message += f"\nMatches:\n{matches_li}"
 
     # Create dict

--- a/ggshield/verticals/secret/output/secret_text_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_text_output_handler.py
@@ -9,6 +9,7 @@ from ggshield.core.lines import Line, get_offset, get_padding
 from ggshield.core.text_utils import (
     STYLE,
     clip_long_line,
+    format_bool,
     format_text,
     pluralize,
     translate_validity,
@@ -304,10 +305,10 @@ def secret_header(
     message = f"""
 {start_line} Secret detected: {secret_type}{validity_msg}
 {indent}Occurrences: {number_occurrences}
-{indent}Known by GitGuardian dashboard: {"YES" if known_secret else "NO"}
+{indent}Known by GitGuardian dashboard: {format_bool(known_secret)}
 {indent}Incident URL: {secret.incident_url if known_secret and secret.incident_url else "N/A"}
 {indent}Secret SHA: {ignore_sha}
-{indent}Secret in Secrets Manager: {secret.is_vaulted}
+{indent}Secret in Secrets Manager: {format_bool(secret.is_vaulted)}
 """
     if secret.documentation_url is not None:
         message += f"{indent}Detector documentation: {secret.documentation_url}\n"

--- a/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
+++ b/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
@@ -1,13 +1,13 @@
+# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
 
 snapshots = Snapshot()
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -15,7 +15,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -23,11 +23,9 @@ snapshots[
                   |__client_id__|
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
                                     |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -35,7 +33,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -43,11 +41,9 @@ snapshots[
                   |__client_id__|
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
                                     |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -57,7 +53,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -65,11 +61,9 @@ secrets-engine-version: 3.14.159
                   |__client_id__|
   1 | +Facebook = 294*********575 | ce3f9f********************5e4372;
                                     |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -79,7 +73,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -87,11 +81,9 @@ secrets-engine-version: 3.14.159
                   |__client_id__|
   1 | +Facebook = 294790898041575 | ce3f9f0362bbe5ab01dfc8ee565e4372;
                                     |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -99,7 +91,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -107,11 +99,9 @@ snapshots[
                        |__client_id__|
   1 | +…= 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
                                                |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -119,7 +109,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -127,11 +117,9 @@ snapshots[
                        |__client_id__|
   1 | +…= 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
                                                |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -141,7 +129,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -149,11 +137,9 @@ secrets-engine-version: 3.14.159
                        |__client_id__|
   1 | +FacebookAppId = 294*********575; FacebookAppSecret = ce3f9f********************5e4372;
                                                             |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -163,7 +149,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -171,11 +157,9 @@ secrets-engine-version: 3.14.159
                        |__client_id__|
   1 | +FacebookAppId = 294790898041575; FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
                                                             |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -183,7 +167,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -191,11 +175,9 @@ snapshots[
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f********************5e4372;
                            |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: Facebook Access Token
@@ -203,7 +185,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -211,11 +193,9 @@ snapshots[
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
                            |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -225,7 +205,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -233,11 +213,9 @@ secrets-engine-version: 3.14.159
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f********************5e4372;
                            |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -247,7 +225,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -255,11 +233,9 @@ secrets-engine-version: 3.14.159
                        |__client_id__|
   2 | +FacebookAppSecret = ce3f9f0362bbe5ab01dfc8ee565e4372;
                            |_________client_secret________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 3 secrets detected
 
 >> Secret detected: Facebook Access Token
@@ -267,7 +243,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -283,7 +259,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -303,18 +279,16 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +**********************+*****************************************
   8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +…-- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
                   |_______________________________apikey______________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 3 secrets detected
 
 >> Secret detected: Facebook Access Token
@@ -322,7 +296,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -338,7 +312,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -358,18 +332,16 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
   8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +…-- token: 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
                   |_______________________________apikey______________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 3 secrets detected
@@ -379,7 +351,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -395,7 +367,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -415,18 +387,16 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +**********************+*****************************************
   8 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +-----END RSA PRIVATE KEY----- token: SG._Yytrtvlj******************************************-**rRJLGFLBLf0M
                                             |_______________________________apikey______________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 3 secrets detected
@@ -436,7 +406,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -452,7 +422,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -472,18 +442,16 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
   8 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
   9 | +-----END RSA PRIVATE KEY----- token: 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
                                             |_______________________________apikey______________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: RSA Private Key
@@ -491,7 +459,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -506,11 +474,9 @@ snapshots[
     9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
         |_____________________________apikey____________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: RSA Private Key
@@ -518,7 +484,7 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -533,11 +499,9 @@ snapshots[
     9 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
         |_____________________________apikey____________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -547,7 +511,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -562,11 +526,9 @@ secrets-engine-version: 3.14.159
     9 | +****+******Xme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
         |_____________________________apikey____________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -576,7 +538,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -591,11 +553,9 @@ secrets-engine-version: 3.14.159
     9 | +RF3C+CMFb0wXme/ovcDeM1+3W/UmSHYUW4b3WYq4
    10 | +-----END RSA PRIVATE KEY-----
         |_____________________________apikey____________________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-hide_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: GitHub Token
@@ -603,17 +563,15 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
   1 | +github_token: 368ac3e**************************37ddf91
                      |________________apikey________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1"
-] = """> This is an example header
+snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-show_secrets] 1'] = '''> This is an example header
 > leak.txt: 1 secret detected
 
 >> Secret detected: GitHub Token
@@ -621,17 +579,15 @@ snapshots[
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
   1 | +github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
                      |________________apikey________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-verbose-hide_secrets] 1"
-] = """
+snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-verbose-hide_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -641,17 +597,15 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
   1 | +github_token: 368ac3e**************************37ddf91
                      |________________apikey________________|
-"""
+'''
 
-snapshots[
-    "test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-verbose-show_secrets] 1"
-] = """
+snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-verbose-show_secrets] 1'] = '''
 secrets-engine-version: 3.14.159
 > This is an example header
 > leak.txt: 1 secret detected
@@ -661,10 +615,10 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: False
+   Secret in Secrets Manager: NO
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
   1 | +github_token: 368ac3edf9e850d1c0ff9d6c526496f8237ddf91
                      |________________apikey________________|
-"""
+'''

--- a/tests/unit/verticals/secret/output/test_sarif_output.py
+++ b/tests/unit/verticals/secret/output/test_sarif_output.py
@@ -12,6 +12,7 @@ from voluptuous import validators
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import Commit
+from ggshield.core.text_utils import format_bool
 from ggshield.verticals.secret import Result, Results, SecretScanCollection
 from ggshield.verticals.secret.output import SecretSARIFOutputHandler
 from ggshield.verticals.secret.output.secret_sarif_output_handler import SCHEMA_URL
@@ -303,7 +304,9 @@ def check_sarif_result(
 
     # Check that the markdown message contains the correct is_vaulted information
     markdown_message = sarif_result["message"]["markdown"]
-    expected_is_vaulted_text = f"Secret in Secrets Manager: {secret.is_vaulted}"
+    expected_is_vaulted_text = (
+        f"Secret in Secrets Manager: {format_bool(secret.is_vaulted)}"
+    )
     assert (
         expected_is_vaulted_text in markdown_message
     ), f"Expected '{expected_is_vaulted_text}' in markdown message, but got: {markdown_message}"

--- a/tests/unit/verticals/secret/output/test_text_output.py
+++ b/tests/unit/verticals/secret/output/test_text_output.py
@@ -6,6 +6,7 @@ import pytest
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import StringScannable
+from ggshield.core.text_utils import format_bool
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.secret import Result, Results, SecretScanCollection
 from ggshield.verticals.secret.output import SecretTextOutputHandler
@@ -294,4 +295,4 @@ def test_vaulted_secret(is_vaulted: bool):
         )
     )
 
-    assert f"Secret in Secrets Manager: {is_vaulted}" in output
+    assert f"Secret in Secrets Manager: {format_bool(is_vaulted)}" in output


### PR DESCRIPTION
## Context

In ggshield text output, the value for the "Known by GitGuardian dashboard" is "YES" or "NO", but the value for the new "Secret in Secrets Manager" is "true" or "false".

## What has been done

This commit makes "Secret in Secrets Manager" use "YES" or "NO" too.

Before:

```
>> Secret detected: Generic Password
   Validity: No Checker
   Occurrences: 1
   Known by GitGuardian dashboard: NO
   Incident URL: N/A
   Secret SHA: bcab461d00a692b05add54f547d83660290e1a22504db841d7a9c325451bf20b
   Secret in Secrets Manager: False
   Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/generics/generic_password
```

After:

```
>> Secret detected: Generic Password
   Validity: No Checker
   Occurrences: 1
   Known by GitGuardian dashboard: NO
   Incident URL: N/A
   Secret SHA: bcab461d00a692b05add54f547d83660290e1a22504db841d7a9c325451bf20b
   Secret in Secrets Manager: NO
   Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/generics/generic_password
```
