### PR TITLE
[MCP] Parse claude plugins and claude.ai servers

### DIFF
--- a/changelog.d/20260428_173029_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260428_173029_paul.petit.ext_HEAD.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- detection of MCP servers installed with Claude plugins or Claude.ai
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -8,7 +8,15 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration, Scope
+from ..models import (
+    Agent,
+    EventType,
+    HookPayload,
+    HookResult,
+    MCPConfiguration,
+    Scope,
+    Transport,
+)
 
 
 class Claude(Agent):
@@ -118,6 +126,12 @@ class Claude(Agent):
         return directory / ".mcp.json"
 
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield user-scoped MCP configurations from every known Claude Code source."""
+        yield from self._get_dot_claude_json_mcp_configurations()
+        yield from self._get_plugin_mcp_configurations()
+        yield from self._get_claudeai_mcp_configurations()
+
+    def _get_dot_claude_json_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         """Look into ~/.claude.json for both user-level and project-level MCP server entries."""
         # Load config file
         filepath = get_user_home_dir() / ".claude.json"
@@ -127,7 +141,7 @@ class Claude(Agent):
         # User-level mcpServers
         yield from self._parse_servers_block(data, Scope.USER, None)
 
-        # Per-project entries in projects dict
+        # Per-project entries in projects dict (local scope: per-user, per-project)
         projects = data.get("projects", {})
         if not isinstance(projects, dict):
             return
@@ -136,6 +150,110 @@ class Claude(Agent):
                 continue
             yield from self._parse_servers_block(
                 project_data, Scope.USER, Path(project_key)
+            )
+
+    def _get_plugin_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield MCP servers contributed by installed Claude Code plugins.
+
+        Plugins are tracked in ``~/.claude/plugins/installed_plugins.json``.
+        Each plugin can declare MCP servers either in ``<installPath>/.mcp.json``
+        or inline under the ``mcpServers`` key of
+        ``<installPath>/.claude-plugin/plugin.json``.
+        """
+        installed_path = self.config_folder / "plugins" / "installed_plugins.json"
+        if not (data := self._load_json_file(installed_path)):
+            return
+
+        plugins = data.get("plugins", {})
+        if not isinstance(plugins, dict):
+            return
+
+        # Expected format: {plugin_id: [{installation1}, {installation2}, ...]}
+        for installations in plugins.values():
+            if not isinstance(installations, list):
+                continue
+            for installation in installations:
+                if not isinstance(installation, dict):
+                    continue
+                yield from self._parse_plugin_installation(installation)
+
+    def _parse_plugin_installation(
+        self, installation: Dict[str, Any]
+    ) -> Iterator[MCPConfiguration]:
+        """Parse a single plugin installation entry and yield any MCP servers."""
+        install_path = installation.get("installPath")
+        if not isinstance(install_path, str):
+            return
+        install_dir = Path(install_path)
+        if not install_dir.is_dir():
+            return
+
+        # Tie project/local-scoped plugins to their project. Local-scoped
+        # plugins remain Scope.USER (per-user, per-project) to match the
+        # convention used for ~/.claude.json[projects] entries.
+        scope_str = installation.get("scope", "user")
+        project_path = installation.get("projectPath")
+        project = Path(project_path) if isinstance(project_path, str) else None
+        scope = Scope.PROJECT if scope_str == "project" else Scope.USER
+
+        # Preferred location: .mcp.json at the plugin root. The file may use
+        # either the wrapped {"mcpServers": {...}} layout or the bare
+        # {"name": {...}} layout, so we normalize before parsing.
+        mcp_data = self._load_json_file(install_dir / ".mcp.json")
+        if mcp_data is not None:
+            if "mcpServers" not in mcp_data and "servers" not in mcp_data:
+                mcp_data = {"mcpServers": mcp_data}
+            yield from self._parse_servers_block(mcp_data, scope, project)
+            return
+
+        # Fallback: inline mcpServers in the plugin manifest.
+        manifest = self._load_json_file(install_dir / ".claude-plugin" / "plugin.json")
+        if not manifest:
+            return
+        inline = manifest.get("mcpServers")
+        if isinstance(inline, dict):
+            yield from self._parse_servers_block({"mcpServers": inline}, scope, project)
+
+    def _get_claudeai_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield MCP servers connected through the user's claude.ai account.
+
+        These are remote connectors hosted by Anthropic; we do not have their
+        URLs locally, only their names. We collect names from two sources
+        and deduplicate them:
+
+        - claudeAiMcpEverConnected in ~/.claude.json (historical list)
+        - ~/.claude/mcp-needs-auth-cache.json (currently-authorized list)
+        """
+        names: List[str] = []
+        seen: set = set()
+
+        def _add(name: str) -> None:
+            name = name.removeprefix("claude.ai ")
+            if name in seen:
+                return
+            seen.add(name)
+            names.append(name)
+
+        claude_json = self._load_json_file(get_user_home_dir() / ".claude.json")
+        if claude_json:
+            for name in claude_json.get("claudeAiMcpEverConnected", []) or []:
+                _add(name)
+
+        auth_cache = self._load_json_file(
+            self.config_folder / "mcp-needs-auth-cache.json"
+        )
+        if auth_cache:
+            for name in auth_cache.keys():
+                _add(name)
+
+        for name in names:
+            yield MCPConfiguration(
+                name=name,
+                agent=self.name,
+                scope=Scope.USER,
+                transport=Transport.HTTP,
+                project=None,
+                url="claude.ai",
             )
 
     def discover_project_directories(self) -> Iterator[Path]:
@@ -160,6 +278,8 @@ class Claude(Agent):
         # The server name can be anything, but we assume no MCP tool has a "__" in its name
         tool = parts[-1]
         server_cfg_name = "__".join(parts[1:-1])
+        # Remove the optional "claude_ai_" prefix
+        server_cfg_name = server_cfg_name.removeprefix("claude_ai_")
 
         # Lookup the server name based on its configuration name
         # Fallback to the server name if not found

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -7,7 +7,7 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import EventType, HookPayload, HookResult
+from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
 from .claude_code import Claude
 
 
@@ -65,6 +65,9 @@ class Copilot(Claude):
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        yield from Agent._get_user_mcp_configurations(self)
 
     def parse_mcp_activity(
         self, payload: HookPayload, ai_config: AIDiscovery

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from pygitguardian.models import MCPToolInfo, UserInfo
 
+from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
@@ -289,6 +290,303 @@ class TestClaudeGetUserMcpConfigurations:
         ):
             claude = Claude()
             configs = list(claude._get_user_mcp_configurations())
+        assert configs == []
+
+
+class TestClaudeGetPluginMcpConfigurations:
+    def _setup(self, tmp_path: Path) -> Path:
+        config_folder = tmp_path / ".claude"
+        (config_folder / "plugins").mkdir(parents=True)
+        return config_folder
+
+    def _make_plugin(
+        self,
+        config_folder: Path,
+        plugin_id: str,
+        version: str = "1.0.0",
+    ) -> Path:
+        install_dir = (
+            config_folder
+            / "plugins"
+            / "cache"
+            / plugin_id.split("@")[1]
+            / plugin_id.split("@")[0]
+            / version
+        )
+        install_dir.mkdir(parents=True)
+        (install_dir / ".claude-plugin").mkdir()
+        (install_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": plugin_id.split("@")[0]})
+        )
+        return install_dir
+
+    def _patch(self, claude: Claude, config_folder: Path):
+        return patch.object(
+            type(claude),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def test_user_scope_plugin_with_bare_mcp_json(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "context7@official")
+        # Bare layout (just servers, no "mcpServers" wrapper)
+        (install_dir / ".mcp.json").write_text(
+            json.dumps({"context7": {"command": "npx", "args": ["-y", "ctx7"]}})
+        )
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "context7@official": [
+                            {
+                                "scope": "user",
+                                "installPath": str(install_dir),
+                                "version": "1.0.0",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "context7"
+        assert configs[0].scope == Scope.USER
+        assert configs[0].project is None
+        assert configs[0].transport == Transport.STDIO
+        assert configs[0].command == "npx"
+
+    def test_project_scope_plugin_tied_to_project(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "shared@official")
+        (install_dir / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"shared-srv": {"command": "node", "args": ["s.js"]}}}
+            )
+        )
+        project_path = get_user_home_dir() / "proj"
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "shared@official": [
+                            {
+                                "scope": "project",
+                                "projectPath": str(project_path),
+                                "installPath": str(install_dir),
+                                "version": "1.0.0",
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "shared-srv"
+        assert configs[0].scope == Scope.PROJECT
+        assert configs[0].project == str(project_path)
+
+    def test_local_scope_plugin_marked_as_user_with_project(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "local@official")
+        (install_dir / ".mcp.json").write_text(
+            json.dumps({"local-srv": {"command": "node"}})
+        )
+        project_path = get_user_home_dir() / "proj"
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "local@official": [
+                            {
+                                "scope": "local",
+                                "projectPath": str(project_path),
+                                "installPath": str(install_dir),
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].scope == Scope.USER
+        assert configs[0].project == str(project_path)
+
+    def test_inline_mcp_servers_in_manifest(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "inline@official")
+        (install_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "inline",
+                    "mcpServers": {
+                        "inline-srv": {
+                            "url": "https://example.com/mcp",
+                            "transport": "sse",
+                        }
+                    },
+                }
+            )
+        )
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "inline@official": [
+                            {
+                                "scope": "user",
+                                "installPath": str(install_dir),
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "inline-srv"
+        assert configs[0].transport == Transport.SSE
+        assert configs[0].url == "https://example.com/mcp"
+
+    def test_missing_install_dir_skipped(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "ghost@official": [
+                            {
+                                "scope": "user",
+                                "installPath": "/does/not/exist",
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert configs == []
+
+    def test_plugin_without_mcp_servers_yields_nothing(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "skills@official")
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "skills@official": [
+                            {
+                                "scope": "user",
+                                "installPath": str(install_dir),
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert configs == []
+
+    def test_missing_installed_plugins_file_yields_nothing(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert configs == []
+
+
+class TestClaudeGetClaudeAiMcpConfigurations:
+    def test_dedup_across_two_sources(self, tmp_path: Path):
+        config_folder = tmp_path / ".claude"
+        config_folder.mkdir()
+        (tmp_path / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiMcpEverConnected": [
+                        "claude.ai Notion",
+                        "claude.ai Granola",
+                    ]
+                }
+            )
+        )
+        (config_folder / "mcp-needs-auth-cache.json").write_text(
+            json.dumps(
+                {
+                    "claude.ai Notion": {"timestamp": 1, "id": "mcpsrv_a"},
+                    "claude.ai Slack": {"timestamp": 2, "id": "mcpsrv_b"},
+                }
+            )
+        )
+
+        claude = Claude()
+        with (
+            patch(
+                "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+                return_value=tmp_path,
+            ),
+            patch.object(
+                type(claude),
+                "config_folder",
+                new_callable=lambda: property(lambda self: config_folder),
+            ),
+        ):
+            configs = list(claude._get_claudeai_mcp_configurations())
+
+        names = [c.name for c in configs]
+        assert names == ["Notion", "Granola", "Slack"]
+        for cfg in configs:
+            assert cfg.scope == Scope.USER
+            assert cfg.transport == Transport.HTTP
+            assert cfg.project is None
+
+    def test_no_sources_yields_nothing(self, tmp_path: Path):
+        config_folder = tmp_path / ".claude"
+        config_folder.mkdir()
+
+        claude = Claude()
+        with (
+            patch(
+                "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+                return_value=tmp_path,
+            ),
+            patch.object(
+                type(claude),
+                "config_folder",
+                new_callable=lambda: property(lambda self: config_folder),
+            ),
+        ):
+            configs = list(claude._get_claudeai_mcp_configurations())
+
         assert configs == []
 
 


### PR DESCRIPTION
## Context

Linear issue: NHI-1619

We didn't detect MCP servers installed as Claude plugins (or through Claude.ai)

## What has been done

Add their detection

## Validation

- Install a plugin with claude that has a MCP server (e.g. Context7)
- `ggshield ai discover`

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
