### PR TITLE
feat(auth): enable OS port selection for OAuth server  Use port 0 to …

### DIFF
--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -104,7 +104,6 @@ class OAuthClient:
         if extra_scopes is not None:
             self._extra_scopes = extra_scopes
 
-        self.158()
         self._redirect_to_login()
         self._wait_for_callback()
         self._print_login_success()


### PR DESCRIPTION
…allow OS to automatically assign available port, removing hardcoded port range (8000-8010) from _prepare_server method. This resolves port conflict issues when the OAuth server fails to bind to predefined ports. Fixes #913

Refactor server preparation to use a dynamic port.

## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
