### PR TITLE
fix(docs): update authentication scope link in login command document…

### DIFF
--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -142,7 +142,7 @@ def login_cmd(
     If a valid personal access token is already configured, this command simply displays
     a success message indicating that ggshield is already ready to use.
 
-    [1]: https://docs.gitguardian.com/api-docs/introduction#scopes
+    [1]: https://docs.gitguardian.com/api-docs/authentication#scopes
     """
     config = ContextObj.get(ctx).config
 


### PR DESCRIPTION
…ation

## Context

The `ggshield auth login -h` command displays help documentation that includes a link to GitGuardian API documentation about scopes. 

The help text was linking to `https://docs.gitguardian.com/api-docs/introduction#scopes` when it should point to `https://docs.gitguardian.com/api-docs/authentication#scopes`.

## What has been done

- Updated the documentation URL in the `login_cmd` function docstring in `ggshield/cmd/auth/login.py`
- Changed the reference link from the introduction page to the correct authentication page section

## Validation

To validate this fix:

1. Run `ggshield auth login -h`
2. Verify the help text now displays the correct link: `https://docs.gitguardian.com/api-docs/authentication#scopes`
3. Optionally, visit the link to confirm it leads to the correct documentation section about API scopes

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) but the PR has no changelog entry