### PR TITLE
fix: docker pull fallback on linux amd64 for apple silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,7 @@ Yanked: release process issue.
 #### IaC
 
 - `ggshield iac scan` now provides three new commands for use as Git hooks:
+
   - `ggshield iac scan pre-commit`
   - `ggshield iac scan pre-push`
   - `ggshield iac scan pre-receive`
@@ -635,6 +636,7 @@ Yanked: release process issue.
 - New command: `ggshield iac scan all`. This command replaces the now-deprecated `ggshield iac scan`. It scans a directory for IaC vulnerabilities.
 
 - New command: `ggshield iac scan diff`. This command scans a Git repository and inspects changes in IaC vulnerabilities between two points in the history.
+
   - All options from `ggshield iac scan all` are supported: `--ignore-policy`, `--minimum-severity`, `--ignore-path` etc. Execute `ggshield iac scan diff -h` for more details.
   - Two new options allow to choose which state to select for the difference: `--ref <GIT-REFERENCE>` and `--staged`.
   - The command can be integrated in Git hooks using the `--pre-commit`, `--pre-push`, `--pre-receive` options.

--- a/changelog.d/20250620_145029_severine.bonnechere_fix_pull_docker_apple_silicon.md
+++ b/changelog.d/20250620_145029_severine.bonnechere_fix_pull_docker_apple_silicon.md
@@ -1,0 +1,3 @@
+### Changed
+
+- When scanning a docker image, if no image is found matching the client platform, try to pull the `linux/amd64` image.

--- a/ggshield/verticals/secret/docker.py
+++ b/ggshield/verticals/secret/docker.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import platform
 import re
 import subprocess
 import tarfile
@@ -297,11 +296,10 @@ def docker_pull_image(image_name: str, timeout: int) -> None:
     if _run_docker_command(base_command, timeout):
         return
 
-    # Apple Silicon: fall back to linux/amd64 if no success
-    if platform.system() == "Darwin" and platform.machine() == "arm64":
-        amd64_command = base_command + ["--platform=linux/amd64"]
-        if _run_docker_command(amd64_command, timeout):
-            return
+    # Fall back to linux/amd64 if no success
+    amd64_command = base_command + ["--platform=linux/amd64"]
+    if _run_docker_command(amd64_command, timeout):
+        return
 
     # Raise error if no success
     raise UsageError(f'Image "{image_name}" not found')
@@ -357,7 +355,7 @@ def docker_save_to_tmp(image_name: str, destination_path: Path, timeout: int) ->
     except subprocess.CalledProcessError as exc:
         err_string = str(exc.stderr)
         if "No such image" in err_string or "reference does not exist" in err_string:
-            ui.display_info("need to download image first")  # ici
+            ui.display_info("need to download image first")
             docker_pull_image(image_name, timeout)
 
             docker_save_to_tmp(image_name, destination_path, timeout)

--- a/tests/unit/verticals/secret/test_scan_docker.py
+++ b/tests/unit/verticals/secret/test_scan_docker.py
@@ -148,6 +148,20 @@ class TestDockerPull:
             ):
                 docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
 
+    def test_docker_pull_image_platform_fallback(self):
+        with patch(
+            "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=[])
+        ) as call, pytest.raises(
+            click.UsageError,
+            match='Image "ggshield-non-existant" not found',
+        ):
+            docker_pull_image("ggshield-non-existant", DOCKER_TIMEOUT)
+            call.assert_called_once_with(
+                ["docker", "pull", "ggshield-non-existant", "--platform=linux/amd64"],
+                check=True,
+                timeout=DOCKER_TIMEOUT,
+            )
+
 
 class TestDockerSave:
     TMP_ARCHIVE = Path("/tmp/as/archive.tar")


### PR DESCRIPTION
## Context
A user reported the following issue on Apple Silicon:
```bash
ggshield secret scan docker bimapangestu/pertamina-login:latest
Saving docker image...
need to download image first
latest: Pulling from bimapangestu/pertamina-login
no matching manifest for linux/arm64/v8 in the manifest list entries

Error: Image "bimapangestu/pertamina-login:latest" not found
```
After pulling the image separately (using `docker pull bimapangestu/pertamina-login:latest` or `docker pull --platform linux/amd64 bimapangestu/pertamina-login:latest`), it ended working.

## What has been done
When `docker pull` command fails, retry pulling specifically the `linux/amd64` image.

## Validation
Use case on Apple Silicon:
- Make sure not to have locally pulled `bimapangestu/pertamina-login:latest` image (`docker rmi -f bimapangestu/pertamina-login:latest`)
- run `ggshield secret scan docker bimapangestu/pertamina-login:latest` on `main`: command fails
- On this branch: command works

## Extra comment
I first added the fallback only for Apple Silicon OS and was advised to make it available for every kind of platform. I'm not opinionated on the topic.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
