### PR TITLE
feat: add msi support

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Install WiX Toolset
         if: matrix.os == 'windows-2022'
         shell: bash
-        run: dotnet tool install --global wix --version 4.0.4
+        run: dotnet tool install --global wix --version 5.0.2
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -161,6 +161,11 @@ jobs:
           # Make it available
           cp rcodesign /usr/local/bin
 
+      - name: Install WiX Toolset
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        run: dotnet tool install --global wix --version 4.0.4
+
       - name: Install dependencies
         shell: bash
         run: |
@@ -273,6 +278,7 @@ jobs:
             packages/ggshield-*.rpm
             packages/ggshield_*.deb
             packages/ggshield.*.nupkg
+            packages/ggshield-*.msi
 
   # Run some basic tests, the goal is to verify the ggshield binary has all the
   # libraries it needs to run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: v3.6.0
     hooks:
       - id: prettier
+        exclude: \.wxs$
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/changelog.d/20260218_145052_aurelien.gateau_msi.md
+++ b/changelog.d/20260218_145052_aurelien.gateau_msi.md
@@ -1,0 +1,3 @@
+### Added
+
+- ggshield is now available as a MSI package.

--- a/doc/dev/os-packages.md
+++ b/doc/dev/os-packages.md
@@ -23,6 +23,7 @@ flowchart TD
     signing -->|no| create_archive
     sign --> create_archive --> pkg[/"pkg 🍏"/]
     create_archive --> zip[/"zip 🪟"/]
+    create_archive --> msi[/"msi 🪟"/]
     create_archive --> tar.gz[/"tar.gz 🐧"/]
     create_archive --> deb[/"deb 🐧"/]
     create_archive --> rpm[/"rpm 🐧"/]
@@ -96,3 +97,13 @@ Note 2: `install-keylocker-tools` expects `$PATH` to already contain the install
 #### Building signed binaries
 
 Once all environment variables are set and DigiCert tools are installed, one can build signed Windows binaries using `build-os-packages --sign`.
