### PR TITLE
chore(nhi): add vault related fields and modify sca…

### DIFF
--- a/changelog.d/20250702_102942_achille.mascia_nhi_ggshield_v2.md
+++ b/changelog.d/20250702_102942_achille.mascia_nhi_ggshield_v2.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added an additional section in ggshield's outputs to return vault related fields if the account setting is enabled.

--- a/ggshield/verticals/secret/output/schemas.py
+++ b/ggshield/verticals/secret/output/schemas.py
@@ -23,6 +23,10 @@ class FlattenedPolicyBreak(BaseSchema):
     known_secret = fields.Bool(required=True, dump_default=False)
     ignore_reason = fields.Nested(IgnoreReasonSchema, dump_default=None)
     secret_vaulted = fields.Bool(required=True, dump_default=False)
+    vault_type = fields.String(required=False, allow_none=True)
+    vault_name = fields.String(required=False, allow_none=True)
+    vault_path = fields.String(required=False, allow_none=True)
+    vault_path_count = fields.Integer(required=False, allow_none=True)
 
 
 class JSONResultSchema(BaseSchema):

--- a/ggshield/verticals/secret/output/secret_json_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_json_output_handler.py
@@ -143,6 +143,14 @@ class SecretJSONOutputHandler(SecretOutputHandler):
 
         if secrets[0].is_vaulted:
             flattened_dict["secret_vaulted"] = secrets[0].is_vaulted
+
+        # Add vault information if available
+        if secrets[0].vault_path is not None:
+            flattened_dict["vault_type"] = secrets[0].vault_type
+            flattened_dict["vault_name"] = secrets[0].vault_name
+            flattened_dict["vault_path"] = secrets[0].vault_path
+            flattened_dict["vault_path_count"] = secrets[0].vault_path_count
+
         for secret in secrets:
             flattened_dict["occurrences"].extend(self.serialize_secret_matches(secret))
 

--- a/ggshield/verticals/secret/output/secret_sarif_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_sarif_output_handler.py
@@ -6,7 +6,7 @@ from pygitguardian.models import SecretIncident
 
 from ggshield import __version__ as ggshield_version
 from ggshield.core.match_span import MatchSpan
-from ggshield.core.text_utils import format_bool
+from ggshield.core.text_utils import pluralize
 
 from ..extended_match import ExtendedMatch
 from ..secret_scan_collection import Result, Secret, SecretScanCollection
