### PR TITLE
fix(secret): skip non-seekable files during scanning

### DIFF
--- a/changelog.d/20251020_174722_salome.voltz_scrt_5971_ggshield_runs_into_oserror_errno_22_invalid_argument_when.md
+++ b/changelog.d/20251020_174722_salome.voltz_scrt_5971_ggshield_runs_into_oserror_errno_22_invalid_argument_when.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Skip non-seekable files instead of crashing.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/scan/__init__.py
+++ b/ggshield/core/scan/__init__.py
@@ -2,7 +2,7 @@ from .commit import Commit
 from .file import File, create_files_from_paths
 from .scan_context import ScanContext
 from .scan_mode import ScanMode
-from .scannable import DecodeError, Scannable, StringScannable
+from .scannable import DecodeError, NonSeekableFileError, Scannable, StringScannable
 
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     "Commit",
     "DecodeError",
     "File",
+    "NonSeekableFileError",
     "ScanContext",
     "ScanMode",
     "Scannable",

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -16,6 +16,7 @@ from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.constants import MAX_WORKERS
 from ggshield.core.errors import handle_api_error
 from ggshield.core.scan import DecodeError, ScanContext, Scannable
+from ggshield.core.scan.scannable import NonSeekableFileError
 from ggshield.core.scanner_ui.scanner_ui import ScannerUI
 from ggshield.core.text_utils import pluralize
 
@@ -156,6 +157,9 @@ class SecretScanner:
                 content = scannable.content
             except DecodeError:
                 scanner_ui.on_skipped(scannable, "can't detect encoding")
+                continue
+            except NonSeekableFileError:
+                scanner_ui.on_skipped(scannable, "file cannot be seeked")
                 continue
 
             if content:


### PR DESCRIPTION
## Context

Ggshield crashes on scanning non-seekable files, to reproduce (only on linux): 
```
> cd test_folder/
> ln -s /proc/self/mounts ./mtab
> ls -l mtab #verify if the symbolic link is correctly set up
> ggshield secret scan path ./mtab
```
Should return: 
```
Scanning... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0 / 1

Error: [Errno 22] Invalid argument
```

Explicitly skip them with a message: 
<img width="942" height="230" alt="image" src="https://github.com/user-attachments/assets/22550fe5-f136-4262-879d-ed2e684c54ad" />