+
+### MSI Package
+
+The build produces an MSI installer (`ggshield-VERSION-x86_64-pc-windows-msvc.msi`) using [WiX Toolset v4](https://wixtoolset.org/). The WiX source file is `scripts/build-os-packages/ggshield.wxs`.
+
+- **Install location**: `C:\Program Files\GitGuardian\ggshield\`
+- **PATH**: The installer adds the install location to the system `PATH`. This is removed on uninstall.
+- **Upgrades**: Installing a newer version automatically removes the previous one (via `MajorUpgrade`).
+- **Silent install**: `msiexec /i ggshield-X.Y.Z-x86_64-pc-windows-msvc.msi /quiet`
+- **Silent uninstall**: `msiexec /x ggshield-X.Y.Z-x86_64-pc-windows-msvc.msi /quiet`

--- a/doc/dev/os-packages.md
+++ b/doc/dev/os-packages.md
@@ -70,6 +70,10 @@ For Gatekeeper to accept the app, the executable and all the dynamic libraries m
 
 ## Windows specific information
 
+### Requirements
+
+Building the MSI requires the [.NET SDK](https://dotnet.microsoft.com/download) and the WiX CLI tool (`dotnet tool install --global wix --version 5.0.2`).
+
 ### Signing
 
 We use [DigiCert](https://www.digicert.com) to sign `ggshield` Windows binaries.
@@ -100,7 +104,7 @@ Once all environment variables are set and DigiCert tools are installed, one can
 
 ### MSI Package
 
-The build produces an MSI installer (`ggshield-VERSION-x86_64-pc-windows-msvc.msi`) using [WiX Toolset v4](https://wixtoolset.org/). The WiX source file is `scripts/build-os-packages/ggshield.wxs`.
+The build produces an MSI installer (`ggshield-VERSION-x86_64-pc-windows-msvc.msi`) using [WiX Toolset v5](https://wixtoolset.org/). The WiX source file is `scripts/build-os-packages/ggshield.wxs`.
 
 - **Install location**: `C:\Program Files\GitGuardian\ggshield\`
 - **PATH**: The installer adds the install location to the system `PATH`. This is removed on uninstall.

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -114,7 +114,7 @@ init_system_vars() {
         EXE_EXT=".exe"
         HUMAN_OS=Windows
         TARGET="$arch-pc-windows-msvc"
-        REQUIREMENTS="$REQUIREMENTS choco"
+        REQUIREMENTS="$REQUIREMENTS choco wix"
         ;;
     *)
         die "Unknown OS. uname printed '$out'"
@@ -323,6 +323,7 @@ step_create_archive() {
     Windows)
         create_windows_packages
         test_chocolatey_package
+        test_msi_package
         ;;
     esac
 }

--- a/scripts/build-os-packages/ggshield.wxs
+++ b/scripts/build-os-packages/ggshield.wxs
@@ -21,8 +21,6 @@
             <File Source="!(bindpath.SourceDir)\ggshield.exe" />
           </Component>
 
-          <Files Include="!(bindpath.SourceDir)\_internal\**" />
-
           <Component Id="PathEntry" Guid="d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80">
             <Environment
               Id="PATH"
@@ -38,8 +36,13 @@
       </Directory>
     </StandardDirectory>
 
+    <ComponentGroup Id="InternalFiles" Directory="INSTALLFOLDER">
+      <Files Include="!(bindpath.SourceDir)\_internal\**" />
+    </ComponentGroup>
+
     <Feature Id="Complete" Level="1">
       <ComponentRef Id="MainExecutable" />
+      <ComponentGroupRef Id="InternalFiles" />
       <ComponentRef Id="PathEntry" />
     </Feature>
   </Package>

--- a/scripts/build-os-packages/ggshield.wxs
+++ b/scripts/build-os-packages/ggshield.wxs
@@ -21,12 +21,7 @@
             <File Source="!(bindpath.SourceDir)\ggshield.exe" />
           </Component>
 
-          <Component
-            Id="InternalFiles"
-            Guid="c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
-          >
-            <Files Include="!(bindpath.SourceDir)\_internal\**" />
-          </Component>
+          <Files Include="!(bindpath.SourceDir)\_internal\**" />
 
           <Component Id="PathEntry" Guid="d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80">
             <Environment
@@ -45,7 +40,6 @@
 
     <Feature Id="Complete" Level="1">
       <ComponentRef Id="MainExecutable" />
-      <ComponentRef Id="InternalFiles" />
       <ComponentRef Id="PathEntry" />
     </Feature>
   </Package>

--- a/scripts/build-os-packages/ggshield.wxs
+++ b/scripts/build-os-packages/ggshield.wxs
@@ -1,0 +1,52 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="ggshield"
+    Manufacturer="GitGuardian"
+    Version="$(var.Version)"
+    UpgradeCode="b0e3a5b8-6a44-4c2f-8c72-5f3e9a1d7b4e"
+    Scope="perMachine"
+    Compressed="yes"
+  >
+    <MajorUpgrade DowngradeErrorMessage="A newer version of ggshield is already installed." />
+
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="GitGuardianDir" Name="GitGuardian">
+        <Directory Id="INSTALLFOLDER" Name="ggshield">
+          <Component
+            Id="MainExecutable"
+            Guid="a1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e"
+          >
+            <File Source="!(bindpath.SourceDir)\ggshield.exe" />
+          </Component>
+
+          <Component
+            Id="InternalFiles"
+            Guid="c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
+          >
+            <Files Include="!(bindpath.SourceDir)\_internal\**" />
+          </Component>
+
+          <Component Id="PathEntry" Guid="d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80">
+            <Environment
+              Id="PATH"
+              Name="PATH"
+              Value="[INSTALLFOLDER]"
+              Permanent="no"
+              Part="last"
+              Action="set"
+              System="yes"
+            />
+          </Component>
+        </Directory>
+      </Directory>
+    </StandardDirectory>
+
+    <Feature Id="Complete" Level="1">
+      <ComponentRef Id="MainExecutable" />
+      <ComponentRef Id="InternalFiles" />
+      <ComponentRef Id="PathEntry" />
+    </Feature>
+  </Package>
+</Wix>

--- a/scripts/build-os-packages/ggshield.wxs
+++ b/scripts/build-os-packages/ggshield.wxs
@@ -32,11 +32,12 @@
               System="yes"
             />
           </Component>
+          <Directory Id="InternalDir" Name="_internal" />
         </Directory>
       </Directory>
     </StandardDirectory>
 
-    <ComponentGroup Id="InternalFiles" Directory="INSTALLFOLDER">
+    <ComponentGroup Id="InternalFiles" Directory="InternalDir">
       <Files Include="!(bindpath.SourceDir)\_internal\**" />
     </ComponentGroup>
 


### PR DESCRIPTION
## What has been done

Adds windows `.msi` builds as a release artifact.
Closes #1174 

## Validation

- Download the windows build artifacts from one of the CI runs
- Install the `.msi`
- Run `ggshield --version` from a new terminal session (the installer should have added `ggshield` to the `PATH`) 

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
