### PR TITLE
MCP 2/3 - new `ai discover` command

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -9,7 +9,7 @@ name = ggshield-layers
 type = layers
 layers = 
 	ggshield.__main__
-	ggshield.cmd.auth | ggshield.cmd.config | ggshield.cmd.hmsl | ggshield.cmd.honeytoken | ggshield.cmd.install | ggshield.cmd.plugin | ggshield.cmd.quota | ggshield.cmd.secret | ggshield.cmd.status | ggshield.cmd.utils
+	ggshield.cmd.ai | ggshield.cmd.auth | ggshield.cmd.config | ggshield.cmd.hmsl | ggshield.cmd.honeytoken | ggshield.cmd.install | ggshield.cmd.plugin | ggshield.cmd.quota | ggshield.cmd.secret | ggshield.cmd.status | ggshield.cmd.utils
 	ggshield.verticals.ai | ggshield.verticals.auth | ggshield.verticals.hmsl | ggshield.verticals.secret
 	ggshield.core
 	click | ggshield.utils | pygitguardian
@@ -22,6 +22,7 @@ unmatched_ignore_imports_alerting = warn
 name = verticals-cmd-transversals
 type = forbidden
 source_modules = 
+	ggshield.cmd.ai
 	ggshield.cmd.auth
 	ggshield.cmd.config
 	ggshield.cmd.hmsl
@@ -38,6 +39,8 @@ forbidden_modules =
 	ggshield.verticals.hmsl
 	ggshield.verticals.secret
 ignore_imports = 
+	ggshield.cmd.ai.** -> ggshield.verticals.ai
+	ggshield.cmd.ai.** -> ggshield.verticals.ai.**
 	ggshield.cmd.auth.** -> ggshield.verticals.auth
 	ggshield.cmd.auth.** -> ggshield.verticals.auth.**
 	ggshield.cmd.auth.** -> ggshield.verticals.hmsl.**

--- a/changelog.d/20260421_191346_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260421_191346_paul.petit.ext_HEAD.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- New `ggshield ai discover` command.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -10,6 +10,7 @@ from typing import Any, List, Optional
 import click
 
 from ggshield import __version__
+from ggshield.cmd.ai import ai_group
 from ggshield.cmd.auth import auth_group
 from ggshield.cmd.config import config_group
 from ggshield.cmd.hmsl import hmsl_group
