### PR TITLE
feat: cache auth check api calls for `secret scan`s

### DIFF
--- a/changelog.d/20260423_145903_6d7a_cache_api_calls.md
+++ b/changelog.d/20260423_145903_6d7a_cache_api_calls.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Successful API key checks are now cached on disk for 5 minutes.

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -7,6 +7,7 @@ from requests.exceptions import ConnectionError
 import ggshield.verticals.hmsl.utils as hmsl_utils
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core import auth_check_cache
 from ggshield.core.client import create_client
 from ggshield.core.config import Config
 from ggshield.core.config.token_store import get_token_store
@@ -70,6 +71,10 @@ def logout_cmd(
 
 def logout(config: Config, instance_url: str, revoke: bool) -> None:
     check_account_config_exists(config, instance_url)
+    # Invalidate first so a failing revoke_token (raises AuthError on non-204)
+    # cannot leave a stale "still valid" cache entry behind, which would let a
+    # subsequent scan pass auth within the TTL window.
+    auth_check_cache.invalidate()
     if revoke:
         revoke_token(config, instance_url)
         hmsl_utils.remove_token_from_disk()

--- a/ggshield/core/auth_check_cache.py
+++ b/ggshield/core/auth_check_cache.py
@@ -1,0 +1,177 @@
+import hashlib
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pygitguardian.models import RemediationMessages, SecretScanPreferences, TokenScope
+
+from ggshield.core.dirs import get_cache_dir
+
+
+logger = logging.getLogger(__name__)
+
+# How long a successful auth check (metadata + token scopes) stays valid.
+# Short enough that revoked tokens and scope changes propagate quickly;
+# long enough that a burst of scans (e.g. IDE on-save) shares one check.
+TTL_SECONDS = 300
+
+
+def _cache_file() -> Path:
+    # Resolved lazily so GG_CACHE_DIR overrides (tests, sandboxed envs) are honored.
+    return get_cache_dir() / "auth_check.yaml"
+
+
+@dataclass
+class CachedAuthCheck:
+    # If not None, these are the scopes fetched from /v1/api_tokens/self.
+    # None means we haven't fetched scopes yet (e.g. from an auth-login flow
+    # where no specific scopes were required).
+    scopes: Optional[set[TokenScope]]
+    secrets_engine_version: Optional[str]
+    maximum_payload_size: Optional[int]
+    secret_scan_preferences: Optional[SecretScanPreferences]
+    remediation_messages: Optional[RemediationMessages]
+
+
+def _key_hash(instance_url: str, api_key: str) -> str:
+    return hashlib.sha256(f"{instance_url}\0{api_key}".encode("utf-8")).hexdigest()
+
+
+def load(instance_url: str, api_key: str) -> Optional[CachedAuthCheck]:
+    """Return the cached auth check for this (instance, key) pair, or None on miss."""
+    path = _cache_file()
+    try:
+        with path.open("r") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Could not load auth check cache: %s", repr(e))
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    if data.get("key_hash") != _key_hash(instance_url, api_key):
+        return None
+    if data.get("expires_at", 0) < time.time():
+        return None
+
+    raw_scopes = data.get("scopes")
+    scopes: Optional[set[TokenScope]]
+    if raw_scopes is None:
+        scopes = None
+    else:
+        scopes = set()
+        for scope_str in raw_scopes:
+            try:
+                scopes.add(TokenScope(scope_str))
+            except ValueError:
+                logger.debug("Ignoring unknown cached scope: '%s'", scope_str)
+
+    raw_version = data.get("secrets_engine_version")
+    secrets_engine_version = raw_version if isinstance(raw_version, str) else None
+
+    raw_max_payload = data.get("maximum_payload_size")
+    maximum_payload_size = raw_max_payload if isinstance(raw_max_payload, int) else None
+
+    raw_ssp = data.get("secret_scan_preferences")
+    secret_scan_preferences: Optional[SecretScanPreferences] = None
+    if isinstance(raw_ssp, dict):
+        try:
+            secret_scan_preferences = SecretScanPreferences(**raw_ssp)
+        except TypeError as e:
+            logger.debug("Ignoring malformed cached secret_scan_preferences: %s", e)
+
+    raw_rm = data.get("remediation_messages")
+    remediation_messages: Optional[RemediationMessages] = None
+    if isinstance(raw_rm, dict):
+        try:
+            remediation_messages = RemediationMessages(**raw_rm)
+        except TypeError as e:
+            logger.debug("Ignoring malformed cached remediation_messages: %s", e)
+
+    return CachedAuthCheck(
+        scopes=scopes,
+        secrets_engine_version=secrets_engine_version,
+        maximum_payload_size=maximum_payload_size,
+        secret_scan_preferences=secret_scan_preferences,
+        remediation_messages=remediation_messages,
+    )
+
+
+def store(instance_url: str, api_key: str, entry: CachedAuthCheck) -> None:
+    """Record a successful auth check.
+
+    Set entry.scopes=None if token scopes were not fetched (only metadata was checked).
+    """
+    ssp = entry.secret_scan_preferences
+    rm = entry.remediation_messages
+    payload = {
+        "key_hash": _key_hash(instance_url, api_key),
+        "scopes": (
+            None if entry.scopes is None else sorted(s.value for s in entry.scopes)
+        ),
+        "secrets_engine_version": entry.secrets_engine_version,
+        "maximum_payload_size": entry.maximum_payload_size,
+        "secret_scan_preferences": (
+            None
+            if ssp is None
+            else {
+                "maximum_document_size": ssp.maximum_document_size,
+                "maximum_documents_per_scan": ssp.maximum_documents_per_scan,
+            }
+        ),
+        "remediation_messages": (
+            None
+            if rm is None
+            else {
+                "pre_commit": rm.pre_commit,
+                "pre_push": rm.pre_push,
+                "pre_receive": rm.pre_receive,
+            }
+        ),
+        "expires_at": int(time.time()) + TTL_SECONDS,
+    }
+
+    path = _cache_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Re-apply on a pre-existing dir, since mkdir's mode is ignored when the
+        # dir already exists. Keeps the auth-check file out of reach of other
+        # local users on shared POSIX hosts.
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError as e:
+            logger.debug("Could not tighten cache dir permissions: %s", repr(e))
+        # Atomic write: a concurrent ggshield process would otherwise be able to
+        # observe a truncated YAML file. tempfile in the same directory so
+        # os.replace stays on one filesystem.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".auth_check.", suffix=".tmp", dir=path.parent
+        )
+        try:
+            os.chmod(tmp_path, 0o600)
+            with os.fdopen(fd, "w") as f:
+                yaml.dump(payload, f, indent=2, default_flow_style=False)
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as e:
+        logger.warning("Could not save auth check cache: %s", repr(e))
+
+
+def invalidate() -> None:
+    """Drop the cached auth check, typically after a 401 from any API call."""
+    try:
+        _cache_file().unlink(missing_ok=True)
+    except OSError as e:
+        logger.warning("Could not invalidate auth check cache: %s", repr(e))

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -10,7 +10,7 @@ from pygitguardian.models import APITokensResponse, Detail, TokenScope
 from requests import Session
 from requests.adapters import HTTPAdapter
 
