### PR TITLE
feat: push linux/arm64 docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,8 @@ jobs:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
 
-  dockerhub-unstable:
-    name: Push Docker image to Docker Hub
+  push_docker_images-unstable:
+    name: Push Docker image to Docker Hub and GitHub Packages
     runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
@@ -173,32 +173,30 @@ jobs:
       - build
       - test_github_secret_scan_action
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and push
-        uses: docker/build-push-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: gitguardian/ggshield
-          tags: unstable
 
-  github_packages-unstable:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-22.04
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs:
-      - lint
-      - build
-      - test_github_secret_scan_action
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ github.actor }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: gitguardian/ggshield/ggshield
-          tags: unstable
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            gitguardian/ggshield:unstable
+            ghcr.io/gitguardian/ggshield/ggshield:unstable

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -92,38 +92,49 @@ jobs:
     with:
       version: ${{ needs.release.outputs.tag }}
 
-  push_to_docker_hub:
-    name: Push Docker image to Docker Hub
+  push_docker_images:
+    name: Push Docker image to Docker Hub and GitHub Packages
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and push
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            gitguardian/ggshield
+            ghcr.io/gitguardian/ggshield/ggshield
+          tags: |
+            type=ref,event=tag
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: gitguardian/ggshield
-          tag_with_ref: true
-          tags: latest
 
-  push_to_github_packages:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ github.actor }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: gitguardian/ggshield/ggshield
-          tag_with_ref: true
-          tags: latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            gitguardian/ggshield:latest
+            ghcr.io/gitguardian/ggshield/ggshield:latest
 
   push_to_cloudsmith:
     needs: build_release_assets

--- a/changelog.d/20250709_184012_severine.bonnechere_produce_docker_arm_images.md
+++ b/changelog.d/20250709_184012_severine.bonnechere_produce_docker_arm_images.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- ggshield docker image is now multi-platform for both linux/amd64 and linux/arm64 (#952).
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
## Context

Solves #952 

- update docker build and push flow in CI: we were using action docker/build-push-action v1 while latest version is v6. Multi-platform isn't supported in v1.
- Provide multi-platform images for linux/amd64 and linux/arm64.

## What has been done
Multi-plaform support is ensured by [this line](https://github.com/GitGuardian/ggshield/pull/1112/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR198)

Most of the work was about updating the jobs to latest version.

Main points of attention / notes:
- ghcr.io is the same as docker.pkg.github.com which is deprecated, see [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry)
- There is 1 unique job pushing to both docker and github registries (instead of 2 previously). This is the standard way of doing as per [docker docs](https://docs.docker.com/build/ci/github-actions/push-multi-registries/)
- Main difference between ci job and tag job is the use of docker/metadata-action [here](https://github.com/GitGuardian/ggshield/pull/1112/commits/62169571accd2daed033bf66cc28e6a8654f656e#diff-84dff8d1094ca39c02ac0e48d951ca22f4da29c76b50ae517f5bd2d50f94c2f6R100). This is required to replace previous option `tag_with_ref: true` which doesn't exist anymore. The writing is largely inspired by [this example](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/) and the [action doc](https://github.com/docker/metadata-action?tab=readme-ov-file#typeref).

## Validation
Commit 2 of this PR shows that the job is working for the `ci` workflow (commit will be revert before merge)
- see job [here](https://github.com/GitGuardian/ggshield/actions/runs/16195470450/job/45723620174)
- see `unstable` version on [docker hub](https://hub.docker.com/r/gitguardian/ggshield) updated today
- see `unstable` version on github hub updated today:
```bash
$ docker pull ghcr.io/gitguardian/ggshield/ggshield:unstable
$ docker inspect ghcr.io/gitguardian/ggshield/ggshield:unstable | grep Created 
"Created": "2025-07-10T09:34:20.054697506Z",
```

⚠️ Unfortunately I have no mean of checking that the `tag` job will work as expected (regarding the version tagging part, using docker/metadata-action).
I think it should work as I followed the doc and example cited above and also saw [other examples](https://github.com/mlflow/mlflow/blob/master/.github/workflows/push-images.yml#L33) on github which seem to work.
If you have an idea how to test it I'm interested.

Regarding the [`latest` tag](https://github.com/GitGuardian/ggshield/pull/1112/commits/62169571accd2daed033bf66cc28e6a8654f656e#diff-84dff8d1094ca39c02ac0e48d951ca22f4da29c76b50ae517f5bd2d50f94c2f6R136), I'm confident it will work as expected because it's exactly the same logic as in the `ci` flow tested here.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