@@ -88,6 +89,7 @@ def _load_plugins() -> PluginRegistry:
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]},
     commands={
+        "ai": ai_group,
         "auth": auth_group,
         "config": config_group,
         "plugin": plugin_group,

--- a/ggshield/cmd/ai/__init__.py
+++ b/ggshield/cmd/ai/__init__.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+import click
+
+from ggshield.cmd.ai.discover import discover_cmd
+from ggshield.cmd.utils.common_options import add_common_options
+
+
+@click.group(commands={"discover": discover_cmd})
+@add_common_options()
+def ai_group(**kwargs: Any) -> None:
+    """Commands to work with MCP (Model Context Protocol) servers."""

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -1,0 +1,68 @@
+"""
+MCP Discover command - Discovers MCP servers and optionally probes them
+for tools, resources, and prompts.
+"""
+
+import json
+from typing import Any
+
+import click
+from rich import print
+
+from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
+from ggshield.core.errors import APIKeyCheckError, UnknownInstanceError
+from ggshield.verticals.ai.discovery import (
+    discover_ai_configuration,
+    submit_ai_discovery,
+)
+
+
+@click.command(name="discover")
+@click.option(
+    "--json",
+    "use_json",
+    is_flag=True,
+    default=False,
+    help="Output as JSON",
+)
+@add_common_options()
+@click.pass_context
+def discover_cmd(
+    ctx: click.Context,
+    use_json: bool,
+    **kwargs: Any,
+) -> None:
+    """
+    Discover MCP servers and their configuration.
+
+    Parses MCP configuration files from supported assistants
+
+    Examples:
+      ggshield mcp discover
+      ggshield mcp discover --json
+    """
+
+    config = discover_ai_configuration()
+
+    if use_json:
+        click.echo(json.dumps(config.to_dict(), indent=2))
+    else:
+        print(config)
+
+    ctx_obj = ContextObj.get(ctx)
+    try:
+        client = create_client_from_config(ctx_obj.config)
+    except (APIKeyCheckError, UnknownInstanceError) as exc:
+        ui.display_warning(
+            f"Skipping upload of AI discovery to GitGuardian ({exc}). "
+            "Authenticate with `ggshield auth login` to enable upload."
+        )
+        return
+
+    try:
+        submit_ai_discovery(client, config)
+    except Exception as exc:
+        ui.display_warning(f"Could not upload AI discovery to GitGuardian: {exc}")

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -4,21 +4,24 @@ for tools, resources, and prompts.
 """
 
 import json
-from typing import Any
+from typing import Any, Dict, List
 
 import click
-from rich import print
+from pygitguardian.models import AIDiscovery
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import APIKeyCheckError, UnknownInstanceError
+from ggshield.core.text_utils import STYLE, format_text, pluralize
+from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.discovery import (
     discover_ai_configuration,
     save_discovery_cache,
     submit_ai_discovery,
 )
+from ggshield.verticals.ai.models import Scope
 
 
 @click.command(name="discover")
@@ -48,10 +51,12 @@ def discover_cmd(
 
     config = discover_ai_configuration()
 
+    summary = _summarize_discovery(config)
+
     if use_json:
-        click.echo(json.dumps(config.to_dict(), indent=2))
+        click.echo(json.dumps(summary, indent=2))
     else:
-        print(config)
+        print_summary(summary)
 
     ctx_obj = ContextObj.get(ctx)
     try:
@@ -68,3 +73,72 @@ def discover_cmd(
         save_discovery_cache(config)
     except Exception as exc:
         ui.display_warning(f"Could not upload AI discovery to GitGuardian: {exc}")
+
+
+def _summarize_discovery(config: AIDiscovery) -> Dict[str, Any]:
+    """Summarize what we want to show of the discovery."""
+    agent_names = set()
+    servers = []
+    for server in config.servers:
+        projects = set()
+        installed_globally = False
+        for conf in server.configurations:
+            agent_names.add(conf.agent)
+            if conf.scope == Scope.USER:
+                installed_globally = True
+            elif conf.project:
+                projects.add(conf.project)
+        servers.append(
+            {
+                "name": server.display_name or server.name,
+                "installed_globally": installed_globally,
+                "projects": sorted(projects),
+            }
+        )
+    return {
+        "agents": [AGENTS[name].display_name for name in agent_names],
+        "servers": servers,
+    }
+
+
+def print_summary(summary: Dict[str, Any]) -> None:
+    """Print the summary of the discovery."""
+    agents: List[str] = summary.get("agents", [])
+    servers: List[Dict[str, Any]] = summary.get("servers", [])
+
+    nb_servers = len(servers)
+    nb_agents = len(agents)
+
+    if nb_servers == 0:
+        click.echo(format_text("No MCP servers discovered", STYLE["no_secret"]))
+        return
+
+    click.echo(
+        f"\n{format_text('Agents discovered:', STYLE['key'])} "
+        f"{', '.join(format_text(agent, STYLE['detector']) for agent in agents) if agents else 'none'} "
+        f"({nb_agents} {pluralize('agent', nb_agents)})"
+    )
+    click.echo(
+        f"{format_text('MCP servers found:', STYLE['key'])} "
+        f"{nb_servers} {pluralize('server', nb_servers)}\n"
+    )
+
+    for i, server in enumerate(servers, start=1):
+        name = server.get("name", "unknown")
+        installed_globally = server.get("installed_globally", False)
+        projects: List[str] = server.get("projects", [])
+
+        start = format_text(">", STYLE["detector_line_start"])
+        server_name = format_text(name, STYLE["detector"])
+        click.echo(f"{start} {server_name}")
+
+        indent = "   "
+        scope = "user" if installed_globally else "project"
+        click.echo(f"{indent}{format_text('Scope:', STYLE['key'])} {scope}")
+        if projects:
+            click.echo(f"{indent}{format_text('Projects:', STYLE['key'])}")
+            for j, project in enumerate(projects):
+                connector = "└─" if j == len(projects) - 1 else "├─"
+                click.echo(f"{indent}{connector} {project}")
+
+    click.echo()

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -16,6 +16,7 @@ from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import APIKeyCheckError, UnknownInstanceError
 from ggshield.verticals.ai.discovery import (
     discover_ai_configuration,
+    save_discovery_cache,
     submit_ai_discovery,
 )
 
@@ -63,6 +64,7 @@ def discover_cmd(
         return
 
     try:
-        submit_ai_discovery(client, config)
+        config = submit_ai_discovery(client, config)
+        save_discovery_cache(config)
     except Exception as exc:
         ui.display_warning(f"Could not upload AI discovery to GitGuardian: {exc}")

--- a/ggshield/verticals/ai/__init__.py
+++ b/ggshield/verticals/ai/__init__.py
@@ -1,4 +1,5 @@
 from .agents import AGENTS
+from .discovery import discover_ai_configuration
 from .hooks import AIHookScanner
 from .installation import install_hooks
 
@@ -6,5 +7,6 @@ from .installation import install_hooks
 __all__ = [
     "AGENTS",
     "AIHookScanner",
+    "discover_ai_configuration",
     "install_hooks",
 ]

--- a/ggshield/verticals/ai/__init__.py
+++ b/ggshield/verticals/ai/__init__.py
@@ -1,5 +1,9 @@
 from .agents import AGENTS
-from .discovery import discover_ai_configuration
+from .discovery import (
+    discover_ai_configuration,
+    load_discovery_cache,
+    save_discovery_cache,
+)
 from .hooks import AIHookScanner
 from .installation import install_hooks
 
@@ -9,4 +13,6 @@ __all__ = [
     "AIHookScanner",
     "discover_ai_configuration",
     "install_hooks",
+    "load_discovery_cache",
+    "save_discovery_cache",
 ]

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -1,9 +1,14 @@
+from typing import Dict
+
+from ..models import Agent
 from .claude_code import Claude
 from .copilot import Copilot
 from .cursor import Cursor
 
 
-AGENTS = {agent.name: agent for agent in [Cursor(), Claude(), Copilot()]}
+AGENTS: Dict[str, Agent] = {
+    agent.name: agent for agent in [Cursor(), Claude(), Copilot()]
+}
 
 
 __all__ = ["AGENTS", "Claude", "Copilot", "Cursor"]

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -1,10 +1,12 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import click
 
-from ..models import Agent, EventType, HookResult
+from ggshield.core.dirs import get_user_home_dir
+
+from ..models import Agent, EventType, HookResult, MCPConfiguration, Scope
 
 
 class Claude(Agent):
@@ -17,6 +19,10 @@ class Claude(Agent):
     @property
     def display_name(self) -> str:
         return "Claude Code"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".claude"
 
     def output_result(self, result: HookResult) -> int:
         response = {}
@@ -106,3 +112,38 @@ class Claude(Agent):
             if "ggshield" in command or "<COMMAND>" in command:
                 return obj
         return None
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".mcp.json"
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Look into ~/.claude.json for both user-level and project-level MCP server entries."""
+        # Load config file
+        filepath = get_user_home_dir() / ".claude.json"
+        if not (data := self._load_json_file(filepath)):
+            return
+
+        # User-level mcpServers
+        yield from self._parse_servers_block(data, Scope.USER, None)
+
+        # Per-project entries in projects dict
+        projects = data.get("projects", {})
+        if not isinstance(projects, dict):
+            return
+        for project_key, project_data in projects.items():
+            if not isinstance(project_data, dict):
+                continue
+            yield from self._parse_servers_block(
+                project_data, Scope.USER, Path(project_key)
+            )
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        """Discover project directories by scraping config files."""
+        history_file = self.config_folder / "history.jsonl"
+        projects = set()
+        for line in self._load_jsonl_file(history_file):
+            if "project" in line:
+                projects.add(Path(line["project"]))
+        for project in projects:
+            if project.is_dir():
+                yield project.resolve()

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,7 +1,10 @@
 import json
 from pathlib import Path
+from typing import Iterator
 
 import click
+
+from ggshield.core.dirs import get_user_home_dir
 
 from ..models import EventType, HookResult
 from .claude_code import Claude
@@ -20,6 +23,10 @@ class Copilot(Claude):
     @property
     def display_name(self) -> str:
         return "Copilot Chat"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".config" / "Code" / "User"
 
     def output_result(self, result: HookResult) -> int:
         response = {}
@@ -45,3 +52,14 @@ class Copilot(Claude):
     @property
     def settings_path(self) -> Path:
         return Path(".github") / "hooks" / "hooks.json"
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".vscode" / "mcp.json"
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        # Try to parse workspaces settings.
+        for file in self.config_folder.glob("workspaceStorage/*/workspace.json"):
+            if (data := self._load_json_file(file)) and "folder" in data:
+                path = Path(data["folder"].removeprefix("file://"))
+                if path.is_dir():
+                    yield path.resolve()

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -3,10 +3,16 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 import click
+from pygitguardian.models import (
+    MCPArgumentInfo,
+    MCPPromptInfo,
+    MCPResourceInfo,
+    MCPToolInfo,
+)
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookResult
+from ..models import Agent, EventType, HookResult, MCPServer
 
 
 class Cursor(Agent):
@@ -80,3 +86,118 @@ class Cursor(Agent):
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()
+
+    def discover_capabilities(self, server: MCPServer) -> bool:
+        # General Cursor strategy:
+        # For each project where Cursor was used, it created a folder with the project name
+        # in its configuration folder. Inside that folder, it stores metadata for every
+        # MCP server available in that project.
+        for configuration in server.configurations:
+            # Look for Cursor configurations
+            if configuration.agent != self.name:
+                continue
+            # We need a folder. Note: this also works for user-level configurations.
+            # as Cursor will have a `home-<username>` "project".
+            if configuration.project is None:
+                continue
+
+            # Lookup where Cursor stores the capabilities for the given project.
+            mangled = (
+                Path(configuration.project).as_posix().replace("/", "-").lstrip("-")
+            )
+            folder = self.config_folder / "projects" / mangled / "mcps"
+            if not folder.exists():
+                continue
+            # Look for a SERVER_METADATA.json file with the expected name.
+            # (each subfolder corresponds to a different MCP server)
+            for file in folder.glob("*/SERVER_METADATA.json"):
+                metadata = self._load_json_file(file)
+                if metadata and metadata.get("serverName") == configuration.name:
+                    # Found it! Update the folder
+                    folder = file.parent
+                    break
+            else:
+                # We didn't find our MCP server's metadata. Try next configuration.
+                continue
+
+            # If we reach this code, we found our MCP server's metadata folder.
+            # Hopefully it is connected. If not, Cursor creates a STATUS.md file.
+            if (folder / "STATUS.md").exists():
+                # Don't go further, we may risk discovering only an "mcp_auth" tool
+                # whereas the MCP server may be properly connected in another project.
+                continue
+
+            filled = False
+            # Tools
+            for file in folder.glob("tools/*.json"):
+                tool = self._load_json_file(file)
+                if not isinstance(tool, dict) or "name" not in tool:
+                    continue
+                server.tools.append(
+                    MCPToolInfo(
+                        name=tool["name"],
+                        description=tool.get("description", ""),
+                        arguments=_parse_tool_arguments(tool.get("arguments")),
+                    )
+                )
+                filled = True
+            # Resources
+            for file in folder.glob("resources/*.json"):
+                resource = self._load_json_file(file)
+                if not isinstance(resource, dict) or "uri" not in resource:
+                    continue
+                server.resources.append(
+                    MCPResourceInfo(
+                        uri=resource["uri"],
+                        name=resource.get("name", ""),
+                        description=resource.get("description", ""),
+                        mime_type=resource.get("mimeType", ""),
+                    )
+                )
+                filled = True
+            # Prompts
+            for file in folder.glob("prompts/*.json"):
+                prompt = self._load_json_file(file)
+                if not isinstance(prompt, dict) or "name" not in prompt:
+                    continue
+                server.prompts.append(
+                    MCPPromptInfo(
+                        name=prompt["name"], description=prompt.get("description", "")
+                    )
+                )
+                filled = True
+            if filled:
+                # Discovery done. Early return.
+                return True
+
+        return False
+
+
+def _parse_tool_arguments(
+    schema: Optional[Dict[str, Any]],
+) -> Optional[List[MCPArgumentInfo]]:
+    """Parse a JSON-Schema ``arguments`` object into a list of MCPArgumentInfo.
+
+    The schema is expected to follow the standard MCP tool descriptor format::
+
+        {"type": "object", "properties": {...}, "required": [...]}
+    """
+    if not isinstance(schema, dict):
+        return None
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+    required_set = set(schema.get("required", []))
+    arguments: List[MCPArgumentInfo] = []
+    for name, prop in properties.items():
+        if not isinstance(prop, dict):
+            continue
+        arguments.append(
+            MCPArgumentInfo(
+                name=name,
+                type=prop.get("type", "string"),
+                description=prop.get("description"),
+                required=name in required_set,
+            )
+        )
+    return arguments or None

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import click
+
+from ggshield.core.dirs import get_user_home_dir
 
 from ..models import Agent, EventType, HookResult
 
@@ -17,6 +19,10 @@ class Cursor(Agent):
     @property
     def display_name(self) -> str:
         return "Cursor"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".cursor"
 
     def output_result(self, result: HookResult) -> int:
         response = {}
@@ -62,3 +68,15 @@ class Cursor(Agent):
             if "ggshield" in command or "<COMMAND>" in command:
                 return obj
         return None
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".cursor" / "mcp.json"
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        # Because Cursor is based on VS Code, we can reuse the same logic than Copilot.
+        user_folder = get_user_home_dir() / ".config" / "Cursor" / "User"
+        for file in user_folder.glob("workspaceStorage/*/workspace.json"):
+            if (data := self._load_json_file(file)) and "folder" in data:
+                path = Path(data["folder"].removeprefix("file://"))
+                if path.is_dir():
+                    yield path.resolve()

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -1,0 +1,123 @@
+import json
+from typing import Dict, Optional, Tuple
+
+from marshmallow.exceptions import ValidationError
+from pygitguardian.models import AIDiscovery
+
+from ggshield.core.dirs import get_cache_dir
+
+from .models import MCPConfiguration, MCPServer, Scope
+
+
+AI_DISCOVERY_CACHE_FILENAME = "ai_discovery.json"
+
+
+def save_discovery_cache(config: AIDiscovery) -> None:
+    """
+    Save probe results to cache.
+    """
+    cache_path = get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(config.to_dict(), indent=4))
+    except OSError:
+        pass
+
+
+def load_discovery_cache() -> Optional[AIDiscovery]:
+    """Load discovery cache if it exists.
+
+    Returns None if the cache does not exist.
+    """
+    cache_path = get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
+    if not cache_path.exists():
+        return None
+    try:
+        return AIDiscovery.from_dict(json.loads(cache_path.read_text()))
+    except (OSError, json.JSONDecodeError, ValidationError):
+        return None
+
+
+def has_changed_from(current: AIDiscovery, other: AIDiscovery) -> bool:
+    """Check if the discovery has changed since a previous discovery."""
+    # We compare :
+    # 1. user info exactly
+    if current.user != other.user:
+        return True
+
+    # 2. MCP configurations should be the same (both in number and content)
+    other_configurations = _confs_by_key(other)
+    new_configurations = _confs_by_key(current)
+    if other_configurations != new_configurations:
+        return True
+
+    # 3. Servers may have been overriden by GIM, but we still want to detect
+    #    whether we discovered new capabilities unknown to GIM.
+    # First, build a map to find the server(s) to compare to
+    # (we know that the keys will be exactly our configurations, thanks to step 2)
+    other_servers: Dict[ConfigurationKey, MCPServer] = {}
+    for server in other.servers:
+        for configuration in server.configurations:
+            other_servers[_key(configuration)] = server
+    # Then, for each server we found, check if we have capabilities unknown to GIM
+    for server in current.servers:
+        # No data, no need to compare
+        if not server.tools and not server.resources and not server.prompts:
+            continue
+        # We don't know how our naive deduplication have been overriden by GIM,
+        # so we need to compare capabilities to each distinct destination.
+        candidates_by_name: Dict[str, MCPServer] = {}
+        for conf in server.configurations:
+            other_server = other_servers[_key(conf)]
+            candidates_by_name[other_server.name] = other_server
+        # If at least one has our capabilities, then no need to update.
+        # said otherwise, update if all candidates don't have our capabilities.
+        if all(
+            _server_has_capabilities_unknown_to(server, candidate)
+            for candidate in candidates_by_name.values()
+        ):
+            return True
+
+    return False
+
+
+ConfigurationKey = Tuple[str, Scope, Optional[str], str]
+
+
+def _key(conf: MCPConfiguration) -> ConfigurationKey:
+    """Return a unique key for the configuration.
+
+    We consider that their should be unicity over (agent, scope, project, name)
+    """
+    return (conf.agent, conf.scope, conf.project, conf.name)
+
+
+def _confs_by_key(discovery: AIDiscovery) -> Dict[ConfigurationKey, MCPConfiguration]:
+    by_key = {}
+    for server in discovery.servers:
+        for conf in server.configurations:
+            by_key[_key(conf)] = conf
+    return by_key
+
+
+def _server_has_capabilities_unknown_to(server: MCPServer, other: MCPServer) -> bool:
+    """Check if the server has capabilities unknown to the other server."""
+    # Note: we assume that if we have discovered a capability,
+    # then we have everything (name, description, etc.)
+    # So we simply check if we have names the other doesn't.
+    other_tools = {tool.name for tool in other.tools}
+    for tool in server.tools:
+        if tool.name not in other_tools:
+            return True
+
+    other_resources = {resource.uri for resource in other.resources}
+    for resource in server.resources:
+        if resource.uri not in other_resources:
+            return True
+
+    other_prompts = {prompt.name for prompt in other.prompts}
+    for prompt in server.prompts:
+        if prompt.name not in other_prompts:
+            return True
+
+    return False

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -54,6 +54,13 @@ def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
     # Merge MCP configurations into servers
     servers = _merge_mcp_configurations(mcp_configurations)
 
