### PR TITLE
feat(auth): use keyring to store gitguardian api token

### DIFF
--- a/changelog.d/20260401_115738_6d7a_ggshield_encrypt_local_api_tokens_and_prevent_cleartext.md
+++ b/changelog.d/20260401_115738_6d7a_ggshield_encrypt_local_api_tokens_and_prevent_cleartext.md
@@ -1,0 +1,3 @@
+### Added
+
+- API tokens are now stored in the OS credential store (macOS Keychain, Windows Credential Locker, Linux Secret Service) via the `keyring` library instead of cleartext in `auth_config.yaml`. Existing cleartext tokens are migrated automatically the next time the configuration is saved. If no OS credential store is available or `GGSHIELD_NO_KEYRING=1`, file-based storage is used as a fall-back.

--- a/doc/schemas/api-status.json
+++ b/doc/schemas/api-status.json
@@ -18,7 +18,7 @@
       "description": "Source the instance was read from"
     },
     "api_key_source": {
-      "enum": ["DOTENV", "ENV_VAR", "USER_CONFIG"],
+      "enum": ["DOTENV", "ENV_VAR", "KEYRING", "USER_CONFIG"],
       "description": "Source the API key was read from"
     },
     "detail": {

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import click
@@ -8,8 +9,12 @@ from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
+from ggshield.core.config.token_store import get_token_store
 from ggshield.core.errors import AuthError, UnexpectedError
 from ggshield.core.url_utils import dashboard_to_api_url
+
+
+logger = logging.getLogger(__name__)
 
 
 CONNECTION_ERROR_MESSAGE = (
@@ -117,6 +122,17 @@ def delete_account_config(config: Config, instance: str) -> None:
     account_config = instance_config.account
 
     assert account_config is not None
+
+    store = get_token_store()
+    if store.uses_external_storage:
+        try:
+            store.delete_token(instance_config.url)
+        except Exception:
+            logger.warning(
+                "Failed to delete token from keyring for %s",
+                instance,
+                exc_info=True,
+            )
 
     instance_config.account = None
     config.auth_config.set_instance(instance_config)

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -6,6 +7,11 @@ from typing import Any, Dict, List, Optional, cast
 import marshmallow_dataclass
 from pygitguardian.models_utils import FromDictMixin, ToDictMixin
 
+from ggshield.core.config.token_store import (
+    KEYRING_SENTINEL,
+    TokenStore,
+    get_token_store,
+)
 from ggshield.core.config.utils import (
     get_auth_config_filepath,
     load_yaml_dict,
@@ -18,6 +24,9 @@ from ggshield.core.errors import (
     UnknownInstanceError,
 )
 from ggshield.utils.datetime import datetime_from_isoformat
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -107,6 +116,23 @@ def prepare_auth_config_dict_for_save(data: Dict[str, Any]) -> Dict[str, Any]:
     return data
 
 
+def _replace_tokens_with_sentinel(
+    data: Dict[str, Any], fallback_urls: set[str]
+) -> None:
+    """Replace real tokens with the keyring sentinel in the serialized dict,
+    except for instances that failed keyring storage."""
+    for instance in data.get("instances", []):
+        if instance.get("url") in fallback_urls:
+            continue
+        for account in instance.get("accounts", []):
+            if (
+                account is not None
+                and account.get("token")
+                and account["token"] != KEYRING_SENTINEL
+            ):
+                account["token"] = KEYRING_SENTINEL
+
+
 @dataclass
 class AuthConfig(FromDictMixin, ToDictMixin):
     """
@@ -119,18 +145,41 @@ class AuthConfig(FromDictMixin, ToDictMixin):
 
     @classmethod
     def load(cls) -> "AuthConfig":
-        """Load the auth config from the app config file"""
+        """Load the auth config from the app config file.
+
+        If the active token store is a keyring backend, tokens marked with the
+        keyring sentinel are hydrated from the OS credential store.
+        """
         config_path = get_auth_config_filepath()
 
         data = load_yaml_dict(config_path)
         if data:
             data = prepare_auth_config_dict_for_parse(data)
-            return cls.from_dict(data)
-        return cls()
+            instance = cls.from_dict(data)
+        else:
+            instance = cls()
+
+        store = get_token_store()
+        if store.uses_external_storage:
+            for inst in instance.instances:
+                cls._hydrate_from_keyring(store, inst)
+        else:
+            for inst in instance.instances:
+                cls._warn_sentinel_without_keyring(inst)
+
+        return instance
 
     def save(self) -> None:
         config_path = get_auth_config_filepath()
+        store = get_token_store()
         data = prepare_auth_config_dict_for_save(self.to_dict())
+
+        if store.uses_external_storage:
+            fallback_urls: set[str] = set()
+            for inst in self.instances:
+                self._persist_to_keyring(store, inst, fallback_urls)
+            _replace_tokens_with_sentinel(data, fallback_urls)
+
         save_yaml_dict(data, config_path, restricted=True)
 
     def get_instance(self, instance_name: str) -> InstanceConfig:
@@ -168,9 +217,69 @@ class AuthConfig(FromDictMixin, ToDictMixin):
         instance = self.get_instance(instance_name)
         if instance.expired:
             raise AuthExpiredError(instance=instance_name)
-        if instance.account is None:
+        if instance.account is None or not instance.account.token:
             raise MissingTokenError(instance=instance_name)
         return instance.account.token
+
+    @staticmethod
+    def _hydrate_from_keyring(store: TokenStore, inst: InstanceConfig) -> None:
+        if inst.account is None or inst.account.token != KEYRING_SENTINEL:
+            return
+        try:
+            token = store.get_token(inst.url)
+        except Exception:
+            logger.warning(
+                "Failed to retrieve token from keyring for %s",
+                inst.url,
+                exc_info=True,
+            )
+            token = None
+
+        if token is not None:
+            inst.account.token = token
+        else:
+            logger.warning(
+                "Token for %s was expected in keyring but not found. "
+                "Re-authenticate with 'ggshield auth login'.",
+                inst.url,
+            )
+            # Preserve account metadata; only clear the token so
+            # that a subsequent save() does not destroy the config.
+            inst.account.token = ""
+
+    @staticmethod
+    def _warn_sentinel_without_keyring(inst: InstanceConfig) -> None:
+        if inst.account is None or inst.account.token != KEYRING_SENTINEL:
+            return
+        logger.warning(
+            "Token for %s is stored in keyring but keyring is disabled. "
+            "Unset GGSHIELD_NO_KEYRING or re-authenticate with "
+            "'ggshield auth login'.",
+            inst.url,
+        )
+        inst.account.token = ""
+
+    @staticmethod
+    def _persist_to_keyring(
+        store: TokenStore,
+        inst: InstanceConfig,
+        fallback_urls: set[str],
+    ) -> None:
+        if (
+            inst.account is None
+            or not inst.account.token
+            or inst.account.token == KEYRING_SENTINEL
+        ):
+            return
+        try:
+            store.store_token(inst.url, inst.account.token)
+        except Exception:
+            logger.warning(
+                "Failed to store token in keyring for %s, storing in config file",
+                inst.url,
+                exc_info=True,
+            )
+            fallback_urls.add(inst.url)
 
 
 AuthConfig.SCHEMA = marshmallow_dataclass.class_schema(AuthConfig)()

--- a/ggshield/core/config/config.py
+++ b/ggshield/core/config/config.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Set, Tuple
 import click
 
 from ggshield.core.config.auth_config import AuthConfig
+from ggshield.core.config.token_store import get_token_store
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import remove_url_trailing_slash
 from ggshield.core.constants import DEFAULT_HMSL_URL, DEFAULT_INSTANCE_URL
@@ -28,6 +29,7 @@ class ConfigSource(Enum):
     CMD_OPTION = "command line option"
     DOTENV = ".env file"
     ENV_VAR = "environment variable"
+    KEYRING = "keyring"
     USER_CONFIG = "user config"
     DEFAULT = "default"
 
@@ -196,7 +198,12 @@ class Config:
             )
         except KeyError:
             key = self.auth_config.get_instance_token(self.instance_name)
-            source = ConfigSource.USER_CONFIG
+            store = get_token_store()
+            source = (
+                ConfigSource.KEYRING
+                if store.uses_external_storage
+                else ConfigSource.USER_CONFIG
+            )
         return key, source
 
     def add_ignored_match(self, *args: Any, **kwargs: Any) -> None:

--- a/ggshield/core/config/token_store.py
+++ b/ggshield/core/config/token_store.py
@@ -1,0 +1,128 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import keyring
+import keyring.backends.fail
+import keyring.errors
+
+from ggshield.utils.os import getenv_bool
+
+
+logger = logging.getLogger(__name__)
+
+KEYRING_SERVICE = "ggshield"
+KEYRING_SENTINEL = "__KEYRING__"
+
+
+class TokenStore(ABC):
+    """Abstract base class for token storage backends."""
+
+    @property
+    @abstractmethod
+    def uses_external_storage(self) -> bool:
+        """Whether tokens are stored externally and should be replaced
+        with sentinels in the YAML config file."""
+        ...
+
+    @abstractmethod
+    def store_token(self, instance_url: str, token: str) -> None: ...
+
+    @abstractmethod
+    def get_token(self, instance_url: str) -> Optional[str]: ...
+
+    @abstractmethod
+    def delete_token(self, instance_url: str) -> None: ...
+
+    @abstractmethod
+    def is_available(self) -> bool: ...
+
+
+class KeyringTokenStore(TokenStore):
+    """Stores tokens in the OS credential store via the keyring library."""
+
+    @property
+    def uses_external_storage(self) -> bool:
+        return True
+
+    def store_token(self, instance_url: str, token: str) -> None:
+        keyring.set_password(KEYRING_SERVICE, instance_url, token)
+
+    def get_token(self, instance_url: str) -> Optional[str]:
+        return keyring.get_password(KEYRING_SERVICE, instance_url)
+
+    def delete_token(self, instance_url: str) -> None:
+        try:
+            keyring.delete_password(KEYRING_SERVICE, instance_url)
+        except keyring.errors.PasswordDeleteError:
+            logger.debug("No keyring entry to delete for instance %s", instance_url)
+
+    def is_available(self) -> bool:
+        """Check if keyring is usable by probing with a test key."""
+        try:
+            kr = keyring.get_keyring()
+            if isinstance(kr, keyring.backends.fail.Keyring):
+                return False
+            # Probe the backend to verify it actually works (e.g. a
+            # ChainerBackend may pass the isinstance check but still fail).
+            probe_key = "__ggshield_probe__"
+            keyring.set_password(KEYRING_SERVICE, probe_key, "test")
+            val = keyring.get_password(KEYRING_SERVICE, probe_key)
+            try:
+                keyring.delete_password(KEYRING_SERVICE, probe_key)
+            except Exception:
+                logger.debug("Failed to clean up keyring probe key")
+            return val == "test"
+        except Exception:
+            return False
+
+
+class FileTokenStore(TokenStore):
+    """Fallback: tokens remain in the YAML config file."""
+
+    @property
+    def uses_external_storage(self) -> bool:
+        return False
+
+    def store_token(self, instance_url: str, token: str) -> None:
+        pass
+
+    def get_token(self, instance_url: str) -> Optional[str]:
+        return None
+
+    def delete_token(self, instance_url: str) -> None:
+        pass
+
+    def is_available(self) -> bool:
+        return True
+
+
+_token_store: Optional[TokenStore] = None
+
+
+def get_token_store() -> TokenStore:
+    """Return the active token store, selecting keyring when available."""
+    global _token_store
+    if _token_store is not None:
+        return _token_store
+
+    if getenv_bool("GGSHIELD_NO_KEYRING", default=False):
+        logger.debug("Keyring disabled via GGSHIELD_NO_KEYRING env var")
+        _token_store = FileTokenStore()
+        return _token_store
+
+    store = KeyringTokenStore()
+    if store.is_available():
+        _token_store = store
+    else:
+        logger.debug(
+            "Keyring is not available, falling back to file-based token storage"
+        )
+        _token_store = FileTokenStore()
+    return _token_store
+
+
+def reset_token_store() -> None:
+    """Reset the cached token store. Used in tests."""
+    global _token_store
+    _token_store = None

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -336,6 +336,9 @@ class OAuthClient:
             self.instance_config.account = None
             return False
 
+        # Trigger a save to migrate cleartext tokens to keyring if needed
+        self.config.auth_config.save()
+
         message = "ggshield is already authenticated "
         if account.expire_at:
             message += "until " + get_pretty_date(account.expire_at)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "urllib3>=2.2.2,<3",
     "truststore>=0.10.1; python_version >= \"3.10\"",
     "notify-py>=0.3.43",
+    "keyring>=24.0.0,<26",
 ]
 
 [project.urls]

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -1,11 +1,12 @@
 from typing import Optional, Tuple
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from requests.exceptions import ConnectionError
 
 from ggshield.__main__ import cli
 from ggshield.core.config import Config
+from ggshield.core.config.token_store import KeyringTokenStore, reset_token_store
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode
 
@@ -77,8 +78,7 @@ class TestAuthLogout:
             )
         else:
             expected_output += (
-                "Your personal access token has been removed "
-                "from your configuration.\n"
+                "Your personal access token has been removed from your configuration.\n"
             )
 
         assert output == expected_output
@@ -158,6 +158,39 @@ class TestAuthLogout:
             assert instance.account is None, output
 
         assert exit_code == ExitCode.SUCCESS, output
+
+    def test_logout_deletes_from_keyring(self, monkeypatch, cli_fs_runner):
+        """
+        GIVEN a saved instance configuration with keyring enabled
+        WHEN running the logout command with --no-revoke
+        THEN the token is deleted from keyring
+        """
+        reset_token_store()
+
+        mock_store = KeyringTokenStore()
+        mock_store.delete_token = MagicMock()
+        mock_store.store_token = MagicMock()
+        mock_store.is_available = MagicMock(return_value=True)
+
+        add_instance_config()
+
+        with (
+            patch(
+                "ggshield.cmd.auth.logout.get_token_store",
+                return_value=mock_store,
+            ),
+            patch(
+                "ggshield.core.config.auth_config.get_token_store",
+                return_value=mock_store,
+            ),
+        ):
+            exit_code, output = self.run_cmd(
+                cli_fs_runner, DEFAULT_INSTANCE_URL, revoke=False
+            )
+
+        assert exit_code == ExitCode.SUCCESS, output
+        mock_store.delete_token.assert_called_once_with(DEFAULT_INSTANCE_URL)
+        reset_token_store()
 
     @staticmethod
     def run_cmd(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -800,6 +800,22 @@ def make_fake_path_inaccessible(fs: FakeFilesystem, path: Union[str, Path]):
 
 
 @pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    """Prevent tests from touching the real OS keyring.
+
+    Sets GGSHIELD_NO_KEYRING=1 and resets the cached token store so every test
+    starts with a FileTokenStore.  Tests that explicitly need keyring behaviour
+    should mock the store directly.
+    """
+    from ggshield.core.config.token_store import reset_token_store
+
+    monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
+    reset_token_store()
+    yield
+    reset_token_store()
+
+
+@pytest.fixture(autouse=True)
 def clear_cache():
     _get_git_path.cache_clear()
     _git_rev_parse_absolute.cache_clear()

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -2,6 +2,7 @@ import os
 import re
 from copy import deepcopy
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,6 +10,11 @@ from ggshield.core.config import Config
 from ggshield.core.config.auth_config import (
     InstanceConfig,
     prepare_auth_config_dict_for_save,
+)
+from ggshield.core.config.token_store import (
+    KEYRING_SENTINEL,
+    KeyringTokenStore,
+    reset_token_store,
 )
 from ggshield.core.config.utils import get_auth_config_filepath
 from ggshield.core.errors import UnknownInstanceError
@@ -160,3 +166,265 @@ class TestAuthConfig:
         assert instance.account.expire_at == datetime(
             2022, 10, 17, 11, 55, 6, tzinfo=timezone.utc
         )
+
+
+@pytest.fixture(autouse=False)
+def _reset_token_store():
+    reset_token_store()
+    yield
+    reset_token_store()
+
+
+@pytest.mark.usefixtures("isolated_fs", "_reset_token_store")
+class TestAuthConfigKeyring:
+    """Tests for keyring integration in AuthConfig load/save."""
+
+    def test_save_with_keyring(self, monkeypatch):
+        """
+        GIVEN a config with a cleartext token
+        WHEN saving with keyring enabled
+        THEN the token is stored in keyring and the YAML contains the sentinel
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
+
+        stored_tokens = {}
+        mock_store = KeyringTokenStore()
+        mock_store.store_token = MagicMock(
+            side_effect=lambda url, token: stored_tokens.update({url: token})
+        )
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+            original_token = config.auth_config.instances[0].account.token
+            config.auth_config.save()
+
+        # Verify token was sent to keyring
+        assert "https://dashboard.gitguardian.com" in stored_tokens
+        assert stored_tokens["https://dashboard.gitguardian.com"] == original_token
+
+        # Verify YAML has sentinel, not cleartext
+        import yaml
+
+        with open(get_auth_config_filepath()) as f:
+            saved_data = yaml.safe_load(f)
+
+        for instance in saved_data["instances"]:
+            for account in instance["accounts"]:
+                assert account["token"] == KEYRING_SENTINEL
+
+    def test_load_with_keyring(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens
+        WHEN loading with keyring enabled
+        THEN tokens are hydrated from keyring
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        # Write config with sentinel tokens
+        sentinel_config = deepcopy(TEST_AUTH_CONFIG)
+        for instance in sentinel_config["instances"]:
+            for account in instance["accounts"]:
+                account["token"] = KEYRING_SENTINEL
+        write_yaml(get_auth_config_filepath(), sentinel_config)
+
+        real_token = "real-token-from-keyring"
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock(return_value=real_token)
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+
+        assert config.auth_config.instances[0].account.token == real_token
+        assert config.auth_config.instances[1].account.token == real_token
+
+    def test_load_keyring_missing_token(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel
+        WHEN the keyring returns None for a token
+        THEN the account metadata is preserved but the token is cleared
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        sentinel_config = deepcopy(TEST_AUTH_CONFIG)
+        for instance in sentinel_config["instances"]:
+            for account in instance["accounts"]:
+                account["token"] = KEYRING_SENTINEL
+        write_yaml(get_auth_config_filepath(), sentinel_config)
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock(return_value=None)
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+
+        # Account metadata is preserved, only the token is cleared
+        assert config.auth_config.instances[0].account is not None
+        assert config.auth_config.instances[0].account.token == ""
+        assert config.auth_config.instances[0].account.token_name == "my_token"
+        assert config.auth_config.instances[1].account is not None
+        assert config.auth_config.instances[1].account.token == ""
+
+    def test_migration_cleartext_to_keyring(self, monkeypatch):
+        """
+        GIVEN a legacy config with cleartext tokens
+        WHEN loading and saving with keyring enabled
+        THEN tokens are migrated to keyring and YAML gets sentinels
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
+
+        stored_tokens = {}
+        mock_store = KeyringTokenStore()
+        mock_store.store_token = MagicMock(
+            side_effect=lambda url, token: stored_tokens.update({url: token})
+        )
+        mock_store.get_token = MagicMock(side_effect=lambda url: stored_tokens.get(url))
+        mock_store.is_available = MagicMock(return_value=True)
+
+        # Load with cleartext (no sentinel, so no keyring lookup)
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+
+        # Tokens should be loaded from YAML (cleartext)
+        original_token_0 = TEST_AUTH_CONFIG["instances"][0]["accounts"][0]["token"]
+        original_token_1 = TEST_AUTH_CONFIG["instances"][1]["accounts"][0]["token"]
+        assert config.auth_config.instances[0].account.token == original_token_0
+        assert config.auth_config.instances[1].account.token == original_token_1
+
+        # Save triggers migration
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config.auth_config.save()
+
+        # Verify tokens were stored in keyring
+        assert len(stored_tokens) == 2
+        assert stored_tokens["https://dashboard.gitguardian.com"] == original_token_0
+
+        # Verify YAML now has sentinels
+        import yaml
+
+        with open(get_auth_config_filepath()) as f:
+            saved_data = yaml.safe_load(f)
+        for instance in saved_data["instances"]:
+            for account in instance["accounts"]:
+                assert account["token"] == KEYRING_SENTINEL
+
+    def test_save_fallback_on_keyring_error(self, monkeypatch):
+        """
+        GIVEN a config with tokens
+        WHEN keyring raises an error during save
+        THEN cleartext tokens are preserved in YAML
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
+
+        mock_store = KeyringTokenStore()
+        mock_store.store_token = MagicMock(side_effect=RuntimeError("keyring broken"))
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+            config.auth_config.save()
+
+        # Verify YAML still has cleartext tokens (not sentinels)
+        import yaml
+
+        with open(get_auth_config_filepath()) as f:
+            saved_data = yaml.safe_load(f)
+
+        original_token_0 = TEST_AUTH_CONFIG["instances"][0]["accounts"][0]["token"]
+        assert saved_data["instances"][0]["accounts"][0]["token"] == original_token_0
+
+    def test_load_keyring_get_token_exception(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel
+        WHEN get_token raises an exception
+        THEN the account metadata is preserved and the token is cleared
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        sentinel_config = deepcopy(TEST_AUTH_CONFIG)
+        for instance in sentinel_config["instances"]:
+            for account in instance["accounts"]:
+                account["token"] = KEYRING_SENTINEL
+        write_yaml(get_auth_config_filepath(), sentinel_config)
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock(side_effect=RuntimeError("keyring locked"))
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+
+        assert config.auth_config.instances[0].account is not None
+        assert config.auth_config.instances[0].account.token == ""
+        assert config.auth_config.instances[0].account.token_name == "my_token"
+
+    def test_load_sentinel_without_keyring(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens
+        WHEN loading with GGSHIELD_NO_KEYRING=1 (keyring disabled)
+        THEN the token is cleared and a warning is logged
+        """
+        monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
+
+        sentinel_config = deepcopy(TEST_AUTH_CONFIG)
+        for instance in sentinel_config["instances"]:
+            for account in instance["accounts"]:
+                account["token"] = KEYRING_SENTINEL
+        write_yaml(get_auth_config_filepath(), sentinel_config)
+
+        config = Config()
+
+        # Sentinel is detected and cleared rather than sent as an API token
+        assert config.auth_config.instances[0].account is not None
+        assert config.auth_config.instances[0].account.token == ""
+        assert config.auth_config.instances[1].account is not None
+        assert config.auth_config.instances[1].account.token == ""
+
+    def test_file_store_preserves_cleartext(self, monkeypatch):
+        """
+        GIVEN GGSHIELD_NO_KEYRING=1
+        WHEN saving config
+        THEN tokens remain in cleartext in YAML
+        """
+        monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
+
+        write_yaml(get_auth_config_filepath(), TEST_AUTH_CONFIG)
+        config = Config()
+        config.auth_config.save()
+
+        import yaml
+
+        with open(get_auth_config_filepath()) as f:
+            saved_data = yaml.safe_load(f)
+
+        original_token = TEST_AUTH_CONFIG["instances"][0]["accounts"][0]["token"]
+        assert saved_data["instances"][0]["accounts"][0]["token"] == original_token

--- a/tests/unit/core/config/test_token_store.py
+++ b/tests/unit/core/config/test_token_store.py
@@ -1,0 +1,165 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ggshield.core.config.token_store import (
+    KEYRING_SENTINEL,
+    KEYRING_SERVICE,
+    FileTokenStore,
+    KeyringTokenStore,
+    get_token_store,
+    reset_token_store,
+)
+
+
+INSTANCE_URL = "https://dashboard.gitguardian.com"
+TOKEN = "test-token-abc123"
+
+
+class TestKeyringTokenStore:
+    def test_store_token(self):
+        store = KeyringTokenStore()
+        with patch("keyring.set_password") as mock_set:
+            store.store_token(INSTANCE_URL, TOKEN)
+            mock_set.assert_called_once_with(KEYRING_SERVICE, INSTANCE_URL, TOKEN)
+
+    def test_get_token(self):
+        store = KeyringTokenStore()
+        with patch("keyring.get_password", return_value=TOKEN) as mock_get:
+            result = store.get_token(INSTANCE_URL)
+            mock_get.assert_called_once_with(KEYRING_SERVICE, INSTANCE_URL)
+            assert result == TOKEN
+
+    def test_get_token_not_found(self):
+        store = KeyringTokenStore()
+        with patch("keyring.get_password", return_value=None):
+            result = store.get_token(INSTANCE_URL)
+            assert result is None
+
+    def test_delete_token(self):
+        store = KeyringTokenStore()
+        with patch("keyring.delete_password") as mock_delete:
+            store.delete_token(INSTANCE_URL)
+            mock_delete.assert_called_once_with(KEYRING_SERVICE, INSTANCE_URL)
+
+    def test_delete_token_not_found(self):
+        import keyring.errors
+
+        store = KeyringTokenStore()
+        with patch(
+            "keyring.delete_password",
+            side_effect=keyring.errors.PasswordDeleteError("not found"),
+        ):
+            # Should not raise
+            store.delete_token(INSTANCE_URL)
+
+    def test_is_available_true(self):
+        store = KeyringTokenStore()
+        mock_keyring = MagicMock()
+        with (
+            patch("keyring.get_keyring", return_value=mock_keyring),
+            patch("keyring.set_password") as mock_set,
+            patch("keyring.get_password", return_value="test") as mock_get,
+            patch("keyring.delete_password") as mock_delete,
+        ):
+            assert store.is_available() is True
+            # Verify the probe cycle ran
+            mock_set.assert_called_once()
+            mock_get.assert_called_once()
+            mock_delete.assert_called_once()
+
+    def test_is_available_false_fail_backend(self):
+        import keyring.backends.fail
+
+        store = KeyringTokenStore()
+        fail_keyring = keyring.backends.fail.Keyring()
+        with patch("keyring.get_keyring", return_value=fail_keyring):
+            assert store.is_available() is False
+
+    def test_is_available_false_probe_fails(self):
+        store = KeyringTokenStore()
+        mock_keyring = MagicMock()
+        with (
+            patch("keyring.get_keyring", return_value=mock_keyring),
+            patch("keyring.set_password"),
+            patch("keyring.get_password", return_value="wrong"),
+            patch("keyring.delete_password"),
+        ):
+            assert store.is_available() is False
+
+    def test_is_available_false_on_exception(self):
+        store = KeyringTokenStore()
+        with patch("keyring.get_keyring", side_effect=RuntimeError("broken")):
+            assert store.is_available() is False
+
+
+class TestFileTokenStore:
+    def test_store_token_is_noop(self):
+        store = FileTokenStore()
+        store.store_token(INSTANCE_URL, TOKEN)  # should not raise
+
+    def test_get_token_returns_none(self):
+        store = FileTokenStore()
+        assert store.get_token(INSTANCE_URL) is None
+
+    def test_delete_token_is_noop(self):
+        store = FileTokenStore()
+        store.delete_token(INSTANCE_URL)  # should not raise
+
+    def test_is_available(self):
+        store = FileTokenStore()
+        assert store.is_available() is True
+
+
+class TestGetTokenStore:
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        reset_token_store()
+        yield
+        reset_token_store()
+
+    def test_returns_keyring_when_available(self, monkeypatch):
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+        mock_keyring = MagicMock()
+        with (
+            patch("keyring.get_keyring", return_value=mock_keyring),
+            patch("keyring.set_password"),
+            patch("keyring.get_password", return_value="test"),
+            patch("keyring.delete_password"),
+        ):
+            store = get_token_store()
+            assert isinstance(store, KeyringTokenStore)
+
+    def test_returns_file_store_when_keyring_unavailable(self, monkeypatch):
+        import keyring.backends.fail
+
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+        fail_keyring = keyring.backends.fail.Keyring()
+        with patch("keyring.get_keyring", return_value=fail_keyring):
+            store = get_token_store()
+            assert isinstance(store, FileTokenStore)
+
+    @pytest.mark.parametrize("value", ("1", "true", "yes", "TRUE", "Yes"))
+    def test_env_var_disables_keyring(self, monkeypatch, value):
+        monkeypatch.setenv("GGSHIELD_NO_KEYRING", value)
+        store = get_token_store()
+        assert isinstance(store, FileTokenStore)
+
+    def test_caches_result(self, monkeypatch):
+        monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
+        store1 = get_token_store()
+        store2 = get_token_store()
+        assert store1 is store2
+
+
+class TestUsesExternalStorage:
+    def test_keyring_store_uses_external_storage(self):
+        assert KeyringTokenStore().uses_external_storage is True
+
+    def test_file_store_does_not_use_external_storage(self):
+        assert FileTokenStore().uses_external_storage is False
+
+
+class TestKeyRingSentinel:
+    def test_sentinel_is_not_a_valid_token(self):
+        assert KEYRING_SENTINEL == "__KEYRING__"

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "black"
 version = "24.3.0"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
@@ -805,6 +814,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "click" },
     { name = "cryptography" },
+    { name = "keyring" },
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },
     { name = "notify-py" },
@@ -871,6 +881,7 @@ requires-dist = [
     { name = "charset-normalizer", specifier = "~=3.1.0" },
     { name = "click", specifier = "~=8.1.0" },
     { name = "cryptography", specifier = "~=43.0.1" },
+    { name = "keyring", specifier = ">=24.0.0,<26" },
     { name = "marshmallow", specifier = "~=3.18.0" },
     { name = "marshmallow-dataclass", specifier = "~=8.5.8" },
     { name = "notify-py", specifier = ">=0.3.43" },
@@ -1118,7 +1129,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1309,6 +1320,62 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
@@ -1390,6 +1457,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context", version = "6.1.1", source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jaraco-context", version = "6.1.2", source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", version = "3.3.3", source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'linux'" },
+    { name = "secretstorage", version = "3.5.0", source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }, marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1599,6 +1686,15 @@ source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packag
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -2931,6 +3027,40 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version < '3.10'" },
+    { name = "jeepney", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version >= '3.10'" },
+    { name = "jeepney", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

`ggshield` used to store the auth token in cleartext in the global YAML config.

## What has been done

This commit adds support for using the system keyring. If not available, the previous cleartext storage will be used as a fallback.

## Validation
- check out `main`, sync and run `uv run ggshield auth login` if you are not logged in with `ggshield`, yet
- inspect `ggshield`'s global `auth_config.yaml` - the token is stored as a clear-text value
- run `uv run ggshield api-status` to make sure your token is valid and used
- check out this branch, sync and run `uv run ggshield auth login`
- inspect `auth_config.yaml`, the clear-text value should have been replaced with a `__KEYRING__` sentinel
- run `uv run ggshield api-status` to make sure your token is accessible and valid

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
