### PR TITLE
fix(errors): extend error status code supported by ggshield

### DIFF
--- a/changelog.d/20250826_171614_salome.voltz_scrt_5812_investigate_ggshield_running_into_an_ownership_issue_in_git.md
+++ b/changelog.d/20250826_171614_salome.voltz_scrt_5812_investigate_ggshield_running_into_an_ownership_issue_in_git.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Extend the range of API error status code supported by ggshield so the UI correctly displays them.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -213,3 +213,7 @@ def handle_api_error(detail: Detail) -> None:
         raise UnexpectedError(f"Scanning failed: {detail.detail}")
     if detail.status_code == 403 and detail.detail == "Quota limit reached.":
         raise QuotaLimitReachedError()
+    if detail.status_code == 400 and "not found" in detail.detail:
+        raise UnexpectedError(detail.detail)
+    if 500 <= detail.status_code < 600:
+        raise ServiceUnavailableError(detail.detail)

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -231,7 +231,7 @@ def handle_scan_chunk_error(detail: Detail, chunk: List[Scannable]) -> None:
     details = None
 
     # Handle source_uuid not found error specifically
-    if "Source not found" in detail.detail:
+    if "Source" in detail.detail and "not found" in detail.detail:
         ui.display_error("The provided source was not found in GitGuardian.")
         return
 

--- a/tests/unit/verticals/secret/__snapshots__/test_secret_scanner.ambr
+++ b/tests/unit/verticals/secret/__snapshots__/test_secret_scanner.ambr
@@ -7,12 +7,6 @@
   
   '''
 # ---
-# name: test_handle_scan_error[source not found]
-  '''
-  Error: The provided source was not found in GitGuardian.
-  
-  '''
-# ---
 # name: test_handle_scan_error[too many documents]
   '''
   Error: Scanning failed. Results may be incomplete.

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -200,19 +200,19 @@ def test_handle_scan_error_api_key():
             ],
             id="single file exception",
         ),
-        pytest.param(
-            Detail("Source not found"),
-            400,
-            [StringScannable(content="test", url="test.txt")],
-            id="source not found",
-        ),
     ],
 )
 def test_handle_scan_error(detail, status_code, chunk, capsys, snapshot):
-    detail.status_code = 400
+    detail.status_code = status_code
     handle_scan_chunk_error(detail, chunk)
     captured = capsys.readouterr()
     assert captured.err == snapshot
+
+
+def test_scan_source_uuid_not_found():
+    detail = Detail(detail="Source not found.", status_code=400)
+    with pytest.raises(UnexpectedError):
+        handle_scan_chunk_error(detail, Mock())
 
 
 def test_handle_scan_quota_limit_reached():


### PR DESCRIPTION
## Context

Some error code return by the API are not detected as such by ggshield. As a result, the UI displays "No secret have been found", while **the scan failed and the files were not processed**. This is misleading.

Examples: 

![CleanShot 2025-07-18 at 12 24 28@2x](https://github.com/user-attachments/assets/f165fc72-11d4-4c67-8539-96a131810a57)
![CleanShot 2025-07-18 at 12 20 52@2x(1)](https://github.com/user-attachments/assets/45714eed-a3a6-4cfb-9294-384c5defc160)

## What has been done

- Extend `handle_api_error` case list to handle "Source not found" error, and 5xx errors
- Fix a bug in `handle_scan_chunk_error` to display the correct error when the source is not found

## Validation

- Run `ggshield secret scan path  --source-uuid b84b3f32-08df-448e-b49f-11186b003e73 <path>` (fake UUID) and ensure the UI displays the expected result. Especially, "No secret have been found" should not be displayed: 
<img width="561" height="65" alt="image" src="https://github.com/user-attachments/assets/fbfa4235-b7a4-45b5-8c44-cc30d488e91a" />

 

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