+    # Try to find the servers' capabilities
+    for server in servers:
+        for agent in AGENTS.values():
+            if agent.discover_capabilities(server):
+                # Discovery succeeded for this server. Early return.
+                break
+
     # Add user information
     user = get_user_info(machine_id=machine_id)
     discovery_duration = perf_counter() - start_time

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -1,0 +1,95 @@
+"""
+MCP Discovery - Discovers MCP server configurations and manages probe result caches.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+from time import perf_counter
+from typing import Dict, List, Optional
+
+from pygitguardian import GGClient
+from pygitguardian.models import AIDiscovery, Detail, MCPConfiguration, MCPServer
+
+from ggshield.core.errors import UnexpectedError
+
+from .agents import AGENTS
+from .user import get_user_info
+
+
+def refresh_and_maybe_submit_discovery(client: GGClient) -> AIDiscovery:
+    """Run discovery and submit it.
+
+    The name of the function implies that we will cache the result later.
+    """
+    discovery = discover_ai_configuration()
+
+    try:
+        # Get the updated version of the discovery, filled with data from the API.
+        discovery = submit_ai_discovery(client, discovery)
+    except Exception:
+        pass  # We don't want to display an error here, as we are in a hook.
+
+    return discovery
+
+
+def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
+    """
+    Discover configurations from all supported assistants.
+
+    Args:
+        directories: additional project directories to scan.
+    """
+    start_time = perf_counter()
+    mcp_configurations: List[MCPConfiguration] = []
+
+    # Discovered project directories
+    projects = {Path.cwd().resolve()}
+    for agent in AGENTS.values():
+        projects.update(agent.discover_project_directories())
+
+    # Discover MCP configurations
+    for agent in AGENTS.values():
+        mcp_configurations.extend(agent.discover_mcp_configurations(projects))
+
+    # Merge MCP configurations into servers
+    servers = _merge_mcp_configurations(mcp_configurations)
+
+    # Add user information
+    user = get_user_info(machine_id=machine_id)
+    discovery_duration = perf_counter() - start_time
+    return AIDiscovery(
+        user=user,
+        servers=servers,
+        discovery_duration=discovery_duration,
+    )
+
+
+def submit_ai_discovery(client: GGClient, discovery: AIDiscovery) -> AIDiscovery:
+    """
+    Send discovery results to the GitGuardian API.
+
+    Returns the updated discovery. Raises an exception if the request fails.
+    """
+    response = client.send_ai_discovery(discovery)
+    if isinstance(response, Detail):
+        raise UnexpectedError(response.detail)
+    return response
+
+
+def _merge_mcp_configurations(
+    mcp_configurations: List[MCPConfiguration],
+) -> List[MCPServer]:
+    """Merge MCP configurations into servers.
+
+    This is a first naive deduplication of MCP configurations based on their name.
+    Deduplicating is useful to avoid discovering capabilities for the same server multiple times.
+    We expect it to be improved by GIM later.
+    """
+    servers: Dict[str, List[MCPConfiguration]] = defaultdict(list)
+    for configuration in mcp_configurations:
+        servers[configuration.name].append(configuration)
+
+    return [
+        MCPServer(name=name, configurations=configurations)
+        for name, configurations in servers.items()
+    ]

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -13,19 +13,25 @@ from pygitguardian.models import AIDiscovery, Detail, MCPConfiguration, MCPServe
 from ggshield.core.errors import UnexpectedError
 
 from .agents import AGENTS
+from .cache import has_changed_from, load_discovery_cache, save_discovery_cache
 from .user import get_user_info
 
 
 def refresh_and_maybe_submit_discovery(client: GGClient) -> AIDiscovery:
-    """Run discovery and submit it.
+    """Always run discovery, compare with cache, submit only if changed."""
+    cached = load_discovery_cache()
+    # If we already have a machine id, reuse it.
+    machine_id = cached.user.machine_id if cached is not None else None
+    discovery = discover_ai_configuration(machine_id=machine_id)
 
-    The name of the function implies that we will cache the result later.
-    """
-    discovery = discover_ai_configuration()
+    # Nothing changed,
+    if cached is not None and not has_changed_from(discovery, cached):
+        return cached
 
     try:
         # Get the updated version of the discovery, filled with data from the API.
         discovery = submit_ai_discovery(client, discovery)
+        save_discovery_cache(discovery)
     except Exception:
         pass  # We don't want to display an error here, as we are in a hook.
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pygitguardian.models import MCPConfiguration
+from pygitguardian.models import MCPConfiguration, MCPServer
 
 from ggshield.core.scan import File, Scannable, StringScannable
 from ggshield.utils.files import is_path_binary
@@ -223,6 +223,13 @@ class Agent(ABC):
             results.extend(self._get_project_mcp_configurations(directory))
 
         return results
+
+    def discover_capabilities(self, server: MCPServer) -> bool:
+        """Discover capabilities for the given server.
+
+        Returns whether the capabilities were discovered.
+        """
+        return False
 
     # Helper methods
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -1,11 +1,20 @@
+import json
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from pygitguardian.models import MCPConfiguration
+
 from ggshield.core.scan import File, Scannable, StringScannable
 from ggshield.utils.files import is_path_binary
+
+
+# Small re-exports arount Py-gitguardian models to make our life easier.
+Transport = MCPConfiguration.Transport
+Scope = MCPConfiguration.Scope
 
 
 class EventType(Enum):
@@ -70,7 +79,7 @@ class Agent(ABC):
     Class that can be derived to implement behavior specific to some AI code assistants.
     """
 
-    # Metadata
+    # Properties
 
     @property
     @abstractmethod
@@ -81,6 +90,11 @@ class Agent(ABC):
     @abstractmethod
     def name(self) -> str:
         """The name of the agent."""
+
+    @property
+    @abstractmethod
+    def config_folder(self) -> Path:
+        """The folder where the assistant's config files are stored."""
 
     # Hooks
 
@@ -128,3 +142,112 @@ class Agent(ABC):
         Returns: the object to update, or None if no object was found.
         """
         return None
+
+    # Discovery
+
+    @abstractmethod
+    def project_mcp_file(self, directory: Path) -> Path:
+        """The file where MCP servers are configured at the project level."""
+
+    @abstractmethod
+    def discover_project_directories(self) -> Iterator[Path]:
+        """Discover project directories by scraping config or history files."""
+
+    def _parse_servers_block(
+        self,
+        data: Dict[str, Dict[str, Any]],
+        scope: Scope,
+        project: Optional[Path],
+    ) -> Iterator[MCPConfiguration]:
+        """Utility function to parse a "mcpServer" block and return the MCP server entries.
+
+        The format is standard across all assistants.
+        """
+        # Lookup the two usual conventions
+        servers = data.get("mcpServers", data.get("servers", {}))
+        for name, entry in servers.items():
+            if "url" in entry:
+                if entry.get("transport") == "sse":
+                    transport = Transport.SSE
+                else:
+                    transport = Transport.HTTP
+            else:
+                transport = Transport.STDIO
+
+            yield MCPConfiguration(
+                name=name,
+                agent=self.name,
+                scope=scope,
+                transport=transport,
+                project=str(project) if project else None,
+                command=entry.get("command"),
+                args=entry.get("args", []),
+                env=entry.get("env", {}),
+                url=entry.get("url"),
+                headers=entry.get("headers", {}),
+            )
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Return the MCP server entries for user-level (global) config files.
+
+        Default implementation looks in the config folder for a file named "mcp.json".
+        """
+        # Load config file
+        filepath = self.config_folder / "mcp.json"
+        if not (data := self._load_json_file(filepath)):
+            return
+        yield from self._parse_servers_block(data, Scope.USER, None)
+
+    def _get_project_mcp_configurations(
+        self, directory: Path
+    ) -> Iterator[MCPConfiguration]:
+        """Return the MCP server entries for project-level config files."""
+        if data := self._load_json_file(self.project_mcp_file(directory)):
+            yield from self._parse_servers_block(data, Scope.PROJECT, directory)
+
+    def discover_mcp_configurations(
+        self, directories: Iterable[Path]
+    ) -> List[MCPConfiguration]:
+        """Discover MCP configurations from user and project config files.
+
+        Iterates over user-level paths, then project-level paths for each
+        directory in *directories*.
+        """
+        results: List[MCPConfiguration] = []
+
+        # User-level configs
+        results.extend(self._get_user_mcp_configurations())
+
+        # Project-level configs
+        for directory in directories:
+            results.extend(self._get_project_mcp_configurations(directory))
+
+        return results
+
+    # Helper methods
+
+    def _load_json_file(self, path: Path) -> Optional[Dict[str, Any]]:
+        """Load a JSON file and return the data, or None if the file doesn't exist (or is not a JSON object)."""
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data
+
+    def _load_jsonl_file(self, path: Path) -> Iterator[Dict[str, Any]]:
+        """Load a JSONL file and return the data line by line,
+        or nothing if the file doesn't exist (or is not a JSON object)."""
+        if not path.is_file():
+            yield from []
+        try:
+            for line in open(path, "r"):
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+        except OSError:
+            yield from []

--- a/ggshield/verticals/ai/user.py
+++ b/ggshield/verticals/ai/user.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from pygitguardian.models import UserInfo
+
+
+def get_user_info(machine_id: Optional[str] = None) -> UserInfo:
+    """Dummy implementation. To replace in next commit."""
+    return UserInfo(
+        hostname="host",
+        username="toto",
+        machine_id=machine_id or "mid",
+        user_email="toto@gg.com",
+    )

--- a/ggshield/verticals/ai/user.py
+++ b/ggshield/verticals/ai/user.py
@@ -1,13 +1,203 @@
+"""
+This module provides information about the current user and machine.
+
+It should be eventually merged with the logic used by local scanning.
+"""
+
+import getpass
+import logging
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+import uuid
+from pathlib import Path
 from typing import Optional
 
 from pygitguardian.models import UserInfo
 
+from ggshield.core.dirs import get_user_home_dir
+
+
+logger = logging.getLogger(__name__)
+
+_MAC_IOREG_UUID_RE = re.compile(r'"IOPlatformUUID"\s*=\s*"([^"]+)"')
+
 
 def get_user_info(machine_id: Optional[str] = None) -> UserInfo:
-    """Dummy implementation. To replace in next commit."""
+    """Collect hostname, username, machine identifier, and best-effort email."""
     return UserInfo(
-        hostname="host",
-        username="toto",
-        machine_id=machine_id or "mid",
-        user_email="toto@gg.com",
+        hostname=_get_hostname(),
+        username=_get_username(),
+        machine_id=machine_id or _get_machine_id(),
+        user_email=_get_user_email(),
     )
