### PR TITLE
fix(pre-commit): handle unmerged files

### DIFF
--- a/changelog.d/20251113_114400_kevin.westphal_handle_unmerged_files.md
+++ b/changelog.d/20251113_114400_kevin.westphal_handle_unmerged_files.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Handle unmerged files in pre-commit scanning during an ongoing merge.
+<!--
+
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/scan/commit_utils.py
+++ b/ggshield/core/scan/commit_utils.py
@@ -160,6 +160,8 @@ class PatchFileInfo:
 
         if "M" in status:  # modify
             mode = Filemode.MODIFY
+        elif "U" in status:  # unmerged
+            mode = Filemode.UNMERGED
         elif "C" in status:  # copy
             mode = Filemode.NEW
         elif "A" in status:  # add

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -56,6 +56,7 @@ class Filemode(Enum):
     NEW = "new file"
     RENAME = "renamed file"
     FILE = "file"
+    UNMERGED = "unmerged file"
     UNKNOWN = "unknown"
 
 

--- a/tests/unit/cassettes/test_precommit_with_unmerged_files.yaml
+++ b/tests/unit/cassettes/test_precommit_with_unmerged_files.yaml
@@ -1,0 +1,210 @@
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.26.0 (Darwin;py3.11.13) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/metadata
+    response:
+      body:
+        string:
+          '{"version":"v2.331.0","preferences":{"marketplaces__aws_product_url":"http://aws.amazon.com/marketplace/pp/prodview-mrmulzykamba6","on_premise__restrict_signup":true,"on_premise__is_email_server_configured":true,"on_premise__default_sso_config_api_id":null,"on_premise__default_sso_config_force_sso":null,"onboarding__segmentation_v1_enabled":true,"onboarding__detectors_for_revocation":["github_fine_grained_pat","github_personal_access_token_v2","github_token","openai_admin_apikey","openai_apikey","openai_project_apikey","openai_project_apikey_v2"],"general__maximum_payload_size":26214400,"general__mutual_tls_mode":"disabled","general__signup_enabled":true},"secret_scan_preferences":{"maximum_documents_per_scan":20,"maximum_document_size":1048576},"remediation_messages":{"pre_commit":">
+          How to remediate\n\n  Since the secret was detected before the commit was
+          made:\n  1. replace the secret with its reference (e.g. environment variable).\n  2.
+          commit again.\n\n> [To apply with caution] If you want to bypass ggshield
+          (false positive or other reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield
+          git commit -m \"<your message\"","pre_push":"> How to remediate\n\n  Since
+          the secret was detected before the push BUT after the commit, you need to:\n  1.
+          rewrite the git history making sure to replace the secret with its reference
+          (e.g. environment variable).\n  2. push again.\n\n  To prevent having to rewrite
+          git history in the future, setup ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [Apply with caution] If you want to bypass ggshield (false positive or other
+          reason), run:\n  - if you use the pre-commit framework:\n\n    SKIP=ggshield-push
+          git push","pre_receive":"> How to remediate\n\n  A pre-receive hook set server
+          side prevented you from pushing secrets.\n\n  Since the secret was detected
+          during the push BUT after the commit, you need to:\n  1. rewrite the git history
+          making sure to replace the secret with its reference (e.g. environment variable).\n  2.
+          push again.\n\n  To prevent having to rewrite git history in the future, setup
+          ggshield as a pre-commit hook:\n    https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit\n\n>
+          [Apply with caution] If you want to bypass ggshield (false positive or other
+          reason), run:\n\n    git push -o breakglass"}}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, HEAD, OPTIONS
+        content-length:
+          - '2399'
+        content-security-policy:
+          - frame-ancestors 'none'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 13 Nov 2025 10:54:01 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.331.0
+        x-content-type-options:
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '34'
+        x-frame-options:
+          - DENY
+        x-secrets-engine-version:
+          - 2.150.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - pygitguardian/1.26.0 (Darwin;py3.11.13) ggshield
+      method: GET
+      uri: https://api.gitguardian.com/v1/api_tokens/self
+    response:
+      body:
+        string: '{"id":"775758eb-b33b-43e9-8ff7-4ce5f5cc73df","name":"ggshield-dev-token","type":"personal_access_token","scopes":["scan"],"member_id":1094429,"workspace_id":8,"created_at":"2025-11-13T08:27:47.394379Z","last_used_at":"2025-11-13T10:54:00Z","expire_at":"2026-05-12T08:27:47.366197Z","revoked_at":null,"status":"active","creator_id":1094429}'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - GET, DELETE, HEAD, OPTIONS
+        content-length:
+          - '339'
+        content-security-policy:
+          - frame-ancestors 'none'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 13 Nov 2025 10:54:03 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.331.0
+        x-content-type-options:
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '24'
+        x-frame-options:
+          - DENY
+        x-secrets-engine-version:
+          - 2.150.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '[{"filename": "commit://staged/conflict.txt", "document": "@@ -1 +1 @@\n-Version
+        from feature\n\\ No newline at end of file\n+Resolved version\n\\ No newline
+        at end of file"}]'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '175'
+        Content-Type:
+          - application/json
+        GGShield-Command-Id:
+          - 12964ae8-7cb5-430e-b403-0df6d90d0f8c
+        GGShield-Command-Path:
+          - cli secret scan pre-commit
+        GGShield-OS-Name:
+          - darwin
+        GGShield-OS-Version:
+          - 'Darwin Kernel Version 24.2.0: Fri Dec  6 18:56:34 PST 2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6020'
+        GGShield-Python-Version:
+          - 3.11.13
+        GGShield-Version:
+          - 1.44.1
+        User-Agent:
+          - pygitguardian/1.26.0 (Darwin;py3.11.13) ggshield
+        mode:
+          - pre_commit
+        scan_options:
+          - '{"show_secrets": false, "ignored_detectors_count": 0, "ignored_matches_count":
+            0, "ignored_paths_count": 14, "ignore_known_secrets": false, "with_incident_details":
+            false, "has_prereceive_remediation_message": false, "all_secrets": false,
+            "source_uuid": null}'
+      method: POST
+      uri: https://api.gitguardian.com/v1/multiscan?all_secrets=True
+    response:
+      body:
+        string: '[{"policy_break_count":0,"policies":["Secrets detection"],"policy_breaks":[],"is_diff":true}]'
+      headers:
+        access-control-expose-headers:
+          - X-App-Version
+        allow:
+          - POST, OPTIONS
+        content-length:
+          - '93'
+        content-security-policy:
+          - frame-ancestors 'none'
+        content-type:
+          - application/json
+        cross-origin-opener-policy:
+          - same-origin
+        date:
+          - Thu, 13 Nov 2025 10:54:04 GMT
+        referrer-policy:
+          - strict-origin-when-cross-origin
+        server:
+          - istio-envoy
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains
+        vary:
+          - Cookie
+        x-app-version:
+          - v2.331.0
+        x-content-type-options:
+          - nosniff
+        x-envoy-upstream-service-time:
+          - '125'
+        x-frame-options:
+          - DENY
+        x-secrets-engine-version:
+          - 2.150.0
+        x-xss-protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/unit/cmd/scan/test_precommit.py
+++ b/tests/unit/cmd/scan/test_precommit.py
@@ -128,3 +128,52 @@ def test_precommit_with_emoji_filename(tmp_path, cli_fs_runner):
         result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
     # Verify the command executed successfully
     assert_invoke_ok(result)