-from . import ui
+from . import auth_check_cache, ui
 from .config import Config
 from .constants import DEFAULT_INSTANCE_URL
 from .errors import (
@@ -173,40 +173,78 @@ def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> 
     (either it is invalid or unset). Raises UnexpectedError if the API is down.
 
     If required_scopes is not empty, also checks that the API key has the required scopes.
-    """
-    try:
-        response = client.read_metadata()
-    except requests.exceptions.ConnectionError as e:
-        raise ServiceUnavailableError(
-            message="Failed to connect to GitGuardian server. Check your"
-            f" instance URL settings.\nDetails: {e}.",
-        )
 
-    if response is None:
-        # None means success
-        pass
-    elif response.status_code == 401:
-        raise APIKeyCheckError(client.base_uri, "Invalid GitGuardian API key.")
-    elif response.status_code == 404:
-        raise UnexpectedError(
-            "The server returned a 404 error. Check your instance URL settings.",
-        )
-    elif response.status_code is not None and 500 <= response.status_code < 600:
-        raise ServiceUnavailableError(
-            message=f"GitGuardian server is not responding.\nDetails: {response.detail}",
-        )
-    else:
-        raise UnexpectedError(
-            f"GitGuardian server is not responding as expected.\nDetails: {response.detail}"
-        )
+    Successful checks are cached on disk for a short TTL so bursty callers (e.g. the
+    GitGuardian VSCode extension) do not re-hit /v1/metadata and
+    /v1/api_tokens/self on every invocation.
+    """
+    cached = auth_check_cache.load(client.base_uri, client.api_key)
+    if cached is not None:
+        # Restore the full set of side effects read_metadata() would normally
+        # apply to the client.
+        if cached.secrets_engine_version is not None:
+            client.secrets_engine_version = cached.secrets_engine_version
+        if cached.maximum_payload_size is not None:
+            client.maximum_payload_size = cached.maximum_payload_size
+        if cached.secret_scan_preferences is not None:
+            client.secret_scan_preferences = cached.secret_scan_preferences
+        if cached.remediation_messages is not None:
+            client.remediation_messages = cached.remediation_messages
+
+    if cached is not None and (
+        not required_scopes
+        or (cached.scopes is not None and required_scopes <= cached.scopes)
+    ):
+        return
+
+    if cached is None:
+        try:
+            response = client.read_metadata()
+        except requests.exceptions.ConnectionError as e:
+            raise ServiceUnavailableError(
+                message="Failed to connect to GitGuardian server. Check your"
+                f" instance URL settings.\nDetails: {e}.",
+            )
+
+        if response is None:
+            # None means success
+            pass
+        elif response.status_code == 401:
+            raise APIKeyCheckError(client.base_uri, "Invalid GitGuardian API key.")
+        elif response.status_code == 404:
+            raise UnexpectedError(
+                "The server returned a 404 error. Check your instance URL settings.",
+            )
+        elif response.status_code is not None and 500 <= response.status_code < 600:
+            raise ServiceUnavailableError(
+                message=f"GitGuardian server is not responding.\nDetails: {response.detail}",
+            )
+        else:
+            raise UnexpectedError(
+                f"GitGuardian server is not responding as expected.\nDetails: {response.detail}"
+            )
+
+    api_scopes: Optional[set[TokenScope]] = (
+        cached.scopes if cached is not None else None
+    )
 
     # Check token scopes if required_scopes is not empty
     if required_scopes:
-        response = client.api_tokens()
+        try:
+            response = client.api_tokens()
+        except requests.exceptions.ConnectionError as e:
+            raise ServiceUnavailableError(
+                message="Failed to connect to GitGuardian server. Check your"
+                f" instance URL settings.\nDetails: {e}.",
+            )
 
         if not isinstance(response, (Detail, APITokensResponse)):
             raise UnexpectedError("Unexpected api_tokens response")
         elif isinstance(response, Detail):
+            if response.status_code == 401:
+                # Drop the cache for re-verification
+                auth_check_cache.invalidate()
+                raise APIKeyCheckError(client.base_uri, "Invalid GitGuardian API key.")
             raise UnexpectedError(response.detail)
 
         # Build set of API scopes, ignoring unknown ones for forward compatibility
@@ -220,3 +258,15 @@ def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> 
         missing_scopes = required_scopes - api_scopes
         if missing_scopes:
             raise MissingScopesError(list(missing_scopes))
+
+    auth_check_cache.store(
+        client.base_uri,
+        client.api_key,
+        auth_check_cache.CachedAuthCheck(
+            scopes=api_scopes,
+            secrets_engine_version=client.secrets_engine_version,
+            maximum_payload_size=client.maximum_payload_size,
+            secret_scan_preferences=client.secret_scan_preferences,
+            remediation_messages=client.remediation_messages,
+        ),
+    )

--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -13,6 +13,7 @@ import click
 from marshmallow import ValidationError
 from pygitguardian.models import Detail, TokenScope
 
+from ggshield.core import auth_check_cache
 from ggshield.core.text_utils import pluralize
 from ggshield.utils.git_shell import InvalidGitRefError
 
@@ -213,6 +214,9 @@ def handle_api_error(detail: Detail) -> None:
     logger.error("status_code=%s", detail.status_code)
     logger.debug("detail=%s", detail.detail)
     if detail.status_code == 401:
+        # The cached metadata/scopes check must not keep masking a revoked
+        # or rotated API key within its TTL.
+        auth_check_cache.invalidate()
         raise click.UsageError(detail.detail)
     if detail.status_code is None:
         raise UnexpectedError(f"Scanning failed: {detail.detail}")

--- a/tests/unit/cmd/auth/test_logout.py
+++ b/tests/unit/cmd/auth/test_logout.py
@@ -5,6 +5,7 @@ import pytest
 from requests.exceptions import ConnectionError
 
 from ggshield.__main__ import cli
+from ggshield.core import auth_check_cache
 from ggshield.core.config import Config
 from ggshield.core.config.token_store import KeyringTokenStore, reset_token_store
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
@@ -191,6 +192,36 @@ class TestAuthLogout:
         assert exit_code == ExitCode.SUCCESS, output
         mock_store.delete_token.assert_called_once_with(DEFAULT_INSTANCE_URL)
         reset_token_store()
+
+    def test_logout_invalidates_auth_check_cache(self, monkeypatch, cli_fs_runner):
+        """
+        GIVEN a saved instance and a populated auth-check cache
+        WHEN running the logout command
+        THEN the auth-check cache file is removed so a stale "still valid" hit
+             cannot survive across the logout
+        """
+        post_mock = Mock(return_value=Mock(status_code=204, ok=True))
+        monkeypatch.setattr("ggshield.core.client.GGClient.post", post_mock)
+
+        add_instance_config()
+
+        auth_check_cache.store(
+            "https://api.gitguardian.com",
+            "test-api-key",
+            auth_check_cache.CachedAuthCheck(
+                scopes=None,
+                secrets_engine_version=None,
+                maximum_payload_size=None,
+                secret_scan_preferences=None,
+                remediation_messages=None,
+            ),
+        )
+        assert auth_check_cache._cache_file().exists()
+
+        exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        assert not auth_check_cache._cache_file().exists()
 
     @staticmethod
     def run_cmd(

--- a/tests/unit/core/test_auth_check_cache.py
+++ b/tests/unit/core/test_auth_check_cache.py
@@ -1,0 +1,547 @@
+import os
+import stat
+import time
+from unittest.mock import Mock
+
+import click
+import pytest
+from pygitguardian import GGClient
+from pygitguardian.models import (
+    APITokensResponse,
+    Detail,
+    RemediationMessages,
+    SecretScanPreferences,
+    TokenScope,
+)
+
+from ggshield.core import auth_check_cache
+from ggshield.core.client import check_client_api_key
+from ggshield.core.errors import APIKeyCheckError, handle_api_error
+from tests.conftest import skipwindows
+
+
+API_TOKENS_RESPONSE = APITokensResponse.from_dict(
+    {
+        "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
+        "name": "test-name",
+        "workspace_id": 1,
+        "type": "personal_access_token",
+        "status": "active",
+        "created_at": "2023-01-01T00:00:00Z",
+        "scopes": [TokenScope.SCAN_CREATE_INCIDENTS.value],
+    }
+)
+
+
+def _entry(
+    scopes=None,
+    secrets_engine_version=None,
+    maximum_payload_size=None,
+    secret_scan_preferences=None,
+    remediation_messages=None,
+) -> auth_check_cache.CachedAuthCheck:
+    return auth_check_cache.CachedAuthCheck(
+        scopes=scopes,
+        secrets_engine_version=secrets_engine_version,
+        maximum_payload_size=maximum_payload_size,
+        secret_scan_preferences=secret_scan_preferences,
+        remediation_messages=remediation_messages,
+    )
+
+
+def _make_client_mock() -> Mock:
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "http://localhost"
+    client_mock.api_key = "test-api-key"
+    client_mock.secrets_engine_version = "2.0.0"
+    client_mock.maximum_payload_size = 1_000_000
+    client_mock.secret_scan_preferences = SecretScanPreferences(
+        maximum_document_size=2_000_000, maximum_documents_per_scan=42
+    )
+    client_mock.remediation_messages = RemediationMessages(
+        pre_commit="custom pre-commit",
+        pre_push="custom pre-push",
+        pre_receive="custom pre-receive",
+    )
+    client_mock.read_metadata.return_value = None  # Success
+    client_mock.api_tokens.return_value = API_TOKENS_RESPONSE
+    return client_mock
+
+
+def test_cache_skips_metadata_and_api_tokens_on_hit():
+    """
+    GIVEN a prior successful check populated the cache
+    WHEN check_client_api_key is called again with the same scopes
+    THEN neither read_metadata nor api_tokens is called
+    """
+    client_mock = _make_client_mock()
+
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+    client_mock.read_metadata.reset_mock()
+    client_mock.api_tokens.reset_mock()
+
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.read_metadata.assert_not_called()
+    client_mock.api_tokens.assert_not_called()
+
+
+def test_cache_hit_restores_metadata_side_effects_on_client():
+    """
+    GIVEN a prior check populated the cache while /v1/metadata set
+          secrets_engine_version, maximum_payload_size, secret_scan_preferences
+          and remediation_messages on the client
+    WHEN a subsequent check hits the cache and skips /v1/metadata
+    THEN every metadata side effect is restored onto the fresh client.
+
+    Without this, a warm-cache fresh process silently falls back to
+    pygitguardian defaults — wrong scan chunk size and generic remediation
+    messages for instances that customize them.
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    # Simulate a fresh subprocess: a new client with defaults reset.
+    fresh_client = _make_client_mock()
+    fresh_client.secrets_engine_version = None
+    fresh_client.maximum_payload_size = -1
+    fresh_client.secret_scan_preferences = SecretScanPreferences()
+    fresh_client.remediation_messages = RemediationMessages()
+
+    check_client_api_key(fresh_client, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    fresh_client.read_metadata.assert_not_called()
+    fresh_client.api_tokens.assert_not_called()
+    assert fresh_client.secrets_engine_version == "2.0.0"
+    assert fresh_client.maximum_payload_size == 1_000_000
+    assert fresh_client.secret_scan_preferences == SecretScanPreferences(
+        maximum_document_size=2_000_000, maximum_documents_per_scan=42
+    )
+    assert fresh_client.remediation_messages == RemediationMessages(
+        pre_commit="custom pre-commit",
+        pre_push="custom pre-push",
+        pre_receive="custom pre-receive",
+    )
+
+
+def test_cache_miss_on_different_api_key():
+    """
+    GIVEN the cache was populated for one api_key
+    WHEN the same instance is checked with a different api_key
+    THEN the cache does not short-circuit
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.api_key = "different-api-key"
+    client_mock.read_metadata.reset_mock()
+    client_mock.api_tokens.reset_mock()
+
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.read_metadata.assert_called_once()
+    client_mock.api_tokens.assert_called_once()
+
+
+def test_cache_hit_for_metadata_still_fetches_scopes_when_needed():
+    """
+    GIVEN a cache entry seeded without scopes (e.g. from an auth-login flow)
+    WHEN check_client_api_key runs with required scopes
+    THEN read_metadata is skipped but api_tokens is still fetched
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, set())  # caches with scopes=None
+    client_mock.read_metadata.reset_mock()
+    client_mock.api_tokens.reset_mock()
+
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.read_metadata.assert_not_called()
+    client_mock.api_tokens.assert_called_once()
+
+
+def test_cache_hit_with_narrower_scopes_refetches_and_widens_cache():
+    """
+    GIVEN a cache entry whose scopes are a strict subset of what the next
+          call requires (cached={SCAN_CREATE_INCIDENTS}, required adds SCAN)
+    WHEN check_client_api_key runs
+    THEN read_metadata is skipped (cache hit on metadata) but api_tokens is
+         re-fetched, and the cache is rewritten with the wider scope set so
+         the next call with the same required_scopes early-returns.
+    """
+    client_mock = _make_client_mock()
+    # Seed cache directly with the narrower scope set (simulates a prior call
+    # whose required_scopes happened to be just SCAN_CREATE_INCIDENTS).
+    auth_check_cache.store(
+        client_mock.base_uri,
+        client_mock.api_key,
+        _entry(scopes={TokenScope.SCAN_CREATE_INCIDENTS}),
+    )
+    client_mock.api_tokens.return_value = APITokensResponse.from_dict(
+        {
+            "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
+            "name": "test-name",
+            "workspace_id": 1,
+            "type": "personal_access_token",
+            "status": "active",
+            "created_at": "2023-01-01T00:00:00Z",
+            "scopes": [TokenScope.SCAN_CREATE_INCIDENTS.value, TokenScope.SCAN.value],
+        }
+    )
+
+    # Require a superset — should skip read_metadata but re-fetch api_tokens.
+    check_client_api_key(
+        client_mock, {TokenScope.SCAN_CREATE_INCIDENTS, TokenScope.SCAN}
+    )
+    client_mock.read_metadata.assert_not_called()
+    client_mock.api_tokens.assert_called_once()
+
+    # Cache should now hold the wider set — a repeat call must early-return.
+    client_mock.api_tokens.reset_mock()
+    check_client_api_key(
+        client_mock, {TokenScope.SCAN_CREATE_INCIDENTS, TokenScope.SCAN}
+    )
+    client_mock.read_metadata.assert_not_called()
+    client_mock.api_tokens.assert_not_called()
+
+
+def test_api_tokens_401_invalidates_cache_and_raises_auth_error():
+    """
+    GIVEN a no-scope cache entry whose token has since been revoked
+    WHEN a scope-requiring check falls through to api_tokens() and gets 401
+    THEN the cache is invalidated and APIKeyCheckError is raised so the
+         caller learns the key is invalid (not just an UnexpectedError that
+         leaves the stale entry behind to mask the next call too).
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, set())  # seed no-scope entry
+    assert auth_check_cache.load("http://localhost", "test-api-key") is not None
+
+    client_mock.read_metadata.reset_mock()
+    client_mock.api_tokens.return_value = Detail("Invalid API key", 401)
+
+    with pytest.raises(APIKeyCheckError):
+        check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.read_metadata.assert_not_called()
+    assert auth_check_cache.load("http://localhost", "test-api-key") is None
+
+
+def test_expired_cache_is_ignored(monkeypatch):
+    """
+    GIVEN the cache TTL has elapsed
+    WHEN check_client_api_key runs
+    THEN both calls are made again
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    later = time.time() + auth_check_cache.TTL_SECONDS + 1
+    monkeypatch.setattr(auth_check_cache.time, "time", lambda: later)
+    client_mock.read_metadata.reset_mock()
+    client_mock.api_tokens.reset_mock()
+
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+    client_mock.read_metadata.assert_called_once()
+    client_mock.api_tokens.assert_called_once()
+
+
+def test_invalidate_removes_cache_entry():
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+    assert auth_check_cache.load("http://localhost", "test-api-key") is not None
+
+    auth_check_cache.invalidate()
+
+    assert auth_check_cache.load("http://localhost", "test-api-key") is None
+
+
+def test_handle_api_error_401_invalidates_cache():
+    """
+    GIVEN the cache was populated by a successful auth check
+    WHEN any later API call surfaces a 401 through handle_api_error
+    THEN the cache entry is dropped so the next check re-verifies the key
+    """
+    client_mock = _make_client_mock()
+    check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+    assert auth_check_cache.load("http://localhost", "test-api-key") is not None
+
+    with pytest.raises(click.UsageError):
+        handle_api_error(Detail("Invalid API key", 401))
+
+    assert auth_check_cache.load("http://localhost", "test-api-key") is None
+
+
+def test_load_returns_none_on_corrupt_yaml():
+    """
+    GIVEN the cache file contains bytes that are not valid YAML
+    WHEN load is called
+    THEN it returns None instead of propagating the parse error
+    """
+    cache_file = auth_check_cache._cache_file()
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("not: valid: yaml: [")
+
+    assert auth_check_cache.load("http://localhost", "test-api-key") is None
+
+
+def test_load_ignores_unknown_cached_scope():
+    """
+    GIVEN a cache entry persisted an API scope the current ggshield build does
+          not know about (forward compatibility with a newer API)
+    WHEN load decodes it
+    THEN the unknown scope is dropped and the rest of the entry is returned
+    """
+    auth_check_cache.store(
+        "http://localhost",
+        "test-api-key",
+        _entry(
+            scopes={TokenScope.SCAN_CREATE_INCIDENTS},
+            secrets_engine_version="2.0.0",
+            maximum_payload_size=1_000_000,
+            secret_scan_preferences=SecretScanPreferences(),
+            remediation_messages=RemediationMessages(),
+        ),
+    )
+    # Inject an extra scope the enum does not know about by rewriting the file.
+    import yaml
+
+    path = auth_check_cache._cache_file()
+    with path.open("r") as f:
+        data = yaml.safe_load(f)
+    assert data is not None
+    data["scopes"] = sorted(data["scopes"] + ["scan:future_scope_not_in_enum"])
+    with path.open("w") as f:
+        yaml.dump(data, f)
+
+    cached = auth_check_cache.load("http://localhost", "test-api-key")
+
+    assert cached is not None
+    assert cached.scopes == {TokenScope.SCAN_CREATE_INCIDENTS}
+
+
+def test_store_failure_is_swallowed(monkeypatch, caplog):
+    """
+    GIVEN saving the cache file raises (e.g. disk full, read-only FS)
+    WHEN store is called
+    THEN the error is logged and does not propagate to the caller
+    """
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(auth_check_cache.tempfile, "mkstemp", _boom)
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    assert any("Could not save auth check cache" in r.message for r in caplog.records)
+
+
+def test_invalidate_failure_is_swallowed(monkeypatch, caplog):
+    """
+    GIVEN unlinking the cache file raises (e.g. permission error)
+    WHEN invalidate is called
+    THEN the error is logged and does not propagate
+    """
+
+    def _boom(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(auth_check_cache.Path, "unlink", _boom)
+
+    auth_check_cache.invalidate()
+
+    assert any(
+        "Could not invalidate auth check cache" in r.message for r in caplog.records
+    )
+
+
+@skipwindows
+def test_store_creates_cache_dir_with_0700():
+    """
+    GIVEN no cache directory yet
+    WHEN store creates it
+    THEN the directory is 0700 so other local users cannot list or open the
+         auth-check file inside it
+    """
+    cache_dir = auth_check_cache._cache_file().parent
+    assert not cache_dir.exists()
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+
+
+def test_load_returns_none_when_yaml_is_not_a_dict():
+    """
+    GIVEN the cache file parses to a non-mapping (e.g. a stray list or scalar
+          left over from a hand-edit or an older incompatible format)
+    WHEN load is called
+    THEN it returns None rather than blowing up on a missing .get
+    """
+    cache_file = auth_check_cache._cache_file()
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("- just\n- a\n- list\n")
+
+    assert auth_check_cache.load("http://localhost", "test-api-key") is None
+
+
+def test_load_ignores_malformed_cached_secret_scan_preferences():
+    """
+    GIVEN a cache entry whose persisted secret_scan_preferences dict cannot be
+          mapped onto SecretScanPreferences (unexpected keys)
+    WHEN load decodes it
+    THEN secret_scan_preferences comes back as None and the rest of the entry
+         is still returned
+    """
+    auth_check_cache.store(
+        "http://localhost",
+        "test-api-key",
+        _entry(
+            scopes={TokenScope.SCAN_CREATE_INCIDENTS},
+            secrets_engine_version="2.0.0",
+            maximum_payload_size=1_000_000,
+            secret_scan_preferences=SecretScanPreferences(),
+            remediation_messages=RemediationMessages(),
+        ),
+    )
+    import yaml
+
+    path = auth_check_cache._cache_file()
+    with path.open("r") as f:
+        data = yaml.safe_load(f)
+    data["secret_scan_preferences"] = {"not_a_real_field": 1}
+    with path.open("w") as f:
+        yaml.dump(data, f)
+
+    cached = auth_check_cache.load("http://localhost", "test-api-key")
+
+    assert cached is not None
+    assert cached.secret_scan_preferences is None
+    assert cached.scopes == {TokenScope.SCAN_CREATE_INCIDENTS}
+
+
+def test_load_ignores_malformed_cached_remediation_messages():
+    """
+    GIVEN a cache entry whose persisted remediation_messages dict cannot be
+          mapped onto RemediationMessages (unexpected keys)
+    WHEN load decodes it
+    THEN remediation_messages comes back as None and the rest of the entry
+         is still returned
+    """
+    auth_check_cache.store(
+        "http://localhost",
+        "test-api-key",
+        _entry(
+            scopes={TokenScope.SCAN_CREATE_INCIDENTS},
+            secrets_engine_version="2.0.0",
+            maximum_payload_size=1_000_000,
+            secret_scan_preferences=SecretScanPreferences(),
+            remediation_messages=RemediationMessages(),
+        ),
+    )
+    import yaml
+
+    path = auth_check_cache._cache_file()
+    with path.open("r") as f:
+        data = yaml.safe_load(f)
+    data["remediation_messages"] = {"not_a_real_field": "x"}
+    with path.open("w") as f:
+        yaml.dump(data, f)
+
+    cached = auth_check_cache.load("http://localhost", "test-api-key")
+
+    assert cached is not None
+    assert cached.remediation_messages is None
+    assert cached.scopes == {TokenScope.SCAN_CREATE_INCIDENTS}
+
+
+@skipwindows
+def test_store_tolerates_chmod_failure_on_existing_dir(monkeypatch, caplog):
+    """
+    GIVEN the cache directory already exists and os.chmod fails on it (e.g.
+          the dir is owned by another user on a shared host)
+    WHEN store runs
+    THEN the failure is logged at debug level and the cache file is still
+         written
+    """
+    cache_dir = auth_check_cache._cache_file().parent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    real_chmod = os.chmod
+
+    def _chmod(path, mode, *args, **kwargs):
+        if str(path) == str(cache_dir):
+            raise OSError("permission denied")
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(auth_check_cache.os, "chmod", _chmod)
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    assert auth_check_cache.load("http://localhost", "test-api-key") is not None
+
+
+def test_store_swallows_failure_when_tempfile_cleanup_also_fails(monkeypatch):
+    """
+    GIVEN yaml.dump raises mid-write AND the tempfile cleanup itself raises
+          (a doubly-degraded filesystem state)
+    WHEN store runs
+    THEN the outer error handler still swallows the failure rather than
+         letting the secondary unlink error escape the cache layer
+    """
+    cache_dir = auth_check_cache._cache_file().parent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _boom_dump(*args, **kwargs):
+        raise OSError("disk full")
+
+    def _boom_unlink(*args, **kwargs):
+        raise OSError("unlink failed")
+
+    monkeypatch.setattr(auth_check_cache.yaml, "dump", _boom_dump)
+    monkeypatch.setattr(auth_check_cache.os, "unlink", _boom_unlink)
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    assert not auth_check_cache._cache_file().exists()
+
+
+def test_store_cleans_up_tempfile_when_write_fails(monkeypatch):
+    """
+    GIVEN yaml.dump raises mid-write (e.g. disk fills up between mkstemp and
+          replace)
+    WHEN store handles the failure
+    THEN the temporary file is unlinked so we do not leak .auth_check.*.tmp
+         files into the cache dir on repeated failures
+    """
+    cache_dir = auth_check_cache._cache_file().parent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(auth_check_cache.yaml, "dump", _boom)
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    leftovers = list(cache_dir.glob(".auth_check.*.tmp"))
+    assert leftovers == []
+    assert not auth_check_cache._cache_file().exists()
+
+
+@skipwindows
+def test_store_tightens_existing_cache_dir_permissions():
+    """
+    GIVEN a cache directory pre-created with permissive (0755) permissions
+    WHEN store writes the auth-check file
+    THEN the directory is re-chmod'd to 0700
+    """
+    cache_dir = auth_check_cache._cache_file().parent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(cache_dir, 0o755)
+
+    auth_check_cache.store("http://localhost", "test-api-key", _entry())
+
+    assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -7,7 +7,13 @@ import pytest
 import requests.exceptions
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pygitguardian import GGClient
-from pygitguardian.models import APITokensResponse, Detail, TokenScope
+from pygitguardian.models import (
+    APITokensResponse,
+    Detail,
+    RemediationMessages,
+    SecretScanPreferences,
+    TokenScope,
+)
 
 from ggshield.core.client import (
     RetryProfile,
@@ -25,12 +31,26 @@ from ggshield.core.errors import (
 )
 
 
+def _make_client_mock() -> Mock:
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "http://localhost"
+    client_mock.api_key = "test-api-key"
+    client_mock.secrets_engine_version = "2.0.0"
+    client_mock.maximum_payload_size = 1_000_000
+    client_mock.secret_scan_preferences = SecretScanPreferences()
+    client_mock.remediation_messages = RemediationMessages()
+    return client_mock
+
+
 @pytest.mark.parametrize(
     ("response", "error_class"),
     (
         (Detail("Guru Meditation", 500), ServiceUnavailableError),
         (Detail("Nobody here", 404), UnexpectedError),
         (Detail("Unauthorized", 401), APIKeyCheckError),
+        # Catch-all branch for status codes we have no specific handling for
+        # (e.g. an unexpected 418 from a misconfigured reverse proxy).
+        (Detail("I'm a teapot", 418), UnexpectedError),
     ),
 )
 def test_check_client_api_key_error(response: Detail, error_class: Type[Exception]):
@@ -39,8 +59,7 @@ def test_check_client_api_key_error(response: Detail, error_class: Type[Exceptio
     WHEN check_client_api_key() is called
     THEN it raises the appropriate exception
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = response
     with pytest.raises(error_class):
         check_client_api_key(client_mock, set())
@@ -52,8 +71,7 @@ def test_check_client_api_key_network_error():
     WHEN check_client_api_key() is called
     THEN it raises a ServiceUnavailableError
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata = Mock(
         side_effect=requests.exceptions.ConnectionError("Connection refused")
     )
@@ -67,8 +85,7 @@ def test_check_client_api_key_with_source_uuid_success():
     WHEN check_client_api_key() is called with scope scan:create-incidents
     THEN it succeeds without raising any exception
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
     client_mock.api_tokens.return_value = APITokensResponse.from_dict(
         {
@@ -92,8 +109,7 @@ def test_check_client_api_key_with_source_uuid_missing_scope():
     WHEN check_client_api_key() is called with scope scan:create-incidents
     THEN it raises MissingScopesError
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
     client_mock.api_tokens.return_value = APITokensResponse.from_dict(
         {
@@ -122,8 +138,7 @@ def test_check_client_api_key_with_source_uuid_api_tokens_error():
     WHEN check_client_api_key() is called with scope scan:create-incidents
     THEN it raises UnexpectedError
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
     client_mock.api_tokens.return_value = Detail("API tokens error", 500)
 
@@ -137,8 +152,7 @@ def test_check_client_api_key_with_source_uuid_unexpected_response():
     WHEN check_client_api_key() is called with scope scan:create-incidents
     THEN it raises UnexpectedError
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
     client_mock.api_tokens.return_value = "unexpected_response_type"
 
@@ -152,8 +166,7 @@ def test_check_client_api_key_without_source_uuid_no_token_check():
     WHEN check_client_api_key() is called without required scopes
     THEN it doesn't call api_tokens
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
 
     check_client_api_key(client_mock, set())
@@ -168,8 +181,7 @@ def test_check_client_api_key_unknown_scope():
     WHEN check_client_api_key() is called with required scopes
     THEN it ignores unknown scopes and validates only the required ones
     """
-    client_mock = Mock(spec=GGClient)
-    client_mock.base_uri = "http://localhost"
+    client_mock = _make_client_mock()
     client_mock.read_metadata.return_value = None  # Success
     client_mock.api_tokens.return_value = APITokensResponse.from_dict(
         {


### PR DESCRIPTION
## Context

`check_client_api_key` hits `/v1/metadata` and `/v1/api_tokens/self` on every invocation. When a caller runs bursty scans — notably the GitGuardian VSCode extension, which rescans on every save — this is two API round-trips per scan even though the key state rarely changes between them.

## What has been done

This PR caches a successful auth check on disk for a short TTL (300s) keyed on `(instance_url, api_key_hash)`. While the entry is fresh, `check_client_api_key` returns without contacting the API, provided the cached scopes cover the required ones. A cache entry seeded without scopes (e.g. from `auth login`) still skips `/v1/metadata` but falls through to `/v1/api_tokens/self` when the caller needs scopes.

Trade-off: a server-side key revocation may not be observed for up to the TTL. This is self-healing — the next API call returns 401, which runs through `handle_api_error` and invalidates the cache.

## Validation

- create a test file to scan `echo "my secret" > /tmp/scan-me.txt`
- run `uv run ggshield --debug secret scan path /tmp/scan-me.txt` twice in succession and confirm the second invocation does not log the metadata/api_tokens round-trips

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.