### PR TITLE
fix: install libstdcpp for clearlinux

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -292,6 +292,14 @@ jobs:
           - clearlinux:latest
 
     steps:
+      - name: Install requirements
+        run: |
+          case "${{ matrix.image }}" in
+            clearlinux*)
+              swupd bundle-add libstdcpp
+              ;;
+          esac
+
       - name: Download OS packages
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -306,6 +306,8 @@ jobs:
               zypper install -y git-core
               ;;
             clearlinux*)
+              # install libstdcpp: as of June 2025, libstdcpp is not part of clearlinux base image
+              # and it is needed by node in actions/download-artifact@v4
               swupd bundle-add libstdcpp
               swupd bundle-add git
               ;;

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -295,8 +295,19 @@ jobs:
       - name: Install requirements
         run: |
           case "${{ matrix.image }}" in
+            debian:*|ubuntu:*)
+              apt update
+              apt install --no-install-recommends -y git
+              ;;
+            rockylinux*)
+              yum install -y git-core
+              ;;
+            opensuse*)
+              zypper install -y git-core
+              ;;
             clearlinux*)
               swupd bundle-add libstdcpp
+              swupd bundle-add git
               ;;
           esac
 
@@ -312,20 +323,15 @@ jobs:
         run: |
           case "${{ matrix.image }}" in
             debian:*|ubuntu:*)
-              apt update
-              apt install --no-install-recommends -y git
               dpkg -i packages/*.deb
               ;;
             rockylinux*)
-              yum install -y git-core
               rpm -i packages/*.rpm
               ;;
             opensuse*)
-              zypper install -y git-core
               rpm -i packages/*.rpm
               ;;
             clearlinux*)
-              swupd bundle-add git
 
               # Unpack ggshield in /usr/local/ggshield
               pkg_dir=$PWD/packages

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  PDM_VERSION: 2.20.1
+  PDM_VERSION: 2.22.4
 
 jobs:
   build_wheel_sdist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - 'README.md'
 
 env:
-  PDM_VERSION: 2.20.1
+  PDM_VERSION: 2.22.4
   DEFAULT_PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -11,7 +11,7 @@ on:
         default: '3.10'
 
 env:
-  PDM_VERSION: 2.20.1
+  PDM_VERSION: 2.22.4
   DEFAULT_PYTHON_VERSION: '3.10'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,7 +551,6 @@ Yanked: release process issue.
 #### IaC
 
 - `ggshield iac scan` now provides three new commands for use as Git hooks:
-
   - `ggshield iac scan pre-commit`
   - `ggshield iac scan pre-push`
   - `ggshield iac scan pre-receive`
@@ -561,7 +560,6 @@ Yanked: release process issue.
 - The new `ggshield iac scan ci` command can be used to perform IaC scans in CI environments.
   It supports the same arguments as hook subcommands (in particular, `--all` to scan the whole repository).
   Supported CIs are:
-
   - Azure
   - Bitbucket
   - CircleCI
@@ -574,7 +572,6 @@ Yanked: release process issue.
 #### SCA
 
 - Introduces new commands to perform SCA scans with ggshield:
-
   - `ggshield sca scan all <DIRECTORY>` : scans a directory or a repository to find all existing SCA vulnerabilities.
   - `ggshield sca scan diff <DIRECTORY> --ref <GIT_REF>`: runs differential scan compared to a given git ref.
   - `ggshield sca scan pre-commit`
@@ -585,7 +582,6 @@ Yanked: release process issue.
 #### Other
 
 - It is now possible to manipulate the default instance using `ggshield config`:
-
   - `ggshield config set instance <THE_INSTANCE_URL>` defines the default instance.
   - `ggshield config unset instance` removes the previously defined instance.
   - The default instance can be printed with `ggshield config get instance` and `ggshield config list`.
@@ -639,7 +635,6 @@ Yanked: release process issue.
 - New command: `ggshield iac scan all`. This command replaces the now-deprecated `ggshield iac scan`. It scans a directory for IaC vulnerabilities.
 
 - New command: `ggshield iac scan diff`. This command scans a Git repository and inspects changes in IaC vulnerabilities between two points in the history.
-
   - All options from `ggshield iac scan all` are supported: `--ignore-policy`, `--minimum-severity`, `--ignore-path` etc. Execute `ggshield iac scan diff -h` for more details.
   - Two new options allow to choose which state to select for the difference: `--ref <GIT-REFERENCE>` and `--staged`.
   - The command can be integrated in Git hooks using the `--pre-commit`, `--pre-push`, `--pre-receive` options.


### PR DESCRIPTION
## Context

[CI is failing](https://github.com/GitGuardian/ggshield/actions/runs/15779418933/job/44482026043) on `clearlinux` tests because libstdcpp is not installed in the docker image for `clearlinux`. This is most likely new and coming from the latest version of the [docker image](https://hub.docker.com/_/clearlinux)  but we can't know for sure as the image isn't versioned. 

## What has been done
- install libstdcpp lib for clearlinux
- cosmetic changes: move all git installs in the new requirements step

## Validation

CI failed before, succeeds after.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
