### PR TITLE
fix(doc): fix docstring/help of ggshield ai discover

### DIFF
--- a/changelog.d/20260429_165828_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260429_165828_paul.petit.ext_HEAD.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- The documentation of the `ai discover` command.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/ai/__init__.py
+++ b/ggshield/cmd/ai/__init__.py
@@ -9,4 +9,4 @@ from ggshield.cmd.utils.common_options import add_common_options
 @click.group(commands={"discover": discover_cmd})
 @add_common_options()
 def ai_group(**kwargs: Any) -> None:
-    """Commands to work with MCP (Model Context Protocol) servers."""
+    """Commands to work with AI assistants."""

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -42,11 +42,11 @@ def discover_cmd(
     """
     Discover MCP servers and their configuration.
 
-    Parses MCP configuration files from supported assistants
+    Parses configuration files from supported assistants.
 
     Examples:
-      ggshield mcp discover
-      ggshield mcp discover --json
+      ggshield ai discover
+      ggshield ai discover --json
     """
 
     config = discover_ai_configuration()


### PR DESCRIPTION
This PR fixes the documentation (docstring) of the `ggshield ai discover` command.