### PR TITLE
fix: the GHE script does not generate an image anymore

### DIFF
--- a/scripts/create-ghe-environment
+++ b/scripts/create-ghe-environment
@@ -97,12 +97,12 @@ archive_path="$PWD/$image_name.tar.gz"
 
 log_progress "Building custom image, based on $distrib"
 # Sanity check
-if ! grep -q -- "-slim as build\$" "$ROOT_DIR/Dockerfile" ; then
+if ! grep -q -- "-slim AS build\$" "$ROOT_DIR/Dockerfile" ; then
     die "Dockerfile has changed, this script is outdated"
 fi
 
 # Modify the FROM command to use the distribution we want
-sed "s/-slim as build\$/-slim-$distrib as build/" "$ROOT_DIR/Dockerfile" \
+sed "s/-slim AS build\$/-slim-$distrib AS build/" "$ROOT_DIR/Dockerfile" \
     | docker build --tag "$image_name" --file - "$ROOT_DIR"
 
 log_progress "Building container from image"


### PR DESCRIPTION
## Context

The script to generate a GHE environment was failing.

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

The sanity check fails because "(...)slim as build" has been changed to "slim AS build" in the root Dockerfile.

## Validation

- Run `./scripts/create-ghe-environment 3.11` → the script runs and produce a valid tarball

