### PR TITLE
fix(client): retry transient connection errors and 5xx responses

### DIFF
--- a/changelog.d/20260427_132908_brigaud_retry_connection_errors.md
+++ b/changelog.d/20260427_132908_brigaud_retry_connection_errors.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Scans of large repositories no longer fail on a single transient network glitch. ggshield now retries connection errors (e.g. `ConnectionResetError`) and 502/503/504 responses with bounded exponential backoff.

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -102,9 +102,22 @@ def create_session(allow_self_signed: bool = False) -> Session:
         )
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         session.verify = False
+    # Retry on transient connection errors (e.g. ConnectionResetError when a
+    # load balancer drops a long-lived connection during a large scan) and on
+    # transient 5xx responses. POST is included because our scan endpoints are
+    # POST-based.
+    retries = urllib3.Retry(
+        total=5,
+        backoff_factor=0.2,
+        status_forcelist=[502, 503, 504],
+        allowed_methods=frozenset(
+            {"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"}
+        ),
+    )
     # Mount HTTPAdapter with larger pool sizes for better concurrency
     adapter = HTTPAdapter(
         pool_maxsize=100,  # default 10
+        max_retries=retries,
     )
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -259,6 +259,24 @@ def test_create_session_pool_configuration():
     assert getattr(adapter, "_pool_maxsize", None) == 100
 
 
+def test_create_session_retry_configuration():
+    """
+    GIVEN create_session is called
+    WHEN the session is created
+    THEN the HTTPAdapter retries transient connection errors and 5xx responses,
+    including for POST requests used by scan endpoints
+    """
+    session = create_session()
+
+    adapter = session.get_adapter("https://example.com")
+    retries = adapter.max_retries
+
+    assert retries.total == 5
+    assert retries.backoff_factor == 0.2
+    assert set(retries.status_forcelist) == {502, 503, 504}
+    assert "POST" in retries.allowed_methods
+
+
 @pytest.mark.parametrize("allow_self_signed", [True, False])
 def test_create_session_with_self_signed_option(allow_self_signed: bool):
     """


### PR DESCRIPTION
## Context

Customer report tracked in [END-176](https://linear.app/gitguardian/issue/END-176/ggshield-connection-aborted-error-message): a `ggshield secret scan` on a 25k-file repository against the SaaS API fails with:

```
Scanning failed: ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer'))
```

Quota was untouched, so it's not a 429. The error surfaces in `ggshield/core/errors.py:217` (`status_code=None`) and exits with code 128.

## Root cause

`ggshield/core/client.py` mounts an `HTTPAdapter` with `pool_maxsize=100` (added in [`ba63b2ff`](https://github.com/GitGuardian/ggshield/commit/ba63b2ff) / #1141, shipped in v1.46.0) but **no retry policy**. A single transient TCP reset on one of the many concurrent POST `multi_content_scan` batches therefore aborts the whole scan; there is no recovery for connection errors or 5xx responses.

The 100-slot pool added in #1141 lets ggshield run a lot more in-flight POST batches than before, which raises the probability that a customer scanning a very large repo hits a transient reset on at least one batch — exactly what's happening here.

A draft adapter with retry config did exist on the never-merged debug branch [`agateau/debug-555-2`](https://github.com/GitGuardian/ggshield/commits/agateau/debug-555-2) ([4d60dd1e](https://github.com/GitGuardian/ggshield/commit/4d60dd1e), April 2024, related to open issue #555), but it was never landed on `main`.

## What has been done

Add a retry policy to the existing pool-tuned adapter:

```python
retries = urllib3.Retry(
    total=5,
    backoff_factor=0.2,
    status_forcelist=[502, 503, 504],
    allowed_methods=frozenset({"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"}),
)
adapter = HTTPAdapter(pool_maxsize=100, max_retries=retries)
```

- `total=5` with `connect=None` makes urllib3 retry connection errors (`ConnectionResetError` and friends) too, not just response statuses.
- `backoff_factor=0.2` gives 0.2 / 0.4 / 0.8 / 1.6 / 3.2 s waits — bounded, gentle on the SaaS edge.
- `status_forcelist=[502, 503, 504]` retries transient gateway errors but lets real failures (4xx, 500) propagate.
- `allowed_methods` includes `POST` (scan endpoints) plus the standard idempotent set so quota / health-check calls also recover from transient failures.

## Validation

- New unit test `test_create_session_retry_configuration` asserts `total`, `backoff_factor`, `status_forcelist`, and `POST` membership.
- Existing `test_create_session_pool_configuration` still passes (`pool_maxsize=100` preserved).

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
