### PR TITLE
MCP 3/3 - add MCP usage monitoring

### DIFF
--- a/changelog.d/20260421_191828_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260421_191828_paul.petit.ext_HEAD.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- The AI hooks now also log/block MCP activity
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -6,6 +6,7 @@ so that other verticals can use the scanner if they are provided one.
 from collections.abc import Sequence
 from typing import Iterable, Optional, Protocol
 
+from pygitguardian import GGClient
 from pygitguardian.models import Match
 
 from ggshield.core.scanner_ui import ScannerUI
@@ -41,6 +42,9 @@ class ResultsProtocol(Protocol):
 
 class ScannerProtocol(Protocol):
     """Protocol for scanners."""
+
+    @property
+    def client(self) -> GGClient: ...
 
     def scan(
         self,

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -1,12 +1,14 @@
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 import click
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookResult, MCPConfiguration, Scope
+from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration, Scope
 
 
 class Claude(Agent):
@@ -147,3 +149,42 @@ class Claude(Agent):
         for project in projects:
             if project.is_dir():
                 yield project.resolve()
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        """Parse the MCP activity from an MCP hook payload."""
+
+        # Claude Code's hook tool name is "mcp__{server}__{tool}"
+        raw_tool_name: str = payload.raw.get("tool_name", "")
+        parts = raw_tool_name.split("__")
+        # The server name can be anything, but we assume no MCP tool has a "__" in its name
+        tool = parts[-1]
+        server_cfg_name = "__".join(parts[1:-1])
+
+        # Lookup the server name based on its configuration name
+        # Fallback to the server name if not found
+        server_name = server_cfg_name
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if _mangle_server_name(configuration.name) == server_cfg_name:
+                    server_name = server.name
+                    break
+
+        return MCPActivityRequest(
+            user=ai_config.user,
+            tool=tool,
+            server=server_name,
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+        )
+
+
+MANGLING_PATTERN = re.compile(r"[^A-Za-z0-9-]")
+
+
+def _mangle_server_name(name: str) -> str:
+    """Mangle a server name in the same way Claude Code does."""
+    return MANGLING_PATTERN.sub("_", name)

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,12 +1,13 @@
 import json
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Tuple
 
 import click
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import EventType, HookResult
+from ..models import EventType, HookPayload, HookResult
 from .claude_code import Claude
 
 
@@ -63,3 +64,39 @@ class Copilot(Claude):
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        """Parse the MCP activity from an MCP hook payload."""
+
+        raw_tool_name: str = payload.raw.get("tool_name", "")
+        server_name, tool_name = _lookup_server_name(raw_tool_name, ai_config)
+
+        return MCPActivityRequest(
+            user=ai_config.user,
+            tool=tool_name,
+            server=server_name,
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+        )
+
+
+def _lookup_server_name(raw_tool_name: str, ai_config: AIDiscovery) -> Tuple[str, str]:
+    # Copilot's hook tool name is "mcp_{server}_{tool}"
+    # which is unfortunate because a lot of tools have a "_" in their name.
+    # For now we hope there won't be "_" in the server configuration name
+    # (this is less likely than in the tool name but very brittle).
+    # TODO: test this more thoroughly and implement a better lookup.
+    _, server_cfg_name, *tool_parts = raw_tool_name.split("_")
+    tool = "_".join(tool_parts)
+
+    # Lookup the server name based on its configuration name
+    # Fallback to the configuration name if not found
+    for server in ai_config.servers:
+        for configuration in server.configurations:
+            if configuration.name == server_cfg_name:
+                return server.name, tool
+    return server_cfg_name, tool

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import click
 from pygitguardian.models import (
+    AIDiscovery,
+    MCPActivityRequest,
     MCPArgumentInfo,
     MCPPromptInfo,
     MCPResourceInfo,
@@ -12,7 +14,7 @@ from pygitguardian.models import (
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookResult, MCPServer
+from ..models import Agent, EventType, HookPayload, HookResult, MCPServer
 
 
 class Cursor(Agent):
@@ -171,6 +173,34 @@ class Cursor(Agent):
                 return True
 
         return False
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        """Parse the MCP activity from an MCP hook payload."""
+
+        # Cursor only sends the MCP tool, not the server.
+        # Fortunately, we should have been able to discover the tools earlier.
+
+        tools_to_server = {}
+        for server in ai_config.servers:
+            for tool in server.tools:
+                # Hopefully we won't have duplicates
+                tools_to_server[tool.name] = server.name
+
+        raw_tool_name: str = payload.raw.get("tool_name", "")
+        tool_name = raw_tool_name.removeprefix("MCP:")
+        server_name = tools_to_server.get(tool_name, "")
+
+        return MCPActivityRequest(
+            user=ai_config.user,
+            tool=tool_name,
+            server=server_name,
+            agent=self.name,
+            model=payload.raw.get("model", ""),
+            cwd=payload.raw.get("workspace_roots", [""])[0],
+            input=payload.raw.get("tool_input", {}),
+        )
 
 
 def _parse_tool_arguments(

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -10,6 +10,7 @@ from ggshield.core.scan import ScannerProtocol
 from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
+from ggshield.verticals.ai.mcp import send_mcp_activity
 
 from .agents import Claude, Copilot, Cursor
 from .models import Agent, EventType, HookPayload, HookResult, Tool
@@ -102,8 +103,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         payloads.extend(_parse_user_prompt(content, event_type, agent))
 
     elif event_type == EventType.PRE_TOOL_USE:
-        tool_name = data.get("tool_name", "").lower()
-        tool = TOOL_NAME_TO_TOOL.get(tool_name, Tool.OTHER)
+        tool = _parse_tool(data)
         tool_input = data.get("tool_input", {})
         # Select the content based on the tool
         if tool == Tool.BASH:
@@ -114,8 +114,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             identifier = lookup(tool_input, ["file_path", "filePath"], "")
 
     elif event_type == EventType.POST_TOOL_USE:
-        tool_name = data.get("tool_name", "").lower()
-        tool = TOOL_NAME_TO_TOOL.get(tool_name, Tool.OTHER)
+        tool = _parse_tool(data)
         content = data.get("tool_output", "") or data.get("tool_response", {})
         # Claude Code returns a dict for the tool output
         if isinstance(content, (dict, list)):
@@ -132,9 +131,18 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             content=content,
             identifier=identifier,
             agent=agent,
+            raw=data,
         )
     )
     return payloads
+
+
+def _parse_tool(data: Dict[str, Any]) -> Tool:
+    """Parse the tool name."""
+    tool_name = data.get("tool_name", "").lower()
+    if tool_name.startswith("mcp"):
+        return Tool.MCP
+    return TOOL_NAME_TO_TOOL.get(tool_name, Tool.OTHER)
 
 
 def _detect_agent(data: Dict[str, Any]) -> Agent:
@@ -167,6 +175,7 @@ def _parse_user_prompt(
                 content="",
                 identifier=match,
                 agent=agent,
+                raw={},
             )
         )
     return payloads
@@ -207,7 +216,7 @@ class AIHookScanner:
         return payload.agent.output_result(result)
 
     def _scan_payloads(self, payloads: List[HookPayload]) -> HookResult:
-        """Scan payloads for secrets using the SecretScanner.
+        """Scan payloads. Scan for secrets and log MCP activity.
 
         Returns:
             The result of the first blocking payload, or a non-blocking result.
@@ -216,10 +225,26 @@ class AIHookScanner:
         if not payloads:
             raise ValueError("Error: no payloads to scan")
         for payload in payloads:
+            # Scan for secrets first
             result = self._scan_content(payload)
             if result.block:
                 return result
+            # We only send the MCP activity if the payload wasn't already blocked.
+            result = self._send_mcp_activity(payload)
+            if result.block:
+                return result
         return HookResult.allow(payloads[0])
+
+    def _send_mcp_activity(self, payload: HookPayload) -> HookResult:
+        """Send MCP activity to the GitGuardian API."""
+        # This works even if the payload is not an MCP pre-tool use.
+        result = send_mcp_activity(self.scanner.client, payload)
+        return HookResult(
+            block=not result.allowed,
+            message=result.reason,
+            nbr_secrets=0,
+            payload=payload,
+        )
 
     def _scan_content(
         self,

--- a/ggshield/verticals/ai/mcp.py
+++ b/ggshield/verticals/ai/mcp.py
@@ -1,0 +1,39 @@
+from pygitguardian import GGClient
+from pygitguardian.models import Detail, MCPActivityResponse
+
+from ggshield.verticals.ai.discovery import refresh_and_maybe_submit_discovery
+
+from .models import EventType, HookPayload, Tool
+
+
+def _mcp_activity_fail_open() -> MCPActivityResponse:
+    return MCPActivityResponse(allowed=True, reason="")
+
+
+def send_mcp_activity(client: GGClient, payload: HookPayload) -> MCPActivityResponse:
+    """Build the MCP activity request and send it to the GitGuardian API.
+
+    Args:
+        client: GitGuardian API client (same instance as secret scans).
+        payload: Hook payload for the MCP pre-tool event.
+
+    Returns:
+        Policy response from the API, or allow if the request fails (fail-open).
+    """
+
+    # if the payload is not an MCP pre-tool use, early return
+    if payload.event_type != EventType.PRE_TOOL_USE or payload.tool != Tool.MCP:
+        return _mcp_activity_fail_open()
+
+    ai_config = refresh_and_maybe_submit_discovery(client)
+    request = payload.agent.parse_mcp_activity(payload, ai_config)
+
+    try:
+        response = client.log_mcp_activity(request)
+    except Exception:
+        return _mcp_activity_fail_open()
+
+    if isinstance(response, Detail):
+        return _mcp_activity_fail_open()
+
+    return response

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -6,7 +6,12 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pygitguardian.models import MCPConfiguration, MCPServer
+from pygitguardian.models import (
+    AIDiscovery,
+    MCPActivityRequest,
+    MCPConfiguration,
+    MCPServer,
+)
 
 from ggshield.core.scan import File, Scannable, StringScannable
 from ggshield.utils.files import is_path_binary
@@ -33,6 +38,7 @@ class Tool(Enum):
 
     BASH = auto()
     READ = auto()
+    MCP = auto()
     # We are not interested in other tools for now
     OTHER = auto()
 
@@ -58,6 +64,7 @@ class HookPayload:
     content: str
     identifier: str
     agent: "Agent"
+    raw: Dict[str, Any]
 
     @property
     def scannable(self) -> Scannable:
@@ -230,6 +237,15 @@ class Agent(ABC):
         Returns whether the capabilities were discovered.
         """
         return False
+
+    @abstractmethod
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        """Parse the MCP activity from an MCP hook payload.
+
+        Implementations can assume that the payload is an MCP pre-tool use.
+        """
 
     # Helper methods
 

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1,11 +1,31 @@
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
-from ggshield.verticals.ai.agents.claude_code import Claude
-from ggshield.verticals.ai.agents.cursor import Cursor
-from ggshield.verticals.ai.models import MCPConfiguration, MCPServer, Scope, Transport
+import pytest
+from pygitguardian.models import MCPToolInfo, UserInfo
+
+from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
+from ggshield.verticals.ai.agents.copilot import Copilot
+from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
+from ggshield.verticals.ai.models import (
+    Agent,
+    AIDiscovery,
+    EventType,
+    HookPayload,
+    MCPConfiguration,
+    MCPServer,
+    Scope,
+    Tool,
+    Transport,
+)
+
+
+def _user() -> UserInfo:
+    return UserInfo(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
 
 
 def _cfg(
@@ -20,6 +40,23 @@ def _cfg(
         scope=scope,
         transport=Transport.STDIO,
         project=str(project) if project else None,
+    )
+
+
+def _ai_discovery(servers: Optional[List[MCPServer]] = None) -> AIDiscovery:
+    return AIDiscovery(user=_user(), servers=servers or [], discovery_duration=0.1)
+
+
+def _payload(
+    agent: Agent, raw: Optional[Dict[str, Any]] = None, tool: Tool = Tool.MCP
+) -> HookPayload:
+    return HookPayload(
+        event_type=EventType.PRE_TOOL_USE,
+        tool=tool,
+        content="",
+        identifier="",
+        agent=agent,
+        raw=raw or {},
     )
 
 
@@ -176,6 +213,44 @@ class TestCursorDiscoverProjectDirectories:
         assert dirs == []
 
 
+class TestCursorParseMcpActivity:
+    def test_strips_mcp_prefix_and_maps_server(self):
+        cursor = Cursor()
+        tool_info = MCPToolInfo(name="run_query")
+        server = MCPServer(
+            name="my-db-server",
+            tools=[tool_info],
+            configurations=[_cfg(name="db", agent="cursor")],
+        )
+        discovery = _ai_discovery(servers=[server])
+        payload = _payload(
+            cursor,
+            raw={
+                "tool_name": "MCP:run_query",
+                "model": "gpt-4",
+                "workspace_roots": ["/home/user/proj"],
+                "tool_input": {"sql": "SELECT 1"},
+            },
+        )
+
+        req = cursor.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "run_query"
+        assert req.server == "my-db-server"
+        assert req.model == "gpt-4"
+        assert req.input == {"sql": "SELECT 1"}
+
+    def test_unknown_tool_returns_empty_server(self):
+        cursor = Cursor()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(cursor, raw={"tool_name": "MCP:unknown"})
+
+        req = cursor.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "unknown"
+        assert req.server == ""
+
+
 # ===========================================================================
 # Claude Code
 # ===========================================================================
@@ -251,3 +326,165 @@ class TestClaudeDiscoverProjectDirectories:
             dirs = list(claude.discover_project_directories())
 
         assert dirs == []
+
+
+class TestClaudeParseMcpActivity:
+    def test_parses_mcp_double_underscore_format(self):
+        claude = Claude()
+        cfg = _cfg(name="my.server", agent="claude-code")
+        server = MCPServer(
+            name="my.server", configurations=[cfg], tools=[MCPToolInfo(name="run")]
+        )
+        discovery = _ai_discovery(servers=[server])
+        # Claude mangles "my.server" → "my_server" in the tool name
+        payload = _payload(
+            claude,
+            raw={"tool_name": "mcp__my_server__run", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = claude.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "run"
+        assert req.server == "my.server"
+
+    def test_server_with_double_underscore_handled(self):
+        claude = Claude()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(
+            claude,
+            raw={
+                "tool_name": "mcp__a__b__tool_name",
+                "cwd": "/tmp",
+                "tool_input": {},
+            },
+        )
+
+        req = claude.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "tool_name"
+        assert req.server == "a__b"  # falls back to mangled name
+
+    def test_fallback_to_mangled_name(self):
+        claude = Claude()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(
+            claude,
+            raw={"tool_name": "mcp__unknown__do_it", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = claude.parse_mcp_activity(payload, discovery)
+
+        assert req.server == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _mangle_server_name
+# ---------------------------------------------------------------------------
+
+
+class TestMangleServerName:
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            pytest.param("my-seRver-123", "my-seRver-123", id="alphanumeric_dashes"),
+            pytest.param(
+                "my.server/v2 alpha", "my_server_v2_alpha", id="special_chars"
+            ),
+            pytest.param("simple", "simple", id="plain_alpha"),
+            pytest.param("a@b#c", "a_b_c", id="symbols"),
+        ],
+    )
+    def test_mangle_server_name(self, name: str, expected: str):
+        assert _mangle_server_name(name) == expected
+
+
+# ===========================================================================
+# Copilot
+# ===========================================================================
+
+
+class TestCopilotParseMcpActivity:
+    def test_simple_server_tool_split(self):
+        copilot = Copilot()
+        cfg = _cfg(name="myserver", agent="copilot")
+        server = MCPServer(name="othername", configurations=[cfg])
+        discovery = _ai_discovery(servers=[server])
+        payload = _payload(
+            copilot,
+            raw={"tool_name": "mcp_myserver_mytool", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "mytool"
+        assert req.server == "othername"
+
+    def test_multiple_underscores(self):
+        """Tools with underscores in their name are supported."""
+        copilot = Copilot()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(
+            copilot,
+            raw={
+                "tool_name": "mcp_server_tool_name_extra",
+                "cwd": "/tmp",
+                "tool_input": {},
+            },
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+        assert req.server == "server"
+        assert req.tool == "tool_name_extra"
+
+    def test_unknown_server_falls_back_to_cfg_name(self):
+        copilot = Copilot()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(
+            copilot,
+            raw={"tool_name": "mcp_unknown_tool", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+
+        assert req.server == "unknown"
+        assert req.tool == "tool"
+
+
+# ===========================================================================
+# _parse_tool_arguments (Cursor helper)
+# ===========================================================================
+
+
+class TestParseToolArguments:
+    def test_valid_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "SQL query"},
+                "limit": {"type": "integer"},
+            },
+            "required": ["query"],
+        }
+        result = _parse_tool_arguments(schema)
+        assert result is not None
+        assert len(result) == 2
+        q = next(a for a in result if a.name == "query")
+        assert q.required is True
+        assert q.description == "SQL query"
+        lim = next(a for a in result if a.name == "limit")
+        assert lim.required is False
+
+    def test_empty_properties_returns_none(self):
+        schema = {"type": "object", "properties": {}}
+        assert _parse_tool_arguments(schema) is None
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            pytest.param(None, id="none"),
+            pytest.param("string", id="string"),
+            pytest.param(42, id="integer"),
+        ],
+    )
+    def test_non_dict_schema_returns_none(self, schema: Any):
+        assert _parse_tool_arguments(schema) is None

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -5,10 +5,13 @@ from typing import List, Set
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pygitguardian import GGClient
+from pygitguardian.models import MCPActivityResponse
 
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import Claude, Copilot, Cursor
 from ggshield.verticals.ai.hooks import AIHookScanner, find_filepaths, parse_hook_input
+from ggshield.verticals.ai.mcp import send_mcp_activity
 from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
 from ggshield.verticals.secret import SecretScanner
 from ggshield.verticals.secret.secret_scan_collection import Result as ScanResult
@@ -22,6 +25,7 @@ def _dummy_payload(event_type: EventType = EventType.OTHER) -> HookPayload:
         content="",
         identifier="",
         agent=Cursor(),
+        raw={},
     )
 
 
@@ -36,6 +40,7 @@ def tmp_file(tmp_path: Path) -> Path:
 def _mock_scanner(matches: List[str]) -> MagicMock:
     """Create a mock SecretScanner that returns the given Results from scan()."""
     mock = MagicMock(spec=SecretScanner)
+    mock.client = MagicMock(spec=GGClient)
     scan_result = Results(
         results=[
             ScanResult(
@@ -88,6 +93,7 @@ class TestAIHookScannerScanContent:
             content="safe content",
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         result = hook_scanner._scan_content(payload)
         assert isinstance(result, HookResult)
@@ -104,6 +110,7 @@ class TestAIHookScannerScanContent:
             content="content with sk-xxx",
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         result = hook_scanner._scan_content(payload)
         assert isinstance(result, HookResult)
@@ -193,6 +200,58 @@ class TestAIHookScannerScan:
             scanner._scan_payloads([])
 
 
+class TestMCPActivity:
+    """Unit tests for MCP activity handling."""
+
+    @pytest.mark.parametrize(
+        "event_type, tool",
+        [
+            (EventType.USER_PROMPT, None),
+            (EventType.POST_TOOL_USE, Tool.MCP),
+            (EventType.PRE_TOOL_USE, Tool.BASH),
+            (EventType.OTHER, None),
+        ],
+    )
+    def test_send_mcp_activity_early_returns_for_non_mcp_pre_tool_use(
+        self, event_type: EventType, tool: Tool
+    ):
+        """send_mcp_activity returns allowed=True without calling the API
+        when the payload is not an MCP PreToolUse."""
+        client = MagicMock(spec=GGClient)
+        payload = HookPayload(
+            event_type=event_type,
+            tool=tool,
+            content="some content",
+            identifier="id",
+            agent=Cursor(),
+            raw={},
+        )
+        result = send_mcp_activity(client, payload)
+        assert isinstance(result, MCPActivityResponse)
+        assert result.allowed is True
+        assert result.reason == ""
+        client.post.assert_not_called()
+
+    @patch("ggshield.verticals.ai.hooks.send_mcp_activity")
+    def test_scan_calls_send_mcp_activity_for_mcp_pre_tool_use(
+        self, mock_send_mcp: MagicMock
+    ):
+        """AIHookScanner.scan() calls send_mcp_activity when the payload is an MCP PreToolUse."""
+        mock_send_mcp.return_value = MCPActivityResponse(allowed=True, reason="")
+        scanner = AIHookScanner(_mock_scanner([]))
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__some_server__some_tool",
+            "tool_input": {"arg": "value"},
+            "cursor_version": "2.5.25",
+        }
+        scanner.scan(json.dumps(data))
+        mock_send_mcp.assert_called_once()
+        call_payload = mock_send_mcp.call_args[0][1]
+        assert call_payload.event_type == EventType.PRE_TOOL_USE
+        assert call_payload.tool == Tool.MCP
+
+
 class TestMessageFromSecrets:
     """Unit tests for AIHookScanner._message_from_secrets with different payload types."""
 
@@ -204,6 +263,7 @@ class TestMessageFromSecrets:
             content="echo sk-xxx",
             identifier="echo sk-xxx",
             agent=Cursor(),
+            raw={},
         )
         message = AIHookScanner._message_from_secrets([_make_secret("sk-xxx")], payload)
         assert "remove the secrets from the command" in message
@@ -217,6 +277,7 @@ class TestMessageFromSecrets:
             content="file content with secret",
             identifier="/path/to/file",
             agent=Cursor(),
+            raw={},
         )
         message = AIHookScanner._message_from_secrets([_make_secret("sk-xxx")], payload)
         assert "remove the secrets from" in message
@@ -229,6 +290,7 @@ class TestMessageFromSecrets:
             content="some content",
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         message = AIHookScanner._message_from_secrets([_make_secret("sk-xxx")], payload)
         assert "remove the secrets from the tool input" in message
@@ -241,6 +303,7 @@ class TestMessageFromSecrets:
             content="content",
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         message = AIHookScanner._message_from_secrets(
             [_make_secret("sk-xxx")], payload, escape_markdown=True

--- a/tests/unit/verticals/ai/test_mcp_activity.py
+++ b/tests/unit/verticals/ai/test_mcp_activity.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+from pygitguardian.models import Detail, MCPActivityResponse, UserInfo
+
+from ggshield.verticals.ai.mcp import send_mcp_activity
+from ggshield.verticals.ai.models import (
+    AIDiscovery,
+    EventType,
+    HookPayload,
+    MCPActivityRequest,
+    Tool,
+)
+
+
+def _user() -> UserInfo:
+    return UserInfo(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
+
+
+def _ai_discovery() -> AIDiscovery:
+    return AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+
+
+def _mcp_activity_request() -> MCPActivityRequest:
+    return MCPActivityRequest(
+        user=_user(),
+        tool="my_tool",
+        server="my_server",
+        agent="cursor",
+        model="gpt-4",
+        cwd="/tmp",
+        input={"key": "value"},
+    )
+
+
+def _payload() -> HookPayload:
+    agent = MagicMock()
+    return HookPayload(
+        event_type=EventType.PRE_TOOL_USE,
+        tool=Tool.MCP,
+        content="content",
+        identifier="id",
+        agent=agent,
+        raw={},
+    )
+
+
+class TestSendMCPActivity:
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_successful_response(self, mock_refresh: MagicMock):
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        activity = MCPActivityResponse(allowed=False, reason="blocked by policy")
+        client = MagicMock()
+        client.log_mcp_activity.return_value = activity
+
+        result = send_mcp_activity(client, payload)
+
+        assert result.allowed is False
+        assert result.reason == "blocked by policy"
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_fail_open_returns_allowed(self, mock_refresh: MagicMock):
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        client = MagicMock()
+        client.log_mcp_activity.return_value = Detail(
+            status_code=400, detail="Validation Error"
+        )
+
+        result = send_mcp_activity(client, payload)
+
+        assert result.allowed is True
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_refresh_called_before_submission(self, mock_refresh: MagicMock):
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        response_data = MCPActivityResponse(allowed=True, reason="")
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.text = response_data.to_json()
+
+        client = MagicMock()
+        client.post.return_value = mock_response
+
+        send_mcp_activity(client, payload)
+
+        mock_refresh.assert_called_once_with(client)

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -33,6 +33,7 @@ class TestHookPayloadScannable:
             content="",
             identifier=str(f),
             agent=Cursor(),
+            raw={},
         )
         assert isinstance(payload.scannable, File)
 
@@ -43,6 +44,7 @@ class TestHookPayloadScannable:
             content="some content",
             identifier="/nonexistent/path.txt",
             agent=Cursor(),
+            raw={},
         )
         assert isinstance(payload.scannable, StringScannable)
 
@@ -55,6 +57,7 @@ class TestHookPayloadScannable:
             content="",
             identifier=str(f),
             agent=Cursor(),
+            raw={},
         )
         assert isinstance(payload.scannable, StringScannable)
 
@@ -65,6 +68,7 @@ class TestHookPayloadScannable:
             content="echo hello",
             identifier="cmd",
             agent=Cursor(),
+            raw={},
         )
         assert isinstance(payload.scannable, StringScannable)
 
@@ -89,6 +93,7 @@ class TestHookPayloadEmpty:
             content=content,
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         assert payload.empty is expected
 
@@ -106,6 +111,7 @@ class TestHookResultAllow:
             content="hi",
             identifier="id",
             agent=Cursor(),
+            raw={},
         )
         result = HookResult.allow(payload)
         assert result.block is False


### PR DESCRIPTION
## Context

See Linear issue https://linear.app/gitguardian/issue/NHI-1513/mcp-discovery-and-usage-in-ggshield

## What has been done

- The `ggshield secret scan ai-hook` now additionally send the activity of MCP PreToolUse hooks to a specific GIM endpoint. In addition to logging the activity, we receive whether we should block the call or not.
- The non-trivial part is building a unified payload, more precisely getting the server and tool used. As usual, most of the heavy-lifting is found in the specific `Agent`s implementations. 

## Validation

- Install AI hooks (`ggshield install -t {cursor|claude-code|copilot}`)
- Have your agent use an MCP tool
- See the activity in GIM.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