@@ -84,7 +84,19 @@ def _create_sarif_result_dict(
         markdown_message = f"Secret detected: [{secret.detector_display_name}]({secret.documentation_url})"
     else:
         markdown_message = f"Secret detected: {secret.detector_display_name}"
-    markdown_message += f"\nSecret in Secrets Manager: {format_bool(secret.is_vaulted)}"
+
+    if secret.is_vaulted:
+        if secret.vault_path_count is None:
+            markdown_message += "\nSecret found in vault: Yes"
+        else:
+            vault_count_text = f"({secret.vault_path_count} {pluralize('location', secret.vault_path_count)})"
+            markdown_message += f"\nSecret found in vault: Yes {vault_count_text}"
+            markdown_message += f"\nVault Type: {secret.vault_type}"
+            markdown_message += f"\nVault Name: {secret.vault_name}"
+            markdown_message += f"\nSecret Path: {secret.vault_path}"
+    else:
+        markdown_message += "\nSecret found in vault: No"
+
     markdown_message += f"\nMatches:\n{matches_li}"
 
     # Create dict

--- a/ggshield/verticals/secret/output/secret_text_output_handler.py
+++ b/ggshield/verticals/secret/output/secret_text_output_handler.py
@@ -302,13 +302,30 @@ def secret_header(
     number_occurrences = format_text(str(len(secrets)), STYLE["occurrence_count"])
     ignore_sha = format_text(ignore_sha, STYLE["ignore_sha"])
 
+    # Build vault status message
+    vault_status_msg = ""
+    vault_details_msg = ""
+
+    if secret.is_vaulted:
+        if secret.vault_path_count is None:
+            vault_status_msg = f"\n{indent}Secret found in vault: Yes"
+        else:
+            vault_count_text = f"({secret.vault_path_count} {pluralize('location', secret.vault_path_count)})"
+            vault_status_msg = (
+                f"\n{indent}Secret found in vault: Yes {vault_count_text}"
+            )
+            vault_details_msg += f"\n{indent}├─ Vault Type: {secret.vault_type}"
+            vault_details_msg += f"\n{indent}├─ Vault Name: {secret.vault_name}"
+            vault_details_msg += f"\n{indent}└─ Secret Path: {secret.vault_path}"
+    else:
+        vault_status_msg = f"\n{indent}Secret found in vault: No"
+
     message = f"""
 {start_line} Secret detected: {secret_type}{validity_msg}
 {indent}Occurrences: {number_occurrences}
 {indent}Known by GitGuardian dashboard: {format_bool(known_secret)}
 {indent}Incident URL: {secret.incident_url if known_secret and secret.incident_url else "N/A"}
-{indent}Secret SHA: {ignore_sha}
-{indent}Secret in Secrets Manager: {format_bool(secret.is_vaulted)}
+{indent}Secret SHA: {ignore_sha}{vault_status_msg}{vault_details_msg}
 """
     if secret.documentation_url is not None:
         message += f"{indent}Detector documentation: {secret.documentation_url}\n"

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -94,6 +94,10 @@ class Secret:
     ignore_reason: Optional[IgnoreReason]
     diff_kind: Optional[DiffKind]
     is_vaulted: bool
+    vault_type: Optional[str]
+    vault_name: Optional[str]
+    vault_path: Optional[str]
+    vault_path_count: Optional[int]
 
     @property
     def policy(self) -> str:
@@ -201,6 +205,10 @@ class Result:
                 ignore_reason=ignore_reason,
                 diff_kind=policy_break.diff_kind,
                 is_vaulted=policy_break.is_vaulted,
+                vault_type=getattr(policy_break, "vault_type", None),
+                vault_name=getattr(policy_break, "vault_name", None),
+                vault_path=getattr(policy_break, "vault_path", None),
+                vault_path_count=getattr(policy_break, "vault_path_count", None),
             )
             for policy_break, ignore_reason in to_keep
         ]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "standalone", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:83e8a01146542b936d2d7d980e1f270f5829cc4caec95966eef95c8737b92c42"
+content_hash = "sha256:d3511da6b8f711bdbc4deec84d12a9b206fa6923c6cb12e33cc2e5f519685f74"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -1679,7 +1679,8 @@ name = "pygitguardian"
 version = "1.23.0"
 requires_python = ">=3.8"
 git = "https://github.com/GitGuardian/py-gitguardian.git"
