### PR TITLE
chore(build-packages): Remove PyInstaller deprecation warning

### DIFF
--- a/changelog.d/20250819_142137_salome.voltz_scrt_5808_pyinstaller_deprecation_warning.md
+++ b/changelog.d/20250819_142137_salome.voltz_scrt_5808_pyinstaller_deprecation_warning.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Remove PyInstaller's pkg_resources deprecation warning when running PyInstaller-based ggshield.
+<!--
+
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -178,7 +178,7 @@ step_build() {
         extra_args="--strip"
     fi
 
-    pyinstaller ggshield/__main__.py --name ggshield --noupx $extra_args
+    pyinstaller ggshield/__main__.py --name ggshield --exclude-module pkg_resources --noupx $extra_args
 
     if [ "$HUMAN_OS" != Windows ] ; then
         # Libraries do not need to be executable


### PR DESCRIPTION
## Context

This MR fixes https://github.com/GitGuardian/ggshield/issues/1119, following [Pyinstaller maintainers recommandations](https://github.com/orgs/pyinstaller/discussions/9148#discussioncomment-13289368) 

## Validation

- Download packages [here](https://github.com/GitGuardian/ggshield/actions/runs/17043104348) 
