### PR TITLE
chore: support higher versions of GHE

### DIFF
--- a/changelog.d/20260306_151518_severine.bonnechere_scrt_6571_ghe_pre_receive_hook_scriptdocs_out_of_date.md
+++ b/changelog.d/20260306_151518_severine.bonnechere_scrt_6571_ghe_pre_receive_hook_scriptdocs_out_of_date.md
@@ -1,0 +1,7 @@
+### Added
+
+- Pre-receive hook can now be setup on GitHub Enterprise Server from v3.14 to higher.
+
+### Removed
+
+- Pre-receive hook on GitHub Enterprise Server v3.9 to v3.13 is no longer supported. v3.13 is EOL since [2025-06-19](https://docs.github.com/en/enterprise-server@3.13/admin/release-notes) and previous versions were discontinued earlier.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,4 +26,4 @@ Creates a GitHub Enterprise Server (GHES) [pre-receive hook environment][ghe] co
 
 To run this script you must have Docker installed. The script must be run on the same machine architecture as the GHES server on which the environment will be uploaded.
 
-[ghe]: https://docs.github.com/en/enterprise-server@3.11/admin/policies/enforcing-policy-with-pre-receive-hooks/creating-a-pre-receive-hook-environment
+[ghe]: https://docs.github.com/en/enterprise-server@3.20/admin/policies/enforcing-policy-with-pre-receive-hooks/creating-a-pre-receive-hook-environment

--- a/scripts/create-ghe-environment
+++ b/scripts/create-ghe-environment
@@ -5,11 +5,6 @@ PROGNAME=$(basename "$0")
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." ; pwd)
 
-declare -A DISTRIB_FOR_GHE_VERSION
-DISTRIB_FOR_GHE_VERSION["3.9"]="buster"
-DISTRIB_FOR_GHE_VERSION["3.10"]="buster"
-DISTRIB_FOR_GHE_VERSION["3.11"]="bookworm"
-
 die() {
     echo "$PROGNAME: $*" >&2
     exit 1
@@ -31,15 +26,6 @@ log_progress() {
     echo "$PROGNAME: $*" >&2
 }
 
-select_distrib() {
-    local wanted_version="$1"
-    local distrib=${DISTRIB_FOR_GHE_VERSION[$wanted_version]:-}
-    if [ -z "$distrib" ] ; then
-        usage "'$wanted_version' is not a supported GitHub Enterprise version."
-    fi
-    echo "$distrib"
-}
-
 usage() {
     if [ "$*" != "" ] ; then
         echo "Error: $*" >&2
@@ -47,12 +33,10 @@ usage() {
     fi
 
     cat << EOF
-Usage: $PROGNAME [OPTION ...] [GHE_VERSION]
+Usage: $PROGNAME [OPTION ...]
 Creates a GitHub Enterprise pre-receive hook environment for GGShield.
 
 Expects GitGuardian API key to be set in \$GITGUARDIAN_API_KEY.
-
-GHE_VERSION must be one of: ${!DISTRIB_FOR_GHE_VERSION[@]}.
 
 Options:
   -h, --help          display this usage message and exit
@@ -61,37 +45,25 @@ EOF
     exit 1
 }
 
-ghe_version=""
 while [ $# -gt 0 ] ; do
     case "$1" in
     -h|--help)
         usage
         ;;
-    -*)
-        usage "Unknown option '$1'"
-        ;;
     *)
-        if [ -z "$ghe_version" ] ; then
-            ghe_version="$1"
-        else
-            usage "Too many arguments"
-        fi
+        usage "Unknown option '$1'"
         ;;
     esac
     shift
 done
 
-if [ -z "$ghe_version" ] ; then
-    usage "Not enough arguments"
-fi
-
 if [ -z "${GITGUARDIAN_API_KEY:-}" ] ; then
     die "\$GITGUARDIAN_API_KEY environment variable not set"
 fi
 
-distrib=$(select_distrib "$ghe_version")
+distrib="trixie"
 
-image_name=ggshield-ghe-$ghe_version
+image_name=ggshield-ghe
 container_name=ggshield-ghe
 archive_path="$PWD/$image_name.tar.gz"
 


### PR DESCRIPTION
## Context

The pre-receive hook installation script could work for higher versions than 3.11 only if version 3.11 was indicated.

Besides:
- GitHub Enterprise Server versions 3.13 and lower aren't supported anymore (cf [here](https://docs.github.com/en/enterprise-server@3.13/admin/release-notes))
- "trixie" is the current version for python debian images.

## What has been done

Updated pre-receive hook installation script to always fetch "trixie" image and drop support of deprecated GHE versions.

Don't ask for GHE version as it isn't needed anymore.

## Validation

Validation was done manually by SE, I can provide more info to the reviewer.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
