### PR TITLE
Improve --type option documentation for hmsl check command

### DIFF
--- a/ggshield/cmd/hmsl/hmsl_common_options.py
+++ b/ggshield/cmd/hmsl/hmsl_common_options.py
@@ -38,7 +38,7 @@ input_type_option = click.option(
     help="""Type of input to process.
 
             \b
-            - `file`: the input is a simple file containing secrets.
+            - `file`: the input is a text file containing secrets. One line per secret.
             - `env`: the input is a file containing environment variables.""",
     callback=lambda _, __, value: InputType[value.upper()],
 )


### PR DESCRIPTION
## Context

Some users have complained about the lack of details in the doc about the input format for `ggshield hmsl check`.

## What has been done

We just update the desciption for the option `--type`. This will be automatically added to the public doc. 
