### PR TITLE
ci: add support for github artifact attestation

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,9 +43,13 @@ jobs:
       tag: ${{ steps.tags.outputs.tag }}
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
-    # This is required for `gh release create` to work
+    # `contents: write` is required for `gh release create` to work.
+    # `id-token: write` and `attestations: write` are required by
+    # actions/attest-build-provenance to generate signed SLSA provenance.
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -65,6 +69,18 @@ jobs:
           pattern: os-packages-*
           path: packages
           merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            packages/ggshield-*.pkg
+            packages/ggshield_*.deb
+            packages/ggshield-*.rpm
+            packages/ggshield-*.zip
+            packages/ggshield.*.nupkg
+            packages/ggshield-*.gz
+            packages/ggshield-*.msi
 
       - name: Create release
         env:

--- a/changelog.d/20260504_104400_6d7a_signed_artifacts.md
+++ b/changelog.d/20260504_104400_6d7a_signed_artifacts.md
@@ -1,0 +1,3 @@
+### Added
+
+- Release binaries published to GitHub Releases now ship with [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), providing signed SLSA build provenance. Users can verify a downloaded asset with `gh attestation verify <file> --repo GitGuardian/ggshield`, and tool managers such as mise (via the aqua backend) will verify automatically at install time.


### PR DESCRIPTION
## Context

Closes #1204

## What has been done

- Release binaries published to GitHub Releases now ship with [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), providing signed SLSA build provenance. Users can verify a downloaded asset with `gh attestation verify <file> --repo GitGuardian/ggshield`, and tool managers such as mise (via the aqua backend) will verify automatically at install time.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