+
+
+def _get_hostname() -> str:
+    if sys.platform == "win32":
+        name = (os.environ.get("COMPUTERNAME") or "").strip()
+        if name:
+            return name
+    try:
+        return socket.gethostname() or "unknown"
+    except OSError:
+        return "unknown"
+
+
+def _get_username() -> str:
+    try:
+        return getpass.getuser()
+    except Exception:
+        pass
+    try:
+        return os.getlogin()
+    except Exception:
+        return "unknown"
+
+
+def _get_user_email() -> Optional[str]:
+    """Best-effort user email; tries `git config user.email` first."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            email = (result.stdout or "").strip()
+            return email or None
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def _read_first_nonempty_line(path: Path) -> Optional[str]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    for line in text:
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _get_linux_system_id() -> Optional[str]:
+    for candidate in (
+        Path("/etc/machine-id"),
+        Path("/sys/class/dmi/id/product_uuid"),
+        Path("/var/lib/dbus/machine-id"),
+    ):
+        value = _read_first_nonempty_line(candidate)
+        if value:
+            return value
+    return None
+
+
+def _get_macos_system_id() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            return None
+        match = _MAC_IOREG_UUID_RE.search(result.stdout)
+        if match:
+            return match.group(1).strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def _parse_wmic_uuid(stdout: str) -> Optional[str]:
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or line.upper() == "UUID":
+            continue
+        try:
+            return str(uuid.UUID(line))
+        except ValueError:
+            pass
+    return None
+
+
+def _get_windows_system_id() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["wmic", "csproduct", "get", "uuid"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout:
+            parsed = _parse_wmic_uuid(result.stdout)
+            if parsed:
+                return parsed
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "(Get-CimInstance Win32_ComputerSystemProduct).UUID",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout:
+            try:
+                return str(uuid.UUID(result.stdout.strip()))
+            except ValueError:
+                pass
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def _get_machine_id() -> str:
+
+    # In case Satori generated a machine id, use it.
+    path = get_user_home_dir() / ".satori" / "machine_id"
+    try:
+        if path.is_file():
+            cached = _read_first_nonempty_line(path)
+            if cached:
+                return cached
+    except OSError:
+        pass
+
+    system = platform.system().lower()
+    system_id = None
+
+    if system == "darwin":
+        system_id = _get_macos_system_id()
+    elif system == "linux":
+        system_id = _get_linux_system_id()
+    elif sys.platform == "win32":
+        system_id = _get_windows_system_id()
+
+    if system_id:
+        return system_id
+
+    # If everything failed, use a random UUID.
+    # Store it so that satori can use it.
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_id + "\n")
+    except OSError:
+        pass
+
+    return new_id

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1,13 +1,127 @@
 import json
 from pathlib import Path
+from typing import Optional
 from unittest.mock import patch
 
 from ggshield.verticals.ai.agents.claude_code import Claude
 from ggshield.verticals.ai.agents.cursor import Cursor
+from ggshield.verticals.ai.models import MCPConfiguration, MCPServer, Scope, Transport
+
+
+def _cfg(
+    name: str = "srv",
+    agent: str = "cursor",
+    scope: Scope = Scope.USER,
+    project: Optional[Path] = None,
+) -> MCPConfiguration:
+    return MCPConfiguration(
+        name=name,
+        agent=agent,
+        scope=scope,
+        transport=Transport.STDIO,
+        project=str(project) if project else None,
+    )
+
 
 # ===========================================================================
 # Cursor
 # ===========================================================================
+
+
+class TestCursorDiscoverCapabilities:
+    def _setup_mcps_folder(
+        self, tmp_path: Path, project_path: Path, server_name: str
+    ) -> Path:
+        """Build a Cursor-style mcps/<server>/ folder layout and return the agent."""
+        mangled = project_path.as_posix().replace("/", "-").lstrip("-")
+        mcps_root = tmp_path / ".cursor" / "projects" / mangled / "mcps"
+        server_dir = mcps_root / "user-my-server"
+        server_dir.mkdir(parents=True, exist_ok=True)
+        # SERVER_METADATA.json
+        (server_dir / "SERVER_METADATA.json").write_text(
+            json.dumps({"serverName": server_name})
+        )
+        return server_dir
+
+    def test_populates_tools_resources_prompts(self, tmp_path: Path):
+        project = Path("/home/user/project")
+        server_dir = self._setup_mcps_folder(tmp_path, project, "my-mcp")
+
+        (server_dir / "tools").mkdir()
+        (server_dir / "tools" / "t1.json").write_text(
+            json.dumps({"name": "do_thing", "description": "Does a thing"})
+        )
+        (server_dir / "resources").mkdir()
+        (server_dir / "resources" / "r1.json").write_text(
+            json.dumps({"uri": "file:///data", "name": "data"})
+        )
+        (server_dir / "prompts").mkdir()
+        (server_dir / "prompts" / "p1.json").write_text(
+            json.dumps({"name": "greeting", "description": "Says hi"})
+        )
+
+        cursor = Cursor()
+        cfg = _cfg(name="my-mcp", agent="cursor", project=project)
+        server = MCPServer(name="my-mcp", configurations=[cfg])
+
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".cursor"),
+        ):
+            result = cursor.discover_capabilities(server)
+
+        assert result is True
+        assert len(server.tools) == 1
+        assert server.tools[0].name == "do_thing"
+        assert len(server.resources) == 1
+        assert server.resources[0].uri == "file:///data"
+        assert len(server.prompts) == 1
+        assert server.prompts[0].name == "greeting"
+
+    def test_status_md_present_returns_false(self, tmp_path: Path):
+        project = Path("/home/user/project")
+        server_dir = self._setup_mcps_folder(tmp_path, project, "my-mcp")
+        (server_dir / "STATUS.md").write_text("disconnected")
+        (server_dir / "tools").mkdir()
+        (server_dir / "tools" / "t1.json").write_text(json.dumps({"name": "t"}))
+
+        cursor = Cursor()
+        cfg = _cfg(name="my-mcp", agent="cursor", project=project)
+        server = MCPServer(name="my-mcp", configurations=[cfg])
+
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".cursor"),
+        ):
+            result = cursor.discover_capabilities(server)
+
+        assert result is False
+        assert len(server.tools) == 0
+
+    def test_no_matching_metadata_returns_false(self, tmp_path: Path):
+        project = Path("/home/user/project")
+        self._setup_mcps_folder(tmp_path, project, "other-server")
+
+        cursor = Cursor()
+        cfg = _cfg(name="my-mcp", agent="cursor", project=project)
+        server = MCPServer(name="my-mcp", configurations=[cfg])
+
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".cursor"),
+        ):
+            result = cursor.discover_capabilities(server)
+
+        assert result is False
+
+    def test_non_cursor_configuration_skipped(self):
+        cursor = Cursor()
+        cfg = _cfg(name="srv", agent="claude-code", project=Path("/proj"))
+        server = MCPServer(name="srv", configurations=[cfg])
+        assert cursor.discover_capabilities(server) is False
 
 
 class TestCursorDiscoverProjectDirectories:

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from ggshield.verticals.ai.agents.claude_code import Claude
+from ggshield.verticals.ai.agents.cursor import Cursor
+
+# ===========================================================================
+# Cursor
+# ===========================================================================
+
+
+class TestCursorDiscoverProjectDirectories:
+    def test_valid_workspace_json_yields_path(self, tmp_path: Path):
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        ws_storage = (
+            tmp_path / ".config" / "Cursor" / "User" / "workspaceStorage" / "abc"
+        )
+        ws_storage.mkdir(parents=True)
+        (ws_storage / "workspace.json").write_text(
+            json.dumps({"folder": f"file://{project_dir}"})
+        )
+
+        cursor = Cursor()
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(
+                lambda self: tmp_path / ".config" / "Cursor" / "User"
+            ),
+        ):
+            with patch(
+                "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+                return_value=tmp_path,
+            ):
+                dirs = list(cursor.discover_project_directories())
+
+        assert project_dir.resolve() in dirs
+
+    def test_missing_folder_key_skipped(self, tmp_path: Path):
+        ws_storage = (
+            tmp_path / ".config" / "Cursor" / "User" / "workspaceStorage" / "abc"
+        )
+        ws_storage.mkdir(parents=True)
+        (ws_storage / "workspace.json").write_text(json.dumps({"other": "val"}))
+
+        cursor = Cursor()
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(
+                lambda self: tmp_path / ".config" / "Cursor" / "User"
+            ),
+        ):
+            with patch(
+                "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+                return_value=tmp_path,
+            ):
+                dirs = list(cursor.discover_project_directories())
+
+        assert dirs == []
+
+
+# ===========================================================================
+# Claude Code
+# ===========================================================================
+
+
+class TestClaudeGetUserMcpConfigurations:
+    def test_user_level_and_project_level_parsed(self, tmp_path: Path):
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        claude_json = {
+            "mcpServers": {"global-srv": {"command": "npx", "args": ["-y", "mcp"]}},
+            "projects": {
+                str(project_dir): {
+                    "mcpServers": {
+                        "project-srv": {"command": "node", "args": ["index.js"]}
+                    }
+                }
+            },
+        }
+        with patch(
+            "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            (tmp_path / ".claude.json").write_text(json.dumps(claude_json))
+            claude = Claude()
+            configs = list(claude._get_user_mcp_configurations())
+
+        names = {c.name for c in configs}
+        assert "global-srv" in names
+        assert "project-srv" in names
+
+    def test_missing_file_yields_nothing(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            claude = Claude()
+            configs = list(claude._get_user_mcp_configurations())
+        assert configs == []
+
+
+class TestClaudeDiscoverProjectDirectories:
+    def test_yields_existing_directories(self, tmp_path: Path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        history = tmp_path / ".claude" / "history.jsonl"
+        history.parent.mkdir(parents=True)
+        history.write_text(json.dumps({"project": str(project)}) + "\n")
+
+        claude = Claude()
+        with patch.object(
+            type(claude),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".claude"),
+        ):
+            dirs = list(claude.discover_project_directories())
+
+        assert project.resolve() in dirs
+
+    def test_skips_nonexistent_directories(self, tmp_path: Path):
+        history = tmp_path / ".claude" / "history.jsonl"
+        history.parent.mkdir(parents=True)
+        history.write_text(
+            json.dumps({"project": str(tmp_path / "nonexistent")}) + "\n"
+        )
+
+        claude = Claude()
+        with patch.object(
+            type(claude),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".claude"),
+        ):
+            dirs = list(claude.discover_project_directories())
+
+        assert dirs == []

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -1,0 +1,238 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import (
+    AIDiscovery,
+    MCPConfiguration,
+    MCPPromptInfo,
+    MCPResourceInfo,
+    MCPToolInfo,
+    UserInfo,
+)
+
+from ggshield.verticals.ai.cache import (
+    _server_has_capabilities_unknown_to,
+    has_changed_from,
+    load_discovery_cache,
+    save_discovery_cache,
+)
+from ggshield.verticals.ai.models import MCPServer, Scope, Transport
+
+
+def _user(**kwargs: Any) -> UserInfo:
+    defaults = dict(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
+    return UserInfo(**(defaults | kwargs))
+
+
+def _server(
+    name: str = "srv",
+    tools: Optional[List[MCPToolInfo]] = None,
+    resources: Optional[List[MCPResourceInfo]] = None,
+    prompts: Optional[List[MCPPromptInfo]] = None,
+    configurations: Optional[List[MCPConfiguration]] = None,
+) -> MCPServer:
+    return MCPServer(
+        name=name,
+        tools=tools or [],
+        resources=resources or [],
+        prompts=prompts or [],
+        configurations=configurations or [],
+    )
+
+
+def _cfg(
+    name: str = "srv",
+    agent: str = "cursor",
+    scope: Scope = Scope.USER,
+    project: Optional[str] = None,
+) -> MCPConfiguration:
+    return MCPConfiguration(
+        name=name,
+        agent=agent,
+        scope=scope,
+        transport=Transport.STDIO,
+        project=project,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCPServer.has_capabilities_unknown_to
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerHasCapabilitiesUnknownTo:
+    @pytest.mark.parametrize(
+        "self_kwargs, other_kwargs, expected",
+        [
+            pytest.param(
+                {"tools": [MCPToolInfo(name="t1")]},
+                {"tools": [MCPToolInfo(name="t1")]},
+                False,
+                id="same_tools",
+            ),
+            pytest.param(
+                {"tools": [MCPToolInfo(name="t1"), MCPToolInfo(name="t2")]},
+                {"tools": [MCPToolInfo(name="t1")]},
+                True,
+                id="extra_tool",
+            ),
+            pytest.param(
+                {"resources": [MCPResourceInfo(uri="r1"), MCPResourceInfo(uri="r2")]},
+                {"resources": [MCPResourceInfo(uri="r1")]},
+                True,
+                id="extra_resource",
+            ),
+            pytest.param(
+                {"prompts": [MCPPromptInfo(name="p1"), MCPPromptInfo(name="p2")]},
+                {"prompts": [MCPPromptInfo(name="p1")]},
+                True,
+                id="extra_prompt",
+            ),
+            pytest.param(
+                {"tools": [MCPToolInfo(name="t1")]},
+                {"tools": [MCPToolInfo(name="t1"), MCPToolInfo(name="t2")]},
+                False,
+                id="subset_of_other",
+            ),
+            pytest.param({}, {}, False, id="both_empty"),
+        ],
+    )
+    def test_has_capabilities_unknown_to(
+        self, self_kwargs: Dict[str, Any], other_kwargs: Dict[str, Any], expected: bool
+    ):
+        assert (
+            _server_has_capabilities_unknown_to(
+                _server(**self_kwargs), _server(**other_kwargs)
+            )
+            is expected
+        )
+
+
+# ---------------------------------------------------------------------------
+# AIDiscovery.has_changed_from
+# ---------------------------------------------------------------------------
+
+
+class TestAIDiscoveryHasChangedFrom:
+    def test_identical_returns_false(self):
+        cfg = _cfg()
+        a = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            discovery_duration=0.2,
+        )
+        assert has_changed_from(a, b) is False
+
+    def test_different_user_returns_true(self):
+        cfg = _cfg()
+        a = AIDiscovery(
+            user=_user(hostname="a"),
+            servers=[_server(configurations=[cfg])],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(hostname="b"),
+            servers=[_server(configurations=[cfg])],
+            discovery_duration=0.1,
+        )
+        assert has_changed_from(a, b) is True
+
+    def test_different_configuration_keys_returns_true(self):
+        a = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[_cfg(name="x")])],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[_cfg(name="y")])],
+            discovery_duration=0.1,
+        )
+        assert has_changed_from(a, b) is True
+
+    def test_new_capabilities_unknown_to_all_candidates_returns_true(self):
+        cfg = _cfg()
+        a = AIDiscovery(
+            user=_user(),
+            servers=[
+                _server(
+                    configurations=[cfg],
+                    tools=[MCPToolInfo(name="new_tool")],
+                )
+            ],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            discovery_duration=0.1,
+        )
+        assert has_changed_from(a, b) is True
+
+    def test_capabilities_known_to_one_candidate_returns_false(self):
+        cfg = _cfg()
+        tool = MCPToolInfo(name="known")
+        a = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg], tools=[tool])],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg], tools=[tool])],
+            discovery_duration=0.1,
+        )
+        assert has_changed_from(a, b) is False
+
+    def test_empty_servers_returns_false(self):
+        a = AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+        b = AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+        assert has_changed_from(a, b) is False
+
+
+# ---------------------------------------------------------------------------
+# load / save discovery cache
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSaveDiscoveryCache:
+    def test_round_trip(self, tmp_path: Path):
+        discovery = AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            save_discovery_cache(discovery)
+            loaded = load_discovery_cache()
+        assert loaded is not None
+        assert loaded.user == discovery.user
+
+    def test_load_returns_none_when_missing(self, tmp_path: Path):
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert load_discovery_cache() is None
+
+    def test_load_returns_none_on_valid_json_bad_schema(self, tmp_path: Path):
+        """Valid JSON that doesn't match AIDiscovery schema."""
+        cache_file = tmp_path / "ai_discovery.json"
+        cache_file.write_text('{"foo": "bar"}')
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert load_discovery_cache() is None
+
+    def test_load_returns_none_on_invalid_json(self, tmp_path: Path):
+        """Valid JSON that doesn't match AIDiscovery schema."""
+        cache_file = tmp_path / "ai_discovery.json"
+        cache_file.write_text("not json")
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert load_discovery_cache() is None
+
+    def test_load_returns_none_on_oserror(self, tmp_path: Path):
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            cache_file = tmp_path / "ai_discovery.json"
+            cache_file.mkdir()  # directory instead of file triggers OSError
+            assert load_discovery_cache() is None

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from ggshield.__main__ import cli
+
+
+# ---------------------------------------------------------------------------
+# ggshield secret scan ai-hook
+# ---------------------------------------------------------------------------
+
+
+class TestAiHookCmd:
+    @patch("ggshield.cmd.secret.scan.ai_hook.AIHookScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.SecretScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.create_client_from_config")
+    def test_valid_json_stdin(
+        self,
+        mock_client: MagicMock,
+        mock_scanner_cls: MagicMock,
+        mock_hook_scanner: MagicMock,
+    ):
+        instance = mock_hook_scanner.return_value
+        instance.scan.return_value = 0
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["secret", "scan", "ai-hook"],
+            input='{"event_type": "test"}',
+        )
+
+        assert result.exit_code == 0
+        instance.scan.assert_called_once()
+
+    @patch("ggshield.cmd.secret.scan.ai_hook.AIHookScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.SecretScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.create_client_from_config")
+    def test_empty_stdin_returns_error(
+        self,
+        mock_client: MagicMock,
+        mock_scanner_cls: MagicMock,
+        mock_hook_scanner: MagicMock,
+    ):
+        instance = mock_hook_scanner.return_value
+        instance.scan.side_effect = ValueError("Empty input")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["secret", "scan", "ai-hook"],
+            input="",
+        )
+
+        assert result.exit_code == 1
+
+    @patch("ggshield.cmd.secret.scan.ai_hook.AIHookScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.SecretScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.create_client_from_config")
+    def test_large_stdin_does_not_crash(
+        self,
+        mock_client: MagicMock,
+        mock_scanner_cls: MagicMock,
+        mock_hook_scanner: MagicMock,
+    ):
+        instance = mock_hook_scanner.return_value
+        instance.scan.return_value = 0
+
+        runner = CliRunner()
+        large_input = "x" * (1024 * 1024)  # 1 MB
+        result = runner.invoke(
+            cli,
+            ["secret", "scan", "ai-hook"],
+            input=large_input,
+        )
+
+        assert result.exit_code == 0

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -105,16 +105,19 @@ class TestDiscoverCmd:
         "ggshield.cmd.ai.discover.submit_ai_discovery",
         return_value=_discovery(),
     )
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
     def test_default_output(
         self,
         mock_save: MagicMock,
         mock_submit: MagicMock,
         mock_client: MagicMock,
+        mock_discover: MagicMock,
     ):
         runner = CliRunner()
         result = runner.invoke(cli, ["ai", "discover"])
 
         assert result.exit_code == 0
