### PR TITLE
ci: mock get API calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
     needs:
       - lint
       - build
+      - functest_api
       - test_github_secret_scan_action
     steps:
       - name: Login to Docker Hub

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,16 +1,14 @@
 import abc
 import http.server
+import json
 import shutil
 import socketserver
 import time
 from multiprocessing import Event, Process, Value
 from pathlib import Path
 from typing import Generator
-from urllib.parse import urlparse
 
 import pytest
-import requests
-from pygitguardian.config import DEFAULT_BASE_URI
 
 from tests.repository import Repository
 
@@ -36,32 +34,57 @@ ggshield {} scan pre-receive --all
 # Use this as a decorator for tests which call the `docker` binary
 requires_docker = pytest.mark.skipif(not HAS_DOCKER, reason="This test requires Docker")
 
+# Fake responses for the mock GG API server, so that tests using mock fixtures
+# do not depend on the real GitGuardian API being reachable.
+_FAKE_METADATA_RESPONSE = json.dumps(
+    {
+        "version": "1.0.0",
+        "preferences": {},
+        "secret_scan_preferences": {
+            "maximum_document_size": 1048576,
+            "maximum_documents_per_scan": 20,
+        },
+        "remediation_messages": {
+            "pre_commit": "",
+            "pre_push": "",
+            "pre_receive": "",
+        },
+    }
+).encode()
+
+_FAKE_API_TOKENS_RESPONSE = json.dumps(
+    {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "fake-token",
+        "workspace_id": 1,
+        "type": "personal_access_token",
+        "status": "active",
+        "created_at": "2020-01-01T00:00:00Z",
+        "scopes": ["scan"],
+    }
+).encode()
+
 
 class AbstractGGAPIHandler(http.server.BaseHTTPRequestHandler, metaclass=abc.ABCMeta):
     def do_HEAD(self):
         self.send_response(200)
 
     def do_GET(self):
-        # Forward all GET calls to the real server
-        url = DEFAULT_BASE_URI + self.path.replace("/exposed", "")
-        headers = {
-            **self.headers,
-            "Host": urlparse(url).netloc,
-        }
+        # Return fake responses so mock-based tests don't depend on the real API
+        if "metadata" in self.path:
+            content = _FAKE_METADATA_RESPONSE
+        elif "api_tokens" in self.path:
+            content = _FAKE_API_TOKENS_RESPONSE
+        else:
+            self.send_response(418)
+            self.end_headers()
+            return
 
-        response = requests.get(url, headers=headers)
-
-        self.send_response(response.status_code)
-
-        for name, value in response.headers.items():
-            if name != "content-encoding" and name != "transfer-encoding":
-                # Forward headers, but not content-encoding nor transfer-encoding
-                # because our response is not compressed and/or chunked content, even if
-                # we received it that way
-                self.send_header(name, value)
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("Content-Length", str(len(content)))
         self.end_headers()
-
-        self.wfile.write(response.content)
+        self.wfile.write(content)
 
     @abc.abstractmethod
     def do_POST(self):

--- a/tests/functional/secret/test_scan_invalid_api_key.py
+++ b/tests/functional/secret/test_scan_invalid_api_key.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from tests.functional.utils import run_ggshield_scan
 
+
+pytestmark = pytest.mark.uses_gitguardian_api
 
 CURRENT_DIR = Path(__file__).parent
 

--- a/tests/functional/secret/test_scan_prereceive.py
+++ b/tests/functional/secret/test_scan_prereceive.py
@@ -9,15 +9,13 @@ from tests.functional.utils import recreate_censored_content
 from tests.repository import Repository
 
 
-pytestmark = pytest.mark.uses_gitguardian_api
-
-
 HOOK_CONTENT = """#!/bin/sh
 set -e
 ggshield secret scan pre-receive
 """
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_prereceive(tmp_path: Path) -> None:
     # GIVEN a remote repository
     remote_repo = Repository.create(tmp_path / "remote", bare=True)
@@ -47,6 +45,7 @@ def test_scan_prereceive(tmp_path: Path) -> None:
     assert recreate_censored_content(secret_content, GG_VALID_TOKEN) in stderr
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_prereceive_branch_without_new_commits(tmp_path: Path) -> None:
     # GIVEN a remote repository
     remote_repo = Repository.create(tmp_path / "remote", bare=True)
