### PR TITLE
ci(release): upload MSI to github releases

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -83,7 +83,8 @@ jobs:
             packages/ggshield-*.rpm \
             packages/ggshield-*.zip \
             packages/ggshield.*.nupkg \
-            packages/ggshield-*.gz
+            packages/ggshield-*.gz \
+            packages/ggshield-*.msi
 
   update_vscode_extension:
     needs: release


### PR DESCRIPTION
## Context

Currently, MSI artifacts are built in CI but not exposed prominently or uploaded.

## What has been done

This PR updates the GitHub release asset upload, so that the MSI artifact is included in the generated release.
