### PR TITLE
chore: obfuscate tokens when running ggshield config list

### DIFF
--- a/changelog.d/20251223_105741_severine.bonnechere_obfuscate_api_keys_listing.md
+++ b/changelog.d/20251223_105741_severine.bonnechere_obfuscate_api_keys_listing.md
@@ -1,0 +1,3 @@
+### Added
+
+- Tokens are obfuscated in `ggshield config list` output.

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -11,6 +11,7 @@ from ggshield.cmd.utils.common_options import (
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config.auth_config import InstanceConfig
+from ggshield.core.filter import censor_string
 
 from .constants import DATETIME_FORMAT, FIELDS
 
@@ -47,7 +48,7 @@ def get_instance_info(
 
     if account is not None:
         workspace_id = account.workspace_id
-        token = account.token
+        token = censor_string(account.token)
         token_name = account.token_name
         expire_at = account.expire_at
         expiry = expire_at.strftime(DATETIME_FORMAT) if expire_at else "never"

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -27,7 +27,7 @@ default_token_lifetime: None
 default_token_lifetime: None
 workspace_id: 1
 url: https://dashboard.gitguardian.com
-token: some token
+token: so** ***en
 token_name: some token name
 expiry: 2022-05-04T17:00:00Z
 
@@ -35,7 +35,7 @@ expiry: 2022-05-04T17:00:00Z
 default_token_lifetime: None
 workspace_id: 1
 url: https://some-gg-instance.com
-token: some token
+token: so** ***en
 token_name: first token
 expiry: 2022-05-04T17:00:00Z
 


### PR DESCRIPTION
## Context

Tokens were listed in clear when running `ggshield config list` in terminal.

## What has been done

Tokens are now obfuscated with `*` characters.

```bash
$ ggshield config list
instance: None
default_token_lifetime: None

[https://dashboard.gitguardian.com]
default_token_lifetime: None
workspace_id: 385637
url: https://dashboard.gitguardian.com
token: DX76F091de3f***********************************************2aC9a88ba7bb
token_name: ggshield token 2025-12-23
expiry: never

[https://dashboard.staging.gitguardian.tech]
default_token_lifetime: None
workspace_id: 1
url: https://dashboard.staging.gitguardian.tech
token: fB8ee05Eb0C5***********************************************c6aEd7415efd
token_name: ggshield token 2024-10-23
expiry: never

[https://dashboard.eu1.gitguardian.com]
default_token_lifetime: None
workspace_id: 1
url: https://dashboard.eu1.gitguardian.com
token: B506dGFAbcBb***********************************************85C8C85e786F
token_name: ggshield token 2025-01-13
expiry: never

[https://dashboard.preprod.gitguardian.com]
default_token_lifetime: None
workspace_id: 1
url: https://dashboard.preprod.gitguardian.com
token: 98BD4b3DeFf6***********************************************Fc9cC5E8d38F
token_name: ggshield token 2024-12-11
expiry: 2025-12-11T13:40:13Z
```

## Validation

- Run `ggshield config list` and check that tokens are well obfuscated.
- Also validated by updated test.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
