### PR TITLE
chore: update py-gitguardian to v1.26.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "standalone", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:8f101bd7430ea257acda3c3862c07edd4f0158ff112086c31bc6a0377d92ae05"
+content_hash = "sha256:244bd753ab3dd6216a94c8fc5192581d895c60269955bbb6aa3e745423784feb"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -1687,11 +1687,8 @@ files = [
 
 [[package]]
 name = "pygitguardian"
-version = "1.25.0"
+version = "1.26.0"
 requires_python = ">=3.8"
-git = "https://github.com/GitGuardian/py-gitguardian.git"
-ref = "11aa57914dc9a3fb93db3579ddc4a0eab2fc8af2"
-revision = "11aa57914dc9a3fb93db3579ddc4a0eab2fc8af2"
 summary = "Python Wrapper for GitGuardian's API -- Scan security policy breaks everywhere"
 groups = ["default"]
 dependencies = [
@@ -1700,6 +1697,10 @@ dependencies = [
     "requests<3,>=2",
     "setuptools>=70.1.0",
     "typing-extensions",
+]
+files = [
+    {file = "pygitguardian-1.26.0-py3-none-any.whl", hash = "sha256:fa33ce78b436bf78e1677112367f622a5f61ce8ab13c9d9313d55b09ad80fe49"},
+    {file = "pygitguardian-1.26.0.tar.gz", hash = "sha256:a6d4aa7d117ce05a7e652f96699c0fbb9fe22011530c55e0162c718df803e91f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "marshmallow~=3.18.0",
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
-    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@11aa57914dc9a3fb93db3579ddc4a0eab2fc8af2",
+    "pygitguardian~=1.26.0",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",


### PR DESCRIPTION
Update `py-gitguardian` to v1.26.0