### PR TITLE
feat(mcp): detect cursor plugins and extensions

### DIFF
--- a/changelog.d/20260430_074704_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260430_074704_paul.petit.ext_HEAD.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- detection of MCP servers installed with Cursor plugins or Cursor extensions
+<!--
+
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/changelog.d/20260430_074704_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260430_074704_paul.petit.ext_HEAD.md
@@ -14,7 +14,7 @@ For top level release notes, leave all the headers commented out.
 
 ### Added
 
-- detection of MCP servers installed with Cursor plugins or Cursor extensions
+- Detect MCP servers installed with Cursor plugins or Cursor extensions.
 <!--
 
 ### Changed

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -14,7 +14,16 @@ from pygitguardian.models import (
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookPayload, HookResult, MCPServer
+from ..models import (
+    Agent,
+    EventType,
+    HookPayload,
+    HookResult,
+    MCPConfiguration,
+    MCPServer,
+    Scope,
+    Transport,
+)
 
 
 class Cursor(Agent):
@@ -79,6 +88,92 @@ class Cursor(Agent):
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".cursor" / "mcp.json"
 
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield user-scoped MCP configurations from every known Cursor source."""
+        yield from super()._get_user_mcp_configurations()
+        yield from self._get_plugin_mcp_configurations()
+        yield from self._get_extension_mcp_configurations()
+
+    def _get_plugin_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield MCP servers contributed by installed Cursor plugins.
+
+        Cursor stores marketplace plugins in
+        ``~/.cursor/plugins/cache/<owner>/<plugin>/<version>/`` and
+        locally-installed plugins in ``~/.cursor/plugins/local/<plugin>/``.
+        Each plugin can declare MCP servers either in
+        ``<installPath>/mcp.json`` (or ``.mcp.json``) or inline under the
+        ``mcpServers`` key of ``<installPath>/.cursor-plugin/plugin.json``.
+        """
+        plugins_root = self.config_folder / "plugins"
+        # Marketplace plugins: cache/<owner>/<plugin>/<version>/
+        for install_dir in plugins_root.glob("cache/*/*/*"):
+            if install_dir.is_dir():
+                yield from self._parse_cursor_plugin_dir(install_dir)
+        # Local plugins: local/<plugin>/
+        for install_dir in plugins_root.glob("local/*"):
+            if install_dir.is_dir():
+                yield from self._parse_cursor_plugin_dir(install_dir)
+
+    def _parse_cursor_plugin_dir(self, install_dir: Path) -> Iterator[MCPConfiguration]:
+        """Parse a single Cursor plugin install directory and yield any MCP servers."""
+        # Preferred location: mcp.json or .mcp.json at the plugin root. The
+        # file may use either the wrapped {"mcpServers": {...}} layout or the
+        # bare {"name": {...}} layout, so we normalize before parsing.
+        for filename in ("mcp.json", ".mcp.json"):
+            mcp_data = self._load_json_file(install_dir / filename)
+            if mcp_data is not None:
+                if "mcpServers" not in mcp_data and "servers" not in mcp_data:
+                    mcp_data = {"mcpServers": mcp_data}
+                yield from self._parse_servers_block(mcp_data, Scope.USER, None)
+                return
+
+        # Fallback: inline mcpServers in the plugin manifest.
+        manifest = self._load_json_file(install_dir / ".cursor-plugin" / "plugin.json")
+        if not manifest:
+            return
+        inline = manifest.get("mcpServers")
+        if isinstance(inline, dict):
+            yield from self._parse_servers_block(
+                {"mcpServers": inline}, Scope.USER, None
+            )
+
+    def _get_extension_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield MCP servers contributed by installed Cursor (VS Code) extensions.
+
+        Extensions can register MCP servers programmatically via the
+        ``contributes.mcpServerDefinitionProviders`` field of their
+        ``package.json``. The server's actual transport/URL/command is set at
+        runtime, so we only emit a placeholder configuration with the
+        provider's id/label as the name and STDIO transport as a sensible
+        default.
+        """
+        packages = self.config_folder.glob("extensions/*/package.json")
+        for package_path in packages:
+            package = self._load_json_file(package_path)
+            if not package:
+                continue
+            providers = package.get("contributes", {}).get(
+                "mcpServerDefinitionProviders", []
+            )
+            if not isinstance(providers, list):
+                continue
+            for provider in providers:
+                if not isinstance(provider, dict):
+                    continue
+                name = provider.get("label") or provider.get("id")
+                if not name:
+                    continue
+                # Cursor seems to truncate the label when parentheses are present.
+                # Could be worth investigating the exact behavior more.
+                name = name.split("(")[0].strip()
+                yield MCPConfiguration(
+                    name=name,
+                    agent=self.name,
+                    scope=Scope.USER,
+                    transport=Transport.STDIO,
+                    project=None,
+                )
+
     def discover_project_directories(self) -> Iterator[Path]:
         # Because Cursor is based on VS Code, we can reuse the same logic than Copilot.
         user_folder = get_user_home_dir() / ".config" / "Cursor" / "User"
@@ -89,31 +184,28 @@ class Cursor(Agent):
                     yield path.resolve()
 
     def discover_capabilities(self, server: MCPServer) -> bool:
-        # General Cursor strategy:
         # For each project where Cursor was used, it created a folder with the project name
         # in its configuration folder. Inside that folder, it stores metadata for every
-        # MCP server available in that project.
-        for configuration in server.configurations:
-            # Look for Cursor configurations
-            if configuration.agent != self.name:
-                continue
-            # We need a folder. Note: this also works for user-level configurations.
-            # as Cursor will have a `home-<username>` "project".
-            if configuration.project is None:
-                continue
+        # MCP server available in that project (one subfolder per server).
+        # General strategy:
+        #  - get all Cursor's configuration names
+        #  - look for a SERVER_METADATA.json file with the expected name.
+        configuration_names = {
+            configuration.name
+            for configuration in server.configurations
+            if configuration.agent == self.name
+        }
 
-            # Lookup where Cursor stores the capabilities for the given project.
-            mangled = (
-                Path(configuration.project).as_posix().replace("/", "-").lstrip("-")
-            )
-            folder = self.config_folder / "projects" / mangled / "mcps"
-            if not folder.exists():
-                continue
-            # Look for a SERVER_METADATA.json file with the expected name.
-            # (each subfolder corresponds to a different MCP server)
-            for file in folder.glob("*/SERVER_METADATA.json"):
+        for configuration_name in configuration_names:
+            # Note: we didn't restrict the project folder,
+            # because some servers (like plugins) won't have them in their configuration.
+            # Fortunately, the name of the folder is derived from the MCP server name,
+            # so we can use it to reduce the number of folders to look at, so it is still fast.
+            for file in self.config_folder.glob(
+                f"projects/*/mcps/*{configuration_name}/SERVER_METADATA.json"
+            ):
                 metadata = self._load_json_file(file)
-                if metadata and metadata.get("serverName") == configuration.name:
+                if self._server_name_matches(metadata, configuration_name):
                     # Found it! Update the folder
                     folder = file.parent
                     break
@@ -172,6 +264,17 @@ class Cursor(Agent):
                 return True
 
         return False
+
+    def _server_name_matches(
+        self, metadata: Optional[Dict[str, Any]], name: str
+    ) -> bool:
+        """Check if the server name matches the metadata."""
+        if metadata is None:
+            return False
+        server_name = metadata.get("serverName", "")
+        # Extension-based servers are prefixed with "extension-"
+        server_name = server_name.removeprefix("extension-")
+        return server_name == name
 
     def parse_mcp_activity(
         self, payload: HookPayload, ai_config: AIDiscovery

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -73,7 +73,7 @@ class TestCursorDiscoverCapabilities:
         """Build a Cursor-style mcps/<server>/ folder layout and return the agent."""
         mangled = project_path.as_posix().replace("/", "-").lstrip("-")
         mcps_root = tmp_path / ".cursor" / "projects" / mangled / "mcps"
-        server_dir = mcps_root / "user-my-server"
+        server_dir = mcps_root / f"user-{server_name}"
         server_dir.mkdir(parents=True, exist_ok=True)
         # SERVER_METADATA.json
         (server_dir / "SERVER_METADATA.json").write_text(
@@ -160,6 +160,228 @@ class TestCursorDiscoverCapabilities:
         cfg = _cfg(name="srv", agent="claude-code", project=Path("/proj"))
         server = MCPServer(name="srv", configurations=[cfg])
         assert cursor.discover_capabilities(server) is False
+
+    def test_extension_prefixed_metadata_matches_short_cfg_name(self, tmp_path: Path):
+        """An extension-provided server (serverName "extension-my-server") must match cfg "my-server"."""
+        project = Path("/home/user/project")
+        mangled = project.as_posix().replace("/", "-").lstrip("-")
+        mcps_root = tmp_path / ".cursor" / "projects" / mangled / "mcps"
+        server_dir = mcps_root / "extension-my-server"
+        server_dir.mkdir(parents=True)
+        (server_dir / "SERVER_METADATA.json").write_text(
+            json.dumps({"serverName": "extension-my-server"})
+        )
+        (server_dir / "tools").mkdir()
+        (server_dir / "tools" / "t1.json").write_text(json.dumps({"name": "find"}))
+
+        cursor = Cursor()
+        cfg = _cfg(name="my-server", agent="cursor", project=project)
+        server = MCPServer(name="server", configurations=[cfg])
+
+        with patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path / ".cursor"),
+        ):
+            assert cursor.discover_capabilities(server) is True
+        assert [t.name for t in server.tools] == ["find"]
+
+
+class TestCursorGetPluginMcpConfigurations:
+    def _patch(self, cursor: Cursor, config_folder: Path):
+        return patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def test_marketplace_plugin_with_mcp_json(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        install_dir = (
+            config_folder / "plugins" / "cache" / "cursor-public" / "sentry" / "abc123"
+        )
+        install_dir.mkdir(parents=True)
+        (install_dir / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "sentry": {"type": "http", "url": "https://mcp.sentry.dev/mcp"}
+                    }
+                }
+            )
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "sentry"
+        assert configs[0].scope == Scope.USER
+        assert configs[0].project is None
+        assert configs[0].transport == Transport.HTTP
+        assert configs[0].url == "https://mcp.sentry.dev/mcp"
+
+    def test_local_plugin_with_dot_mcp_json_bare_layout(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        install_dir = config_folder / "plugins" / "local" / "my-plugin"
+        install_dir.mkdir(parents=True)
+        # Bare layout (no "mcpServers" wrapper)
+        (install_dir / ".mcp.json").write_text(
+            json.dumps({"my-srv": {"command": "node", "args": ["index.js"]}})
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "my-srv"
+        assert configs[0].transport == Transport.STDIO
+        assert configs[0].command == "node"
+
+    def test_inline_mcp_servers_in_manifest(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        install_dir = config_folder / "plugins" / "cache" / "owner" / "inline" / "v1"
+        install_dir.mkdir(parents=True)
+        (install_dir / ".cursor-plugin").mkdir()
+        (install_dir / ".cursor-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "inline",
+                    "mcpServers": {
+                        "inline-srv": {
+                            "url": "https://example.com/mcp",
+                            "transport": "sse",
+                        }
+                    },
+                }
+            )
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "inline-srv"
+        assert configs[0].transport == Transport.SSE
+        assert configs[0].url == "https://example.com/mcp"
+
+    def test_plugin_without_mcp_servers_yields_nothing(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        install_dir = (
+            config_folder / "plugins" / "cache" / "owner" / "skills-only" / "v1"
+        )
+        install_dir.mkdir(parents=True)
+        (install_dir / ".cursor-plugin").mkdir()
+        (install_dir / ".cursor-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "skills-only"})
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert configs == []
+
+    def test_missing_plugins_folder_yields_nothing(self, tmp_path: Path):
+        cursor = Cursor()
+        with self._patch(cursor, tmp_path / ".cursor"):
+            configs = list(cursor._get_plugin_mcp_configurations())
+        assert configs == []
+
+
+class TestCursorGetExtensionMcpConfigurations:
+    def _patch(self, cursor: Cursor, config_folder: Path):
+        return patch.object(
+            type(cursor),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def _write_registry(self, config_folder: Path, entries: List[Dict[str, Any]]):
+        ext_root = config_folder / "extensions"
+        ext_root.mkdir(parents=True, exist_ok=True)
+        (ext_root / "extensions.json").write_text(json.dumps(entries))
+
+    def test_extension_with_mcp_provider_yields_config(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        ext_dir = config_folder / "extensions" / "eamodio.gitlens-17.12.2-universal"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "package.json").write_text(
+            json.dumps(
+                {
+                    "contributes": {
+                        "mcpServerDefinitionProviders": [
+                            {
+                                "id": "gitlens.gkMcpProvider",
+                                "label": "GitKraken (bundled with GitLens)",
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+        self._write_registry(
+            config_folder,
+            [{"relativeLocation": "eamodio.gitlens-17.12.2-universal"}],
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_extension_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "GitKraken"
+        assert configs[0].scope == Scope.USER
+        assert configs[0].project is None
+        assert configs[0].transport == Transport.STDIO
+
+    def test_extension_without_mcp_provider_skipped(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        ext_dir = config_folder / "extensions" / "pub.plain-1.0.0"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "package.json").write_text(
+            json.dumps({"contributes": {"commands": [{"command": "foo"}]}})
+        )
+        self._write_registry(config_folder, [{"relativeLocation": "pub.plain-1.0.0"}])
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_extension_mcp_configurations())
+
+        assert configs == []
+
+    def test_multiple_providers_yield_one_each(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        ext_dir = config_folder / "extensions" / "pub.multi-1.0.0"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "package.json").write_text(
+            json.dumps(
+                {
+                    "contributes": {
+                        "mcpServerDefinitionProviders": [
+                            {"id": "p1", "label": "Provider 1"},
+                            {"id": "p2", "label": "Provider 2"},
+                        ]
+                    }
+                }
+            )
+        )
+        self._write_registry(config_folder, [{"relativeLocation": "pub.multi-1.0.0"}])
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_extension_mcp_configurations())
+
+        assert [c.name for c in configs] == ["Provider 1", "Provider 2"]
+
+    def test_missing_registry_yields_nothing(self, tmp_path: Path):
+        cursor = Cursor()
+        with self._patch(cursor, tmp_path / ".cursor"):
+            configs = list(cursor._get_extension_mcp_configurations())
+        assert configs == []
 
 
 class TestCursorDiscoverProjectDirectories:


### PR DESCRIPTION
## Context

Following the detection of MCP servers installed via plugins in Claude, this PR adds the same improvement for Cursor.

## What has been done

- detect servers declared in both `plugins/` and `extensions/`.
- the capability discovery logic has been changed to be able to detect tools for these servers.

## Validation

- install a plugin in Cursor (and activate the installed MCP in a project)
- it should appear in `ggshield ai discover`

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

