### PR TITLE
ci: update pdm to v2.26.0

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  PDM_VERSION: 2.22.4
+  PDM_VERSION: 2.26.0
 
 jobs:
   build_wheel_sdist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
       - 'README.md'
 
 env:
-  PDM_VERSION: 2.22.4
+  PDM_VERSION: 2.26.0
   DEFAULT_PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -11,7 +11,7 @@ on:
         default: '3.10'
 
 env:
-  PDM_VERSION: 2.22.4
+  PDM_VERSION: 2.26.0
   DEFAULT_PYTHON_VERSION: '3.10'
 
 jobs:


### PR DESCRIPTION
[httpcore <1.0.8 was relying on Union.__module__ that does not exist in python 3.14](https://github.com/encode/httpcore/discussions/995). Updating pdm resolves the issue upstream.