### PR TITLE
fix(auth): do not query keyring if API key env var is set

### DIFF
--- a/changelog.d/20260430_092300_6d7a_deprioritize_keyring_check.md
+++ b/changelog.d/20260430_092300_6d7a_deprioritize_keyring_check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Skip OS keyring access at startup when `GITGUARDIAN_API_KEY` is set in the environment (or in a `.env` file). This avoids redundant keychain unlock prompts on systems using multiple ggshield intances.

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -127,10 +127,16 @@ def cli(
     instance: Optional[str],
     **kwargs: Any,
 ) -> None:
+    # Load .env before Config so AuthConfig.load() can see GITGUARDIAN_API_KEY
+    # set via dotenv and skip keyring access when an env-provided token will be
+    # used instead.
+    dotenv_vars = load_dot_env()
+
     # Create ContextObj, load config
     ctx.obj = ctx_obj = ContextObj()
     ctx_obj.cache = Cache()
     ctx_obj.config = Config(config_path)
+    ctx_obj.config._dotenv_vars = dotenv_vars
     user_config = ctx_obj.config.user_config
 
     # If the config wants a higher UI level, set it now
@@ -144,8 +150,6 @@ def cli(
     # --insecure, the config will contain `insecure: true`.
     if insecure or allow_self_signed:
         user_config.insecure = True
-
-    ctx_obj.config._dotenv_vars = load_dot_env()
 
     # Apply instance from command line
     if instance:

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -149,6 +150,13 @@ class AuthConfig(FromDictMixin, ToDictMixin):
 
         If the active token store is a keyring backend, tokens marked with the
         keyring sentinel are hydrated from the OS credential store.
+
+        When ``GITGUARDIAN_API_KEY`` is set in the environment it overrides any
+        stored token in :meth:`Config.get_api_key_and_source`, so we skip the
+        keyring access here to avoid prompting the user (e.g. for OS keychain
+        unlock) for a credential that will not be used. This matters for
+        global ggshield invocations like pre-commit hooks that already supply
+        a token via the environment.
         """
         config_path = get_auth_config_filepath()
 
@@ -158,6 +166,9 @@ class AuthConfig(FromDictMixin, ToDictMixin):
             instance = cls.from_dict(data)
         else:
             instance = cls()
+
+        if os.environ.get("GITGUARDIAN_API_KEY"):
+            return instance
 
         store = get_token_store()
         if store.uses_external_storage:

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -179,6 +179,13 @@ def _reset_token_store():
 class TestAuthConfigKeyring:
     """Tests for keyring integration in AuthConfig load/save."""
 
+    @pytest.fixture(autouse=True)
+    def _no_env_api_key(self, monkeypatch):
+        """AuthConfig.load() skips keyring access when GITGUARDIAN_API_KEY is
+        set in the environment. The session-wide test fixture sets a dummy
+        value, so unset it here to exercise the keyring path."""
+        monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
+
     def test_save_with_keyring(self, monkeypatch):
         """
         GIVEN a config with a cleartext token
@@ -408,6 +415,36 @@ class TestAuthConfigKeyring:
         assert config.auth_config.instances[0].account.token == ""
         assert config.auth_config.instances[1].account is not None
         assert config.auth_config.instances[1].account.token == ""
+
+    def test_load_skips_keyring_when_env_api_key_set(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens AND GITGUARDIAN_API_KEY set
+        WHEN loading
+        THEN the keyring is not accessed (no prompt to the user) since the
+             env-provided key would override stored tokens anyway
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+        monkeypatch.setenv("GITGUARDIAN_API_KEY", "env-token")
+
+        sentinel_config = deepcopy(TEST_AUTH_CONFIG)
+        for instance in sentinel_config["instances"]:
+            for account in instance["accounts"]:
+                account["token"] = KEYRING_SENTINEL
+        write_yaml(get_auth_config_filepath(), sentinel_config)
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock()
+        mock_store.is_available = MagicMock()
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ) as mock_get_store:
+            Config()
+
+        mock_get_store.assert_not_called()
+        mock_store.is_available.assert_not_called()
+        mock_store.get_token.assert_not_called()
 
     def test_file_store_preserves_cleartext(self, monkeypatch):
         """


### PR DESCRIPTION
## Context

Currently, the keyring will be queried even in the event that a PAT is provided through an environment variable. This can lead to degraded UX in the following case:
- one `ggshield` instance with keyring-based credentials is in the PATH
- another `ggshield` instance (for example in a pre-commit environment) with env-var-based credential executes a command that needs authentication
In the above case, the keyring will be queried, and since the second instance did not write the original keyring entry, the user will be prompted to give the second instance access to the credential. 

## What has been done

Before querying the keyring, the auth flow always checks for an environment variable. Auth-method precedence is unchanged.

## Validation

- install or update a global `ggshield` installation to `1.50.2`
- authenticate the first instance using `ggshield auth login`
- update or set up a `ggshield` pre-commit hook set to `rev: 6d7a/deprioritize-keyring-check`
- run `pre-commit run --all-files` to confirm that the pre-commit asks for keyring access
- run `GITGUARDIAN_API_KEY=gg_pat_*** pre-commit run --all-files` to confirm that the PAT from the environment is used without asking for keyring access

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
