### PR TITLE
feat: do not block on connection or server error

### DIFF
--- a/changelog.d/20260416_100952_6d7a_do_not_block_on_connection_or_server_error.md
+++ b/changelog.d/20260416_100952_6d7a_do_not_block_on_connection_or_server_error.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `secret scan pre-commit`, `secret scan pre-push`, `secret scan ci`, and `secret scan pre-receive` no longer block git operations when the GitGuardian server is unreachable or returns a server error. A warning is displayed and the command exits with code 0.

--- a/changelog.d/20260416_100952_6d7a_do_not_block_on_connection_or_server_error.md
+++ b/changelog.d/20260416_100952_6d7a_do_not_block_on_connection_or_server_error.md
@@ -1,3 +1,7 @@
+### Added
+
+- Added a new `secret.fail_on_server_error` configuration option (default `True`), available as the `--fail-on-server-error/--no-fail-on-server-error` flag or `GITGUARDIAN_FAIL_ON_SERVER_ERROR` environment variable. When set to `False`, `secret scan pre-commit`, `secret scan pre-push`, `secret scan pre-receive`, and `secret scan ci` exit with code `0` and display a warning instead of blocking the git operation when the GitGuardian server is unreachable or returns a 5xx response. The default preserves the previous blocking behavior.
+
 ### Changed
 
