### PR TITLE
chore: Remove clearlinux from os package testing

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -288,9 +288,6 @@ jobs:
           - rockylinux/rockylinux:8.8
           - rockylinux/rockylinux:9
           - opensuse/leap
-          # Test a distribution with no deb or rpm support
-          - clearlinux:latest
-
     steps:
       - name: Install requirements
         run: |
@@ -304,12 +301,6 @@ jobs:
               ;;
             opensuse*)
               zypper install -y git-core
-              ;;
-            clearlinux*)
-              # install libstdcpp: as of June 2025, libstdcpp is not part of clearlinux base image
-              # and it is needed by node in actions/download-artifact@v4
-              swupd bundle-add libstdcpp
-              swupd bundle-add git
               ;;
           esac
 

--- a/changelog.d/20251014_155609_salome.voltz_remove_test_on_clearlinux.md
+++ b/changelog.d/20251014_155609_salome.voltz_remove_test_on_clearlinux.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Changed
+
+- Removed Clear Linux from the OS package testing workflow as the project has been discontinued.
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
## Context

This merge request removes Clear Linux from the OS package testing workflow in our CI pipeline.
Intel has [officially discontinued the project](https://community.clearlinux.org/t/all-good-things-come-to-an-end-shutting-down-clear-linux-os/10716?utm_source=chatgpt.com). 