### PR TITLE
chore: fix Secret typing following py-gitguardian changes

### DIFF
--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -84,8 +84,8 @@ class Secret:
     """
 
     detector_display_name: str
-    detector_name: str
-    detector_group_name: str
+    detector_name: Optional[str]
+    detector_group_name: Optional[str]
     documentation_url: Optional[str]
     validity: str
     known_secret: bool


### PR DESCRIPTION
## Context

Changes have been made in py-gitguardian to fix the compatibility with older GitGuardian API versions. 

The typing in ggshield must now be updated