### PR TITLE
Add curl and jq to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 RUN \
     apt-get update \
     && apt-get dist-upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends git openssh-client \
+    && apt-get install -y --no-install-recommends git openssh-client curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 RUN \
     apt-get update \
     && apt-get dist-upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends git openssh-client curl \
+    && apt-get install -y --no-install-recommends git openssh-client curl jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/changelog.d/20250826_161154_philippe.gablain_add_curl_to_image.md
+++ b/changelog.d/20250826_161154_philippe.gablain_add_curl_to_image.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- The Docker image now includes curl and jq
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
## Context

With the new Bring Your Own Source feature in GIM, we want to propose a simple way to scan CI logs.
But in order to allow this kind of jobs, we must interact with the CI platform to fetch the logs and analyse them.

This PR adds minimal tooling to the ggshield image (curl, jq) to allow  listing, fetching CI logs.
 


## What has been done

Added curl and jq packages to the ggshield image.

## Validation

See the associated GIM MR.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
