### PR TITLE
chore: update py-gitguardian to use pypi release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
     "packaging>=22.0",
-    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@015c125",
+    "pygitguardian~=1.30.0",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",
@@ -65,9 +65,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 path = "ggshield/__init__.py"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.uv]
 # Exclude packages released in the last 3 days to avoid pulling a freshly

--- a/uv.lock
+++ b/uv.lock
@@ -9,8 +9,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-20T12:47:08.200956462Z"
+exclude-newer = "2026-04-25T12:47:50.060819Z"
 exclude-newer-span = "P3D"
+
+[options.exclude-newer-package]
+pygitguardian = false
 
 [manifest]
 overrides = [
@@ -941,7 +944,7 @@ requires-dist = [
     { name = "oauthlib", specifier = "~=3.2.1" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=015c125" },
+    { name = "pygitguardian", specifier = "~=1.30.0" },
     { name = "pyjwt", specifier = "~=2.6.0" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
@@ -2677,14 +2680,18 @@ wheels = [
 
 [[package]]
 name = "pygitguardian"
-version = "1.29.0"
-source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=015c125#015c125b1a6a1595b1813beb274b7e64b96fe52f" }
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },
     { name = "requests" },
     { name = "setuptools" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/d9/15e6d313c47c1e8753d7c0a274717b8841f34e9e187ba8a9f5b9598096f4/pygitguardian-1.30.0.tar.gz", hash = "sha256:fd6a43a2650d181c06d3e0a5c38b7a9ed9e4868bdd1997ce4e6c5863c94de9fe", size = 56271, upload-time = "2026-04-28T12:02:32.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/3e/aefd6fcc2fcb88dfe5fd1a026a3ca5d5ba87eb7baba3feea70ce4db117c4/pygitguardian-1.30.0-py3-none-any.whl", hash = "sha256:9ff6acb3e6a47ddc96fb4fc7f70dbe058ccb828c5cef67097ab5cef897c88219", size = 23518, upload-time = "2026-04-28T12:02:31.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context
Updates the `py-gitguardian` dependency to use the released changes in `1.30.0`.