@@ -73,6 +72,7 @@ def test_scan_prereceive_branch_without_new_commits(tmp_path: Path) -> None:
     local_repo.push("-u", "origin", branch_name)
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_prereceive_push_force(tmp_path: Path) -> None:
     # GIVEN a remote repository
     remote_repo = Repository.create(tmp_path / "remote", bare=True)
@@ -132,6 +132,7 @@ def test_scan_prereceive_timeout(
     with caplog.at_level(logging.WARNING):
         monkeypatch.setenv("GITGUARDIAN_API_URL", slow_gitguardian_api)
         monkeypatch.delenv("GITGUARDIAN_INSTANCE", raising=False)
+        monkeypatch.setenv("GITGUARDIAN_API_KEY", "dummy")
         local_repo.push()
 
     # AND the error message contains timeout message

--- a/tests/functional/secret/test_scan_repo.py
+++ b/tests/functional/secret/test_scan_repo.py
@@ -1,6 +1,4 @@
 import json
-import os
-from unittest.mock import patch
 
 import jsonschema
 import pytest
@@ -8,9 +6,6 @@ import pytest
 from tests.conftest import GG_VALID_TOKEN
 from tests.functional.utils import recreate_censored_content, run_ggshield_scan
 from tests.repository import Repository
-
-
-pytestmark = pytest.mark.uses_gitguardian_api
 
 
 LEAK_CONTENT = f"password = {GG_VALID_TOKEN}"
@@ -35,6 +30,7 @@ def leaky_repo(tmp_path_factory: pytest.TempPathFactory) -> Repository:
     return repo
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_repo(leaky_repo: Repository) -> None:
     # GIVEN a repository with a past commit containing a leak
     # WHEN scanning the repo
@@ -47,6 +43,7 @@ def test_scan_repo(leaky_repo: Repository) -> None:
     assert recreate_censored_content(LEAK_CONTENT, GG_VALID_TOKEN) in proc.stdout
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_repo_json(leaky_repo: Repository, secret_json_schema) -> None:
     # GIVEN a repository with a past commit containing a leak
     # WHEN scanning the repo
@@ -60,22 +57,21 @@ def test_scan_repo_json(leaky_repo: Repository, secret_json_schema) -> None:
 
 
 def test_scan_repo_quota_limit_reached(
-    leaky_repo: Repository, no_quota_gitguardian_api: str, caplog
+    leaky_repo: Repository, no_quota_gitguardian_api: str, monkeypatch, caplog
 ) -> None:
     # GIVEN a repository with a past commit containing a leak
 
     # WHEN scanning the repo
     # THEN error code is 128
-    with patch.dict(
-        os.environ, {**os.environ, "GITGUARDIAN_API_URL": no_quota_gitguardian_api}
-    ):
-        proc = run_ggshield_scan(
-            "repo",
-            str(leaky_repo.path),
-            "--json",
-            expected_code=128,
-            cwd=leaky_repo.path,
-        )
+    monkeypatch.setenv("GITGUARDIAN_API_URL", no_quota_gitguardian_api)
+    monkeypatch.setenv("GITGUARDIAN_API_KEY", "dummy")
+    proc = run_ggshield_scan(
+        "repo",
+        str(leaky_repo.path),
+        "--json",
+        expected_code=128,
+        cwd=leaky_repo.path,
+    )
 
     # AND stderr contains an error message
     assert (
@@ -86,6 +82,7 @@ def test_scan_repo_quota_limit_reached(
     assert proc.stdout.strip() == ""
 
 
+@pytest.mark.uses_gitguardian_api
 def test_scan_repo_exclude_patterns(
     leaky_repo: Repository,
 ) -> None:


### PR DESCRIPTION

## Context

The test mock of the GitGuardian API forwards GET requests implicitly to the public API. This can cause rate-limiting issues on many concurrent CI runs.

## What has been done

This commit introduces mocks for the GET endpoints used in tests. As far as I can see from git logs, we used to forward get requests to the public API in order to prevent having to update the mock frequently. Since the GET requests `ggshield` barely changed, we may assume that breaking the mock is less of a concern than rate-limiting. This PR also requires functional tests to succeed in order to push the unstable docker image.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