+        mock_discover.assert_called_once()
 
     @patch(
         "ggshield.cmd.ai.discover.discover_ai_configuration",
@@ -125,11 +128,13 @@ class TestDiscoverCmd:
         "ggshield.cmd.ai.discover.submit_ai_discovery",
         return_value=_discovery(),
     )
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
     def test_json_flag(
         self,
         mock_save: MagicMock,
         mock_submit: MagicMock,
         mock_client: MagicMock,
+        mock_discover: MagicMock,
     ):
         runner = CliRunner()
         result = runner.invoke(cli, ["ai", "discover", "--json"])

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -1,11 +1,15 @@
 import json
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
+import click
 from click.testing import CliRunner
-from pygitguardian.models import AIDiscovery, UserInfo
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
 
 from ggshield.__main__ import cli
+from ggshield.cmd.ai.discover import print_summary
 from ggshield.core.errors import APIKeyCheckError
+from ggshield.verticals.ai.models import Scope, Transport
 
 
 def _user():
@@ -14,8 +18,35 @@ def _user():
     )
 
 
-def _discovery():
-    return AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+def _discovery(servers: Optional[List[MCPServer]] = None):
+    return AIDiscovery(user=_user(), servers=servers or [], discovery_duration=0.1)
+
+
+def _server(
+    name: str,
+    display_name: Optional[str] = None,
+    configurations: Optional[List[MCPConfiguration]] = None,
+) -> MCPServer:
+    return MCPServer(
+        name=name,
+        display_name=display_name,
+        configurations=configurations or [],
+    )
+
+
+def _config(
+    name: str = "srv",
+    agent: str = "cursor",
+    scope: Scope = Scope.PROJECT,
+    project: Optional[str] = None,
+) -> MCPConfiguration:
+    return MCPConfiguration(
+        name=name,
+        agent=agent,
+        scope=scope,
+        transport=Transport.STDIO,
+        project=project,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +172,8 @@ class TestDiscoverCmd:
 
         assert result.exit_code == 0
         parsed = json.loads(result.output)
-        assert "user" in parsed
+        assert "agents" in parsed
+        assert "servers" in parsed
 
     @patch(
         "ggshield.cmd.ai.discover.discover_ai_configuration",
@@ -177,3 +209,203 @@ class TestDiscoverCmd:
 
         assert result.exit_code == 0
         assert "Could not upload" in result.output or "warning" in result.output.lower()
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+    )
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    def test_text_output_with_servers(
+        self,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        """Text output lists agents, servers, scope, and projects."""
+        discovery = _discovery(
+            servers=[
+                _server(
+                    "my-mcp",
+                    display_name="My MCP",
+                    configurations=[
+                        _config(
+                            agent="cursor",
+                            scope=Scope.USER,
+                        ),
+                    ],
+                ),
+                _server(
+                    "project-srv",
+                    display_name="Project Server",
+                    configurations=[
+                        _config(
+                            agent="cursor",
+                            scope=Scope.PROJECT,
+                            project="/home/user/project-a",
+                        ),
+                        _config(
+                            agent="cursor",
+                            scope=Scope.PROJECT,
+                            project="/home/user/project-b",
+                        ),
+                    ],
+                ),
+            ]
+        )
+        mock_discover.return_value = discovery
+        mock_submit.return_value = discovery
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover"])
+
+        assert result.exit_code == 0
+        assert "Cursor" in result.output
+        assert "2 servers" in result.output
+        assert "My MCP" in result.output
+        assert "Scope: user" in result.output
+        assert "Project Server" in result.output
+        assert "Scope: project" in result.output
+        assert "/home/user/project-a" in result.output
+        assert "/home/user/project-b" in result.output
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+    )
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    def test_json_output_with_servers(
+        self,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        """JSON output contains structured data for agents and servers."""
+        discovery = _discovery(
+            servers=[
+                _server(
+                    "my-mcp",
+                    display_name="My MCP",
+                    configurations=[
+                        _config(agent="cursor", scope=Scope.USER),
+                    ],
+                ),
+            ]
+        )
+        mock_discover.return_value = discovery
+        mock_submit.return_value = discovery
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["agents"] == ["Cursor"]
+        assert len(parsed["servers"]) == 1
+        assert parsed["servers"][0]["name"] == "My MCP"
+        assert parsed["servers"][0]["installed_globally"] is True
+
+
+# ---------------------------------------------------------------------------
+# print_summary (unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestPrintSummary:
+    def test_empty_servers(self):
+        """No servers: prints a 'no servers' message."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                _echo_summary_cmd,
+                args=[],
+                input=json.dumps({"agents": [], "servers": []}),
+            )
+        assert "No MCP servers discovered" in result.output
+
+    def test_single_global_server(self):
+        summary: Dict[str, Any] = {
+            "agents": ["Cursor"],
+            "servers": [
+                {
+                    "name": "my-server",
+                    "installed_globally": True,
+                    "projects": [],
+                }
+            ],
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                _echo_summary_cmd, args=[], input=json.dumps(summary)
+            )
+        assert "1 server" in result.output
+        assert "1 agent" in result.output
+        assert "my-server" in result.output
+        assert "Scope: user" in result.output
+
+    def test_multiple_servers_with_projects(self):
+        summary: Dict[str, Any] = {
+            "agents": ["Cursor", "Claude Code"],
+            "servers": [
+                {
+                    "name": "server-a",
+                    "installed_globally": False,
+                    "projects": ["/path/to/proj1", "/path/to/proj2"],
+                },
+                {
+                    "name": "server-b",
+                    "installed_globally": True,
+                    "projects": [],
+                },
+            ],
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                _echo_summary_cmd, args=[], input=json.dumps(summary)
+            )
+        output = result.output
+        assert "2 servers" in output
+        assert "2 agents" in output
+        assert "server-a" in output
+        assert "server-b" in output
+        assert "/path/to/proj1" in output
+        assert "/path/to/proj2" in output
+        assert "├─" in output
+        assert "└─" in output
+
+    def test_server_name_fallback(self):
+        """Servers with missing name get 'unknown'."""
+        summary: Dict[str, Any] = {
+            "agents": [],
+            "servers": [
+                {
+                    "installed_globally": False,
+                    "projects": [],
+                }
+            ],
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                _echo_summary_cmd, args=[], input=json.dumps(summary)
+            )
+        assert "unknown" in result.output
+
+
+@click.command()
+@click.pass_context
+def _echo_summary_cmd(ctx: click.Context) -> None:
+    """Helper command that reads a summary from stdin and prints it."""
+    import sys
+
+    data = json.load(sys.stdin)
+    print_summary(data)

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -1,8 +1,21 @@
+import json
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
+from pygitguardian.models import AIDiscovery, UserInfo
 
 from ggshield.__main__ import cli
+from ggshield.core.errors import APIKeyCheckError
+
+
+def _user():
+    return UserInfo(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
+
+
+def _discovery():
+    return AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
 
 
 # ---------------------------------------------------------------------------
@@ -75,3 +88,87 @@ class TestAiHookCmd:
         )
 
         assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# ggshield ai discover
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverCmd:
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        return_value=_discovery(),
+    )
+    def test_default_output(
+        self,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover"])
+
+        assert result.exit_code == 0
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        return_value=_discovery(),
+    )
+    def test_json_flag(
+        self,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "user" in parsed
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch(
+        "ggshield.cmd.ai.discover.create_client_from_config",
+        side_effect=APIKeyCheckError("https://api.gitguardian.com", "no key"),
+    )
+    def test_auth_failure_shows_warning(
+        self, mock_client: MagicMock, mock_discover: MagicMock
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover"])
+
+        assert result.exit_code == 0
+        assert "Skipping upload" in result.output or "warning" in result.output.lower()
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        side_effect=RuntimeError("API error"),
+    )
+    def test_api_submission_failure_shows_warning(
+        self, mock_submit: MagicMock, mock_client: MagicMock, mock_discover: MagicMock
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover"])
+
+        assert result.exit_code == 0
+        assert "Could not upload" in result.output or "warning" in result.output.lower()

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, Detail, MCPServer, UserInfo
+
+from ggshield.core.errors import UnexpectedError
+from ggshield.verticals.ai.discovery import (
+    _merge_mcp_configurations,
+    discover_ai_configuration,
+    submit_ai_discovery,
+)
+from ggshield.verticals.ai.models import MCPConfiguration, Scope, Transport
+
+
+def _user(**kwargs: Any) -> UserInfo:
+    defaults = dict(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
+    return UserInfo.from_dict(defaults | kwargs)
+
+
+def _cfg(
+    name: str = "srv", agent: str = "cursor", scope: Scope = Scope.USER
+) -> MCPConfiguration:
+    return MCPConfiguration(
+        name=name, agent=agent, scope=scope, transport=Transport.STDIO
+    )
+
+
+def _discovery(
+    user: UserInfo = _user(),
+    servers: List[MCPServer] = [],
+    discovery_duration: float = 0.1,
+) -> AIDiscovery:
+    return AIDiscovery(
+        user=user, servers=servers, discovery_duration=discovery_duration
+    )
+
+
+# ---------------------------------------------------------------------------
+# _merge_mcp_configurations
+# ---------------------------------------------------------------------------
+
+
+class TestMergeMcpConfigurations:
+    def test_different_names_produce_separate_servers(self):
+        configs = [_cfg(name="a"), _cfg(name="b")]
+        servers = _merge_mcp_configurations(configs)
+        assert len(servers) == 2
+        names = {s.name for s in servers}
+        assert names == {"a", "b"}
+
+    def test_same_name_merged_under_one_server(self):
+        configs = [_cfg(name="x", agent="cursor"), _cfg(name="x", agent="claude-code")]
+        servers = _merge_mcp_configurations(configs)
+        assert len(servers) == 1
+        assert len(servers[0].configurations) == 2
+
+    def test_empty_list_returns_empty(self):
+        assert _merge_mcp_configurations([]) == []
+
+
+# ---------------------------------------------------------------------------
+# discover_ai_configuration
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverAIConfiguration:
+    @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
+    @patch("ggshield.verticals.ai.discovery.AGENTS")
+    def test_aggregates_agents(
+        self, mock_agents: MagicMock, mock_user_info: MagicMock, tmp_path: Path
+    ):
+        agent1 = MagicMock()
+        agent1.discover_project_directories.return_value = iter([tmp_path / "p1"])
+        agent1.discover_mcp_configurations.return_value = [_cfg(name="s1")]
+        agent1.discover_capabilities.return_value = False
+
+        agent2 = MagicMock()
+        agent2.discover_project_directories.return_value = iter([])
+        agent2.discover_mcp_configurations.return_value = [_cfg(name="s2")]
+        agent2.discover_capabilities.return_value = False
+
+        mock_agents.values.return_value = [agent1, agent2]
+
+        result = discover_ai_configuration()
+
+        assert result.user == _user()
+        assert len(result.servers) == 2
+        assert result.discovery_duration > 0
+
+    @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
+    @patch("ggshield.verticals.ai.discovery.AGENTS")
+    def test_stops_capability_discovery_at_first_success(
+        self, mock_agents: MagicMock, mock_user_info: MagicMock
+    ):
+        agent1 = MagicMock()
+        agent1.discover_project_directories.return_value = iter([])
+        agent1.discover_mcp_configurations.return_value = [_cfg(name="s")]
+
+        agent2 = MagicMock()
+        agent2.discover_project_directories.return_value = iter([])
+        agent2.discover_mcp_configurations.return_value = []
+
+        mock_agents.values.return_value = [agent1, agent2]
+
+        discover_ai_configuration()
+
+
+# ---------------------------------------------------------------------------
+# submit_ai_discovery
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitAIDiscovery:
+    def test_successful_response(self):
+        discovery = _discovery()
+        client = MagicMock()
+        client.send_ai_discovery.return_value = discovery
+
+        result = submit_ai_discovery(client, discovery)
+        assert result.user == discovery.user
+
+    def test_non_200_raises(self):
+        discovery = _discovery()
+        client = MagicMock()
+        client.send_ai_discovery.return_value = Detail(
+            status_code=500, detail="Internal Server Error"
+        )
+
+        with pytest.raises(UnexpectedError):
+            submit_ai_discovery(client, discovery)

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -9,6 +9,7 @@ from ggshield.core.errors import UnexpectedError
 from ggshield.verticals.ai.discovery import (
     _merge_mcp_configurations,
     discover_ai_configuration,
+    refresh_and_maybe_submit_discovery,
     submit_ai_discovery,
 )
 from ggshield.verticals.ai.models import MCPConfiguration, Scope, Transport
@@ -137,3 +138,116 @@ class TestSubmitAIDiscovery:
 
         with pytest.raises(UnexpectedError):
             submit_ai_discovery(client, discovery)
+
+
+# ---------------------------------------------------------------------------
+# refresh_and_maybe_submit_discovery
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAndMaybeSubmitDiscovery:
+    def _patch_all(self):
+        return (
+            patch(
+                "ggshield.verticals.ai.discovery.load_discovery_cache",
+            ),
+            patch(
+                "ggshield.verticals.ai.discovery.discover_ai_configuration",
+            ),
+            patch(
+                "ggshield.verticals.ai.discovery.submit_ai_discovery",
+            ),
+            patch(
+                "ggshield.verticals.ai.discovery.save_discovery_cache",
+            ),
+        )
+
+    def test_no_cache_submits_and_saves(self):
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = None
+            new_disc = _discovery()
+            m_discover.return_value = new_disc
+            submitted = _discovery(discovery_duration=0.5)
+            m_submit.return_value = submitted
+
+            result = refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_submit.assert_called_once()
+            m_save.assert_called_once_with(submitted)
+            assert result == submitted
+
+    def test_unchanged_returns_cache_without_submission(self):
+        cached = _discovery()
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = cached
+            m_discover.return_value = cached  # identical discovery
+
+            result = refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_submit.assert_not_called()
+            m_save.assert_not_called()
+            assert result == cached
+
+    def test_changed_submits_and_saves(self):
+        cached = _discovery(user=_user(hostname="old"))
+        new_disc = _discovery(user=_user(hostname="new"))
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = cached
+            m_discover.return_value = new_disc
+            m_submit.return_value = new_disc
+
+            refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_submit.assert_called_once()
+            m_save.assert_called_once()
+
+    def test_api_error_swallowed(self):
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = None
+            new_disc = _discovery()
+            m_discover.return_value = new_disc
+            m_submit.side_effect = RuntimeError("network")
+
+            result = refresh_and_maybe_submit_discovery(MagicMock())
+
+            assert result == new_disc
+            m_save.assert_not_called()
+
+    def test_reuses_machine_id_from_cache(self):
+        cached = _discovery(user=_user(machine_id="cached-id"))
+        p_load, p_discover = self._patch_all()[:2]
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+        ):
+            m_load.return_value = cached
+            m_discover.return_value = cached
+
+            refresh_and_maybe_submit_discovery(MagicMock())
+
+            _, kwargs = m_discover.call_args
+            assert kwargs.get("machine_id") == "cached-id"

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -99,14 +99,19 @@ class TestDiscoverAIConfiguration:
         agent1 = MagicMock()
         agent1.discover_project_directories.return_value = iter([])
         agent1.discover_mcp_configurations.return_value = [_cfg(name="s")]
+        agent1.discover_capabilities.return_value = True
 
         agent2 = MagicMock()
         agent2.discover_project_directories.return_value = iter([])
         agent2.discover_mcp_configurations.return_value = []
+        agent2.discover_capabilities.return_value = False
 
         mock_agents.values.return_value = [agent1, agent2]
 
         discover_ai_configuration()
+
+        agent1.discover_capabilities.assert_called_once()
+        agent2.discover_capabilities.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+import pytest
+
+from ggshield.core.scan import File, StringScannable
+from ggshield.verticals.ai.agents import Cursor
+from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
+
+
+# ---------------------------------------------------------------------------
+# HookPayload.scannable
+# ---------------------------------------------------------------------------
+
+
+class TestHookPayloadScannable:
+    def test_read_tool_existing_text_file_returns_file(self, tmp_path: Path):
+        f = tmp_path / "code.py"
+        f.write_text("secret = 'abc'")
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="",
+            identifier=str(f),
+            agent=Cursor(),
+        )
+        assert isinstance(payload.scannable, File)
+
+    def test_read_tool_missing_file_returns_string_scannable(self):
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="some content",
+            identifier="/nonexistent/path.txt",
+            agent=Cursor(),
+        )
+        assert isinstance(payload.scannable, StringScannable)
+
+    def test_read_tool_binary_file_returns_string_scannable(self, tmp_path: Path):
+        f = tmp_path / "image.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="",
+            identifier=str(f),
+            agent=Cursor(),
+        )
+        assert isinstance(payload.scannable, StringScannable)
+
+    def test_non_read_tool_returns_string_scannable(self):
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.BASH,
+            content="echo hello",
+            identifier="cmd",
+            agent=Cursor(),
+        )
+        assert isinstance(payload.scannable, StringScannable)
+
+
+# ---------------------------------------------------------------------------
+# HookPayload.empty
+# ---------------------------------------------------------------------------
+
+
+class TestHookPayloadEmpty:
+    @pytest.mark.parametrize(
+        "content, expected",
+        [
+            pytest.param("non-empty", False, id="non_empty_content"),
+            pytest.param("", True, id="empty_content"),
+        ],
+    )
+    def test_empty(self, content: str, expected: bool):
+        payload = HookPayload(
+            event_type=EventType.USER_PROMPT,
+            tool=None,
+            content=content,
+            identifier="id",
+            agent=Cursor(),
+        )
+        assert payload.empty is expected
+
+
+# ---------------------------------------------------------------------------
+# HookResult.allow
+# ---------------------------------------------------------------------------
+
+
+class TestHookResultAllow:
+    def test_allow_creates_non_blocking_result(self):
+        payload = HookPayload(
+            event_type=EventType.USER_PROMPT,
+            tool=None,
+            content="hi",
+            identifier="id",
+            agent=Cursor(),
+        )
+        result = HookResult.allow(payload)
+        assert result.block is False
+        assert result.message == ""
+        assert result.nbr_secrets == 0
+        assert result.payload is payload

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -1,10 +1,21 @@
+import json
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
 
 import pytest
+from pygitguardian.models import MCPConfiguration
 
 from ggshield.core.scan import File, StringScannable
 from ggshield.verticals.ai.agents import Cursor
-from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
+from ggshield.verticals.ai.models import (
+    EventType,
+    HookPayload,
+    HookResult,
+    Scope,
+    Tool,
+    Transport,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -101,3 +112,151 @@ class TestHookResultAllow:
         assert result.message == ""
         assert result.nbr_secrets == 0
         assert result.payload is payload
+
+
+# ---------------------------------------------------------------------------
+# Agent._parse_servers_block
+# ---------------------------------------------------------------------------
+
+
+class TestParseServersBlock:
+    def _parse(
+        self,
+        data: Dict[str, Any],
+        scope: Scope = Scope.USER,
+        project: Optional[Path] = None,
+    ) -> List[MCPConfiguration]:
+        return list(Cursor()._parse_servers_block(data, scope, project))
+
+    def test_mcp_servers_key_stdio(self):
+        data = {
+            "mcpServers": {
+                "myserver": {
+                    "command": "npx",
+                    "args": ["-y", "mcp-server"],
+                    "env": {"KEY": "val"},
+                }
+            }
+        }
+        configs = self._parse(data)
+        assert len(configs) == 1
+        cfg = configs[0]
+        assert cfg.name == "myserver"
+        assert cfg.transport == Transport.STDIO
+        assert cfg.command == "npx"
+        assert cfg.args == ["-y", "mcp-server"]
+        assert cfg.env == {"KEY": "val"}
+
+    def test_servers_key(self):
+        data = {"servers": {"s1": {"command": "node"}}}
+        configs = self._parse(data)
+        assert len(configs) == 1
+        assert configs[0].name == "s1"
+
+    def test_url_entry_detected_as_http(self):
+        data = {"mcpServers": {"remote": {"url": "https://example.com/mcp"}}}
+        configs = self._parse(data)
+        assert configs[0].transport == Transport.HTTP
+        assert configs[0].url == "https://example.com/mcp"
+
+    def test_url_entry_with_sse_transport(self):
+        data = {
+            "mcpServers": {
+                "remote": {"url": "https://example.com/sse", "transport": "sse"}
+            }
+        }
+        configs = self._parse(data)
+        assert configs[0].transport == Transport.SSE
+
+    def test_empty_block_yields_nothing(self):
+        assert self._parse({}) == []
+        assert self._parse({"mcpServers": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# Agent._load_json_file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJsonFile:
+    def test_returns_dict_for_valid_json(self, tmp_path: Path):
+        f = tmp_path / "ok.json"
+        f.write_text(json.dumps({"key": "value"}))
+        assert Cursor()._load_json_file(f) == {"key": "value"}
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path):
+        assert Cursor()._load_json_file(tmp_path / "missing.json") is None
+
+    def test_returns_none_for_invalid_json(self, tmp_path: Path):
+        f = tmp_path / "bad.json"
+        f.write_text("{not valid json")
+        assert Cursor()._load_json_file(f) is None
+
+    def test_returns_none_for_non_dict_json(self, tmp_path: Path):
+        f = tmp_path / "list.json"
+        f.write_text(json.dumps([1, 2, 3]))
+        assert Cursor()._load_json_file(f) is None
+
+
+# ---------------------------------------------------------------------------
+# Agent._load_jsonl_file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadJsonlFile:
+    def test_yields_valid_lines(self, tmp_path: Path):
+        f = tmp_path / "data.jsonl"
+        f.write_text('{"a":1}\n{"b":2}\n')
+        assert list(Cursor()._load_jsonl_file(f)) == [{"a": 1}, {"b": 2}]
+
+    def test_skips_invalid_lines(self, tmp_path: Path):
+        f = tmp_path / "mixed.jsonl"
+        f.write_text('{"ok":true}\nnot json\n{"also":"ok"}\n')
+        assert list(Cursor()._load_jsonl_file(f)) == [
+            {"ok": True},
+            {"also": "ok"},
+        ]
+
+    def test_yields_nothing_for_missing_file(self, tmp_path: Path):
+        assert list(Cursor()._load_jsonl_file(tmp_path / "nope.jsonl")) == []
+
+
+# ---------------------------------------------------------------------------
+# Agent.discover_mcp_configurations
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverMcpConfigurations:
+    def test_combines_user_and_project_configs(self, tmp_path: Path):
+        # User-level config
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"global-srv": {"command": "node", "args": []}}})
+        )
+
+        # Project-level config
+        project = tmp_path / "project"
+        project.mkdir()
+        cursor_dir = project / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"proj-srv": {"command": "python", "args": []}}})
+        )
+
+        agent = Cursor()
+        with patch.object(type(agent), "config_folder", new=config_dir):
+            result = agent.discover_mcp_configurations([project])
+
+        assert len(result) == 2
+        assert result[0].name == "global-srv"
+        assert result[0].scope == Scope.USER
+        assert result[1].name == "proj-srv"
+        assert result[1].scope == Scope.PROJECT
+        assert result[1].project == str(project)
+
+    def test_no_configs_returns_empty(self, tmp_path: Path):
+        agent = Cursor()
+        with patch.object(type(agent), "config_folder", new=tmp_path / "empty"):
+            result = agent.discover_mcp_configurations([])
+        assert result == []

--- a/tests/unit/verticals/ai/test_user.py
+++ b/tests/unit/verticals/ai/test_user.py
@@ -1,0 +1,390 @@
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ggshield.verticals.ai.user import (
+    _get_hostname,
+    _get_linux_system_id,
+    _get_machine_id,
+    _get_macos_system_id,
+    _get_user_email,
+    _get_username,
+    _get_windows_system_id,
+    _parse_wmic_uuid,
+    _read_first_nonempty_line,
+    get_user_info,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_user_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserInfo:
+    @patch("ggshield.verticals.ai.user._get_hostname", return_value="myhost")
+    @patch("ggshield.verticals.ai.user._get_username", return_value="myuser")
+    @patch("ggshield.verticals.ai.user._get_machine_id", return_value="abc-123")
+    @patch("ggshield.verticals.ai.user._get_user_email", return_value="me@test.com")
+    def test_populates_all_fields(self, *_mocks: MagicMock):
+        info = get_user_info()
+        assert info.hostname == "myhost"
+        assert info.username == "myuser"
+        assert info.machine_id == "abc-123"
+        assert info.user_email == "me@test.com"
+
+    @patch("ggshield.verticals.ai.user._get_hostname", return_value="h")
+    @patch("ggshield.verticals.ai.user._get_username", return_value="u")
+    @patch("ggshield.verticals.ai.user._get_machine_id", return_value="generated")
+    @patch("ggshield.verticals.ai.user._get_user_email", return_value=None)
+    def test_reuses_provided_machine_id(self, *_mocks: MagicMock):
+        info = get_user_info(machine_id="provided-id")
+        assert info.machine_id == "provided-id"
+
+
+# ---------------------------------------------------------------------------
+# _get_hostname
+# ---------------------------------------------------------------------------
+
+
+class TestGetHostname:
+    @patch("ggshield.verticals.ai.user.sys")
+    @patch("ggshield.verticals.ai.user.socket.gethostname", return_value="linuxbox")
+    def test_linux_returns_gethostname(
+        self, _mock_host: MagicMock, mock_sys: MagicMock
+    ):
+        mock_sys.platform = "linux"
+        assert _get_hostname() == "linuxbox"
+
+    @patch("ggshield.verticals.ai.user.sys")
+    @patch("ggshield.verticals.ai.user.os.environ", {"COMPUTERNAME": "WINBOX"})
+    def test_windows_prefers_computername(self, mock_sys: MagicMock):
+        mock_sys.platform = "win32"
+        assert _get_hostname() == "WINBOX"
+
+    @patch("ggshield.verticals.ai.user.sys")
+    @patch("ggshield.verticals.ai.user.socket.gethostname", side_effect=OSError)
+    def test_oserror_returns_unknown(self, _mock_host: MagicMock, mock_sys: MagicMock):
+        mock_sys.platform = "linux"
+        assert _get_hostname() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _get_username
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsername:
+    @patch("ggshield.verticals.ai.user.getpass.getuser", return_value="alice")
+    def test_returns_getuser(self, _mock: MagicMock):
+        assert _get_username() == "alice"
+
+    @patch("ggshield.verticals.ai.user.os.getlogin", return_value="bob")
+    @patch("ggshield.verticals.ai.user.getpass.getuser", side_effect=Exception)
+    def test_falls_back_to_getlogin(self, *_mocks: MagicMock):
+        assert _get_username() == "bob"
+
+    @patch("ggshield.verticals.ai.user.os.getlogin", side_effect=Exception)
+    @patch("ggshield.verticals.ai.user.getpass.getuser", side_effect=Exception)
+    def test_returns_unknown_when_both_fail(self, *_mocks: MagicMock):
+        assert _get_username() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _get_user_email
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserEmail:
+    @pytest.mark.parametrize(
+        "run_return, expected",
+        [
+            pytest.param(
+                MagicMock(returncode=0, stdout="me@example.com\n"),
+                "me@example.com",
+                id="valid_email",
+            ),
+            pytest.param(
+                MagicMock(returncode=1, stdout=""),
+                None,
+                id="git_failure",
+            ),
+            pytest.param(
+                MagicMock(returncode=0, stdout="  \n"),
+                None,
+                id="empty_output",
+            ),
+        ],
+    )
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_get_user_email(
+        self, mock_run: MagicMock, run_return: MagicMock, expected: str
+    ):
+        mock_run.return_value = run_return
+        assert _get_user_email() == expected
+
+    @patch(
+        "ggshield.verticals.ai.user.subprocess.run",
+        side_effect=OSError("git not found"),
+    )
+    def test_returns_none_on_oserror(self, _mock: MagicMock):
+        assert _get_user_email() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_machine_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetMachineId:
+    def test_returns_satori_cached_id(self, tmp_path: Path):
+        satori_dir = tmp_path / ".satori"
+        satori_dir.mkdir()
+        (satori_dir / "machine_id").write_text("cached-uuid\n")
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            assert _get_machine_id() == "cached-uuid"
+
+    @patch("ggshield.verticals.ai.user.platform.system", return_value="Linux")
+    @patch(
+        "ggshield.verticals.ai.user._get_linux_system_id",
+        return_value="linux-machine-id",
+    )
+    def test_linux_reads_system_id(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            assert _get_machine_id() == "linux-machine-id"
+
+    @patch("ggshield.verticals.ai.user.platform.system", return_value="Darwin")
+    @patch(
+        "ggshield.verticals.ai.user._get_macos_system_id",
+        return_value="mac-uuid-123",
+    )
+    def test_macos_parses_ioreg(
+        self, _mock_mac: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            assert _get_machine_id() == "mac-uuid-123"
+
+    @patch("ggshield.verticals.ai.user.platform.system", return_value="Linux")
+    @patch("ggshield.verticals.ai.user._get_linux_system_id", return_value=None)
+    @patch("ggshield.verticals.ai.user.uuid.uuid4")
+    def test_generates_uuid_when_all_fail(
+        self,
+        mock_uuid4: MagicMock,
+        _mock_linux: MagicMock,
+        _mock_platform: MagicMock,
+        tmp_path: Path,
+    ):
+        fixed_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        mock_uuid4.return_value = fixed_uuid
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            result = _get_machine_id()
+        assert result == str(fixed_uuid)
+        assert (tmp_path / ".satori" / "machine_id").read_text().strip() == str(
+            fixed_uuid
+        )
+
+    @patch("ggshield.verticals.ai.user.platform.system", return_value="Linux")
+    @patch("ggshield.verticals.ai.user._get_linux_system_id", return_value=None)
+    @patch("ggshield.verticals.ai.user.uuid.uuid4")
+    def test_persistence_failure_still_returns_uuid(
+        self,
+        mock_uuid4: MagicMock,
+        _mock_linux: MagicMock,
+        _mock_platform: MagicMock,
+        tmp_path: Path,
+    ):
+        fixed_uuid = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        mock_uuid4.return_value = fixed_uuid
+        # Make .satori a file so mkdir fails
+        (tmp_path / ".satori").write_text("block")
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            result = _get_machine_id()
+        assert result == str(fixed_uuid)
+
+
+# ---------------------------------------------------------------------------
+# _parse_wmic_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestParseWmicUuid:
+    @pytest.mark.parametrize(
+        "stdout, expected",
+        [
+            pytest.param(
+                "UUID\n4C4C4544-0044-4810-8057-B5C04F4A5331\n",
+                "4c4c4544-0044-4810-8057-b5c04f4a5331",
+                id="valid_uuid",
+            ),
+            pytest.param("UUID\n", None, id="header_only"),
+            pytest.param("UUID\nnot-a-uuid\n", None, id="invalid_line"),
+            pytest.param("", None, id="empty_string"),
+        ],
+    )
+    def test_parse_wmic_uuid(self, stdout: str, expected: str):
+        assert _parse_wmic_uuid(stdout) == expected
+
+
+# ---------------------------------------------------------------------------
+# _read_first_nonempty_line
+# ---------------------------------------------------------------------------
+
+
+class TestReadFirstNonemptyLine:
+    def test_returns_first_nonempty_line(self, tmp_path: Path):
+        f = tmp_path / "data.txt"
+        f.write_text("\n  \nhello\nworld\n")
+        assert _read_first_nonempty_line(f) == "hello"
+
+    def test_returns_none_for_all_blank_lines(self, tmp_path: Path):
+        f = tmp_path / "blank.txt"
+        f.write_text("  \n\n  \n")
+        assert _read_first_nonempty_line(f) is None
+
+    def test_returns_none_on_oserror(self, tmp_path: Path):
+        assert _read_first_nonempty_line(tmp_path / "nonexistent.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# _get_linux_system_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetLinuxSystemId:
+    @patch(
+        "ggshield.verticals.ai.user._read_first_nonempty_line",
+        side_effect=[None, "dmi-uuid", "ignored"],
+    )
+    def test_returns_first_successful_candidate(self, _mock: MagicMock):
+        assert _get_linux_system_id() == "dmi-uuid"
+
+    @patch(
+        "ggshield.verticals.ai.user._read_first_nonempty_line",
+        return_value=None,
+    )
+    def test_returns_none_when_all_fail(self, _mock: MagicMock):
+        assert _get_linux_system_id() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_macos_system_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetMacosSystemId:
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_returns_uuid_from_ioreg(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='  "IOPlatformUUID" = "ABCD-1234-EF56"\n',
+        )
+        assert _get_macos_system_id() == "ABCD-1234-EF56"
+
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_returns_none_on_nonzero_returncode(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert _get_macos_system_id() is None
+
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_returns_none_when_regex_does_not_match(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(returncode=0, stdout="no uuid here\n")
+        assert _get_macos_system_id() is None
+
+    @patch(
+        "ggshield.verticals.ai.user.subprocess.run",
+        side_effect=OSError("ioreg not found"),
+    )
+    def test_returns_none_on_oserror(self, _mock: MagicMock):
+        assert _get_macos_system_id() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_windows_system_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetWindowsSystemId:
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_returns_uuid_from_wmic(self, mock_run: MagicMock):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="UUID\n4C4C4544-0044-4810-8057-B5C04F4A5331\n",
+        )
+        assert _get_windows_system_id() == "4c4c4544-0044-4810-8057-b5c04f4a5331"
+
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_falls_back_to_powershell(self, mock_run: MagicMock):
+        wmic_result = MagicMock(returncode=1, stdout="")
+        ps_result = MagicMock(
+            returncode=0,
+            stdout="4C4C4544-0044-4810-8057-B5C04F4A5331\n",
+        )
+        mock_run.side_effect = [wmic_result, ps_result]
+        assert _get_windows_system_id() == "4c4c4544-0044-4810-8057-b5c04f4a5331"
+
+    @patch("ggshield.verticals.ai.user.subprocess.run")
+    def test_powershell_invalid_uuid_returns_none(self, mock_run: MagicMock):
+        wmic_result = MagicMock(returncode=1, stdout="")
+        ps_result = MagicMock(returncode=0, stdout="not-a-uuid\n")
+        mock_run.side_effect = [wmic_result, ps_result]
+        assert _get_windows_system_id() is None
+
+    @patch(
+        "ggshield.verticals.ai.user.subprocess.run",
+        side_effect=OSError("cmd not found"),
+    )
+    def test_returns_none_when_all_commands_fail(self, _mock: MagicMock):
+        assert _get_windows_system_id() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_machine_id (additional branches)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMachineIdExtraBranches:
+    @patch("ggshield.verticals.ai.user.platform.system", return_value="Windows")
+    @patch("ggshield.verticals.ai.user.sys")
+    @patch(
+        "ggshield.verticals.ai.user._get_windows_system_id",
+        return_value="win-uuid-456",
+    )
+    def test_windows_branch(
+        self,
+        _mock_win: MagicMock,
+        mock_sys: MagicMock,
+        _mock_platform: MagicMock,
+        tmp_path: Path,
+    ):
+        mock_sys.platform = "win32"
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ):
+            assert _get_machine_id() == "win-uuid-456"
+
+    def test_satori_oserror_is_handled(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.user.get_user_home_dir", return_value=tmp_path
+        ), patch.object(
+            Path, "is_file", side_effect=OSError("permission denied")
+        ), patch(
+            "ggshield.verticals.ai.user.platform.system", return_value="Linux"
+        ), patch(
+            "ggshield.verticals.ai.user._get_linux_system_id",
+            return_value="fallback-id",
+        ):
+            assert _get_machine_id() == "fallback-id"


### PR DESCRIPTION
## Context

This PR is part of the new "Agentic AI" stack of PRs and introduces the `ggshield ai discover` command, which is the biggest part of the stack.

## What has been done

The PR is split in 7 commits:

+ The first adds a few tests to the existing model to increase coverage.
+ The second is the main one and adds the new `ai` group and the `ai discovery` command.
+ The "capability discovery" (detecting MCP tools/resources/prompts) is added (Cursor only).
+ The user info is filled using the same logic than our machine scan plugin (should be merged in the future).
+ The result of the discovery is cached in a local file to avoid unnecessary roundtrips with GIM.
+ The raw output of the command is replaced with a proper summary.
+ Changelog.

## Validation

- Clone repository
- cd into `repo`.
- run `ggshield ai discover`, it should show you all the MCP servers and configurations detected.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