-revision = "b1c4bef71e2ebb2fd912da3e5bcba6e07fb992e2"
+ref = "007c1098d4e17bf71087453b431beafbaf425825"
+revision = "007c1098d4e17bf71087453b431beafbaf425825"
 summary = "Python Wrapper for GitGuardian's API -- Scan security policy breaks everywhere"
 groups = ["default"]
 dependencies = [
@@ -2420,7 +2421,7 @@ files = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "1.1.0"
-summary = "The Cranelift compiler for the `wasmer` package (to compile WebAssembly module)"
+summary = "Python extension to run WebAssembly binaries"
 groups = ["tests"]
 files = [
     {file = "wasmer_compiler_cranelift-1.1.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:9869910179f39696a020edc5689f7759257ac1cce569a7a0fcf340c59788baad"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "marshmallow~=3.18.0",
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
-    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@007c1098d4e17bf71087453b431beafbaf425825",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -70,6 +70,10 @@ class PolicyBreakFactory(factory.Factory):
     is_vaulted = False
     exclude_reason = None
     diff_kind = None
+    vault_type = None
+    vault_name = None
+    vault_path = None
+    vault_path_count = None
     content = factory.Faker("text")
     nb_matches = factory.fuzzy.FuzzyInteger(1, 2)
 
@@ -111,3 +115,7 @@ class SecretFactory(factory.Factory):
     ignore_reason = None
     diff_kind = None
     is_vaulted = False
+    vault_type = None
+    vault_name = None
+    vault_path = None
+    vault_path_count = None

--- a/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
+++ b/tests/unit/verticals/secret/output/snapshots/snap_test_text_output.py
@@ -15,7 +15,7 @@ snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-cl
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -33,7 +33,7 @@ snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_OVERLAY_SCAN_RESULT-cl
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -53,7 +53,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -73,7 +73,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -91,7 +91,7 @@ snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -109,7 +109,7 @@ snapshots['test_leak_message[_MULTI_SECRET_ONE_LINE_PATCH_SCAN_RESULT-clip_long_
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -129,7 +129,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -149,7 +149,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1 @@
@@ -167,7 +167,7 @@ snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -185,7 +185,7 @@ snapshots['test_leak_message[_MULTI_SECRET_TWO_LINES_PATCH_SCAN_RESULT-clip_long
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -205,7 +205,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -225,7 +225,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 38d9d3464520ed68f18d16e640a4a8b37ef5b17608b455267d100aa487ead314
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +2 @@
@@ -243,7 +243,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -259,7 +259,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -279,7 +279,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +**********************+*****************************************
@@ -296,7 +296,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -312,7 +312,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -332,7 +332,7 @@ snapshots['test_leak_message[_ONE_LINE_AND_MULTILINE_PATCH_CONTENT-clip_long_lin
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
@@ -351,7 +351,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -367,7 +367,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -387,7 +387,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +**********************+*****************************************
@@ -406,7 +406,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 1945f4a0c42abb19c1a420ddd09b4b4681249a3057c427b95f794b18595e7ffa
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/facebook_access_token
 
     | @@ -0,0 +1,29 @@
@@ -422,7 +422,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
     | @@ -0,0 +1,29 @@
@@ -442,7 +442,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 530e5a4a7ea00814db8845dd0cae5efaa4b974a3ce1c76d0384ba715248a5dc1
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/sendgrid_key
 
   7 | +bLaA/DCNPniBAiA0l//bzg+M3srIhm04xzLdR9Vb9IjPRlkvN074zdKDVwIhAKJb
@@ -459,7 +459,7 @@ snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_lon
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -484,7 +484,7 @@ snapshots['test_leak_message[_SIMPLE_SECRET_MULTILINE_PATCH_SCAN_RESULT-clip_lon
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -511,7 +511,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -538,7 +538,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 060bf63de122848f5efa122fe6cea504aae3b24cea393d887fdefa1529c6a02e
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/private_key_rsa
 
       | @@ -0,0 +1,29 @@
@@ -563,7 +563,7 @@ snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-hi
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
@@ -579,7 +579,7 @@ snapshots['test_leak_message[_SIMPLE_SECRET_PATCH_SCAN_RESULT-clip_long_lines-sh
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
@@ -597,7 +597,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@
@@ -615,7 +615,7 @@ secrets-engine-version: 3.14.159
    Known by GitGuardian dashboard: NO
    Incident URL: N/A
    Secret SHA: 2b5840babacb6f089ddcce1fe5a56b803f8b1f636c6f44cdbf14b0c77a194c93
-   Secret in Secrets Manager: NO
+   Secret found in vault: No
    Detector documentation: https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/github_access_token
 
     | @@ -0,0 +1 @@


### PR DESCRIPTION
Use the newly introduced `vault_type`, `vault_name`, `vault_path` and `vault_path_count` field to modify all types of ggshield outputs.
Works in review app (see the new ` Secret's path:` line):

With the AccountSetting:
<img width="1275" height="418" alt="Screenshot 2025-07-10 at 15 24 22" src="https://github.com/user-attachments/assets/7d0a11d2-2fdd-4b06-a002-adb052d3af1f" />

Without the setting:
<img width="1250" height="371" alt="Screenshot 2025-07-10 at 15 33 30" src="https://github.com/user-attachments/assets/340c0520-459f-4087-b3c2-c5341392dcc1" />