### PR TITLE
feat(auth): add --no-browser flag for browser-less OAuth login

### DIFF
--- a/changelog.d/20260428_103000_tdelion_oauth_no_browser.md
+++ b/changelog.d/20260428_103000_tdelion_oauth_no_browser.md
@@ -1,3 +1,0 @@
-### Added
-
-- `ggshield auth login --no-browser` for browser-less environments (SSH sessions, headless servers). Prints the authorization URL, lets you open it on another device, and exchanges the code you paste back into the terminal. Uses the OAuth out-of-band sentinel (`urn:ietf:wg:oauth:2.0:oob`) — requires a server that supports it.

--- a/changelog.d/20260428_103000_tdelion_oauth_no_browser.md
+++ b/changelog.d/20260428_103000_tdelion_oauth_no_browser.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield auth login --no-browser` for browser-less environments (SSH sessions, headless servers). Prints the authorization URL, lets you open it on another device, and exchanges the code you paste back into the terminal. Uses the OAuth out-of-band sentinel (`urn:ietf:wg:oauth:2.0:oob`) — requires a server that supports it.

--- a/changelog.d/20260428_103000_tdelion_oauth_oob.md
+++ b/changelog.d/20260428_103000_tdelion_oauth_oob.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield auth login --method oob` for browser-less environments (SSH sessions, headless servers). Prints the authorization URL, lets you open it on another device, and exchanges the code you paste back into the terminal. Uses the OAuth out-of-band sentinel (`urn:ietf:wg:oauth:2.0:oob`) — requires a server that supports it.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -110,6 +110,17 @@ def print_default_instance_message(config: Config) -> None:
     help="Number of days before the token expires. 0 means the token never expires.",
     metavar="DAYS",
 )
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    default=False,
+    help=(
+        "Run the web login flow without opening a browser. ggshield prints the"
+        " authorization URL; open it on any device, sign in, then paste the"
+        " code shown by the dashboard back into the terminal. Useful on"
+        " headless machines (SSH sessions, containers, CI shells)."
+    ),
+)
 @add_common_options()
 @click.pass_context
 def login_cmd(
@@ -120,6 +131,7 @@ def login_cmd(
     token_name: Optional[str],
     lifetime: Optional[int],
     sso_url: Optional[str],
+    no_browser: bool,
     **kwargs: Any,
 ) -> int:
     """
@@ -157,13 +169,27 @@ def login_cmd(
                 "--scopes is reserved for the web login method.", param_hint="scopes"
             )
 
+        if no_browser:
+            raise click.BadParameter(
+                "--no-browser is reserved for the web login method.",
+                param_hint="no-browser",
+            )
+
     if method == "token":
         token_login(config, instance)
         return 0
 
     if method == "web":
         extra_scopes = scopes.split(" ") if scopes else None
-        web_login(config, instance, token_name, lifetime, sso_url, extra_scopes)
+        web_login(
+            config,
+            instance,
+            token_name,
+            lifetime,
+            sso_url,
+            extra_scopes,
+            no_browser=no_browser,
+        )
         return 0
 
     return 1
@@ -223,6 +249,7 @@ def web_login(
     lifetime: Optional[int],
     sso_url: Optional[str],
     extra_scopes: Optional[List[str]],
+    no_browser: bool = False,
 ) -> None:
     instance, login_path = validate_login_path(instance=instance, sso_url=sso_url)
     if instance:
@@ -242,5 +269,6 @@ def web_login(
         lifetime=lifetime,
         login_path=login_path,
         extra_scopes=extra_scopes,
+        no_browser=no_browser,
     )
     print_default_instance_message(config)

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -69,8 +69,14 @@ def print_default_instance_message(config: Config) -> None:
     "--method",
     required=False,
     default="web",
-    type=click.Choice(["token", "web"]),
-    help="Authentication method.",
+    type=click.Choice(["token", "web", "oob"]),
+    help=(
+        "Authentication method. `web` opens a browser and listens on"
+        " localhost for the OAuth callback. `oob` (out-of-band) prints the"
+        " authorize URL and prompts for the code shown by the dashboard —"
+        " useful on headless machines (SSH sessions, containers, CI"
+        " shells). `token` skips OAuth and reads a pre-existing token."
+    ),
 )
 @click.option(
     "--instance",
@@ -110,17 +116,6 @@ def print_default_instance_message(config: Config) -> None:
     help="Number of days before the token expires. 0 means the token never expires.",
     metavar="DAYS",
 )
-@click.option(
-    "--no-browser",
-    is_flag=True,
-    default=False,
-    help=(
-        "Run the web login flow without opening a browser. ggshield prints the"
-        " authorization URL; open it on any device, sign in, then paste the"
-        " code shown by the dashboard back into the terminal. Useful on"
-        " headless machines (SSH sessions, containers, CI shells)."
-    ),
-)
 @add_common_options()
 @click.pass_context
 def login_cmd(
@@ -131,7 +126,6 @@ def login_cmd(
     token_name: Optional[str],
     lifetime: Optional[int],
     sso_url: Optional[str],
-    no_browser: bool,
     **kwargs: Any,
 ) -> int:
     """
@@ -143,6 +137,10 @@ def login_cmd(
     The default authentication method is `web`.
     ggshield launches a web browser to authenticate you to your GitGuardian instance,
     then automatically generates a token on your behalf.
+
+    On a headless machine (SSH session, container, CI shell), use `--method oob`
+    instead: ggshield prints the authorization URL, you open it on any device,
+    sign in, and paste back the code shown by the dashboard.
 
     Alternatively, you can use `--method token` to authenticate using an already existing token.
     The minimum required scope for the token is `scan`.
@@ -158,7 +156,7 @@ def login_cmd(
     """
     config = ContextObj.get(ctx).config
 
-    if method != "web":
+    if method == "token":
         if sso_url is not None:
             raise click.BadParameter(
                 "--sso-url is reserved for the web login method.", param_hint="sso-url"
@@ -169,17 +167,10 @@ def login_cmd(
                 "--scopes is reserved for the web login method.", param_hint="scopes"
             )
 
-        if no_browser:
-            raise click.BadParameter(
-                "--no-browser is reserved for the web login method.",
-                param_hint="no-browser",
-            )
-
-    if method == "token":
         token_login(config, instance)
         return 0
 
-    if method == "web":
+    if method in ("web", "oob"):
         extra_scopes = scopes.split(" ") if scopes else None
         web_login(
             config,
@@ -188,7 +179,7 @@ def login_cmd(
             lifetime,
             sso_url,
             extra_scopes,
-            no_browser=no_browser,
+            no_browser=method == "oob",
         )
         return 0
 

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -28,6 +28,13 @@ from ggshield.utils.datetime import get_pretty_date
 CLIENT_ID = "ggshield_oauth"
 SCAN_SCOPE = "scan"
 
+# Sentinel `redirect_uri` value used by the out-of-band (browser-less) OAuth
+# flow. Mirrors gcloud's `--no-launch-browser` and the historical Google
+# `urn:ietf:wg:oauth:2.0:oob` pattern. When the CLI sends this value, the
+# backend renders a page displaying the authorization code as text instead of
+# redirecting to localhost; the user pastes the code back into the terminal.
+OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+
 # potential port range to be used to run local server
 # to handle authorization code callback
 # this is the largest band of not commonly occupied ports
@@ -74,6 +81,12 @@ class OAuthClient:
         self._port = USABLE_PORT_RANGE[0]
         self.server: Optional[HTTPServer] = None
 
+        # When True, run the browser-less (out-of-band) flow: the CLI prints
+        # the authorize URL and prompts the user to paste back the code shown
+        # by the dashboard, instead of opening a browser and listening on
+        # localhost.
+        self._no_browser: bool = False
+
         self._generate_pkce_pair()
 
     def oauth_process(
@@ -82,11 +95,19 @@ class OAuthClient:
         lifetime: Optional[int] = None,
         login_path: Optional[str] = None,
         extra_scopes: Optional[List[str]] = None,
+        no_browser: bool = False,
     ) -> None:
         """
-        Handle the whole oauth process which includes
-        - opening the user's webbrowser to GitGuardian login page
-        - open a server and wait for the callback processing
+        Handle the whole oauth process.
+
+        Two modes are supported:
+        - localhost flow (default): open the user's webbrowser to
+          GitGuardian login page and wait for the OAuth callback on a
+          temporary local HTTP server.
+        - out-of-band flow (``no_browser=True``): print the authorize URL,
+          ask the user to open it and paste back the code shown by the
+          dashboard. No browser is opened and no localhost listener is
+          started.
         """
         # enable redirection to http://localhost
         os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = str(True)
@@ -104,10 +125,59 @@ class OAuthClient:
         if extra_scopes is not None:
             self._extra_scopes = extra_scopes
 
-        self._prepare_server()
-        self._redirect_to_login()
-        self._wait_for_callback()
+        self._no_browser = no_browser
+
+        if no_browser:
+            # OOB flow: skip the localhost listener entirely, prompt the
+            # user for the code, and exchange it directly.
+            self._run_oob_flow()
+        else:
+            self._prepare_server()
+            self._redirect_to_login()
+            self._wait_for_callback()
         self._print_login_success()
+
+    def _run_oob_flow(self) -> None:
+        """
+        Run the out-of-band (browser-less) authorization code flow.
+
+        Print the authorize URL on stderr (so it stays visible even when
+        stdout is piped), prompt the user for the code displayed by the
+        dashboard, then exchange it for a personal access token.
+
+        Note on state validation: in the localhost flow, the CLI checks
+        that the ``state`` query param of the redirect matches the one it
+        sent. In OOB mode there is no redirect — the user only pastes the
+        ``code``, with no ``state`` to check. PKCE (``code_verifier`` /
+        ``code_challenge``) still binds the token exchange to this client,
+        so dropping the state check is safe and matches how OOB flows
+        work in other tools (e.g. gcloud).
+        """
+        request_uri = self._build_authorize_uri()
+        click.echo(
+            "Open the following URL in a browser, sign in, and paste "
+            "the code shown on the page below.\n"
+            f"  {request_uri}",
+            err=True,
+        )
+        try:
+            authorization_code = click.prompt(
+                "Authorization code", hide_input=False, type=str
+            ).strip()
+        except click.Abort:
+            # User pressed Ctrl-C at the prompt: re-raise so click exits
+            # cleanly without leaving any temporary state behind (we
+            # never started a server in OOB mode).
+            raise
+        if not authorization_code:
+            raise UnexpectedError("No authorization code was provided.")
+
+        try:
+            self._claim_token(authorization_code)
+        except OAuthError as error:
+            raise UnexpectedError(error.message)
+        token_data = self._validate_access_token()
+        self._save_token(token_data)
 
     def process_callback(self, callback_url: str) -> None:
         """
@@ -136,9 +206,13 @@ class OAuthClient:
             .rstrip("=")
         )
 
-    def _redirect_to_login(self) -> None:
+    def _build_authorize_uri(self) -> str:
         """
-        Open the user's browser to the GitGuardian ggshield authentication page
+        Build the authorize URL with all the standard query parameters
+        (PKCE challenge, state, scope, client_id, response_type,
+        auth_mode, utm tags) and the current ``redirect_uri`` (which is
+        the OOB sentinel in browser-less mode and ``http://localhost:port``
+        otherwise).
         """
         static_params = {
             "auth_mode": "ggshield_login",
@@ -146,7 +220,7 @@ class OAuthClient:
             "utm_medium": "login",
             "utm_campaign": "ggshield",
         }
-        request_uri = self._oauth_client.prepare_request_uri(
+        return self._oauth_client.prepare_request_uri(
             uri=urljoin(self.dashboard_url, self._login_path),
             redirect_uri=self.redirect_uri,
             scope=[SCAN_SCOPE, *self._extra_scopes],
@@ -155,6 +229,12 @@ class OAuthClient:
             state=self.state,
             **static_params,
         )
+
+    def _redirect_to_login(self) -> None:
+        """
+        Open the user's browser to the GitGuardian ggshield authentication page
+        """
+        request_uri = self._build_authorize_uri()
         click.echo(
             f"Complete the login process at:\n"
             f"  {request_uri}.\n"
@@ -296,6 +376,8 @@ class OAuthClient:
 
     @property
     def redirect_uri(self) -> str:
+        if self._no_browser:
+            return OOB_REDIRECT_URI
         return f"http://localhost:{self._port}"
 
     @property

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -53,7 +53,9 @@ def _mask_code(code: str) -> str:
     """Return ``code`` with all but the first 4 characters replaced by ``*``."""
     if len(code) <= _OOB_CODE_VISIBLE_PREFIX:
         return "*" * len(code)
-    return code[:_OOB_CODE_VISIBLE_PREFIX] + "*" * (len(code) - _OOB_CODE_VISIBLE_PREFIX)
+    return code[:_OOB_CODE_VISIBLE_PREFIX] + "*" * (
+        len(code) - _OOB_CODE_VISIBLE_PREFIX
+    )
 
 
 def get_error_param(parsed_url: urlparse.ParseResult) -> Optional[str]:

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -43,6 +43,18 @@ USABLE_PORT_RANGE = (29170, 29998)
 
 logger = logging.getLogger(__name__)
 
+# Number of leading characters of an authorization code we keep visible when
+# echoing it back; the rest is replaced by `*` so the full code never lands
+# in the terminal scrollback in plain text.
+_OOB_CODE_VISIBLE_PREFIX = 4
+
+
+def _mask_code(code: str) -> str:
+    """Return ``code`` with all but the first 4 characters replaced by ``*``."""
+    if len(code) <= _OOB_CODE_VISIBLE_PREFIX:
+        return "*" * len(code)
+    return code[:_OOB_CODE_VISIBLE_PREFIX] + "*" * (len(code) - _OOB_CODE_VISIBLE_PREFIX)
+
 
 def get_error_param(parsed_url: urlparse.ParseResult) -> Optional[str]:
     """
@@ -161,8 +173,12 @@ class OAuthClient:
             err=True,
         )
         try:
+            # hide_input=True prevents the terminal from echoing the pasted
+            # code, so it doesn't end up in the scrollback in plain text.
+            # We print a masked confirmation ourselves below so the user
+            # gets visual feedback that something was received.
             authorization_code = click.prompt(
-                "Authorization code", hide_input=False, type=str
+                "Authorization code", hide_input=True, type=str
             ).strip()
         except click.Abort:
             # User pressed Ctrl-C at the prompt: re-raise so click exits
@@ -171,6 +187,7 @@ class OAuthClient:
             raise
         if not authorization_code:
             raise UnexpectedError("No authorization code was provided.")
+        click.echo(f"Authorization code: {_mask_code(authorization_code)}", err=True)
 
         try:
             self._claim_token(authorization_code)

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -50,7 +50,7 @@ _OOB_CODE_VISIBLE_PREFIX = 4
 
 
 def _mask_code(code: str) -> str:
-    """Return ``code`` with all but the first 4 characters replaced by ``*``."""
+    """Return ``code`` with all but the first 4 characters replaced by ``*`` (fully masked if ≤ 4 chars)."""
     if len(code) <= _OOB_CODE_VISIBLE_PREFIX:
         return "*" * len(code)
     return code[:_OOB_CODE_VISIBLE_PREFIX] + "*" * (
@@ -193,9 +193,9 @@ class OAuthClient:
 
         try:
             self._claim_token(authorization_code)
+            token_data = self._validate_access_token()
         except OAuthError as error:
             raise UnexpectedError(error.message)
-        token_data = self._validate_access_token()
         self._save_token(token_data)
 
     def process_callback(self, callback_url: str) -> None:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -1010,3 +1010,196 @@ class TestAuthLoginWeb:
         exit_code, output = self.run_cmd(cli_fs_runner)
         assert exit_code == ExitCode.SUCCESS, output
         self._webbrowser_open_mock.assert_called()
+
+
+OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+
+
+class TestAuthLoginWebNoBrowser:
+    """Tests for the browser-less (out-of-band / `--no-browser`) flow.
+
+    These mirror TestAuthLoginWeb but check that:
+    - the authorize URL uses the OOB sentinel as redirect_uri,
+    - the browser is NOT opened,
+    - the localhost listener is NOT started,
+    - the code is read from stdin,
+    - the token-exchange POST body sends redirect_uri=<OOB sentinel>.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, monkeypatch):
+        # Ensure webbrowser.open_new_tab is never called: monkeypatch it to
+        # something that would fail loudly if invoked.
+        self._webbrowser_open_mock = Mock()
+        monkeypatch.setattr(
+            "ggshield.verticals.auth.oauth.webbrowser.open_new_tab",
+            self._webbrowser_open_mock,
+        )
+        # Localhost listener: replace HTTPServer with a Mock so that any
+        # attempt to start it would fail the test.
+        self._http_server_mock = Mock(
+            side_effect=AssertionError(
+                "HTTPServer must not be instantiated in OOB mode"
+            )
+        )
+        monkeypatch.setattr(
+            "ggshield.verticals.auth.oauth.HTTPServer", self._http_server_mock
+        )
+
+        self._request_mock = RequestMock()
+        monkeypatch.setattr("ggshield.core.client.Session.request", self._request_mock)
+
+        config = Config()
+        assert len(config.auth_config.instances) == 0
+
+    def _add_token_endpoints(self, post_checker=None):
+        token = "mysupertoken"
+        token_payload = VALID_TOKEN_RESPONSE.json().copy()
+        self._request_mock.add_POST(
+            "/v1/oauth/token",
+            create_json_response({"key": token, **token_payload}),
+            post_checker,
+        )
+        self._request_mock.add_GET(TOKEN_ENDPOINT, create_json_response(token_payload))
+        return token
+
+    def test_no_browser_happy_path(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN --no-browser is passed
+        WHEN the user pastes a valid authorization code
+        THEN the authorize URL uses the OOB sentinel,
+             the browser is not opened,
+             the localhost listener is not started,
+             and the token is persisted as in the localhost flow.
+        """
+        captured = {}
+
+        def post_checker(payload):
+            request_body = urlparse.parse_qs(payload)
+            captured["redirect_uri"] = request_body["redirect_uri"][0]
+            captured["code"] = request_body["code"][0]
+            captured["grant_type"] = request_body["grant_type"][0]
+            assert "code_verifier" in request_body
+            assert request_body["client_id"][0] == "ggshield_oauth"
+
+        token = self._add_token_endpoints(post_checker)
+
+        # Capture the authorize URL by patching click.echo to record stderr
+        # output (we print the URL with err=True). Easier: spy on _build_authorize_uri.
+        captured_urls = []
+        original_build = OAuthClient._build_authorize_uri
+
+        def spy_build(self):
+            url = original_build(self)
+            captured_urls.append(url)
+            return url
+
+        monkeypatch.setattr(
+            "ggshield.verticals.auth.oauth.OAuthClient._build_authorize_uri",
+            spy_build,
+        )
+
+        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        result = cli_fs_runner.invoke(
+            cli, cmd, color=False, input="some_authorization_code\n"
+        )
+        assert result.exit_code == ExitCode.SUCCESS, result.output
+
+        # No browser, no listener.
+        self._webbrowser_open_mock.assert_not_called()
+        self._http_server_mock.assert_not_called()
+
+        # Authorize URL has the OOB sentinel as redirect_uri.
+        assert len(captured_urls) == 1
+        parsed = urlparse.urlparse(captured_urls[0])
+        url_params = urlparse.parse_qs(parsed.query)
+        assert url_params["redirect_uri"] == [OOB_REDIRECT_URI]
+        # Standard params are still there.
+        for key, value in _EXPECTED_URL_PARAMS.items():
+            assert url_params[key] == value, key
+
+        # Token exchange used the OOB sentinel and the pasted code.
+        assert captured["redirect_uri"] == OOB_REDIRECT_URI
+        assert captured["code"] == "some_authorization_code"
+        assert captured["grant_type"] == "authorization_code"
+
+        # Config persisted exactly like the localhost flow.
+        config = Config()
+        assert (
+            config.auth_config.get_instance(config.instance_name).account.token == token
+        )
+
+        # Successful login message.
+        assert "Success! You are now authenticated" in result.output
+        # Stderr should mention pasting the code.
+        assert (
+            "paste" in result.output.lower() or "paste" in (result.stderr or "").lower()
+        )
+
+        self._request_mock.assert_all_requests_happened()
+
+    def test_no_browser_strips_whitespace_around_code(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN --no-browser
+        WHEN the user pastes a code surrounded by whitespace
+        THEN the whitespace is stripped before sending the code to the backend.
+        """
+        captured = {}
+
+        def post_checker(payload):
+            request_body = urlparse.parse_qs(payload)
+            captured["code"] = request_body["code"][0]
+
+        self._add_token_endpoints(post_checker)
+
+        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        result = cli_fs_runner.invoke(cli, cmd, color=False, input="  padded_code  \n")
+        assert result.exit_code == ExitCode.SUCCESS, result.output
+        assert captured["code"] == "padded_code"
+
+    def test_no_browser_empty_code_errors_out(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN --no-browser
+        WHEN the user submits an empty code (just whitespace)
+        THEN the command fails with a friendly error and no token POST is sent.
+        """
+        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        result = cli_fs_runner.invoke(cli, cmd, color=False, input="   \n")
+        assert result.exit_code != 0
+        assert "No authorization code was provided." in result.output
+        # No HTTP POST should have happened.
+        self._request_mock.assert_all_requests_happened()
+        self._webbrowser_open_mock.assert_not_called()
+        self._http_server_mock.assert_not_called()
+
+    def test_no_browser_token_exchange_failure(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN --no-browser
+        WHEN the backend rejects the code at the token endpoint
+        THEN the error is surfaced like the localhost flow does.
+        """
+        self._request_mock.add_POST(
+            "/v1/oauth/token",
+            create_json_response({"detail": "kaboom"}, status_code=400),
+        )
+
+        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        result = cli_fs_runner.invoke(
+            cli, cmd, color=False, input="some_authorization_code\n"
+        )
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Cannot create a token: kaboom." in result.output
+        self._webbrowser_open_mock.assert_not_called()
+        self._http_server_mock.assert_not_called()
+        self._request_mock.assert_all_requests_happened()
+
+    def test_no_browser_rejected_for_non_web_method(self, cli_fs_runner):
+        """
+        GIVEN --no-browser combined with --method=token
+        WHEN running the login command
+        THEN the CLI rejects the combination (the flag is web-only).
+        """
+        cmd = ["auth", "login", "--method=token", "--no-browser"]
+        result = cli_fs_runner.invoke(cli, cmd, color=False)
+        assert result.exit_code != 0
+        assert "--no-browser is reserved for the web login method." in result.output

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -13,6 +13,7 @@ from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
 from ggshield.utils.datetime import get_pretty_date
 from ggshield.verticals.auth import OAuthClient, OAuthError
+from ggshield.verticals.auth.oauth import OOB_REDIRECT_URI
 from tests.unit.conftest import assert_invoke_ok
 from tests.unit.request_mock import (
     RequestMock,
@@ -1012,9 +1013,6 @@ class TestAuthLoginWeb:
         self._webbrowser_open_mock.assert_called()
 
 
-OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
-
-
 class TestAuthLoginWebNoBrowser:
     """Tests for the browser-less (out-of-band / `--no-browser`) flow.
 
@@ -1139,7 +1137,11 @@ class TestAuthLoginWebNoBrowser:
         # Pasted code must not appear in plain text in the terminal output.
         # Only the first 4 chars are echoed back, followed by `*` placeholders.
         assert "some_authorization_code" not in result.output
-        assert "some" + "*" * (len("some_authorization_code") - 4) in result.output
+        assert (
+                "some" + "*" * (len("some_authorization_code") - 4) in result.output
+                or "some" + "*" * (len("some_authorization_code") - 4)
+                in (result.stderr or "")
+        )
 
         self._request_mock.assert_all_requests_happened()
 

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -1136,6 +1136,11 @@ class TestAuthLoginWebNoBrowser:
             "paste" in result.output.lower() or "paste" in (result.stderr or "").lower()
         )
 
+        # Pasted code must not appear in plain text in the terminal output.
+        # Only the first 4 chars are echoed back, followed by `*` placeholders.
+        assert "some_authorization_code" not in result.output
+        assert "some" + "*" * (len("some_authorization_code") - 4) in result.output
+
         self._request_mock.assert_all_requests_happened()
 
     def test_no_browser_strips_whitespace_around_code(self, cli_fs_runner, monkeypatch):

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -1013,8 +1013,8 @@ class TestAuthLoginWeb:
         self._webbrowser_open_mock.assert_called()
 
 
-class TestAuthLoginWebNoBrowser:
-    """Tests for the browser-less (out-of-band / `--no-browser`) flow.
+class TestAuthLoginOob:
+    """Tests for the browser-less (out-of-band / `--method=oob`) flow.
 
     These mirror TestAuthLoginWeb but check that:
     - the authorize URL uses the OOB sentinel as redirect_uri,
@@ -1061,9 +1061,9 @@ class TestAuthLoginWebNoBrowser:
         self._request_mock.add_GET(TOKEN_ENDPOINT, create_json_response(token_payload))
         return token
 
-    def test_no_browser_happy_path(self, cli_fs_runner, monkeypatch):
+    def test_oob_happy_path(self, cli_fs_runner, monkeypatch):
         """
-        GIVEN --no-browser is passed
+        GIVEN --method=oob is passed
         WHEN the user pastes a valid authorization code
         THEN the authorize URL uses the OOB sentinel,
              the browser is not opened,
@@ -1097,7 +1097,7 @@ class TestAuthLoginWebNoBrowser:
             spy_build,
         )
 
-        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        cmd = ["auth", "login", "--method=oob"]
         result = cli_fs_runner.invoke(
             cli, cmd, color=False, input="some_authorization_code\n"
         )
@@ -1137,17 +1137,17 @@ class TestAuthLoginWebNoBrowser:
         # Pasted code must not appear in plain text in the terminal output.
         # Only the first 4 chars are echoed back, followed by `*` placeholders.
         assert "some_authorization_code" not in result.output
-        assert (
-                "some" + "*" * (len("some_authorization_code") - 4) in result.output
-                or "some" + "*" * (len("some_authorization_code") - 4)
-                in (result.stderr or "")
+        assert "some" + "*" * (
+            len("some_authorization_code") - 4
+        ) in result.output or "some" + "*" * (len("some_authorization_code") - 4) in (
+            result.stderr or ""
         )
 
         self._request_mock.assert_all_requests_happened()
 
-    def test_no_browser_strips_whitespace_around_code(self, cli_fs_runner, monkeypatch):
+    def test_oob_strips_whitespace_around_code(self, cli_fs_runner, monkeypatch):
         """
-        GIVEN --no-browser
+        GIVEN --method=oob
         WHEN the user pastes a code surrounded by whitespace
         THEN the whitespace is stripped before sending the code to the backend.
         """
@@ -1159,18 +1159,18 @@ class TestAuthLoginWebNoBrowser:
 
         self._add_token_endpoints(post_checker)
 
-        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        cmd = ["auth", "login", "--method=oob"]
         result = cli_fs_runner.invoke(cli, cmd, color=False, input="  padded_code  \n")
         assert result.exit_code == ExitCode.SUCCESS, result.output
         assert captured["code"] == "padded_code"
 
-    def test_no_browser_empty_code_errors_out(self, cli_fs_runner, monkeypatch):
+    def test_oob_empty_code_errors_out(self, cli_fs_runner, monkeypatch):
         """
-        GIVEN --no-browser
+        GIVEN --method=oob
         WHEN the user submits an empty code (just whitespace)
         THEN the command fails with a friendly error and no token POST is sent.
         """
-        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        cmd = ["auth", "login", "--method=oob"]
         result = cli_fs_runner.invoke(cli, cmd, color=False, input="   \n")
         assert result.exit_code != 0
         assert "No authorization code was provided." in result.output
@@ -1179,9 +1179,9 @@ class TestAuthLoginWebNoBrowser:
         self._webbrowser_open_mock.assert_not_called()
         self._http_server_mock.assert_not_called()
 
-    def test_no_browser_token_exchange_failure(self, cli_fs_runner, monkeypatch):
+    def test_oob_token_exchange_failure(self, cli_fs_runner, monkeypatch):
         """
-        GIVEN --no-browser
+        GIVEN --method=oob
         WHEN the backend rejects the code at the token endpoint
         THEN the error is surfaced like the localhost flow does.
         """
@@ -1190,7 +1190,7 @@ class TestAuthLoginWebNoBrowser:
             create_json_response({"detail": "kaboom"}, status_code=400),
         )
 
-        cmd = ["auth", "login", "--method=web", "--no-browser"]
+        cmd = ["auth", "login", "--method=oob"]
         result = cli_fs_runner.invoke(
             cli, cmd, color=False, input="some_authorization_code\n"
         )
@@ -1200,13 +1200,13 @@ class TestAuthLoginWebNoBrowser:
         self._http_server_mock.assert_not_called()
         self._request_mock.assert_all_requests_happened()
 
-    def test_no_browser_rejected_for_non_web_method(self, cli_fs_runner):
+    def test_unknown_method_rejected(self, cli_fs_runner):
         """
-        GIVEN --no-browser combined with --method=token
+        GIVEN an unknown --method value
         WHEN running the login command
-        THEN the CLI rejects the combination (the flag is web-only).
+        THEN click rejects it via the Choice type.
         """
-        cmd = ["auth", "login", "--method=token", "--no-browser"]
+        cmd = ["auth", "login", "--method=no-browser"]
         result = cli_fs_runner.invoke(cli, cmd, color=False)
         assert result.exit_code != 0
-        assert "--no-browser is reserved for the web login method." in result.output
+        assert "'no-browser' is not one of 'token', 'web', 'oob'" in result.output

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -4,7 +4,7 @@ import pytest
 
 from ggshield.core.config import Config
 from ggshield.verticals.auth import OAuthClient
-from ggshield.verticals.auth.oauth import get_error_param
+from ggshield.verticals.auth.oauth import _mask_code, get_error_param
 
 
 @pytest.mark.parametrize(
@@ -63,3 +63,25 @@ def test_get_error_message(error_code, expected_message):
     oauth_client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
     error_message = oauth_client.get_server_error_message(error_code)
     assert error_message == expected_message
+
+
+@pytest.mark.parametrize(
+    ["code", "expected"],
+    [
+        # Long code: first 4 chars kept, rest masked.
+        ("Mhpf80jek7oP8bL43mEVTrL1wluEvB", "Mhpf" + "*" * 26),
+        # Edge cases where the code is shorter than the visible prefix:
+        # everything is masked so no characters leak.
+        ("abc", "***"),
+        ("abcd", "****"),
+        ("", ""),
+    ],
+)
+def test_mask_code(code, expected):
+    """
+    GIVEN an OOB authorization code
+    WHEN it is masked for terminal display
+    THEN at most the first 4 characters are visible, the rest are `*`,
+    and short codes are fully masked
+    """
+    assert _mask_code(code) == expected


### PR DESCRIPTION
## Summary

Adds `ggshield auth login --no-browser` for environments without a browser (SSH sessions, headless servers).

When the flag is set, ggshield:
1. Builds the authorize URL with `redirect_uri=urn:ietf:wg:oauth:2.0:oob` (the standard OAuth out-of-band sentinel).
2. Prints the URL to stderr — the user opens it on another device.
3. Reads the displayed code from stdin via `click.prompt`.
4. Exchanges it at `/v1/oauth/token` with the same OOB redirect_uri and the existing `code_verifier`.

PKCE still binds the exchange to the local CLI. The localhost listener is not started in OOB mode. State validation is intentionally absent (no redirect to inspect) — documented inline.

Server side: MR in GIM : https://gitlab.gitguardian.ovh/gg-code/prm/ward-runs-app/-/merge_requests/24425

<img width="1244" height="100" alt="image" src="https://github.com/user-attachments/assets/3a5af577-4465-4642-bde1-cbf4c465adec" />
<img width="563" height="382" alt="image" src="https://github.com/user-attachments/assets/f8953047-3eb9-4e09-a32c-5bd5782e1766" />
<img width="747" height="164" alt="image" src="https://github.com/user-attachments/assets/a2815f58-0c57-4006-a87b-392dce7e543d" />

Loom video : https://www.loom.com/share/4b358456740b4905a16ee9d2af2a8c6f

## Test plan

- [x] New unit tests cover: URL contains the sentinel + no browser opened + no listener started, POST body has the sentinel, code-stripping, empty-code error, 4xx surfacing, and `--no-browser` rejection with `--method=token`.
- [x] All pre-existing auth tests still pass (358/358).
- [x] `black --check` / `isort --check` clean on changed files.
- [ ] Manual smoke against a backend with OOB support.

Refs: SI-2994