-- `secret scan pre-commit`, `secret scan pre-push`, `secret scan ci`, and `secret scan pre-receive` no longer block git operations when the GitGuardian server is unreachable or returns a server error. A warning is displayed and the command exits with code 0.
+- **Breaking**: `secret scan pre-receive` no longer fail-opens by default when the GitGuardian server returns a 5xx response. Previously the push was allowed through with a warning; now it is blocked, matching the other git hooks. Set `secret.fail_on_server_error` to `False` (or pass `--no-fail-on-server-error`) to restore the previous fail-open behavior.

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -11,7 +11,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import (
     exception_wrapper,
-    non_blocking_server_error,
+    non_blocking_on_server_error,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
@@ -27,7 +27,7 @@ from ggshield.verticals.secret.repo import scan_commit_range
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
-@non_blocking_server_error
+@non_blocking_on_server_error
 def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Scan the set of pushed commits that triggered the CI pipeline.

--- a/ggshield/cmd/secret/scan/ci.py
+++ b/ggshield/cmd/secret/scan/ci.py
@@ -9,7 +9,10 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.common_decorators import (
+    exception_wrapper,
+    non_blocking_server_error,
+)
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
@@ -24,6 +27,7 @@ from ggshield.verticals.secret.repo import scan_commit_range
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
+@non_blocking_server_error
 def ci_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Scan the set of pushed commits that triggered the CI pipeline.

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -8,7 +8,10 @@ import click
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
-from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.common_decorators import (
+    exception_wrapper,
+    non_blocking_server_error,
+)
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core import ui
@@ -51,6 +54,7 @@ def check_is_merge_with_conflict(cwd: Path) -> bool:
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
+@non_blocking_server_error
 def precommit_cmd(
     ctx: click.Context,
     scan_all_merge_files: bool,

--- a/ggshield/cmd/secret/scan/precommit.py
+++ b/ggshield/cmd/secret/scan/precommit.py
@@ -10,7 +10,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import (
     exception_wrapper,
-    non_blocking_server_error,
+    non_blocking_on_server_error,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
@@ -54,7 +54,7 @@ def check_is_merge_with_conflict(cwd: Path) -> bool:
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
-@non_blocking_server_error
+@non_blocking_on_server_error
 def precommit_cmd(
     ctx: click.Context,
     scan_all_merge_files: bool,

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -10,7 +10,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
 )
 from ggshield.cmd.utils.common_decorators import (
     exception_wrapper,
-    non_blocking_server_error,
+    non_blocking_on_server_error,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
-@non_blocking_server_error
+@non_blocking_on_server_error
 def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> int:
     """
     Scan as a pre-push git hook all commits that are about to be pushed.

--- a/ggshield/cmd/secret/scan/prepush.py
+++ b/ggshield/cmd/secret/scan/prepush.py
@@ -8,7 +8,10 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
-from ggshield.cmd.utils.common_decorators import exception_wrapper
+from ggshield.cmd.utils.common_decorators import (
+    exception_wrapper,
+    non_blocking_server_error,
+)
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.hooks import check_user_requested_skip
 from ggshield.core import ui
@@ -32,6 +35,7 @@ logger = logging.getLogger(__name__)
 @add_secret_scan_common_options()
 @click.pass_context
 @exception_wrapper
+@non_blocking_server_error
 def prepush_cmd(ctx: click.Context, prepush_args: List[str], **kwargs: Any) -> int:
     """
     Scan as a pre-push git hook all commits that are about to be pushed.

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -12,6 +12,7 @@ from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
     create_output_handler,
 )
+from ggshield.cmd.utils.common_decorators import fail_on_server_error_option
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
@@ -79,6 +80,7 @@ def _execute_prereceive(
     hidden=True,
 )
 @add_secret_scan_common_options()
+@fail_on_server_error_option
 @click.pass_context
 def prereceive_cmd(
     ctx: click.Context, web: bool, prereceive_args: List[str], **kwargs: Any
@@ -142,6 +144,9 @@ def prereceive_cmd(
         process.kill()
         return 0
     if process.exitcode == ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE:
+        if config.user_config.secret.fail_on_server_error:
+            ui.display_error("\nGitGuardian server is not responding.")
+            return ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE
         ui.display_error("\nGitGuardian server is not responding. Skipping checks.")
         return 0
 

--- a/ggshield/cmd/utils/common_decorators.py
+++ b/ggshield/cmd/utils/common_decorators.py
@@ -3,7 +3,7 @@ from typing import Callable, TypeVar
 
 from typing_extensions import ParamSpec
 
-from ggshield.core.errors import handle_exception
+from ggshield.core.errors import ServiceUnavailableError, handle_exception
 
 
 T = TypeVar("T")
@@ -17,5 +17,28 @@ def exception_wrapper(func: Callable[P, int]) -> Callable[P, int]:
             return func(*args, **kwargs)
         except Exception as error:
             return handle_exception(error)
+
+    return wrapper
+
+
+def non_blocking_server_error(func: Callable[P, int]) -> Callable[P, int]:
+    """Decorator for git hook/CI commands that should not block when the
+    GitGuardian server is unavailable.
+
+    Catches ServiceUnavailableError and returns exit code 0 with a warning,
+    instead of blocking the git operation.
+    """
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> int:
+        try:
+            return func(*args, **kwargs)
+        except ServiceUnavailableError as exc:
+            # Lazy import to avoid circular imports (same pattern as handle_exception)
+            from ggshield.core import ui
+
+            ui.display_warning(str(exc))
+            ui.display_warning("Skipping ggshield checks.")
+            return 0
 
     return wrapper

--- a/ggshield/cmd/utils/common_decorators.py
+++ b/ggshield/cmd/utils/common_decorators.py
@@ -1,8 +1,10 @@
 from functools import wraps
 from typing import Callable, TypeVar
 
+import click
 from typing_extensions import ParamSpec
 
+from ggshield.cmd.utils.common_options import create_config_callback
 from ggshield.core.errors import ServiceUnavailableError, handle_exception
 
 
@@ -21,12 +23,31 @@ def exception_wrapper(func: Callable[P, int]) -> Callable[P, int]:
     return wrapper
 
 
-def non_blocking_server_error(func: Callable[P, int]) -> Callable[P, int]:
-    """Decorator for git hook/CI commands that should not block when the
-    GitGuardian server is unavailable.
+fail_on_server_error_option = click.option(
+    "--fail-on-server-error/--no-fail-on-server-error",
+    "fail_on_server_error",
+    is_flag=True,
+    default=None,
+    envvar="GITGUARDIAN_FAIL_ON_SERVER_ERROR",
+    help=(
+        "Whether git hook and CI scan commands should fail when the GitGuardian"
+        " server is unreachable or returns a 5xx response. When disabled, the"
+        " command exits with code 0 and a warning is displayed instead of"
+        " blocking the git operation. Defaults to enabled. Can also be set with"
+        " the `GITGUARDIAN_FAIL_ON_SERVER_ERROR` environment variable."
+    ),
+    callback=create_config_callback("secret", "fail_on_server_error"),
+)
 
-    Catches ServiceUnavailableError and returns exit code 0 with a warning,
-    instead of blocking the git operation.
+
+def non_blocking_on_server_error(func: Callable[P, int]) -> Callable[P, int]:
+    """Decorator for git hook / CI commands that may opt in to not blocking
+    when the GitGuardian server is unavailable.
+
+    Bundles the ``--fail-on-server-error`` CLI option with a handler that
+    catches ``ServiceUnavailableError``: when ``secret.fail_on_server_error``
+    is False, the command exits with code 0 and a warning; otherwise the error
+    is re-raised and handled like any other error.
     """
 
     @wraps(func)
@@ -34,11 +55,22 @@ def non_blocking_server_error(func: Callable[P, int]) -> Callable[P, int]:
         try:
             return func(*args, **kwargs)
         except ServiceUnavailableError as exc:
-            # Lazy import to avoid circular imports (same pattern as handle_exception)
+            # Lazy import to avoid circular imports (same pattern as handle_exception).
+            from ggshield.cmd.utils.context_obj import ContextObj
             from ggshield.core import ui
 
-            ui.display_warning(str(exc))
-            ui.display_warning("Skipping ggshield checks.")
+            ctx = click.get_current_context(silent=True)
+            fail_on_server_error = True
+            if ctx is not None and ctx.obj is not None:
+                fail_on_server_error = ContextObj.get(
+                    ctx
+                ).config.user_config.secret.fail_on_server_error
+
+            if fail_on_server_error:
+                raise
+
+            ui.display_error(str(exc))
+            ui.display_error("Skipping ggshield checks.")
             return 0
 
-    return wrapper
+    return fail_on_server_error_option(wrapper)

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -121,9 +121,9 @@ def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> 
     try:
         response = client.read_metadata()
     except requests.exceptions.ConnectionError as e:
-        raise UnexpectedError(
-            "Failed to connect to GitGuardian server. Check your"
-            f" instance URL settings.\nDetails: {e}."
+        raise ServiceUnavailableError(
+            message="Failed to connect to GitGuardian server. Check your"
+            f" instance URL settings.\nDetails: {e}.",
         )
 
     if response is None:

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -46,6 +46,10 @@ class SecretConfig(FilteredConfig):
     all_secrets: bool = False
     prereceive_remediation_message: str = ""
     source_uuid: Optional[UUID] = None
+    # When False, pre-commit / pre-push / pre-receive / ci hooks exit 0 instead
+    # of blocking git operations when the GitGuardian server is unreachable or
+    # returns a 5xx. Defaults to True so upgrades keep blocking behavior.
+    fail_on_server_error: bool = True
 
     def add_ignored_match(self, secret: IgnoredMatch) -> None:
         """
@@ -75,6 +79,7 @@ class SecretConfig(FilteredConfig):
                 "source_uuid": (
                     str(self.source_uuid) if self.source_uuid is not None else None
                 ),
+                "fail_on_server_error": self.fail_on_server_error,
             }
         )
 

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -7,6 +7,7 @@ from ast import literal_eval
 from concurrent.futures import Future
 from typing import Dict, Iterable, List, Optional, Union
 
+import requests
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, MultiScanResult, TokenScope
 
@@ -15,13 +16,17 @@ from ggshield.core.cache import Cache
 from ggshield.core.client import check_client_api_key
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.constants import MAX_WORKERS
-from ggshield.core.errors import handle_api_error
+from ggshield.core.errors import (
+    ServiceUnavailableError,
+    UnexpectedError,
+    handle_api_error,
+)
 from ggshield.core.scan import DecodeError, ScanContext, Scannable
 from ggshield.core.scan.scannable import NonSeekableFileError
 from ggshield.core.scanner_ui.scanner_ui import ScannerUI
 from ggshield.core.text_utils import pluralize
 
-from .secret_scan_collection import Error, Result, Results
+from .secret_scan_collection import Result, Results
 
 
 # GitGuardian API does not accept paths longer than this
@@ -194,7 +199,6 @@ class SecretScanner:
         self.cache.purge()
 
         results = []
-        errors = []
         for future in concurrent.futures.as_completed(chunks_for_futures):
             chunk = chunks_for_futures[future]
             scanner_ui.on_scanned(chunk)
@@ -203,13 +207,18 @@ class SecretScanner:
             if exception is None:
                 scan = future.result()
             else:
-                scan = Detail(detail=str(exception))
-                errors.append(
-                    Error(
-                        files=[(x.filename, x.filemode) for x in chunk],
-                        description=scan.detail,
-                    )
-                )
+                # Only connectivity failures are eligible for the
+                # --no-fail-on-server-error skip path. Any other exception is
+                # opaque (SSL failure, JSON decode, internal bug, ...) and must
+                # not be silently swallowed when fail-open is enabled.
+                if isinstance(
+                    exception,
+                    (requests.exceptions.ConnectionError, requests.exceptions.Timeout),
+                ):
+                    raise ServiceUnavailableError(
+                        f"Scanning failed: {exception}"
+                    ) from exception
+                raise UnexpectedError(f"Scanning failed: {exception}") from exception
 
             if not scan.success:
                 assert isinstance(scan, Detail)
@@ -228,7 +237,7 @@ class SecretScanner:
                 results.append(result)
 
         self.cache.save()
-        return Results(results=results, errors=errors)
+        return Results(results=results)
 
 
 def handle_scan_chunk_error(detail: Detail, chunk: List[Scannable]) -> None:

--- a/tests/unit/cmd/scan/test_ci.py
+++ b/tests/unit/cmd/scan/test_ci.py
@@ -10,7 +10,7 @@ import pytest
 
 from ggshield.__main__ import cli
 from ggshield.core import ui
-from ggshield.core.errors import ExitCode
+from ggshield.core.errors import ExitCode, ServiceUnavailableError
 from ggshield.core.git_hooks.ci.commit_range import collect_commit_range_from_ci_env
 from ggshield.utils.git_shell import EMPTY_SHA
 from ggshield.utils.os import cd
@@ -192,6 +192,64 @@ def test_ci_cmd_does_not_work_if_ci_env_is_odd(
 
     # And the error message explains why
     assert "Current CI is not detected" in result.stdout
+
+
+@patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
+@patch("ggshield.cmd.secret.scan.ci.check_git_dir")
+def test_ci_server_unavailable(
+    _: Mock,
+    get_list_mock: Mock,
+    scan_commit_range_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN a CI environment
+    WHEN the server returns a 5xx error
+    THEN the command should return 0
+    AND display an error message about skipping checks
+    """
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    get_list_mock.return_value = ["a"] * 3
+    scan_commit_range_mock.side_effect = ServiceUnavailableError(
+        message="GitGuardian server is not responding.\nDetails: 503",
+    )
+
+    result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
+    assert_invoke_ok(result)
+    assert "Skipping ggshield checks" in result.output
+
+
+@patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
+@patch("ggshield.cmd.secret.scan.ci.check_git_dir")
+def test_ci_connection_error(
+    _: Mock,
+    get_list_mock: Mock,
+    scan_commit_range_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN a CI environment
+    WHEN the server is not reachable (ConnectionError)
+    THEN the command should return 0
+    AND display an error message about skipping checks
+    """
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    get_list_mock.return_value = ["a"] * 3
+    scan_commit_range_mock.side_effect = ServiceUnavailableError(
+        message="Failed to connect to GitGuardian server.",
+    )
+
+    result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
+    assert_invoke_ok(result)
+    assert "Skipping ggshield checks" in result.output
 
 
 DUMMY_REPO: Optional[tarfile.TarFile] = None

--- a/tests/unit/cmd/scan/test_ci.py
+++ b/tests/unit/cmd/scan/test_ci.py
@@ -10,7 +10,12 @@ import pytest
 
 from ggshield.__main__ import cli
 from ggshield.core import ui
-from ggshield.core.errors import ExitCode, ServiceUnavailableError
+from ggshield.core.errors import (
+    APIKeyCheckError,
+    ExitCode,
+    QuotaLimitReachedError,
+    ServiceUnavailableError,
+)
 from ggshield.core.git_hooks.ci.commit_range import collect_commit_range_from_ci_env
 from ggshield.utils.git_shell import EMPTY_SHA
 from ggshield.utils.os import cd
@@ -197,7 +202,7 @@ def test_ci_cmd_does_not_work_if_ci_env_is_odd(
 @patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
 @patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
 @patch("ggshield.cmd.secret.scan.ci.check_git_dir")
-def test_ci_server_unavailable(
+def test_ci_server_unavailable_default_blocks(
     _: Mock,
     get_list_mock: Mock,
     scan_commit_range_mock: Mock,
@@ -206,6 +211,36 @@ def test_ci_server_unavailable(
 ):
     """
     GIVEN a CI environment
+    AND the default configuration (fail_on_server_error=True)
+    WHEN the server returns a 5xx error
+    THEN the command exits with GITGUARDIAN_SERVER_UNAVAILABLE
+    """
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    get_list_mock.return_value = ["a"] * 3
+    scan_commit_range_mock.side_effect = ServiceUnavailableError(
+        message="GitGuardian server is not responding.\nDetails: 503",
+    )
+
+    result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
+    assert_invoke_exited_with(result, ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE)
+    assert "Skipping ggshield checks" not in result.output
+
+
+@patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
+@patch("ggshield.cmd.secret.scan.ci.check_git_dir")
+def test_ci_server_unavailable_opt_in_fail_open(
+    _: Mock,
+    get_list_mock: Mock,
+    scan_commit_range_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN a CI environment
+    AND --no-fail-on-server-error is passed
     WHEN the server returns a 5xx error
     THEN the command should return 0
     AND display an error message about skipping checks
@@ -218,7 +253,9 @@ def test_ci_server_unavailable(
         message="GitGuardian server is not responding.\nDetails: 503",
     )
 
-    result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
+    result = cli_fs_runner.invoke(
+        cli, ["secret", "scan", "ci", "--no-fail-on-server-error"]
+    )
     assert_invoke_ok(result)
     assert "Skipping ggshield checks" in result.output
 
@@ -226,7 +263,7 @@ def test_ci_server_unavailable(
 @patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
 @patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
 @patch("ggshield.cmd.secret.scan.ci.check_git_dir")
-def test_ci_connection_error(
+def test_ci_connection_error_opt_in_fail_open(
     _: Mock,
     get_list_mock: Mock,
     scan_commit_range_mock: Mock,
@@ -235,6 +272,7 @@ def test_ci_connection_error(
 ):
     """
     GIVEN a CI environment
+    AND GITGUARDIAN_FAIL_ON_SERVER_ERROR=false
     WHEN the server is not reachable (ConnectionError)
     THEN the command should return 0
     AND display an error message about skipping checks
@@ -242,6 +280,7 @@ def test_ci_connection_error(
     monkeypatch.setenv("CI", "1")
     monkeypatch.setenv("GITLAB_CI", "1")
     monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    monkeypatch.setenv("GITGUARDIAN_FAIL_ON_SERVER_ERROR", "false")
     get_list_mock.return_value = ["a"] * 3
     scan_commit_range_mock.side_effect = ServiceUnavailableError(
         message="Failed to connect to GitGuardian server.",
@@ -250,6 +289,65 @@ def test_ci_connection_error(
     result = cli_fs_runner.invoke(cli, ["secret", "scan", "ci"])
     assert_invoke_ok(result)
     assert "Skipping ggshield checks" in result.output
+
+
+@patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
+@patch("ggshield.cmd.secret.scan.ci.check_git_dir")
+def test_ci_quota_error_still_fails_with_flag(
+    _: Mock,
+    get_list_mock: Mock,
+    scan_commit_range_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN --no-fail-on-server-error is passed
+    WHEN the server returns a non-5xx error (e.g. quota reached / 403)
+    THEN the command still fails: only server errors are caught, not auth or
+    quota errors.
+    """
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    get_list_mock.return_value = ["a"] * 3
+    scan_commit_range_mock.side_effect = QuotaLimitReachedError()
+
+    result = cli_fs_runner.invoke(
+        cli, ["secret", "scan", "ci", "--no-fail-on-server-error"]
+    )
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
+
+
+@patch("ggshield.cmd.secret.scan.ci.scan_commit_range")
+@patch("ggshield.core.git_hooks.ci.commit_range.get_list_commit_SHA")
+@patch("ggshield.cmd.secret.scan.ci.check_git_dir")
+def test_ci_auth_error_still_fails_with_flag(
+    _: Mock,
+    get_list_mock: Mock,
+    scan_commit_range_mock: Mock,
+    cli_fs_runner: click.testing.CliRunner,
+    monkeypatch,
+):
+    """
+    GIVEN --no-fail-on-server-error is passed
+    WHEN the API key is rejected (401)
+    THEN the command still fails with AUTHENTICATION_ERROR. Fail-open is
+    scoped to server unavailability; auth misconfiguration must be visible.
+    """
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.setenv("GITLAB_CI", "1")
+    monkeypatch.setenv("CI_COMMIT_SHA", "abc123")
+    get_list_mock.return_value = ["a"] * 3
+    scan_commit_range_mock.side_effect = APIKeyCheckError(
+        "https://example.com", "Invalid GitGuardian API key."
+    )
+
+    result = cli_fs_runner.invoke(
+        cli, ["secret", "scan", "ci", "--no-fail-on-server-error"]
+    )
+    assert_invoke_exited_with(result, ExitCode.AUTHENTICATION_ERROR)
+    assert "Skipping ggshield checks" not in result.output
 
 
 DUMMY_REPO: Optional[tarfile.TarFile] = None

--- a/tests/unit/cmd/scan/test_precommit.py
+++ b/tests/unit/cmd/scan/test_precommit.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -9,6 +10,7 @@ from ggshield.cmd.secret.scan.precommit import (
     check_is_merge_without_conflict,
     get_merge_branch_from_reflog,
 )
+from ggshield.core.errors import ServiceUnavailableError
 from ggshield.utils.os import cd
 from tests.repository import Repository
 from tests.unit.conftest import assert_invoke_ok, my_vcr
@@ -177,3 +179,65 @@ def test_precommit_with_unmerged_files(tmp_path, cli_fs_runner):
 
     # Verify the command executed successfully
     assert_invoke_ok(result)
+
+
+@patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
+@patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
+def test_precommit_server_unavailable(
+    check_dir_mock: Mock,
+    scanner_mock: Mock,
+    tmp_path,
+    cli_fs_runner,
+):
+    """
+    GIVEN a repository with staged changes
+    WHEN the server returns a 5xx error
+    THEN the command should return 0
+    AND display an error message about skipping checks
+    """
+    scanner_mock.side_effect = ServiceUnavailableError(
+        message="GitGuardian server is not responding.\nDetails: 503",
+    )
+
+    repo = Repository.create(tmp_path)
+    (tmp_path / "test.txt").write_text("content")
+    repo.add(".")
+    repo.create_commit("initial commit")
+    (tmp_path / "test.txt").write_text("modified")
+    repo.add(".")
+
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
+    assert_invoke_ok(result)
+    assert "Skipping ggshield checks" in result.output
+
+
+@patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
+@patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
+def test_precommit_connection_error(
+    check_dir_mock: Mock,
+    scanner_mock: Mock,
+    tmp_path,
+    cli_fs_runner,
+):
+    """
+    GIVEN a repository with staged changes
+    WHEN the server is not reachable (ConnectionError)
+    THEN the command should return 0
+    AND display an error message about skipping checks
+    """
+    scanner_mock.side_effect = ServiceUnavailableError(
+        message="Failed to connect to GitGuardian server.",
+    )
+
+    repo = Repository.create(tmp_path)
+    (tmp_path / "test.txt").write_text("content")
+    repo.add(".")
+    repo.create_commit("initial commit")
+    (tmp_path / "test.txt").write_text("modified")
+    repo.add(".")
+
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
+    assert_invoke_ok(result)
+    assert "Skipping ggshield checks" in result.output

--- a/tests/unit/cmd/scan/test_precommit.py
+++ b/tests/unit/cmd/scan/test_precommit.py
@@ -10,10 +10,15 @@ from ggshield.cmd.secret.scan.precommit import (
     check_is_merge_without_conflict,
     get_merge_branch_from_reflog,
 )
-from ggshield.core.errors import ServiceUnavailableError
+from ggshield.core.errors import (
+    APIKeyCheckError,
+    ExitCode,
+    QuotaLimitReachedError,
+    ServiceUnavailableError,
+)
 from ggshield.utils.os import cd
 from tests.repository import Repository
-from tests.unit.conftest import assert_invoke_ok, my_vcr
+from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok, my_vcr
 
 
 def test_is_merge_not_merge(tmp_path):
@@ -181,9 +186,19 @@ def test_precommit_with_unmerged_files(tmp_path, cli_fs_runner):
     assert_invoke_ok(result)
 
 
+def _prepare_staged_repo(tmp_path) -> Repository:
+    repo = Repository.create(tmp_path)
+    (tmp_path / "test.txt").write_text("content")
+    repo.add(".")
+    repo.create_commit("initial commit")
+    (tmp_path / "test.txt").write_text("modified")
+    repo.add(".")
+    return repo
+
+
 @patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
 @patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
-def test_precommit_server_unavailable(
+def test_precommit_server_unavailable_default_blocks(
     check_dir_mock: Mock,
     scanner_mock: Mock,
     tmp_path,
@@ -191,6 +206,32 @@ def test_precommit_server_unavailable(
 ):
     """
     GIVEN a repository with staged changes
+    AND the default configuration (fail_on_server_error=True)
+    WHEN the server returns a 5xx error
+    THEN the command exits with GITGUARDIAN_SERVER_UNAVAILABLE
+    """
+    scanner_mock.side_effect = ServiceUnavailableError(
+        message="GitGuardian server is not responding.\nDetails: 503",
+    )
+    repo = _prepare_staged_repo(tmp_path)
+
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
+    assert_invoke_exited_with(result, ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE)
+    assert "Skipping ggshield checks" not in result.output
+
+
+@patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
+@patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
+def test_precommit_server_unavailable_opt_in_fail_open(
+    check_dir_mock: Mock,
+    scanner_mock: Mock,
+    tmp_path,
+    cli_fs_runner,
+):
+    """
+    GIVEN a repository with staged changes
+    AND --no-fail-on-server-error is passed
     WHEN the server returns a 5xx error
     THEN the command should return 0
     AND display an error message about skipping checks
@@ -198,13 +239,37 @@ def test_precommit_server_unavailable(
     scanner_mock.side_effect = ServiceUnavailableError(
         message="GitGuardian server is not responding.\nDetails: 503",
     )
+    repo = _prepare_staged_repo(tmp_path)
 
-    repo = Repository.create(tmp_path)
-    (tmp_path / "test.txt").write_text("content")
-    repo.add(".")
-    repo.create_commit("initial commit")
-    (tmp_path / "test.txt").write_text("modified")
-    repo.add(".")
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(
+            cli, ["secret", "scan", "pre-commit", "--no-fail-on-server-error"]
+        )
+    assert_invoke_ok(result)
+    assert "Skipping ggshield checks" in result.output
+
+
+@patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
+@patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
+def test_precommit_connection_error_opt_in_fail_open(
+    check_dir_mock: Mock,
+    scanner_mock: Mock,
+    tmp_path,
+    cli_fs_runner,
+    monkeypatch,
+):
+    """
+    GIVEN a repository with staged changes
+    AND GITGUARDIAN_FAIL_ON_SERVER_ERROR=false
+    WHEN the server is not reachable (ConnectionError)
+    THEN the command should return 0
+    AND display an error message about skipping checks
+    """
+    scanner_mock.side_effect = ServiceUnavailableError(
+        message="Failed to connect to GitGuardian server.",
+    )
+    repo = _prepare_staged_repo(tmp_path)
+    monkeypatch.setenv("GITGUARDIAN_FAIL_ON_SERVER_ERROR", "false")
 
     with cd(repo.path):
         result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
@@ -214,30 +279,50 @@ def test_precommit_server_unavailable(
 
 @patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
 @patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
-def test_precommit_connection_error(
+def test_precommit_quota_error_still_fails_with_flag(
     check_dir_mock: Mock,
     scanner_mock: Mock,
     tmp_path,
     cli_fs_runner,
 ):
     """
-    GIVEN a repository with staged changes
-    WHEN the server is not reachable (ConnectionError)
-    THEN the command should return 0
-    AND display an error message about skipping checks
+    GIVEN --no-fail-on-server-error is passed
+    WHEN the server returns a non-5xx error (e.g. quota reached)
+    THEN the command still fails
     """
-    scanner_mock.side_effect = ServiceUnavailableError(
-        message="Failed to connect to GitGuardian server.",
-    )
-
-    repo = Repository.create(tmp_path)
-    (tmp_path / "test.txt").write_text("content")
-    repo.add(".")
-    repo.create_commit("initial commit")
-    (tmp_path / "test.txt").write_text("modified")
-    repo.add(".")
+    scanner_mock.side_effect = QuotaLimitReachedError()
+    repo = _prepare_staged_repo(tmp_path)
 
     with cd(repo.path):
-        result = cli_fs_runner.invoke(cli, ["secret", "scan", "pre-commit"])
-    assert_invoke_ok(result)
-    assert "Skipping ggshield checks" in result.output
+        result = cli_fs_runner.invoke(
+            cli, ["secret", "scan", "pre-commit", "--no-fail-on-server-error"]
+        )
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
+
+
+@patch("ggshield.cmd.secret.scan.precommit.SecretScanner")
+@patch("ggshield.cmd.secret.scan.precommit.check_git_dir")
+def test_precommit_auth_error_still_fails_with_flag(
+    check_dir_mock: Mock,
+    scanner_mock: Mock,
+    tmp_path,
+    cli_fs_runner,
+):
+    """
+    GIVEN --no-fail-on-server-error is passed
+    WHEN the API key is rejected (401)
+    THEN the command still fails with AUTHENTICATION_ERROR. Fail-open must
+    be limited to server unavailability — auth failures are a configuration
+    problem the user has to fix and must never be silently skipped.
+    """
+    scanner_mock.side_effect = APIKeyCheckError(
+        "https://example.com", "Invalid GitGuardian API key."
+    )
+    repo = _prepare_staged_repo(tmp_path)
+
+    with cd(repo.path):
+        result = cli_fs_runner.invoke(
+            cli, ["secret", "scan", "pre-commit", "--no-fail-on-server-error"]
+        )
+    assert_invoke_exited_with(result, ExitCode.AUTHENTICATION_ERROR)
+    assert "Skipping ggshield checks" not in result.output

--- a/tests/unit/cmd/scan/test_prepush.py
+++ b/tests/unit/cmd/scan/test_prepush.py
@@ -8,7 +8,11 @@ from ggshield.__main__ import cli
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     IGNORED_DEFAULT_WILDCARDS,
 )
-from ggshield.core.errors import ExitCode, ServiceUnavailableError
+from ggshield.core.errors import (
+    ExitCode,
+    QuotaLimitReachedError,
+    ServiceUnavailableError,
+)
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import EMPTY_SHA, EMPTY_TREE
@@ -449,7 +453,7 @@ class TestPrepush:
     @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
     @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
-    def test_server_unavailable(
+    def test_server_unavailable_default_blocks(
         self,
         scan_commit_range_mock: Mock,
         get_list_mock: Mock,
@@ -458,9 +462,9 @@ class TestPrepush:
     ):
         """
         GIVEN a prepush range with commits
+        AND the default configuration (fail_on_server_error=True)
         WHEN the server returns a 5xx error
-        THEN it should return 0
-        AND display an error message about skipping checks
+        THEN the command exits with GITGUARDIAN_SERVER_UNAVAILABLE
         """
         scan_commit_range_mock.side_effect = ServiceUnavailableError(
             message="GitGuardian server is not responding.\nDetails: 503",
@@ -471,13 +475,13 @@ class TestPrepush:
             ["-v", "secret", "scan", "pre-push"],
             env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
         )
-        assert_invoke_ok(result)
-        assert "Skipping ggshield checks" in result.output
+        assert_invoke_exited_with(result, ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE)
+        assert "Skipping ggshield checks" not in result.output
 
     @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
     @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
     @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
-    def test_connection_error(
+    def test_server_unavailable_opt_in_fail_open(
         self,
         scan_commit_range_mock: Mock,
         get_list_mock: Mock,
@@ -486,6 +490,36 @@ class TestPrepush:
     ):
         """
         GIVEN a prepush range with commits
+        AND --no-fail-on-server-error is passed
+        WHEN the server returns a 5xx error
+        THEN it should return 0
+        AND display an error message about skipping checks
+        """
+        scan_commit_range_mock.side_effect = ServiceUnavailableError(
+            message="GitGuardian server is not responding.\nDetails: 503",
+        )
+        get_list_mock.return_value = ["a"] * 3
+        result = cli_fs_runner.invoke(
+            cli,
+            ["-v", "secret", "scan", "pre-push", "--no-fail-on-server-error"],
+            env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
+        )
+        assert_invoke_ok(result)
+        assert "Skipping ggshield checks" in result.output
+
+    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
+    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
+    @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
+    def test_connection_error_opt_in_fail_open(
+        self,
+        scan_commit_range_mock: Mock,
+        get_list_mock: Mock,
+        check_dir_mock: Mock,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN a prepush range with commits
+        AND GITGUARDIAN_FAIL_ON_SERVER_ERROR=false
         WHEN the server is not reachable (ConnectionError)
         THEN it should return 0
         AND display an error message about skipping checks
@@ -497,7 +531,35 @@ class TestPrepush:
         result = cli_fs_runner.invoke(
             cli,
             ["-v", "secret", "scan", "pre-push"],
-            env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
+            env={
+                "PRE_COMMIT_FROM_REF": "a" * 40,
+                "PRE_COMMIT_TO_REF": "b" * 40,
+                "GITGUARDIAN_FAIL_ON_SERVER_ERROR": "false",
+            },
         )
         assert_invoke_ok(result)
         assert "Skipping ggshield checks" in result.output
+
+    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
+    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
+    @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
+    def test_quota_error_still_fails_with_flag(
+        self,
+        scan_commit_range_mock: Mock,
+        get_list_mock: Mock,
+        check_dir_mock: Mock,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN --no-fail-on-server-error is passed
+        WHEN the server returns a non-5xx error (e.g. quota reached)
+        THEN the command still fails
+        """
+        scan_commit_range_mock.side_effect = QuotaLimitReachedError()
+        get_list_mock.return_value = ["a"] * 3
+        result = cli_fs_runner.invoke(
+            cli,
+            ["-v", "secret", "scan", "pre-push", "--no-fail-on-server-error"],
+            env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
+        )
+        assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)

--- a/tests/unit/cmd/scan/test_prepush.py
+++ b/tests/unit/cmd/scan/test_prepush.py
@@ -8,7 +8,7 @@ from ggshield.__main__ import cli
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     IGNORED_DEFAULT_WILDCARDS,
 )
-from ggshield.core.errors import ExitCode
+from ggshield.core.errors import ExitCode, ServiceUnavailableError
 from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import EMPTY_SHA, EMPTY_TREE
@@ -445,3 +445,59 @@ class TestPrepush:
     SKIP=ggshield-push git push"""
             in result.output
         )
+
+    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
+    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
+    @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
+    def test_server_unavailable(
+        self,
+        scan_commit_range_mock: Mock,
+        get_list_mock: Mock,
+        check_dir_mock: Mock,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN a prepush range with commits
+        WHEN the server returns a 5xx error
+        THEN it should return 0
+        AND display an error message about skipping checks
+        """
+        scan_commit_range_mock.side_effect = ServiceUnavailableError(
+            message="GitGuardian server is not responding.\nDetails: 503",
+        )
+        get_list_mock.return_value = ["a"] * 3
+        result = cli_fs_runner.invoke(
+            cli,
+            ["-v", "secret", "scan", "pre-push"],
+            env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
+        )
+        assert_invoke_ok(result)
+        assert "Skipping ggshield checks" in result.output
+
+    @patch("ggshield.cmd.secret.scan.prepush.check_git_dir")
+    @patch("ggshield.cmd.secret.scan.prepush.get_list_commit_SHA")
+    @patch("ggshield.cmd.secret.scan.prepush.scan_commit_range")
+    def test_connection_error(
+        self,
+        scan_commit_range_mock: Mock,
+        get_list_mock: Mock,
+        check_dir_mock: Mock,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN a prepush range with commits
+        WHEN the server is not reachable (ConnectionError)
+        THEN it should return 0
+        AND display an error message about skipping checks
+        """
+        scan_commit_range_mock.side_effect = ServiceUnavailableError(
+            message="Failed to connect to GitGuardian server.",
+        )
+        get_list_mock.return_value = ["a"] * 3
+        result = cli_fs_runner.invoke(
+            cli,
+            ["-v", "secret", "scan", "pre-push"],
+            env={"PRE_COMMIT_FROM_REF": "a" * 40, "PRE_COMMIT_TO_REF": "b" * 40},
+        )
+        assert_invoke_ok(result)
+        assert "Skipping ggshield checks" in result.output

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -370,14 +370,14 @@ class TestPreReceive:
         "pygitguardian.client.GGClient.read_metadata",
         return_value=Detail("Service is unavailable", 503),
     )
-    def test_server_unavailable(self, _: Mock, tmp_path, cli_fs_runner: CliRunner):
+    def test_server_unavailable_default_blocks(
+        self, _: Mock, tmp_path, cli_fs_runner: CliRunner
+    ):
         """
-        GIVEN a repo on which the command is ran
+        GIVEN the default configuration (fail_on_server_error=True)
         WHEN the server is not responding (503)
-        THEN it should return 0
-        AND display an error message
+        THEN the command exits with GITGUARDIAN_SERVER_UNAVAILABLE
         """
-        # setting up repo to run the command
         repo = create_pre_receive_repo(tmp_path)
         old_sha = repo.get_top_sha()
         shas = [repo.create_commit() for _ in range(3)]
@@ -387,19 +387,47 @@ class TestPreReceive:
                 ["-v", "secret", "scan", "pre-receive"],
                 input=f"{old_sha} {shas[-1]} origin/main\n",
             )
+        assert_invoke_exited_with(result, ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE)
+        assert "GitGuardian server is not responding" in result.output
+        assert "Skipping checks" not in result.output
+
+    @patch(
+        "pygitguardian.client.GGClient.read_metadata",
+        return_value=Detail("Service is unavailable", 503),
+    )
+    def test_server_unavailable_opt_in_fail_open(
+        self, _: Mock, tmp_path, cli_fs_runner: CliRunner
+    ):
+        """
+        GIVEN --no-fail-on-server-error is set via env var
+        WHEN the server is not responding (503)
+        THEN it should return 0 and display an error about skipping checks
+        """
+        repo = create_pre_receive_repo(tmp_path)
+        old_sha = repo.get_top_sha()
+        shas = [repo.create_commit() for _ in range(3)]
+        with cd(repo.path):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "secret", "scan", "pre-receive"],
+                input=f"{old_sha} {shas[-1]} origin/main\n",
+                env={"GITGUARDIAN_FAIL_ON_SERVER_ERROR": "false"},
+            )
         assert_invoke_ok(result)
         assert "GitGuardian server is not responding" in result.output
+        assert "Skipping checks" in result.output
 
     @patch(
         "pygitguardian.client.GGClient.read_metadata",
         side_effect=requests.exceptions.ConnectionError("Connection refused"),
     )
-    def test_connection_error(self, _: Mock, tmp_path, cli_fs_runner: CliRunner):
+    def test_connection_error_default_blocks(
+        self, _: Mock, tmp_path, cli_fs_runner: CliRunner
+    ):
         """
-        GIVEN a repo on which the command is run
+        GIVEN the default configuration (fail_on_server_error=True)
         WHEN the server is not reachable (ConnectionError)
-        THEN it should return 0
-        AND display an error message
+        THEN the command exits with GITGUARDIAN_SERVER_UNAVAILABLE
         """
         repo = create_pre_receive_repo(tmp_path)
         old_sha = repo.get_top_sha()
@@ -410,5 +438,32 @@ class TestPreReceive:
                 ["-v", "secret", "scan", "pre-receive"],
                 input=f"{old_sha} {shas[-1]} origin/main\n",
             )
+        assert_invoke_exited_with(result, ExitCode.GITGUARDIAN_SERVER_UNAVAILABLE)
+        assert "GitGuardian server is not responding" in result.output
+        assert "Skipping checks" not in result.output
+
+    @patch(
+        "pygitguardian.client.GGClient.read_metadata",
+        side_effect=requests.exceptions.ConnectionError("Connection refused"),
+    )
+    def test_connection_error_opt_in_fail_open(
+        self, _: Mock, tmp_path, cli_fs_runner: CliRunner
+    ):
+        """
+        GIVEN --no-fail-on-server-error is set via env var
+        WHEN the server is not reachable (ConnectionError)
+        THEN it should return 0 and display an error about skipping checks
+        """
+        repo = create_pre_receive_repo(tmp_path)
+        old_sha = repo.get_top_sha()
+        shas = [repo.create_commit() for _ in range(3)]
+        with cd(repo.path):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "secret", "scan", "pre-receive"],
+                input=f"{old_sha} {shas[-1]} origin/main\n",
+                env={"GITGUARDIAN_FAIL_ON_SERVER_ERROR": "false"},
+            )
         assert_invoke_ok(result)
         assert "GitGuardian server is not responding" in result.output
+        assert "Skipping checks" in result.output

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, Mock, patch
 
 import pytest
+import requests.exceptions
 from click.testing import CliRunner
 from pygitguardian.models import Detail
 
@@ -377,6 +378,29 @@ class TestPreReceive:
         AND display an error message
         """
         # setting up repo to run the command
+        repo = create_pre_receive_repo(tmp_path)
+        old_sha = repo.get_top_sha()
+        shas = [repo.create_commit() for _ in range(3)]
+        with cd(repo.path):
+            result = cli_fs_runner.invoke(
+                cli,
+                ["-v", "secret", "scan", "pre-receive"],
+                input=f"{old_sha} {shas[-1]} origin/main\n",
+            )
+        assert_invoke_ok(result)
+        assert "GitGuardian server is not responding" in result.output
+
+    @patch(
+        "pygitguardian.client.GGClient.read_metadata",
+        side_effect=requests.exceptions.ConnectionError("Connection refused"),
+    )
+    def test_connection_error(self, _: Mock, tmp_path, cli_fs_runner: CliRunner):
+        """
+        GIVEN a repo on which the command is run
+        WHEN the server is not reachable (ConnectionError)
+        THEN it should return 0
+        AND display an error message
+        """
         repo = create_pre_receive_repo(tmp_path)
         old_sha = repo.get_top_sha()
         shas = [repo.create_commit() for _ in range(3)]

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -49,12 +49,14 @@ def test_check_client_api_key_network_error():
     """
     GIVEN a client with a wrong instance URL
     WHEN check_client_api_key() is called
-    THEN it raises an UnexpectedError
+    THEN it raises a ServiceUnavailableError
     """
-    client_mock = Mock()
-    client_mock.health_check = Mock(side_effect=requests.exceptions.ConnectionError)
-    client_mock.read_metadata = Mock(return_value=Detail("Not found", 404))
-    with pytest.raises(UnexpectedError):
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "http://localhost"
+    client_mock.read_metadata = Mock(
+        side_effect=requests.exceptions.ConnectionError("Connection refused")
+    )
+    with pytest.raises(ServiceUnavailableError):
         check_client_api_key(client_mock, set())
 
 

--- a/tests/unit/core/test_errors.py
+++ b/tests/unit/core/test_errors.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ggshield.core.errors import handle_api_error
+from ggshield.core.errors import UnexpectedError, handle_api_error
 
 
 def test_handle_api_error_logs_detail_at_debug(caplog):
@@ -24,3 +24,21 @@ def test_handle_api_error_logs_detail_at_debug(caplog):
     error_msgs = [r.message for r in caplog.records if r.levelno == logging.ERROR]
     assert any("sensitive diagnostic info" in m for m in debug_msgs)
     assert not any("sensitive diagnostic info" in m for m in error_msgs)
+
+
+def test_handle_api_error_unknown_status_raises_unexpected_error():
+    """
+    GIVEN a Detail with status_code=None (e.g., malformed response from a proxy)
+    WHEN handle_api_error() is called
+    THEN it raises UnexpectedError, NOT ServiceUnavailableError. The
+    --no-fail-on-server-error skip path is reserved for known connectivity
+    failures (handled by SecretScanner._collect_results); a missing status
+    code is opaque and must surface as a hard failure rather than be silently
+    skipped.
+    """
+    detail = MagicMock()
+    detail.status_code = None
+    detail.detail = "Proxy returned HTML error page"
+
+    with pytest.raises(UnexpectedError):
+        handle_api_error(detail)

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, Mock, patch
 
 import click
 import pytest
+import requests
 from click import Command, Context, Group
 from pygitguardian.models import (
     APITokensResponse,
@@ -21,6 +22,7 @@ from ggshield.core.errors import (
     ExitCode,
     MissingScopesError,
     QuotaLimitReachedError,
+    ServiceUnavailableError,
     UnexpectedError,
 )
 from ggshield.core.scan import (
@@ -429,11 +431,15 @@ def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets
 
 
 @patch("pygitguardian.GGClient.multi_content_scan")
-def test_scan_unexpected_error(scan_mock: Mock, client):
+def test_scan_opaque_exception_raises_unexpected_error(scan_mock: Mock, client):
     """
-    GIVEN a call multi_content_scan raising an exception
+    GIVEN a call to multi_content_scan raising a generic, opaque exception
+    (e.g. an internal bug, JSON decode failure, SSL failure other than the
+    requests.exceptions.ConnectionError class, ...)
     WHEN calling scanner.scan
-    THEN an UnexpectedError is raised
+    THEN an UnexpectedError is raised — NOT ServiceUnavailableError. This
+    guarantees that --no-fail-on-server-error cannot silently skip scans on
+    failures whose nature we don't recognize.
     """
     scannable = StringScannable(url="localhost", content="known\nunknown")
 
@@ -450,6 +456,41 @@ def test_scan_unexpected_error(scan_mock: Mock, client):
         secret_config=SecretConfig(),
     )
     with pytest.raises(UnexpectedError, match="Scanning failed.*"):
+        scanner.scan([scannable], scanner_ui=Mock())
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(requests.exceptions.ConnectionError("boom"), id="ConnectionError"),
+        pytest.param(requests.exceptions.Timeout("boom"), id="Timeout"),
+    ],
+)
+@patch("pygitguardian.GGClient.multi_content_scan")
+def test_scan_connectivity_exception_raises_service_unavailable(
+    scan_mock: Mock, client, exception
+):
+    """
+    GIVEN multi_content_scan raises a known connectivity exception
+    WHEN calling scanner.scan
+    THEN a ServiceUnavailableError is raised, so git hook / CI commands can
+    honor --no-fail-on-server-error for genuine network failures.
+    """
+    scannable = StringScannable(url="localhost", content="known\nunknown")
+
+    scan_mock.side_effect = exception
+
+    scanner = SecretScanner(
+        client=client,
+        cache=Cache(),
+        scan_context=ScanContext(
+            scan_mode=ScanMode.PATH,
+            command_path="ggshield",
+        ),
+        check_api_key=False,
+        secret_config=SecretConfig(),
+    )
+    with pytest.raises(ServiceUnavailableError, match="Scanning failed.*"):
         scanner.scan([scannable], scanner_ui=Mock())
 
 


### PR DESCRIPTION
## Context

Currently, `ggshield` blocks in pre-push, pre-commit, and pre-receive hooks as well as in CI if the gitguardian server does not respond. In pre-push and pre-commit hooks and CI `ggshield` also blocks if the server reponds with an internal server error. 
In order to reduce dev friction, ~we should not block in any of the cases above neither on server error responses or connection errors.~ we should introduce a parameter to configure the failure mode. 

## What has been done

This PR adds a new `secret.fail_on_server_error` configuration option (default `True`), available as the `--fail-on-server-error/--no-fail-on-server-error` flag or `GITGUARDIAN_FAIL_ON_SERVER_ERROR` environment variable. When set to `False`, `secret scan pre-commit`, `secret scan pre-push`, `secret scan pre-receive`, and `secret scan ci` exit with code `0` and display a warning instead of blocking the git operation when the GitGuardian server is unreachable or returns a 5xx response. The default preserves the previous blocking behavior.

## Validation

- make sure your command-line environment variables aren't overridden by another source
- `GITGUARDIAN_FAIL_ON_SERVER_ERROR=False GITGUARDIAN_API_URL=https://localhost:1 GITGUARDIAN_API_KEY=fake uv run ggshield -v secret scan pre-commit` should return exit code 0
- `GITGUARDIAN_API_URL=https://localhost:1 GITGUARDIAN_API_KEY=fake uv run ggshield -v secret scan pre-commit` should return exit code 127

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.