### PR TITLE
Exempt pygitguardian from "exclude-newer"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ allow-direct-references = true
 # Exclude packages released in the last 3 days to avoid pulling a freshly
 # published (and possibly malicious) version before it's had time to be vetted.
 exclude-newer = "3 days"
+exclude-newer-package = { "pygitguardian" = false }
 override-dependencies = [
     # vcrpy requires urllib3 < 2 if Python is < 3.10, but it works for us with
     # Python 3.9, so force urllib3 version.


### PR DESCRIPTION
## Context

We recently excluded packages more recent than three days as a security measure, but in our release process we publish a new version of `pygitguardian` just before releasing `ggshield`.

## What has been done

Exempt `py-gitguardian` from this rule.

