### PR TITLE
feat(git-hooks): set repo remote fallback with env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,11 @@ GITGUARDIAN_INSTANCE=https://dashboard.gitguardian.com/
 
 # Used by functional tests for the --ignore-known-secrets feature
 # Set this to a single-match secret known by your dashboard
-#TEST_KNOWN_SECRET=
+# TEST_KNOWN_SECRET=
 # Set this to a single-match secret unknown by your dashboard. Unlike
 # TEST_KNOWN_SECRET, this one has a default value, so you do not have to set
 # it unless the default value does not work for you
-#TEST_UNKNOWN_SECRET=
+# TEST_UNKNOWN_SECRET=
 
 # You might need to set those 2 vars to run tests
 # - push a valid GitGuardian test token in your workspace
@@ -16,3 +16,7 @@ GITGUARDIAN_INSTANCE=https://dashboard.gitguardian.com/
 # - and set TEST_GG_VALID_TOKEN_IGNORE_SHA to matching commit sha
 # TEST_GG_VALID_TOKEN=
 # TEST_GG_VALID_TOKEN_IGNORE_SHA=
+
+# Fallback value for the repository remote URL in case it cannot be determined using `git remote -v`
+# This variable is particularly relevant when running ggshield in a git pre-receive hook
+# GITGUARDIAN_GIT_REMOTE_FALLBACK_URL=

--- a/changelog.d/20251210_173258_kevin.westphal_set_repo_url_in_env_var.md
+++ b/changelog.d/20251210_173258_kevin.westphal_set_repo_url_in_env_var.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Add `GITGUARDIAN_GIT_REMOTE_FALLBACK_URL` environment variable that allows setting a fallback value for the repository remote.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -85,6 +85,10 @@ def prereceive_cmd(
 ) -> int:
     """
     Scan as a pre-receive git hook all commits about to enter the remote git repository.
+
+    The GITGUARDIAN_GIT_REMOTE_FALLBACK_URL environment variable can be set to provide
+    a fallback repository URL when it cannot be detected from the git remote
+    configuration.
     """
     ctx_obj = ContextObj.get(ctx)
     ctx_obj.client = create_client_from_config(ctx_obj.config)

--- a/ggshield/core/env_utils.py
+++ b/ggshield/core/env_utils.py
@@ -14,6 +14,7 @@ TRACKED_ENV_VARS = {
     "GITGUARDIAN_INSTANCE",
     "GITGUARDIAN_API_URL",
     "GITGUARDIAN_API_KEY",
+    "GITGUARDIAN_GIT_REMOTE_FALLBACK_URL",
 }
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Closes #1158

## Context

In some configurations ggshield runs in repositories without a configured remote, for example when running in a git pre-receive hook.

## What has been done

This commit adds a `REPOSITORY_REMOTE_FALLBACK` environment variable for setting a fallback value for the remote URL.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