+
+
+@my_vcr.use_cassette("test_precommit_with_unmerged_files")
+def test_precommit_with_unmerged_files(tmp_path, cli_fs_runner):
+    """
+    GIVEN a repository with a merge conflict containing unmerged files
+    WHEN the precommit command is run
+    THEN it executes successfully and scans the conflicted files
+    """
+    # Create repository with initial commit
+    repo = Repository.create(tmp_path, initial_branch="master")
+    repo.create_commit("Initial commit on master")
+
+    # Create feature branch and add a file
+    repo.create_branch("feature_branch")
+    repo.checkout("master")
+    conflict_file = tmp_path / "conflict.txt"
+    conflict_file.write_text("Version from master")
+    non_conflict_file = tmp_path / "no_conflict.txt"
+    non_conflict_file.write_text("This file won't conflict")
+    repo.add(".")
+    repo.create_commit("Commit on master")
+
+    # Switch to feature branch and create conflicting change
+    repo.checkout("feature_branch")
+    conflict_file.write_text("Version from feature")
+    another_file = tmp_path / "feature.txt"
+    another_file.write_text("New file from feature")
+    repo.add(".")
+    repo.create_commit("Commit on feature_branch")
+
+    # Attempt merge which will create conflict
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        repo.git("merge", "master")
+
+    # Verify we have a conflict
+    stdout = exc.value.stdout.decode()
+    assert "CONFLICT" in stdout
+
+    # Resolve conflict and stage the resolution
+    conflict_file.write_text("Resolved version")
+    repo.add(conflict_file)
+
+    # Run pre-commit scan on the merge with unmerged files
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
+
+    # Verify the command executed successfully
+    assert_invoke_ok(result)

--- a/tests/unit/core/scan/test_commit.py
+++ b/tests/unit/core/scan/test_commit.py
@@ -20,6 +20,7 @@ Date:   Fri Oct 18 13:20:00 2012 +0100
     + ":000000 100644 0000000 19465ef A\0tests/test_scannable.py\0"
     + ":100644 100755 b4d3aef b4d3aef M\0bin/shutdown.sh\0"
     + ":000000 100644 0000000 12356ef A\0.env\0"
+    + ":000000 100644 0000000 12323ef U\0unmerged.txt\0"
     + ":100644 100644 ac204ec ac204ec R100\0ggshield/tests/test_config.py\0tests/test_config.py\0"
     + ":100644 100644 6546aef b41653f M\0data/utils/email_sender.py\0"
     + """\0diff --git a/ggshield/tests/cassettes/test_files_yes.yaml b/ggshield/tests/cassettes/test_files_yes.yaml


### PR DESCRIPTION
## Context

When calling `ggshield secret scan pre-commit` during an ongoing merge with unmerged files, `ggshield` throws an error. This PR fixes this.

Closes #1002

## What has been done

Unmerged files that are scanned by the pre-commit hook during an ongoing merge will be marked as unmerged and scanned if they contain diffs.

## Validation

See #1002 for a reproducible example.

## PR check list

- [X] As much as possible, the changes include tests (unit and/or functional)
- [X] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
