### PR TITLE
feat(plugin): install plugins from the GitGuardian platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.worktrees/
+
 # Created by .ignore support plugin (hsz.mobi)
 ### Python template
 # Byte-compiled / optimized / DLL files

--- a/changelog.d/20260505_120000_benjamin.rigaud_platform_plugin_install.md
+++ b/changelog.d/20260505_120000_benjamin.rigaud_platform_plugin_install.md
@@ -1,0 +1,7 @@
+### Added
+
+- `ggshield plugin install` / `update` / `status` now discover and pull plugins from the GitGuardian instance the user is authenticated against, replacing the hard-coded GitHub release URL. Streaming download + sigstore bundle proxying happen via `/v1/endpoints/plugins/<reference>/{download,signature}`. Requires the matching backend feature.
+
+### Changed
+
+- `ggshield plugin list` now renders the install source from the manifest verbatim (`platform`, `local file`, `url`, `github release`, `github artifact`) instead of `local`/`pip`. Plugins installed without a manifest still fall back to `pip` (entry-point only) or `on-disk`.

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -17,16 +17,17 @@ from ggshield.core.errors import ExitCode
 from ggshield.core.plugin.client import (
     PluginAPIClient,
     PluginAPIError,
-    PluginNotAvailableError,
+    PluginsNotEnabledError,
     PluginSourceType,
 )
 from ggshield.core.plugin.downloader import (
     ChecksumMismatchError,
-    DownloadError,
     GitHubArtifactError,
     InsecureSourceError,
     PluginDownloader,
 )
+from ggshield.core.plugin.loader import resolve_config_key
+from ggshield.core.plugin.platform import get_platform_info
 from ggshield.core.plugin.signature import (
     SignatureVerificationError,
     SignatureVerificationMode,
@@ -65,7 +66,7 @@ def detect_source_type(plugin_source: str) -> PluginSourceType:
         return PluginSourceType.LOCAL_FILE
 
     # Default: assume it's a plugin name for GitGuardian API
-    return PluginSourceType.GITGUARDIAN_API
+    return PluginSourceType.PLATFORM
 
 
 @click.command()
@@ -153,15 +154,20 @@ def _install_from_gitguardian(
     version: Optional[str],
     signature_mode: SignatureVerificationMode = SignatureVerificationMode.STRICT,
 ) -> None:
-    """Install a plugin from GitGuardian API."""
+    """Install a plugin from the GitGuardian platform."""
     ctx_obj = ContextObj.get(ctx)
     config = ctx_obj.config
 
-    # Fetch available plugins
     try:
         client = create_client_from_config(config)
         plugin_api_client = PluginAPIClient(client)
         catalog = plugin_api_client.get_available_plugins()
+    except PluginsNotEnabledError:
+        ui.display_error(
+            "Plugin system is not available on this workspace. "
+            "Contact your administrator."
+        )
+        ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except PluginAPIError as e:
         ui.display_error(str(e))
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
@@ -169,11 +175,9 @@ def _install_from_gitguardian(
         ui.display_error(f"Failed to connect to GitGuardian: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
 
-    # Check if plugin is available
     available_plugins = {p.name: p for p in catalog.plugins if p.available}
 
     if plugin_name not in available_plugins:
-        # Check if plugin exists but is not available
         unavailable = next((p for p in catalog.plugins if p.name == plugin_name), None)
         if unavailable:
             ui.display_error(
@@ -186,30 +190,49 @@ def _install_from_gitguardian(
             ui.display_info("Use 'ggshield plugin status' to see available plugins")
         ctx.exit(ExitCode.USAGE_ERROR)
 
-    # Install the plugin
     downloader = PluginDownloader()
     enterprise_config = EnterpriseConfig.load()
+    platform_info = get_platform_info()
 
     ui.display_info(f"Installing {plugin_name}...")
 
     try:
-        # Get download info
-        download_info = plugin_api_client.get_download_info(
-            plugin_name, version=version
-        )
+        with plugin_api_client.download_plugin(
+            plugin_name, platform_info=platform_info, version=version
+        ) as (info, chunks):
+            bundle_bytes: Optional[bytes] = None
+            if info.signature_url:
+                try:
+                    bundle_bytes = plugin_api_client.download_signature_bundle(
+                        info.signature_url
+                    )
+                except PluginAPIError as bundle_err:
+                    # In STRICT mode, an unreachable bundle is a hard
+                    # failure — the user expects signature verification.
+                    # In WARN mode they have opted into accepting
+                    # unsigned plugins, so a bundle the proxy couldn't
+                    # serve is equivalent to "no signature available"
+                    # rather than a reason to abort an otherwise valid
+                    # wheel download.
+                    if signature_mode == SignatureVerificationMode.STRICT:
+                        raise
+                    ui.display_warning(
+                        f"Could not fetch signature bundle for {plugin_name}: "
+                        f"{bundle_err}. Continuing without verification "
+                        f"(--allow-unsigned)."
+                    )
+            wheel_path = downloader.download_and_install(
+                info,
+                chunks,
+                plugin_name,
+                signature_mode=signature_mode,
+                bundle_bytes=bundle_bytes,
+            )
 
-        # Download and install
-        downloader.download_and_install(
-            download_info, plugin_name, signature_mode=signature_mode
-        )
-
-        # Enable in config
-        enterprise_config.enable_plugin(plugin_name, version=download_info.version)
-
-        # Save config
+        config_key = resolve_config_key(wheel_path, fallback=plugin_name)
+        enterprise_config.enable_plugin(config_key, version=info.version)
         enterprise_config.save()
-
-        ui.display_info(f"Installed {plugin_name} v{download_info.version}")
+        ui.display_info(f"Installed {plugin_name} v{info.version}")
 
     except SignatureVerificationError as e:
         ui.display_error(f"Signature verification failed for {plugin_name}: {e}")
@@ -219,15 +242,13 @@ def _install_from_gitguardian(
             "pass --allow-unsigned."
         )
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except PluginNotAvailableError as e:
-        ui.display_error(f"Failed to install {plugin_name}: {e}")
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except DownloadError as e:
-        ui.display_error(f"Failed to install {plugin_name}: {e}")
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except Exception as e:
         ui.display_error(f"Failed to install {plugin_name}: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
+
+    plugin_api_client.report_installation(
+        plugin_name, info.version, platform_info.os, platform_info.arch
+    )
 
 
 def _install_from_local_wheel(
@@ -248,12 +269,12 @@ def _install_from_local_wheel(
     ui.display_info(f"Installing from {wheel_path.name}...")
 
     try:
-        plugin_name, version, _ = downloader.install_from_wheel(
+        plugin_name, version, installed_wheel = downloader.install_from_wheel(
             wheel_path, signature_mode=signature_mode
         )
 
-        # Enable in config
-        enterprise_config.enable_plugin(plugin_name, version=version)
+        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
+        enterprise_config.enable_plugin(config_key, version=version)
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -265,9 +286,6 @@ def _install_from_local_wheel(
             "If you trust its origin and still want to install it, "
             "pass --allow-unsigned."
         )
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except DownloadError as e:
-        ui.display_error(f"Failed to install from wheel: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except Exception as e:
         ui.display_error(f"Failed to install from wheel: {e}")
@@ -287,12 +305,12 @@ def _install_from_url(
     ui.display_info("Installing from URL...")
 
     try:
-        plugin_name, version, _ = downloader.download_from_url(
+        plugin_name, version, installed_wheel = downloader.download_from_url(
             url, sha256, signature_mode=signature_mode
         )
 
-        # Enable in config
-        enterprise_config.enable_plugin(plugin_name, version=version)
+        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
+        enterprise_config.enable_plugin(config_key, version=version)
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -310,9 +328,6 @@ def _install_from_url(
         ctx.exit(ExitCode.USAGE_ERROR)
     except ChecksumMismatchError as e:
         ui.display_error(f"Checksum verification failed: {e}")
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except DownloadError as e:
-        ui.display_error(f"Failed to install from URL: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except Exception as e:
         ui.display_error(f"Failed to install from URL: {e}")
@@ -332,12 +347,12 @@ def _install_from_github_release(
     ui.display_info("Installing from GitHub release...")
 
     try:
-        plugin_name, version, _ = downloader.download_from_github_release(
+        plugin_name, version, installed_wheel = downloader.download_from_github_release(
             url, sha256, signature_mode=signature_mode
         )
 
-        # Enable in config
-        enterprise_config.enable_plugin(plugin_name, version=version)
+        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
+        enterprise_config.enable_plugin(config_key, version=version)
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -355,9 +370,6 @@ def _install_from_github_release(
         ctx.exit(ExitCode.USAGE_ERROR)
     except ChecksumMismatchError as e:
         ui.display_error(f"Checksum verification failed: {e}")
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except DownloadError as e:
-        ui.display_error(f"Failed to install from GitHub release: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except Exception as e:
         ui.display_error(f"Failed to install from GitHub release: {e}")
@@ -378,12 +390,12 @@ def _install_from_github_artifact(
     ui.display_info("Installing from GitHub artifact...")
 
     try:
-        plugin_name, version, _ = downloader.download_from_github_artifact(
-            url, signature_mode=signature_mode
+        plugin_name, version, installed_wheel = (
+            downloader.download_from_github_artifact(url, signature_mode=signature_mode)
         )
 
-        # Enable in config
-        enterprise_config.enable_plugin(plugin_name, version=version)
+        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
+        enterprise_config.enable_plugin(config_key, version=version)
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -398,9 +410,6 @@ def _install_from_github_artifact(
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except GitHubArtifactError as e:
         ui.display_error(str(e))
-        ctx.exit(ExitCode.UNEXPECTED_ERROR)
-    except DownloadError as e:
-        ui.display_error(f"Failed to install from GitHub artifact: {e}")
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except Exception as e:
         ui.display_error(f"Failed to install from GitHub artifact: {e}")

--- a/ggshield/cmd/plugin/plugin_list.py
+++ b/ggshield/cmd/plugin/plugin_list.py
@@ -47,21 +47,23 @@ def list_cmd(ctx: click.Context, **kwargs: Any) -> None:
     for plugin in discovered:
         status_parts = []
 
-        # Version
         if plugin.version:
             status_parts.append(f"v{plugin.version}")
 
-        # Enabled/disabled
         if plugin.is_enabled:
             status_parts.append("enabled")
         else:
             status_parts.append("disabled")
 
-        # Source
-        if plugin.wheel_path:
-            status_parts.append("local")
+        source = (
+            downloader.get_plugin_source(plugin.name) if plugin.wheel_path else None
+        )
+        if source is not None:
+            status_parts.append(source.type.value.replace("_", " "))
         elif plugin.entry_point:
             status_parts.append("pip")
+        elif plugin.wheel_path:
+            status_parts.append("on-disk")
 
         sig_label = downloader.get_installed_signature_label(plugin.name)
         if sig_label:

--- a/ggshield/cmd/plugin/status.py
+++ b/ggshield/cmd/plugin/status.py
@@ -12,7 +12,11 @@ from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config.enterprise_config import EnterpriseConfig
 from ggshield.core.errors import ExitCode
-from ggshield.core.plugin.client import PluginAPIClient, PluginAPIError
+from ggshield.core.plugin.client import (
+    PluginAPIClient,
+    PluginAPIError,
+    PluginsNotEnabledError,
+)
 from ggshield.core.plugin.downloader import PluginDownloader
 
 
@@ -23,7 +27,7 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> None:
     """
     Show available plugins for your GitGuardian account.
 
-    Displays your account's plan, available plugins, and feature flags.
+    Displays available plugins and their status for your workspace.
     Requires authentication with GitGuardian.
     """
     ctx_obj = ContextObj.get(ctx)
@@ -33,6 +37,12 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> None:
         client = create_client_from_config(config)
         plugin_api_client = PluginAPIClient(client)
         catalog = plugin_api_client.get_available_plugins()
+    except PluginsNotEnabledError:
+        ui.display_error(
+            "Plugin system is not available on this workspace. "
+            "Contact your administrator."
+        )
+        ctx.exit(ExitCode.UNEXPECTED_ERROR)
     except PluginAPIError as e:
         ui.display_error(str(e))
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
@@ -43,18 +53,6 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> None:
     # Load local config for installed plugins info
     enterprise_config = EnterpriseConfig.load()
     downloader = PluginDownloader()
-
-    # Display plan
-    ui.display_heading("Account Status")
-    ui.display_info(f"Plan: {catalog.plan}")
-
-    # Display features
-    if catalog.features:
-        ui.display_heading("Features")
-        for feature, enabled in sorted(catalog.features.items()):
-            status = "enabled" if enabled else "disabled"
-            icon = "+" if enabled else "-"
-            ui.display_info(f"  [{icon}] {feature}: {status}")
 
     # Display available plugins
     ui.display_heading("Available Plugins")
@@ -70,7 +68,6 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> None:
                     status_parts.append("enabled")
                 else:
                     status_parts.append("disabled")
-                # Check for updates
                 if plugin.latest_version and installed_version != plugin.latest_version:
                     status_parts.append(f"update available: v{plugin.latest_version}")
             else:

--- a/ggshield/cmd/plugin/update.py
+++ b/ggshield/cmd/plugin/update.py
@@ -4,6 +4,7 @@ Plugin update command - updates installed plugins.
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import click
@@ -19,16 +20,32 @@ from ggshield.core.errors import ExitCode
 from ggshield.core.plugin.client import (
     PluginAPIClient,
     PluginAPIError,
-    PluginNotAvailableError,
+    PluginsNotEnabledError,
     PluginSourceType,
 )
 from ggshield.core.plugin.downloader import DownloadError, PluginDownloader
-from ggshield.core.plugin.loader import PluginLoader
+from ggshield.core.plugin.loader import PluginLoader, resolve_config_key
+from ggshield.core.plugin.platform import get_platform_info
 from ggshield.core.plugin.signature import SignatureVerificationMode
 from ggshield.core.text_utils import pluralize
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _InstallationReport:
+    """Args for one deferred ``report_installation`` call.
+
+    Buffered during the update loop and fired after ``enterprise_config.save()``
+    so a stalled ``/installed`` endpoint can't desync wheel-on-disk from
+    the on-disk version record.
+    """
+
+    name: str
+    version: str
+    platform: str
+    arch: str
 
 
 def _is_newer_version(installed_version: str, candidate_version: str) -> bool:
@@ -141,9 +158,9 @@ def update_cmd(
     for name in plugins_to_process:
         source = downloader.get_plugin_source(name)
         if source is None:
-            # Legacy manifest or unknown source - try GitGuardian API
+            # Legacy manifest or unknown source - try platform
             gitguardian_plugins.append(name)
-        elif source.type == PluginSourceType.GITGUARDIAN_API:
+        elif source.type == PluginSourceType.PLATFORM:
             gitguardian_plugins.append(name)
         elif source.type == PluginSourceType.GITHUB_RELEASE:
             github_release_plugins.append(name)
@@ -152,20 +169,29 @@ def update_cmd(
             non_updatable_plugins.append(
                 {
                     "name": name,
-                    "source_type": source.type.value,
+                    "source_type": source.type,
                 }
             )
 
     # Check GitGuardian API for updates
     updates_available: List[Dict[str, Any]] = []
     plugin_api_client: Optional[PluginAPIClient] = None
+    # Tracks whether we asked the platform for catalog updates and got a
+    # usable answer. Stays False when there were no platform plugins in
+    # the batch OR when the catalog fetch failed and we degraded to
+    # github-only checks. Drives the empty-result message at the bottom
+    # so we don't claim "All updatable plugins are up to date" when half
+    # the picture was actually missing.
+    platform_checked = False
 
     if gitguardian_plugins:
+        catalog_error: Optional[str] = None
         try:
             client = create_client_from_config(config)
             plugin_api_client = PluginAPIClient(client)
             catalog = plugin_api_client.get_available_plugins()
             available_plugins = {p.name: p for p in catalog.plugins if p.available}
+            platform_checked = True
 
             for name in gitguardian_plugins:
                 installed = installed_plugins.get(name)
@@ -187,16 +213,36 @@ def update_cmd(
                             "name": name,
                             "installed_version": installed_version,
                             "latest_version": latest_version,
-                            "source_type": PluginSourceType.GITGUARDIAN_API,
+                            "source_type": PluginSourceType.PLATFORM,
                         }
                     )
 
+        except PluginsNotEnabledError:
+            catalog_error = (
+                "Plugin system is not available on this workspace. "
+                "Contact your administrator."
+            )
         except PluginAPIError as e:
-            ui.display_error(str(e))
-            ctx.exit(ExitCode.UNEXPECTED_ERROR)
+            catalog_error = str(e)
         except Exception as e:
-            ui.display_error(f"Failed to connect to GitGuardian: {e}")
-            ctx.exit(ExitCode.UNEXPECTED_ERROR)
+            catalog_error = f"Failed to connect to GitGuardian: {e}"
+
+        if catalog_error is not None:
+            # Degrade rather than abort when there's still other work to do:
+            # GitHub-release plugins and the non-updatable footer don't depend
+            # on the GitGuardian catalog, so a single failed fetch shouldn't
+            # kill an otherwise valid ``update --all`` invocation. When the
+            # platform fetch is the only thing we were asked to do (no
+            # github_release plugins in the batch), surface as a hard error
+            # so the exit code still reflects the failure.
+            if github_release_plugins:
+                ui.display_warning(
+                    f"Skipping GitGuardian-hosted plugin updates: {catalog_error}"
+                )
+            else:
+                ui.display_error(catalog_error)
+                ctx.exit(ExitCode.UNEXPECTED_ERROR)
+                return
 
     # Check GitHub releases for updates
     for name in github_release_plugins:
@@ -226,6 +272,18 @@ def update_cmd(
                         }
                     )
 
+    # When the platform check was skipped (catalog fetch failed but we
+    # still have github_release work to do), the "everything is up to
+    # date" wording lies about half the picture. Surface that the
+    # platform side wasn't actually checked so the user knows their
+    # GitGuardian-hosted plugins are unverified, not confirmed-current.
+    no_updates_msg = (
+        "No updates found for checked plugins; "
+        "GitGuardian-hosted plugins were skipped."
+        if gitguardian_plugins and not platform_checked
+        else "All updatable plugins are up to date."
+    )
+
     # Check-only mode
     if check_only:
         if updates_available:
@@ -233,7 +291,7 @@ def update_cmd(
             for update in updates_available:
                 source_label = (
                     "GitGuardian"
-                    if update["source_type"] == PluginSourceType.GITGUARDIAN_API
+                    if update["source_type"] == PluginSourceType.PLATFORM
                     else "GitHub"
                 )
                 ui.display_info(
@@ -243,16 +301,9 @@ def update_cmd(
             ui.display_info("")
             ui.display_info("Run 'ggshield plugin update --all' to update.")
         else:
-            ui.display_info("All updatable plugins are up to date.")
+            ui.display_info(no_updates_msg)
 
-        if non_updatable_plugins:
-            ui.display_info("")
-            ui.display_heading("Cannot Auto-Update")
-            for plugin in non_updatable_plugins:
-                ui.display_info(
-                    f"  {plugin['name']}: installed from {plugin['source_type']}"
-                )
-            ui.display_info("Re-install these plugins manually to update.")
+        _display_non_updatable_footer(non_updatable_plugins)
         return
 
     # Update mode
@@ -261,22 +312,37 @@ def update_cmd(
             # Check if it's non-updatable
             source = downloader.get_plugin_source(plugin_name)
             if source and source.type not in (
-                PluginSourceType.GITGUARDIAN_API,
+                PluginSourceType.PLATFORM,
                 PluginSourceType.GITHUB_RELEASE,
             ):
                 ui.display_error(
-                    f"Plugin '{plugin_name}' was installed from {source.type.value} "
-                    "and cannot be auto-updated."
+                    f"Plugin '{plugin_name}' was installed from "
+                    f"{source.type.value.replace('_', ' ')} and cannot be "
+                    f"auto-updated."
                 )
                 ui.display_info("Re-install the plugin manually to update.")
                 ctx.exit(ExitCode.USAGE_ERROR)
             ui.display_info(f"Plugin '{plugin_name}' is already up to date.")
+        elif update_all:
+            ui.display_info(no_updates_msg)
+            # Non-updatable plugins are still worth surfacing even when
+            # everything else is current — the user asked about every
+            # installed plugin, not just the auto-updatable ones.
+            _display_non_updatable_footer(non_updatable_plugins)
         else:
-            ui.display_info("All updatable plugins are already up to date.")
+            ui.display_info(no_updates_msg)
         return
 
     success_count = 0
     error_count = 0
+    # Deferred best-effort report calls. ``report_installation`` is
+    # synchronous over HTTP, and update.py historically invoked it
+    # between the wheel install and the final ``enterprise_config.save()``
+    # — a stalled ``/installed`` endpoint would block the command after
+    # the wheel was already on disk but before the version was persisted.
+    # Buffer the calls instead and fire them after ``save()`` so the
+    # config is always durable before we attempt analytics.
+    installation_reports: List[_InstallationReport] = []
 
     for update in updates_available:
         name = update["name"]
@@ -288,23 +354,54 @@ def update_cmd(
         )
 
         try:
-            updated = False
-
-            if source_type == PluginSourceType.GITGUARDIAN_API:
+            if source_type == PluginSourceType.PLATFORM:
                 assert plugin_api_client is not None
-                # Get download info from API
-                download_info = plugin_api_client.get_download_info(
-                    name, version=latest_version
+                platform_info = get_platform_info()
+                with plugin_api_client.download_plugin(
+                    name,
+                    platform_info=platform_info,
+                    version=latest_version,
+                ) as (info, chunks):
+                    bundle_bytes: Optional[bytes] = None
+                    if info.signature_url:
+                        try:
+                            bundle_bytes = plugin_api_client.download_signature_bundle(
+                                info.signature_url
+                            )
+                        except PluginAPIError as bundle_err:
+                            # See install.py: STRICT propagates; WARN
+                            # treats the bundle as unavailable rather
+                            # than aborting an otherwise valid upgrade.
+                            if signature_mode == SignatureVerificationMode.STRICT:
+                                raise
+                            ui.display_warning(
+                                f"Could not fetch signature bundle for {name}: "
+                                f"{bundle_err}. Continuing without verification "
+                                f"(--allow-unsigned)."
+                            )
+                    wheel_path = downloader.download_and_install(
+                        info,
+                        chunks,
+                        name,
+                        signature_mode=signature_mode,
+                        bundle_bytes=bundle_bytes,
+                    )
+                # Mirror install.py: the loader keys enablement by the
+                # wheel's entry-point name (when present), so update
+                # must use the same key — otherwise the row written
+                # below falls out of sync with discover_plugins and
+                # the plugin is silently disabled after the upgrade.
+                config_key = resolve_config_key(wheel_path, fallback=name)
+                installation_reports.append(
+                    _InstallationReport(
+                        name=name,
+                        version=info.version,
+                        platform=platform_info.os,
+                        arch=platform_info.arch,
+                    )
                 )
-
-                # Download and install (overwrites existing)
-                downloader.download_and_install(
-                    download_info, name, signature_mode=signature_mode
-                )
-                updated = True
 
             elif source_type == PluginSourceType.GITHUB_RELEASE:
-                # Download from GitHub release URL
                 download_url = update.get("download_url")
                 github_repo = update.get("github_repo")
                 if not download_url or not github_repo:
@@ -312,35 +409,40 @@ def update_cmd(
                         "Missing GitHub release metadata for plugin update"
                     )
 
-                downloader.download_from_github_release(
+                _, _, wheel_path = downloader.download_from_github_release(
                     download_url, signature_mode=signature_mode
                 )
-                updated = True
+                config_key = resolve_config_key(wheel_path, fallback=name)
 
             else:
                 raise DownloadError(f"Unsupported plugin source type: {source_type}")
 
-            if not updated:
-                raise DownloadError("Plugin update was skipped")
-
-            # Update config
-            enterprise_config.enable_plugin(name, version=latest_version)
+            enterprise_config.enable_plugin(config_key, version=latest_version)
 
             ui.display_info(f"  Updated {name} to v{latest_version}")
             success_count += 1
 
-        except PluginNotAvailableError as e:
-            ui.display_error(f"  Failed to update {name}: {e}")
-            error_count += 1
-        except DownloadError as e:
-            ui.display_error(f"  Failed to update {name}: {e}")
-            error_count += 1
         except Exception as e:
             ui.display_error(f"  Failed to update {name}: {e}")
             error_count += 1
 
-    # Save config
+    # Save config FIRST so a hang inside the analytics reports below
+    # can't desync the on-disk version from the wheel that's already on
+    # disk. Each report is best-effort and bounded by HTTP_TIMEOUT_SECONDS
+    # inside ``report_installation`` itself.
     enterprise_config.save()
+
+    # ``installation_reports`` is only appended inside the PLATFORM branch
+    # above, which itself runs after ``plugin_api_client`` has been set —
+    # the buffer is non-empty IFF the client exists, so no None-guard needed.
+    for report in installation_reports:
+        assert plugin_api_client is not None  # invariant: see comment above
+        plugin_api_client.report_installation(
+            report.name,
+            report.version,
+            report.platform,
+            report.arch,
+        )
 
     # Summary
     if success_count > 0:
@@ -349,15 +451,32 @@ def update_cmd(
             f"{success_count} {pluralize('plugin', success_count)} updated successfully."
         )
 
-    if non_updatable_plugins and update_all:
-        ui.display_info("")
-        ui.display_info(
-            f"{len(non_updatable_plugins)} {pluralize('plugin', len(non_updatable_plugins))} "
-            "cannot be auto-updated (installed from local file, URL, or artifact)."
-        )
+    if update_all:
+        _display_non_updatable_footer(non_updatable_plugins)
 
     if error_count > 0:
         ctx.exit(ExitCode.UNEXPECTED_ERROR)
+
+
+def _display_non_updatable_footer(
+    non_updatable_plugins: List[Dict[str, Any]],
+) -> None:
+    """Render the shared 'Cannot Auto-Update' footer.
+
+    Lists each non-updatable plugin with a humanised source label
+    (matching ``plugin list``'s ``local_file`` → ``local file`` style)
+    so the user gets the same vocabulary across commands.
+    """
+    if not non_updatable_plugins:
+        return
+    ui.display_info("")
+    ui.display_heading("Cannot Auto-Update")
+    for plugin in non_updatable_plugins:
+        ui.display_info(
+            f"  {plugin['name']}: installed from "
+            f"{plugin['source_type'].value.replace('_', ' ')}"
+        )
+    ui.display_info("Re-install these plugins manually to update.")
 
 
 def _check_github_release_update(github_repo: str) -> Optional[Dict[str, Any]]:

--- a/ggshield/core/plugin/client.py
+++ b/ggshield/core/plugin/client.py
@@ -2,24 +2,133 @@
 Plugin API client - fetches available plugins from GitGuardian API.
 """
 
-from dataclasses import dataclass, field
+import logging
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Generator, Iterator, List, Optional, Tuple
+from urllib.parse import ParseResult, urlparse
 
 import requests
 from pygitguardian import GGClient
 
+from ggshield.core.plugin.http_security import (
+    assert_all_https,
+    is_insecure_loopback_allowed,
+    is_loopback,
+)
 from ggshield.core.plugin.platform import PlatformInfo, get_platform_info
+from ggshield.core.plugin.wheel_utils import InvalidWheelError, sanitize_wheel_filename
+
+
+logger = logging.getLogger(__name__)
+
+
+HTTP_TIMEOUT_SECONDS = 30
+MAX_WHEEL_SIZE_BYTES = 256 * 1024 * 1024
+MAX_BUNDLE_SIZE_BYTES = 1 * 1024 * 1024
+
+
+def _iter_with_size_cap(
+    chunks: Iterator[bytes], max_bytes: int
+) -> Generator[bytes, None, None]:
+    """Yield chunks from ``chunks`` until ``max_bytes`` is exceeded."""
+    written = 0
+    for chunk in chunks:
+        written += len(chunk)
+        if written > max_bytes:
+            raise PluginAPIError(
+                f"Response body exceeded maximum size of {max_bytes} bytes"
+            )
+        yield chunk
+
+
+def _parse_content_length(response: "requests.Response", *, what: str) -> int:
+    """Parse ``Content-Length`` and surface malformed values as PluginAPIError.
+
+    ``int(response.headers.get("Content-Length", 0))`` raises a raw
+    ``TypeError``/``ValueError`` on a malformed header — those don't match
+    the ``except requests.RequestException`` arms in the download methods
+    and leak past the typed-error contract that callers depend on.
+    """
+    # Missing header defaults to "0" and passes the size cap silently,
+    # because the streaming reader (``_iter_with_size_cap``) enforces the
+    # real bound while bytes flow in. Do not "harden" this default to
+    # raise — well-behaved upstreams that omit the header on small
+    # responses would then fail for no reason.
+    raw = response.headers.get("Content-Length", "0")
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise PluginAPIError(
+            f"Malformed Content-Length header for {what}: {raw!r}"
+        ) from exc
+
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin(parsed: ParseResult) -> Tuple[Optional[str], Optional[str], Optional[int]]:
+    """Normalise a parsed URL to a comparable (scheme, host, port) triple.
+
+    ``urlparse`` reports an implicit port as ``None`` and an explicit
+    default port (``:443`` for https, ``:80`` for http) as the integer
+    — so ``https://api.example.com`` and ``https://api.example.com:443``
+    have different ``.port`` values even though the origins are
+    semantically identical. Without normalisation, the same-origin
+    check in ``download_signature_bundle`` rejects bundles whose URL
+    came back from the backend with an explicit default port (or vice
+    versa from a config edit).
+    """
+    port = parsed.port
+    if port is None:
+        port = _DEFAULT_PORTS.get(parsed.scheme)
+    return (parsed.scheme, parsed.hostname, port)
+
+
+def _assert_base_url_https(base_url: str) -> None:
+    """Refuse to send authenticated traffic to an http:// base URL.
+
+    The instance URL is normally validated by ``validate_instance_url`` at
+    ``auth login`` time, which already rejects non-HTTPS schemes outside
+    of loopback. This guard catches the residual cases — a manually
+    edited config or a non-loopback http base that slipped through — so
+    the API token can't be sent in cleartext before the response-side
+    redirect check has anything to inspect.
+
+    The same ``GITGUARDIAN_ALLOW_INSECURE_LOOPBACK=1`` bypass used by
+    ``assert_all_https`` applies here, so local dev against
+    ``http://localhost:3000`` keeps working.
+    """
+    if base_url.startswith("https://"):
+        return
+    if is_insecure_loopback_allowed() and is_loopback(base_url):
+        return
+    raise PluginAPIError(
+        f"Refusing to send authenticated request to non-HTTPS base URL {base_url!r}"
+    )
 
 
 class PluginSourceType(Enum):
     """Types of plugin sources."""
 
-    GITGUARDIAN_API = "gitguardian_api"
+    PLATFORM = "platform"
     LOCAL_FILE = "local_file"
     URL = "url"
     GITHUB_RELEASE = "github_release"
     GITHUB_ARTIFACT = "github_artifact"
+    # Legacy alias kept so attribute-access uses (``PluginSourceType.GITGUARDIAN_API``)
+    # in older code paths and tests still resolve to the same enum member as
+    # ``PLATFORM``. Pairs with ``_missing_`` below for value-based lookup.
+    GITGUARDIAN_API = "platform"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Optional["PluginSourceType"]:
+        """Accept legacy manifest value written by the PoC (< v1.50)."""
+        if value == "gitguardian_api":
+            return cls.PLATFORM
+        return None
 
 
 @dataclass
@@ -66,37 +175,27 @@ class PluginInfo:
     description: str
     available: bool
     latest_version: Optional[str]
-    supported_platforms: List[str] = field(default_factory=list)
     reason: Optional[str] = None
-
-    def is_platform_supported(self, platform: str, arch: str) -> bool:
-        """Check if this plugin supports the given platform/arch."""
-        if not self.supported_platforms:
-            return True
-        return (
-            f"{platform}-{arch}" in self.supported_platforms
-            or "any-any" in self.supported_platforms
-        )
 
 
 @dataclass
 class PluginCatalog:
     """Catalog of available plugins for the account."""
 
-    plan: str
-    features: Dict[str, bool]
     plugins: List[PluginInfo]
 
 
 @dataclass
 class PluginDownloadInfo:
-    """Information needed to download a plugin."""
+    """Metadata about a plugin wheel received from the platform download endpoint."""
 
-    download_url: str
-    filename: str
-    sha256: str
-    version: str
-    expires_at: str
+    filename: str  # from Content-Disposition header
+    sha256: str  # from X-Plugin-SHA256 header
+    version: str  # from X-Plugin-Version header
+    size_bytes: int  # from Content-Length header
+    # Absolute URL of the sigstore bundle, from the X-Plugin-Signature-URL
+    # response header. None when the platform has no bundle for this
+    # artifact — STRICT verification then fails fast (as it should).
     signature_url: Optional[str] = None
 
 
@@ -118,6 +217,30 @@ class PluginNotAvailableError(Exception):
         super().__init__(message)
 
 
+class PluginsNotEnabledError(Exception):
+    """Plugin system is not enabled on this workspace (feature-flag OFF)."""
+
+    pass
+
+
+def _extract_server_detail(response: "requests.Response") -> Optional[str]:
+    """Return the server's ``detail`` field when available, else None.
+
+    Falls back to None on empty bodies, non-JSON responses, or JSON
+    shapes without a ``detail`` field — so callers can use their own
+    default message in those cases.
+    """
+    try:
+        body = response.json()
+    except (ValueError, requests.RequestException):
+        return None
+    if isinstance(body, dict):
+        detail = body.get("detail")
+        if isinstance(detail, str) and detail:
+            return detail
+    return None
+
+
 class PluginAPIClient:
     """Client for GitGuardian plugin API."""
 
@@ -129,122 +252,209 @@ class PluginAPIClient:
 
     def get_available_plugins(self) -> PluginCatalog:
         """Fetch available plugins for the authenticated account."""
+        _assert_base_url_https(self.base_url)
         platform_info = get_platform_info()
 
         try:
             response = self.client.session.get(
-                f"{self.base_url}/{self.API_VERSION}/plugins",
+                f"{self.base_url}/{self.API_VERSION}/endpoints/plugins",
                 params={
                     "platform": platform_info.os,
                     "arch": platform_info.arch,
                 },
-                headers=self._get_headers(),
+                timeout=HTTP_TIMEOUT_SECONDS,
             )
+            assert_all_https(response, exc_factory=PluginAPIError)
+            if response.status_code == 404:
+                raise PluginsNotEnabledError()
             response.raise_for_status()
         except requests.RequestException as e:
             raise PluginAPIError(f"Failed to fetch plugins: {e}") from e
 
-        data = response.json()
-
-        account_data = data.get("account", {})
-        current_platform = f"{platform_info.os}-{platform_info.arch}"
-
-        return PluginCatalog(
-            plan=account_data.get("plan", data.get("plan", "unknown")),
-            features=account_data.get("features", data.get("features", {})),
-            plugins=[
+        # Treat any structural mismatch (missing `reference`, non-list body,
+        # non-JSON payload) as a `PluginAPIError`. The bare `p["reference"]`
+        # would otherwise raise `KeyError` straight to the user — the
+        # `except RequestException` above doesn't catch it.
+        try:
+            plugins_data = response.json()
+            plugins = [
                 PluginInfo(
-                    name=p.get("name", "unknown"),
-                    display_name=p.get("display_name", p.get("name", "Unknown")),
+                    name=p["reference"],
+                    display_name=p.get("display_name", p["reference"]),
                     description=p.get("description", ""),
-                    available=self._is_plugin_available(p, current_platform),
-                    latest_version=p.get("latest_version"),
-                    supported_platforms=p.get("supported_platforms", []),
-                    reason=self._get_unavailable_reason(p, current_platform),
+                    available=p.get("available", False),
+                    latest_version=(
+                        p["releases"][0]["version"] if p.get("releases") else None
+                    ),
+                    reason=p.get("reason"),
                 )
-                for p in data.get("plugins", [])
-            ],
-        )
+                for p in plugins_data
+            ]
+        except (KeyError, TypeError, ValueError) as e:
+            raise PluginAPIError(f"Malformed plugin catalog response: {e}") from e
 
-    def get_download_info(
+        return PluginCatalog(plugins=plugins)
+
+    @contextmanager
+    def download_plugin(
         self,
-        plugin_name: str,
-        version: Optional[str] = None,
+        reference: str,
         platform_info: Optional[PlatformInfo] = None,
-    ) -> PluginDownloadInfo:
-        """Get download URL for a plugin wheel."""
-        resolved_platform_info: PlatformInfo
-        if platform_info is None:
-            resolved_platform_info = get_platform_info()
-        else:
-            resolved_platform_info = platform_info
+        version: Optional[str] = None,
+    ) -> Generator[Tuple[PluginDownloadInfo, Iterator[bytes]], None, None]:
+        """Stream a plugin wheel from the platform.
 
+        Usage::
+
+            with client.download_plugin("tokenscanner") as (info, chunks):
+                downloader.download_and_install(info, chunks, "tokenscanner")
+        """
+        resolved = platform_info if platform_info is not None else get_platform_info()
         params: Dict[str, str] = {
-            "platform": resolved_platform_info.os,
-            "arch": resolved_platform_info.arch,
-            "python_abi": resolved_platform_info.python_abi,
+            "platform": resolved.os,
+            "arch": resolved.arch,
+            "python_abi": resolved.python_abi,
         }
         if version:
             params["version"] = version
 
+        _assert_base_url_https(self.base_url)
+        response = None
         try:
             response = self.client.session.get(
-                f"{self.base_url}/{self.API_VERSION}/plugins/{plugin_name}/download",
+                f"{self.base_url}/{self.API_VERSION}/endpoints/plugins/{reference}/download",
                 params=params,
-                headers=self._get_headers(),
+                stream=True,
+                timeout=HTTP_TIMEOUT_SECONDS,
             )
-
-            if response.status_code == 403:
-                raise PluginNotAvailableError(plugin_name)
-            elif response.status_code == 404:
-                raise PluginNotAvailableError(
-                    plugin_name, "Plugin or version not found"
-                )
-
+            assert_all_https(response, exc_factory=PluginAPIError)
+            if response.status_code in (403, 404):
+                detail = _extract_server_detail(response)
+                if not detail and response.status_code == 404:
+                    detail = "Plugin or version not found"
+                raise PluginNotAvailableError(reference, detail)
             response.raise_for_status()
 
-        except PluginNotAvailableError:
-            raise
+            content_disposition = response.headers.get("Content-Disposition", "")
+            match = re.search(r'filename="([^"]+)"', content_disposition)
+            raw_filename = match.group(1) if match else f"{reference}.whl"
+            try:
+                filename = sanitize_wheel_filename(raw_filename)
+            except InvalidWheelError as exc:
+                raise PluginAPIError(str(exc)) from exc
+
+            sha256 = response.headers.get("X-Plugin-SHA256")
+            if not sha256:
+                raise PluginAPIError(
+                    f"Server response missing X-Plugin-SHA256 header for {reference}"
+                )
+            resolved_version = response.headers.get("X-Plugin-Version")
+            if not resolved_version:
+                raise PluginAPIError(
+                    f"Server response missing X-Plugin-Version header for {reference}"
+                )
+
+            size_bytes = _parse_content_length(response, what="plugin wheel")
+            if size_bytes > MAX_WHEEL_SIZE_BYTES:
+                raise PluginAPIError(
+                    f"Plugin wheel size {size_bytes} exceeds maximum "
+                    f"of {MAX_WHEEL_SIZE_BYTES} bytes"
+                )
+
+            info = PluginDownloadInfo(
+                filename=filename,
+                sha256=sha256,
+                version=resolved_version,
+                size_bytes=size_bytes,
+                signature_url=response.headers.get("X-Plugin-Signature-URL") or None,
+            )
+            yield info, _iter_with_size_cap(
+                response.iter_content(chunk_size=65536), MAX_WHEEL_SIZE_BYTES
+            )
         except requests.RequestException as e:
-            raise PluginAPIError(f"Failed to get download info: {e}") from e
+            raise PluginAPIError(f"Failed to download plugin: {e}") from e
+        finally:
+            if response is not None:
+                response.close()
 
-        data = response.json()
+    def download_signature_bundle(self, signature_url: str) -> bytes:
+        """Fetch a sigstore bundle using the authenticated session.
 
-        return PluginDownloadInfo(
-            download_url=data["download_url"],
-            filename=data["filename"],
-            sha256=data["sha256"],
-            version=data["version"],
-            expires_at=data["expires_at"],
-            signature_url=data.get("signature_url"),
-        )
+        The platform's ``X-Plugin-Signature-URL`` header points at our own
+        ``/download/signature`` proxy (the upstream mirror URL is kept
+        server-side), and that proxy requires the same Token auth as
+        ``/download`` — hence using ``self.client.session`` rather than a
+        bare ``requests.get``. We require the URL to share the platform's
+        origin so a compromised or misconfigured backend can't coerce us
+        into sending our Token to a third-party host.
+        """
+        _assert_base_url_https(self.base_url)
+        base = urlparse(self.base_url)
+        target = urlparse(signature_url)
+        if _origin(target) != _origin(base):
+            raise PluginAPIError(
+                f"Refusing to fetch signature bundle from foreign origin "
+                f"{target.scheme}://{target.hostname}"
+            )
 
-    def _is_plugin_available(
-        self, plugin_data: Dict[str, Any], current_platform: str
-    ) -> bool:
-        if not plugin_data.get("available", True):
-            return False
-        supported = plugin_data.get("supported_platforms", [])
-        if not supported:
-            return True
-        return current_platform in supported or "any-any" in supported
+        try:
+            with self.client.session.get(
+                signature_url, timeout=HTTP_TIMEOUT_SECONDS, stream=True
+            ) as response:
+                assert_all_https(response, exc_factory=PluginAPIError)
+                response.raise_for_status()
 
-    def _get_unavailable_reason(
-        self, plugin_data: Dict[str, Any], current_platform: str
-    ) -> Optional[str]:
-        if plugin_data.get("reason"):
-            return plugin_data["reason"]
-        supported = plugin_data.get("supported_platforms", [])
-        if (
-            supported
-            and current_platform not in supported
-            and "any-any" not in supported
-        ):
-            return f"Not available for {current_platform}. Supported: {', '.join(supported)}"
-        return None
+                size_bytes = _parse_content_length(response, what="signature bundle")
+                if size_bytes > MAX_BUNDLE_SIZE_BYTES:
+                    raise PluginAPIError(
+                        f"Signature bundle size {size_bytes} exceeds maximum "
+                        f"of {MAX_BUNDLE_SIZE_BYTES} bytes"
+                    )
 
-    def _get_headers(self) -> Dict[str, str]:
-        return {
-            "Authorization": f"Token {self.client.api_key}",
-            "Content-Type": "application/json",
-        }
+                buffer = bytearray()
+                for chunk in _iter_with_size_cap(
+                    response.iter_content(chunk_size=65536), MAX_BUNDLE_SIZE_BYTES
+                ):
+                    buffer.extend(chunk)
+                return bytes(buffer)
+        except requests.RequestException as e:
+            raise PluginAPIError(
+                f"Failed to download signature bundle from {signature_url}: {e}"
+            ) from e
+
+    def report_installation(
+        self, reference: str, version: str, platform: str, arch: str
+    ) -> None:
+        """Report a successful plugin installation for analytics (best-effort).
+
+        Never raises — a failure here must not fail the install. The
+        explicit ``timeout`` matters because ``update.py`` historically
+        called this between the wheel install and the config save, so a
+        stalled ``/installed`` endpoint would leave the wheel on disk
+        with the version still pointing at the previous release. The
+        timeout (and the ``Exception`` catch below) keeps the call from
+        blocking the user's terminal even when the backend is degraded.
+        """
+        try:
+            # The pre-flight HTTPS check, the network call itself, and the
+            # response-side redirect check all live inside the broad catch
+            # below. The bare ``except Exception`` is load-bearing for the
+            # "never raises" contract; ``exc_info=True`` preserves the
+            # underlying cause (PluginAPIError from base-URL guard, requests
+            # error from the network, etc.) in the log so it's still
+            # diagnosable when someone reports a missing analytics record.
+            _assert_base_url_https(self.base_url)
+            response = self.client.session.post(
+                f"{self.base_url}/{self.API_VERSION}/endpoints/plugins/{reference}/installed",
+                json={"version": version, "platform": platform, "arch": arch},
+                timeout=HTTP_TIMEOUT_SECONDS,
+            )
+            assert_all_https(response, exc_factory=PluginAPIError)
+            response.raise_for_status()
+        except Exception:
+            logger.warning(
+                "Failed to report plugin installation for %s v%s",
+                reference,
+                version,
+                exc_info=True,
+            )

--- a/ggshield/core/plugin/downloader.py
+++ b/ggshield/core/plugin/downloader.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import requests
 
@@ -21,18 +21,83 @@ from ggshield.core.plugin.client import (
     PluginSource,
     PluginSourceType,
 )
+from ggshield.core.plugin.http_security import assert_all_https
 from ggshield.core.plugin.signature import (
     SignatureInfo,
     SignatureStatus,
-    SignatureVerificationError,
     SignatureVerificationMode,
     verify_wheel_signature,
 )
-from ggshield.core.plugin.trust import PluginTrustStore
-from ggshield.core.plugin.wheel_utils import WheelError, extract_wheel_metadata
+from ggshield.core.plugin.trust import PluginTrustStore, compute_file_sha256
+from ggshield.core.plugin.wheel_utils import (
+    InvalidWheelError,
+    WheelError,
+    extract_wheel_metadata,
+    sanitize_wheel_filename,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+def _wheel_distribution_name(filename: str) -> str:
+    """Return the PEP 503-normalised distribution name from a wheel filename.
+
+    PEP 427 wheel filenames are
+    ``{distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl``.
+    The distribution segment uses ``_`` in place of ``-`` from the
+    canonical name, so the inverse normalisation
+    (``lower()`` + ``_ -> -``) recovers the PEP 503 form. We only need
+    the distribution segment, so a simple split on ``-`` is enough.
+    """
+    if not filename.endswith(".whl"):
+        raise DownloadError(f"Not a wheel filename: {filename!r}")
+    stem = filename.removesuffix(".whl")
+    parts = stem.split("-", 1)
+    if len(parts) < 2 or not parts[0]:
+        raise DownloadError(f"Invalid wheel filename: {filename!r}")
+    return parts[0].lower().replace("_", "-")
+
+
+HTTP_TIMEOUT_SECONDS = 30
+MAX_WHEEL_SIZE_BYTES = 256 * 1024 * 1024
+MAX_BUNDLE_SIZE_BYTES = 1 * 1024 * 1024
+
+
+def _stream_to_file(
+    response: "requests.Response",
+    dest: Path,
+    max_bytes: int,
+    *,
+    hash_bytes: bool = False,
+) -> Optional[str]:
+    """Stream an HTTP response body to ``dest`` with a hard size cap.
+
+    When ``hash_bytes`` is True, also computes SHA256 in a single pass and
+    returns the hex digest; otherwise returns None. Raises ``DownloadError``
+    if the response body exceeds ``max_bytes``; the partial file is then
+    removed before the exception propagates.
+    """
+    sha256_hash = hashlib.sha256() if hash_bytes else None
+    written = 0
+    try:
+        with open(dest, "wb") as f:
+            for chunk in response.iter_content(chunk_size=65536):
+                if not chunk:
+                    continue
+                written += len(chunk)
+                if written > max_bytes:
+                    raise DownloadError(
+                        f"Response body exceeded maximum size of {max_bytes} bytes"
+                    )
+                f.write(chunk)
+                if sha256_hash is not None:
+                    sha256_hash.update(chunk)
+    except BaseException:
+        if dest.exists():
+            dest.unlink()
+        raise
+    return sha256_hash.hexdigest() if sha256_hash is not None else None
 
 
 def get_signature_label(
@@ -100,27 +165,77 @@ class PluginDownloader:
     def download_and_install(
         self,
         download_info: PluginDownloadInfo,
+        chunks: Iterator[bytes],
         plugin_name: str,
         source: Optional[PluginSource] = None,
         signature_mode: SignatureVerificationMode = SignatureVerificationMode.STRICT,
+        bundle_bytes: Optional[bytes] = None,
     ) -> Path:
-        """Download a plugin wheel and install it locally."""
+        """Install a plugin wheel from a byte stream.
+
+        The on-disk plugin directory is named after the wheel's
+        distribution name (PEP 427 → PEP 503), same as
+        :meth:`install_from_wheel`. ``plugin_name`` is the catalog
+        reference used for the API call and stored in the manifest;
+        when it differs from the wheel's distribution name (e.g. the
+        catalog references ``machine_scan`` while the wheel ships
+        as ``satori-python``), a subsequent local-wheel install of
+        the same package overwrites this install in place rather than
+        creating a side-by-side directory.
+
+        Args:
+            download_info: Filename, SHA256, version from the platform response headers.
+            chunks: Iterator of raw bytes (from streaming HTTP response or test fixture).
+            plugin_name: Catalog reference used for the API call and stored in the manifest.
+            source: Manifest source record. Defaults to PluginSourceType.PLATFORM.
+            signature_mode: Sigstore verification mode.
+            bundle_bytes: Optional sigstore bundle bytes fetched by the
+                caller (typically via ``PluginAPIClient.download_signature_bundle``
+                using the ``X-Plugin-Signature-URL`` header). Written next
+                to the wheel before verification runs, so STRICT mode
+                succeeds when the platform exposes a signature.
+
+        Returns:
+            Path to the installed wheel file. The parent directory's name
+            is the wheel's distribution name and matches what
+            :meth:`install_from_wheel` would use for the same wheel.
+
+        Raises:
+            ChecksumMismatchError: SHA256 of received bytes does not match download_info.sha256.
+            DownloadError: File system error during installation.
+            SignatureVerificationError: In STRICT mode when signature is invalid.
+        """
         self._validate_plugin_name(plugin_name)
 
-        plugin_dir = self.plugins_dir / plugin_name
-        plugin_dir.mkdir(parents=True, exist_ok=True)
+        # The on-disk plugin directory comes from the wheel's
+        # distribution name (PEP 427 → PEP 503), not from the catalog
+        # reference, so the catalog install converges with a previous
+        # ``install_from_wheel`` of the same wheel rather than creating
+        # a side-by-side directory. ``download_info.filename`` was
+        # validated by the API client (``sanitize_wheel_filename``) and
+        # came from the trusted catalog response.
+        install_dir_name = _wheel_distribution_name(download_info.filename)
+        self._validate_plugin_name(install_dir_name)
 
+        plugin_dir = self.plugins_dir / install_dir_name
+        plugin_dir.mkdir(parents=True, exist_ok=True)
         wheel_path = plugin_dir / download_info.filename
         temp_path = plugin_dir / f"{download_info.filename}.tmp"
 
-        try:
-            logger.info("Downloading %s...", download_info.filename)
-            response = requests.get(download_info.download_url, stream=True)
-            response.raise_for_status()
+        # Drop the new bundle next to the TEMP wheel so verification can
+        # happen before we touch the previous install. ``temp_bundle_path``
+        # is cleaned up alongside ``temp_path`` in the finally block.
+        temp_bundle_path = (
+            temp_path.parent / (temp_path.name + ".sigstore")
+            if bundle_bytes is not None
+            else None
+        )
 
+        try:
+            logger.info("Installing %s...", download_info.filename)
             sha256_hash = hashlib.sha256()
             with open(temp_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
+                for chunk in chunks:
                     f.write(chunk)
                     sha256_hash.update(chunk)
 
@@ -128,28 +243,35 @@ class PluginDownloader:
             if computed_hash.lower() != download_info.sha256.lower():
                 raise ChecksumMismatchError(download_info.sha256, computed_hash)
 
-            # Remove any stale bundle sidecars for this wheel name before
-            # writing the new wheel/bundle pair.
+            if temp_bundle_path is not None:
+                temp_bundle_path.write_bytes(bundle_bytes)  # type: ignore[arg-type]
+
+            # Verify on the temp wheel BEFORE we touch the existing
+            # install. ``verify_wheel_signature`` looks for the bundle
+            # next to the wheel; we placed it next to ``temp_path`` for
+            # exactly that. A STRICT failure here leaves the previous
+            # working wheel + manifest intact.
+            sig_info = verify_wheel_signature(temp_path, signature_mode)
+
+            # Verification passed: now safe to swap. Remove the stale
+            # bundle sidecars, move the new wheel into place, then drop
+            # the fresh bundle next to it.
             self._remove_bundle_files(wheel_path)
+            temp_path.replace(wheel_path)
+            if temp_bundle_path is not None:
+                final_bundle_path = wheel_path.parent / (wheel_path.name + ".sigstore")
+                temp_bundle_path.replace(final_bundle_path)
 
-            # Download signature bundle if available
-            temp_path.rename(wheel_path)
-            self._download_bundle(download_info, plugin_dir)
-
-            # Verify signature
-            sig_info = verify_wheel_signature(wheel_path, signature_mode)
-
-            # Use GitGuardian API as default source if not provided
             if source is None:
-                source = PluginSource(type=PluginSourceType.GITGUARDIAN_API)
+                source = PluginSource(type=PluginSourceType.PLATFORM)
 
             # Sync trust record before writing the manifest so a trust failure
             # cannot leave an orphaned manifest pointing at a wheel we remove
             # during cleanup.
-            self._sync_trust_record(plugin_name, download_info.sha256, sig_info)
+            self._sync_trust_record(install_dir_name, download_info.sha256, sig_info)
             self._write_manifest(
                 plugin_dir=plugin_dir,
-                plugin_name=plugin_name,
+                plugin_name=install_dir_name,
                 version=download_info.version,
                 wheel_filename=download_info.filename,
                 sha256=download_info.sha256,
@@ -157,22 +279,37 @@ class PluginDownloader:
                 signature_info=sig_info,
             )
 
-            logger.info("Installed %s v%s", plugin_name, download_info.version)
+            # Sweep older wheels left behind by previous installs of
+            # the same plugin under a different version-stamped name.
+            self._remove_stale_wheels(plugin_dir, keep_filename=download_info.filename)
 
+            # Migrate a legacy install that lived under the catalog
+            # reference instead of the wheel distribution name (older
+            # ggshield versions named the dir after ``plugin_name``).
+            # If a directory at ``plugins_dir/<plugin_name>`` exists,
+            # is distinct from the new install dir, and looks like a
+            # plugin (manifest present), remove it. Otherwise
+            # ``_resolve_plugin_dir(plugin_name)`` would keep returning
+            # the stale directory and ``status``/``update`` would read
+            # the pre-upgrade version.
+            self._cleanup_legacy_install_dir(
+                catalog_reference=plugin_name,
+                current_dir=plugin_dir,
+            )
+
+            logger.info("Installed %s v%s", install_dir_name, download_info.version)
             return wheel_path
 
-        except requests.RequestException as e:
-            self._cleanup_failed_install(wheel_path)
-            raise DownloadError(f"Failed to download plugin: {e}") from e
-        except SignatureVerificationError:
-            self._cleanup_failed_install(wheel_path)
-            raise
-        except Exception:
-            self._cleanup_failed_install(wheel_path)
-            raise
         finally:
+            # No except: pre-swap errors leave the existing install
+            # intact and only need temp cleanup (below); post-swap
+            # errors leave a verified wheel at ``wheel_path`` that we
+            # must not delete, or the user is left with neither the
+            # old nor the new wheel. A retry rewrites manifest/trust.
             if temp_path.exists():
                 temp_path.unlink()
+            if temp_bundle_path is not None and temp_bundle_path.exists():
+                temp_bundle_path.unlink()
 
     def install_from_wheel(
         self,
@@ -194,37 +331,40 @@ class PluginDownloader:
             DownloadError: If installation fails.
             SignatureVerificationError: In STRICT mode when signature is invalid.
         """
-        # Extract metadata from wheel
         try:
             metadata = extract_wheel_metadata(wheel_path)
         except WheelError as e:
             raise DownloadError(f"Invalid wheel file: {e}") from e
 
-        plugin_name = metadata.name
+        # Canonicalise via the wheel filename so the install dir matches
+        # what ``download_and_install`` writes for the same package
+        # (PEP 503: lower + ``_ -> -``). Without this, a wheel whose
+        # METADATA Name is ``Foo_Bar`` lands under ``plugins_dir/Foo_Bar/``
+        # while the platform install of the same package lands under
+        # ``plugins_dir/foo-bar/``, breaking convergence.
+        plugin_name = _wheel_distribution_name(wheel_path.name)
         version = metadata.version
         self._validate_plugin_name(plugin_name)
 
-        # Create plugin directory
+        # Verify on the caller-provided wheel path — the bundle (if any)
+        # lives alongside the source wheel. Copying first would leave a
+        # rejected wheel under plugins/<name>/ on STRICT failure.
+        sig_info = verify_wheel_signature(wheel_path, signature_mode)
+
+        sha256 = compute_file_sha256(wheel_path)
+
         plugin_dir = self.plugins_dir / plugin_name
         plugin_dir.mkdir(parents=True, exist_ok=True)
 
-        # Copy wheel to plugin directory
         dest_wheel_path = plugin_dir / wheel_path.name
         self._remove_bundle_files(dest_wheel_path)
         shutil.copy2(wheel_path, dest_wheel_path)
 
-        # Copy bundle if it exists alongside the wheel
         from ggshield.core.plugin.signature import get_bundle_path
 
         bundle_path = get_bundle_path(wheel_path)
         if bundle_path is not None:
             shutil.copy2(bundle_path, plugin_dir / bundle_path.name)
-
-        # Verify signature
-        sig_info = verify_wheel_signature(dest_wheel_path, signature_mode)
-
-        # Compute SHA256
-        sha256 = self._compute_sha256(dest_wheel_path)
 
         # Create source tracking
         source = PluginSource(
@@ -243,6 +383,7 @@ class PluginDownloader:
             source=source,
             signature_info=sig_info,
         )
+        self._remove_stale_wheels(plugin_dir, keep_filename=wheel_path.name)
 
         logger.info("Installed %s v%s from local wheel", plugin_name, version)
 
@@ -280,36 +421,35 @@ class PluginDownloader:
         if not url.startswith("https://"):
             raise DownloadError(f"Invalid URL scheme: {url}")
 
-        # Download to temp file
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Extract filename from URL
-            filename = url.split("/")[-1].split("?")[0]
-            if not filename.endswith(".whl"):
+            raw_filename = url.split("/")[-1].split("?")[0]
+            try:
+                filename = sanitize_wheel_filename(raw_filename)
+            except InvalidWheelError:
+                # Fallback for URLs whose tail isn't a recognisable wheel
+                # filename. The actual wheel name is irrelevant on disk —
+                # only the bytes matter for verification.
                 filename = "plugin.whl"
 
             temp_wheel_path = Path(temp_dir) / filename
 
             try:
                 logger.info("Downloading from %s...", url)
-                response = requests.get(url, stream=True)
+                response = requests.get(url, stream=True, timeout=HTTP_TIMEOUT_SECONDS)
+                assert_all_https(response, exc_factory=InsecureSourceError)
                 response.raise_for_status()
 
-                sha256_hash = hashlib.sha256()
-                with open(temp_wheel_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
-                        sha256_hash.update(chunk)
+                computed_hash = _stream_to_file(
+                    response, temp_wheel_path, MAX_WHEEL_SIZE_BYTES, hash_bytes=True
+                )
+                assert computed_hash is not None
 
-                computed_hash = sha256_hash.hexdigest()
-
-                # Verify checksum if provided
                 if sha256 and computed_hash.lower() != sha256.lower():
                     raise ChecksumMismatchError(sha256, computed_hash)
 
             except requests.RequestException as e:
                 raise DownloadError(f"Failed to download from URL: {e}") from e
 
-            # Extract metadata
             try:
                 metadata = extract_wheel_metadata(temp_wheel_path)
             except WheelError as e:
@@ -319,7 +459,15 @@ class PluginDownloader:
             version = metadata.version
             self._validate_plugin_name(plugin_name)
 
-            # Create plugin directory and copy wheel
+            # Fetch sigstore bundle alongside the wheel in the temp dir so
+            # verification runs before we touch the final plugin directory.
+            self._download_url_bundle(url, temp_wheel_path)
+
+            # Verify before we place anything in the final destination so a
+            # STRICT-mode signature failure can't leave a rejected wheel on
+            # disk under plugins/<name>/.
+            sig_info = verify_wheel_signature(temp_wheel_path, signature_mode)
+
             plugin_dir = self.plugins_dir / plugin_name
             plugin_dir.mkdir(parents=True, exist_ok=True)
 
@@ -327,13 +475,13 @@ class PluginDownloader:
             self._remove_bundle_files(dest_wheel_path)
             shutil.copy2(temp_wheel_path, dest_wheel_path)
 
-        # Try downloading the signature bundle alongside the wheel
-        self._download_url_bundle(url, dest_wheel_path)
+            # Copy the bundle too if one was fetched.
+            for ext in (".sigstore", ".sigstore.json"):
+                bundle_src = temp_wheel_path.parent / (temp_wheel_path.name + ext)
+                if bundle_src.exists():
+                    shutil.copy2(bundle_src, plugin_dir / bundle_src.name)
+                    break
 
-        # Verify signature
-        sig_info = verify_wheel_signature(dest_wheel_path, signature_mode)
-
-        # Create source tracking
         source = PluginSource(
             type=PluginSourceType.URL,
             url=url,
@@ -350,6 +498,7 @@ class PluginDownloader:
             source=source,
             signature_info=sig_info,
         )
+        self._remove_stale_wheels(plugin_dir, keep_filename=dest_wheel_path.name)
 
         logger.info("Installed %s v%s from URL", plugin_name, version)
 
@@ -372,26 +521,31 @@ class PluginDownloader:
         Returns:
             Tuple of (plugin_name, version, installed_wheel_path).
         """
-        # Extract repo info from URL for source tracking
         github_repo = self._extract_github_repo(url)
 
-        # Download using standard URL method
         plugin_name, version, wheel_path = self.download_from_url(
             url, sha256, signature_mode=signature_mode
         )
 
-        # Update source to track GitHub release
+        # Upgrade the provenance record from "url" to "github_release". Use
+        # the same tmp+replace path as _write_manifest so a crash mid-write
+        # can't corrupt the manifest.
         manifest_path = self.plugins_dir / plugin_name / "manifest.json"
         manifest = json.loads(manifest_path.read_text())
-
-        source = PluginSource(
+        manifest["source"] = PluginSource(
             type=PluginSourceType.GITHUB_RELEASE,
             url=url,
             github_repo=github_repo,
             sha256=manifest.get("sha256"),
-        )
-        manifest["source"] = source.to_dict()
-        manifest_path.write_text(json.dumps(manifest, indent=2))
+        ).to_dict()
+
+        tmp_path = manifest_path.with_suffix(".json.tmp")
+        try:
+            tmp_path.write_text(json.dumps(manifest, indent=2))
+            tmp_path.replace(manifest_path)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
 
         return plugin_name, version, wheel_path
 
@@ -456,12 +610,12 @@ class PluginDownloader:
                         "X-GitHub-Api-Version": "2022-11-28",
                     },
                     stream=True,
+                    timeout=HTTP_TIMEOUT_SECONDS,
                 )
+                assert_all_https(response, exc_factory=InsecureSourceError)
                 response.raise_for_status()
 
-                with open(artifact_zip_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
+                _stream_to_file(response, artifact_zip_path, MAX_WHEEL_SIZE_BYTES)
 
             except requests.RequestException as e:
                 raise GitHubArtifactError(f"Failed to download artifact: {e}") from e
@@ -476,20 +630,26 @@ class PluginDownloader:
             except Exception as e:
                 raise GitHubArtifactError(f"Failed to extract artifact: {e}") from e
 
-            # Find wheel file in extracted contents
-            wheel_files = list(extract_dir.glob("**/*.whl"))
+            # Sort so multi-wheel artifacts pick deterministically. Without
+            # this, selection depends on filesystem traversal order, which
+            # would let a tampered wheel slipped into a multi-wheel artifact
+            # win against the legitimate one on some hosts but not others.
+            # We can't fully defend against an attacker who has supplanted
+            # the upstream artifact, but adding ordering non-determinism
+            # on top of it would be strictly worse.
+            wheel_files = sorted(extract_dir.glob("**/*.whl"))
             if not wheel_files:
                 raise GitHubArtifactError("No wheel file found in artifact")
 
             if len(wheel_files) > 1:
                 logger.warning(
-                    "Multiple wheel files found in artifact, using first: %s",
+                    "Multiple wheel files found in artifact, using first "
+                    "(alphabetical): %s",
                     wheel_files[0].name,
                 )
 
             temp_wheel_path = wheel_files[0]
 
-            # Extract metadata
             try:
                 metadata = extract_wheel_metadata(temp_wheel_path)
             except WheelError as e:
@@ -499,7 +659,12 @@ class PluginDownloader:
             version = metadata.version
             self._validate_plugin_name(plugin_name)
 
-            # Create plugin directory and copy wheel
+            # Verify on the temp path before we touch plugin_dir — a STRICT
+            # signature failure must not leave a rejected wheel on disk.
+            sig_info = verify_wheel_signature(temp_wheel_path, signature_mode)
+
+            sha256 = compute_file_sha256(temp_wheel_path)
+
             plugin_dir = self.plugins_dir / plugin_name
             plugin_dir.mkdir(parents=True, exist_ok=True)
 
@@ -507,20 +672,12 @@ class PluginDownloader:
             self._remove_bundle_files(dest_wheel_path)
             shutil.copy2(temp_wheel_path, dest_wheel_path)
 
-            # Copy bundle alongside the wheel if present in the artifact
             for ext in (".sigstore", ".sigstore.json"):
                 bundle_src = temp_wheel_path.parent / (temp_wheel_path.name + ext)
                 if bundle_src.exists():
                     shutil.copy2(bundle_src, plugin_dir / bundle_src.name)
                     break
 
-            # Compute SHA256
-            sha256 = self._compute_sha256(dest_wheel_path)
-
-        # Verify signature
-        sig_info = verify_wheel_signature(dest_wheel_path, signature_mode)
-
-        # Create source tracking
         source = PluginSource(
             type=PluginSourceType.GITHUB_ARTIFACT,
             url=url,
@@ -538,6 +695,7 @@ class PluginDownloader:
             source=source,
             signature_info=sig_info,
         )
+        self._remove_stale_wheels(plugin_dir, keep_filename=dest_wheel_path.name)
 
         logger.info("Installed %s v%s from GitHub artifact", plugin_name, version)
 
@@ -571,9 +729,18 @@ class PluginDownloader:
         return self.get_installed_version(plugin_name) is not None
 
     def _resolve_plugin_dir(self, plugin_name: str) -> Optional[Path]:
-        """Resolve a plugin directory from a package or entry point name."""
+        """Resolve a plugin directory from a package or entry point name.
+
+        Prefer the direct path only when it actually looks like a plugin
+        install (``manifest.json`` present). A bare ``plugins_dir/<name>/``
+        without a manifest is treated as residue — typically a stale dir
+        left behind by an aborted install or hand-created by the user —
+        and falls through to the entry-point scan so the real install
+        (which may live under the wheel's distribution-name directory)
+        still resolves.
+        """
         plugin_dir = self.plugins_dir / plugin_name
-        if plugin_dir.exists():
+        if plugin_dir.is_dir() and (plugin_dir / "manifest.json").exists():
             return plugin_dir
         return self._find_plugin_dir_by_entry_point(plugin_name)
 
@@ -664,11 +831,20 @@ class PluginDownloader:
 
         trusted_unsigned = False
         wheel_path = self.get_wheel_path(plugin_name)
-        if wheel_path is not None:
-            trusted_unsigned = self.trust_store.is_trusted(
-                wheel_path.parent.name,
-                self._compute_sha256(wheel_path),
-            )
+        plugin_dir = self._resolve_plugin_dir(plugin_name)
+        # Hash the on-disk wheel, not manifest["sha256"]: feeding the
+        # manifest value back into is_trusted is a tautology (trust
+        # record + manifest were written from the same digest), so a
+        # post-install wheel tamper would still render as "trusted".
+        if wheel_path is not None and plugin_dir is not None:
+            try:
+                disk_sha256 = compute_file_sha256(wheel_path)
+            except OSError:
+                disk_sha256 = None
+            if disk_sha256 is not None:
+                trusted_unsigned = self.trust_store.is_trusted(
+                    plugin_dir.name, disk_sha256
+                )
 
         return get_signature_label(manifest, trusted_unsigned=trusted_unsigned)
 
@@ -681,7 +857,7 @@ class PluginDownloader:
         source_data = manifest.get("source")
         if not source_data:
             # Legacy manifest without source tracking - assume GitGuardian API
-            return PluginSource(type=PluginSourceType.GITGUARDIAN_API)
+            return PluginSource(type=PluginSourceType.PLATFORM)
 
         try:
             return PluginSource.from_dict(source_data)
@@ -763,40 +939,6 @@ class PluginDownloader:
             signature_info.status.value,
         )
 
-    def _download_bundle(
-        self,
-        download_info: PluginDownloadInfo,
-        plugin_dir: Path,
-    ) -> Optional[Path]:
-        """Download the sigstore bundle for a wheel if a signature URL is available."""
-        if not download_info.signature_url:
-            return None
-
-        bundle_filename = download_info.filename + ".sigstore"
-        bundle_path = plugin_dir / bundle_filename
-
-        try:
-            logger.info("Downloading signature bundle...")
-            response = requests.get(
-                download_info.signature_url, stream=True, timeout=30
-            )
-            response.raise_for_status()
-
-            try:
-                with open(bundle_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
-            except BaseException:
-                # Remove any partial bundle left behind by a mid-stream error.
-                if bundle_path.exists():
-                    bundle_path.unlink()
-                raise
-
-            return bundle_path
-        except requests.RequestException as e:
-            logger.warning("Failed to download signature bundle: %s", e)
-            return None
-
     def _download_url_bundle(
         self, wheel_url: str, dest_wheel_path: Path
     ) -> Optional[Path]:
@@ -808,21 +950,17 @@ class PluginDownloader:
             bundle_url = wheel_url + ext
             bundle_path = dest_wheel_path.parent / (dest_wheel_path.name + ext)
             try:
-                response = requests.get(bundle_url, stream=True, timeout=30)
+                response = requests.get(
+                    bundle_url, stream=True, timeout=HTTP_TIMEOUT_SECONDS
+                )
+                assert_all_https(response, exc_factory=InsecureSourceError)
                 response.raise_for_status()
 
-                try:
-                    with open(bundle_path, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=8192):
-                            f.write(chunk)
-                except BaseException:
-                    if bundle_path.exists():
-                        bundle_path.unlink()
-                    raise
+                _stream_to_file(response, bundle_path, MAX_BUNDLE_SIZE_BYTES)
 
                 logger.info("Downloaded signature bundle from %s", bundle_url)
                 return bundle_path
-            except requests.RequestException:
+            except (requests.RequestException, InsecureSourceError, DownloadError):
                 continue
 
         logger.debug("No signature bundle found at URL conventions for %s", wheel_url)
@@ -835,6 +973,39 @@ class PluginDownloader:
             if bundle.exists():
                 bundle.unlink()
 
+    def _remove_stale_wheels(self, plugin_dir: Path, keep_filename: str) -> None:
+        """Remove old wheels left over from a previous install.
+
+        Upgrades from ``foo-1.0-py3-none-any.whl`` to
+        ``foo-2.0-py3-none-any.whl`` write the new wheel under a new
+        name and update the manifest to point at it — but they don't
+        remove the old wheel file. Without this sweep, the plugin
+        directory accumulates one stale wheel + sidecar per upgrade.
+        The manifest still routes loading to the right wheel, but the
+        stale files inflate disk usage and complicate any future
+        audit ("which of these three wheels is the one ggshield is
+        actually running?").
+
+        Only ``*.whl`` files whose name differs from ``keep_filename``
+        are touched, along with their ``.sigstore`` / ``.sigstore.json``
+        sidecars. Anything else in ``plugin_dir`` (manifest.json,
+        user-dropped fixtures, the kept wheel + its sidecars) is left
+        in place.
+        """
+        if not plugin_dir.is_dir():
+            return
+        for entry in plugin_dir.iterdir():
+            if not entry.is_file():
+                continue
+            if entry.suffix != ".whl" or entry.name == keep_filename:
+                continue
+            try:
+                entry.unlink()
+            except OSError as exc:
+                logger.warning("Failed to remove stale wheel %s: %s", entry, exc)
+                continue
+            self._remove_bundle_files(entry)
+
     def _cleanup_failed_install(self, wheel_path: Path) -> None:
         """Remove wheel and bundle files after a failed install."""
         if wheel_path.exists():
@@ -842,21 +1013,112 @@ class PluginDownloader:
 
         self._remove_bundle_files(wheel_path)
 
-    def _compute_sha256(self, file_path: Path) -> str:
-        """Compute SHA256 hash of a file."""
-        sha256_hash = hashlib.sha256()
-        with open(file_path, "rb") as f:
-            for chunk in iter(lambda: f.read(8192), b""):
-                sha256_hash.update(chunk)
-        return sha256_hash.hexdigest()
+    # Manifest ``source.type`` values that signal "this directory was
+    # written by a previous platform install of the same plugin and is
+    # safe to migrate away from in place". Anything else — ``local_file``,
+    # ``url``, ``github_release``, ``github_artifact``, or a manifest we
+    # can't parse — is a legitimate user-managed install that must not
+    # be deleted just because its directory name happens to collide with
+    # the current catalog reference.
+    _LEGACY_PLATFORM_SOURCE_TYPES = frozenset(
+        {
+            PluginSourceType.PLATFORM.value,
+            # Manifests written by ggshield < 1.50 used the old enum value.
+            "gitguardian_api",
+        }
+    )
+
+    def _cleanup_legacy_install_dir(
+        self, catalog_reference: str, current_dir: Path
+    ) -> None:
+        """Remove a stale install dir named after the catalog reference.
+
+        Older ggshield builds named the on-disk plugin directory after
+        the catalog reference (``plugin_name``) regardless of the
+        wheel's distribution name. The current install dir comes from
+        the wheel distribution name, so a user upgrading from one of
+        those builds can end up with two directories: a stale legacy
+        one keyed on ``catalog_reference`` and the current one keyed
+        on the wheel name. Without cleanup the entry-point fallback in
+        :meth:`_resolve_plugin_dir` would still find the new install,
+        but ``status`` / ``update`` queries that hit the catalog
+        reference first would keep reading the pre-upgrade manifest.
+
+        We only remove the legacy dir when ALL of the following hold:
+        - it's distinct from ``current_dir`` (the new install we just
+          finished writing),
+        - it has a ``manifest.json`` we can parse, and
+        - that manifest's ``source.type`` says the directory was
+          previously written by a platform install (``platform`` or
+          the legacy ``gitguardian_api`` value).
+
+        The last condition is the safety net: if the catalog reference
+        collides with the directory name of a real ``local_file`` /
+        ``url`` / ``github_release`` install (e.g. the user grabbed a
+        wheel called ``tokenscanner`` from disk and the new catalog
+        reference is also ``tokenscanner`` while the platform wheel's
+        distribution is ``ggshield-tokenscanner``), we leave the
+        user-managed install untouched.
+        """
+        if not self._is_valid_plugin_name(catalog_reference):
+            return
+        legacy_dir = self.plugins_dir / catalog_reference
+        if not legacy_dir.exists() or legacy_dir.resolve() == current_dir.resolve():
+            return
+        manifest_path = legacy_dir / "manifest.json"
+        if not manifest_path.exists():
+            return
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            # Unreadable / malformed manifest is ambiguous evidence —
+            # could be a half-written platform install but could also
+            # be a user-owned directory. Leave it alone and let the
+            # entry-point fallback in ``_resolve_plugin_dir`` route
+            # callers to the new install instead.
+            logger.warning(
+                "Refusing to remove %s: cannot parse manifest (%s)", legacy_dir, exc
+            )
+            return
+        legacy_source = (manifest.get("source") or {}).get("type")
+        if legacy_source not in self._LEGACY_PLATFORM_SOURCE_TYPES:
+            logger.info(
+                "Leaving %s in place: manifest source.type=%r is user-managed",
+                legacy_dir,
+                legacy_source,
+            )
+            return
+        try:
+            shutil.rmtree(legacy_dir)
+        except OSError as exc:
+            logger.warning("Failed to remove stale plugin dir %s: %s", legacy_dir, exc)
+            return
+        # Drop the trust record for the legacy entry so a future install
+        # under the catalog reference doesn't inherit a stale SHA from
+        # the now-removed wheel.
+        try:
+            self.trust_store.revoke_plugin(catalog_reference)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to revoke trust record for %s: %s", catalog_reference, exc
+            )
+        logger.info("Removed legacy plugin dir %s", legacy_dir)
 
     def _extract_github_repo(self, url: str) -> Optional[str]:
         """Extract owner/repo from a GitHub URL."""
-        # Pattern: github.com/{owner}/{repo}/...
         match = re.match(r"https://github\.com/([^/]+)/([^/]+)", url)
-        if match:
-            return f"{match.group(1)}/{match.group(2)}"
-        return None
+        if not match:
+            return None
+        owner, repo = match.group(1), match.group(2)
+        if repo.endswith(".git"):
+            repo = repo[: -len(".git")]
+        # Reject path-traversal-like segments; the repo value is later
+        # interpolated into api.github.com URLs and stored in manifests.
+        if owner in {"", ".", ".."} or repo in {"", ".", ".."}:
+            return None
+        if "/" in owner or "/" in repo or "\\" in owner or "\\" in repo:
+            return None
+        return f"{owner}/{repo}"
 
     def _parse_github_artifact_url(self, url: str) -> Optional[Tuple[str, str, str]]:
         """

--- a/ggshield/core/plugin/http_security.py
+++ b/ggshield/core/plugin/http_security.py
@@ -1,0 +1,63 @@
+"""HTTPS-redirect guard shared by client.py and downloader.py.
+
+Plugins are downloaded from at least three source types (GitGuardian
+platform, GitHub artifacts, GitHub releases). All of them must reject
+non-HTTPS redirect chains, but each layer wraps the failure in its own
+domain exception. This module provides the primitive; callers pass the
+exception factory.
+"""
+
+import os
+from typing import Callable
+from urllib.parse import urlparse
+
+import requests
+
+
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "[::1]", "::1"})
+INSECURE_LOOPBACK_ENV_VAR = "GITGUARDIAN_ALLOW_INSECURE_LOOPBACK"
+
+
+def is_loopback(url: str) -> bool:
+    """Return True when ``url`` targets a loopback host."""
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    return host in LOOPBACK_HOSTS
+
+
+def is_insecure_loopback_allowed() -> bool:
+    """Return True when the loopback HTTPS bypass is enabled.
+
+    Read at call time so tests and QA harnesses can monkeypatch via
+    ``monkeypatch.setenv``. Only the literal value ``"1"`` enables the
+    bypass — any other value (including ``"true"``) is treated as off.
+    """
+    return os.environ.get(INSECURE_LOOPBACK_ENV_VAR) == "1"
+
+
+def assert_all_https(
+    response: "requests.Response",
+    *,
+    exc_factory: Callable[[str], Exception],
+) -> None:
+    """Reject non-HTTPS hops in the redirect chain.
+
+    A non-HTTPS hop targeting a loopback host is allowed only when
+    ``GITGUARDIAN_ALLOW_INSECURE_LOOPBACK=1`` is set. This is intended
+    for local development and QA against an on-prem stack served on
+    ``http://localhost:3000``; production deployments must leave the
+    variable unset.
+
+    ``exc_factory`` builds the exception to raise (e.g.
+    ``PluginAPIError`` in ``client.py``, ``InsecureSourceError`` in
+    ``downloader.py``). It MUST accept a single ``str`` argument.
+    """
+    allow_loopback = is_insecure_loopback_allowed()
+    for hop in list(response.history) + [response]:
+        if hop.url.startswith("https://"):
+            continue
+        if allow_loopback and is_loopback(hop.url):
+            continue
+        raise exc_factory(f"Refusing insecure redirect through {hop.url!r}")

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -73,6 +73,39 @@ def read_entry_point_from_wheel(wheel_path: Path) -> Optional[Tuple[str, str]]:
     return None
 
 
+def resolve_config_key(wheel_path: Path, fallback: str) -> str:
+    """Return the key to use when calling ``EnterpriseConfig.enable_plugin``.
+
+    ``PluginLoader.discover_plugins`` keys wheel-installed plugins by
+    their ``ggshield.plugins`` entry-point name when present, and only
+    falls back to the wheel's distribution name when no entry point is
+    declared. Enablement is checked against that same key. If install
+    (or update) writes the config under the distribution name while
+    discovery looks it up under the entry-point name, the plugin ends
+    up silently disabled: install reports success but ``plugin list``
+    shows it off and the plugin never loads.
+
+    Reading the entry point from the wheel on the write side makes the
+    two layers agree, regardless of whether the upstream package picked
+    matching or divergent names. The fallback covers wheels that
+    declare no entry point and wheels that error during decoding
+    (``read_entry_point_from_wheel`` returns ``None`` in both cases —
+    indistinguishable here, and the next step after ``enable_plugin``
+    is the loader itself which will surface a real diagnostic).
+
+    ``wheel_path`` is the installed wheel returned by the downloader
+    and exists on every success path; the ``.exists()`` guard is
+    defensive against future refactors that might pass a path before
+    the wheel is on disk.
+    """
+    if not wheel_path.exists():
+        return fallback
+    entry_point = read_entry_point_from_wheel(wheel_path)
+    if entry_point is None:
+        return fallback
+    return entry_point[0]
+
+
 @dataclass
 class DiscoveredPlugin:
     """Information about a discovered plugin."""

--- a/ggshield/core/plugin/wheel_utils.py
+++ b/ggshield/core/plugin/wheel_utils.py
@@ -5,7 +5,7 @@ Wheel utilities - extract metadata from wheel files.
 import email.parser
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional
 from zipfile import BadZipFile, ZipFile
 
@@ -120,3 +120,27 @@ def validate_wheel_file(wheel_path: Path) -> bool:
         return True
     except WheelError:
         return False
+
+
+def sanitize_wheel_filename(raw: str) -> str:
+    """Return a wheel filename safe to use as a single path segment.
+
+    Strips path components the server may have included and rejects
+    values that would resolve outside the plugin directory (``..``,
+    empty segment, embedded NUL, backslash, Windows drive-qualified
+    or UNC-prefixed paths). Requires a ``.whl`` suffix.
+
+    Raises:
+        InvalidWheelError: when the input doesn't satisfy the rules.
+    """
+    name = PurePosixPath(raw).name
+    # Reject backslash and colon as well as posix path tricks: on
+    # Windows, ``Path("plugins") / "D:evil.whl"`` resolves drive-
+    # relative and escapes the plugins directory; ``\\?\C:\...`` and
+    # ``\\share\...`` have the same effect. ``PurePosixPath`` doesn't
+    # strip those, so we filter explicitly here.
+    if not name or name in {".", ".."} or "\x00" in name or "\\" in name or ":" in name:
+        raise InvalidWheelError(f"Server returned unsafe filename: {raw!r}")
+    if not name.endswith(".whl"):
+        raise InvalidWheelError(f"Wheel filename must end in .whl: {raw!r}")
+    return name

--- a/tests/unit/cmd/plugin/test_install.py
+++ b/tests/unit/cmd/plugin/test_install.py
@@ -2,10 +2,9 @@
 Tests for the enterprise install command.
 """
 
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
-
-import pytest
 
 from ggshield.__main__ import cli
 from ggshield.cmd.plugin.install import detect_source_type
@@ -15,12 +14,6 @@ from ggshield.core.plugin.client import (
     PluginDownloadInfo,
     PluginInfo,
     PluginSourceType,
-)
-from ggshield.core.plugin.downloader import ChecksumMismatchError, DownloadError
-from ggshield.core.plugin.signature import (
-    SignatureStatus,
-    SignatureVerificationError,
-    SignatureVerificationMode,
 )
 
 
@@ -42,10 +35,9 @@ class TestPluginInstall:
         """
         GIVEN a plugin is available
         WHEN running 'ggshield plugin install <plugin>'
-        THEN the plugin is downloaded and installed
+        THEN the plugin is downloaded and installed via streaming
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -56,16 +48,17 @@ class TestPluginInstall:
                     reason=None,
                 ),
             ],
-            features={},
         )
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-1.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
             sha256="abc123",
             version="1.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b"wheel-data"])
 
         with (
             mock.patch(
@@ -81,12 +74,11 @@ class TestPluginInstall:
                 "ggshield.cmd.plugin.install.EnterpriseConfig"
             ) as mock_config_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_downloader = mock.MagicMock()
@@ -105,23 +97,356 @@ class TestPluginInstall:
         assert "Installing tokenscanner" in result.output
         assert "Installed tokenscanner v1.0.0" in result.output
         mock_downloader.download_and_install.assert_called_once()
-        call_args = mock_downloader.download_and_install.call_args
-        assert call_args[0] == (mock_download_info, "tokenscanner")
+        mock_plugin_api_client.report_installation.assert_called_once_with(
+            "tokenscanner", "1.0.0", mock.ANY, mock.ANY
+        )
         mock_config.enable_plugin.assert_called_once_with(
             "tokenscanner", version="1.0.0"
         )
         mock_config.save.assert_called_once()
 
-    @pytest.mark.parametrize(
-        "reason",
-        [
-            pytest.param("Requires Business plan", id="with_reason"),
-            pytest.param(None, id="without_reason"),
-        ],
-    )
-    def test_install_unavailable_plugin(self, cli_fs_runner, reason):
+    def test_install_platform_uses_entry_point_name_for_config_key(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a catalog reference (``machine-scan``) whose installed wheel
+            exposes a divergent entry-point name (``machine_scan``)
+        WHEN ``ggshield plugin install machine-scan`` succeeds via the
+            platform flow
+        THEN ``enable_plugin`` is called with the entry-point name —
+            matching the loader's enablement key — so ``plugin list``
+            shows the plugin enabled and the loader picks it up.
+        """
+        import zipfile
+
+        installed_wheel = tmp_path / "satori_python-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(installed_wheel, "w") as zf:
+            zf.writestr(
+                "satori_python-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmachine_scan = satori_python.plugin:Plugin\n",
+            )
+
         mock_catalog = PluginCatalog(
-            plan="Free",
+            plugins=[
+                PluginInfo(
+                    name="machine-scan",
+                    display_name="Machine Scan",
+                    description="",
+                    available=True,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_info = PluginDownloadInfo(
+            filename="satori_python-1.0.0-py3-none-any.whl",
+            sha256="a" * 64,
+            version="1.0.0",
+            size_bytes=100,
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b"wheel-data"])
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_and_install.return_value = installed_wheel
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "machine-scan"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        mock_config.enable_plugin.assert_called_once_with(
+            "machine_scan", version="1.0.0"
+        )
+
+    def test_install_warn_mode_continues_when_signature_bundle_fails(
+        self, cli_fs_runner
+    ):
+        """
+        GIVEN --allow-unsigned and a backend whose signature proxy 5xxs
+        WHEN running 'ggshield plugin install <plugin> --allow-unsigned'
+        THEN the install still succeeds; bundle_bytes is None and a
+        warning is surfaced.
+
+        The bundle fetch failing here is a server issue, not user input;
+        the user already opted out of strict signature verification by
+        passing --allow-unsigned, so refusing to install an otherwise
+        valid wheel because of an unrelated proxy outage is wrong.
+        """
+        from ggshield.core.plugin.client import PluginAPIError
+
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="tokenscanner",
+                    display_name="Token Scanner",
+                    description="Local secret scanning",
+                    available=True,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
+            sha256="abc123",
+            version="1.0.0",
+            size_bytes=100,
+            signature_url="https://api.example/v1/.../signature",
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b"wheel-data"])
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client.download_signature_bundle.side_effect = (
+                PluginAPIError("upstream 500")
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "tokenscanner", "--allow-unsigned"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed tokenscanner v1.0.0" in result.output
+        assert "Could not fetch signature bundle" in result.output
+        mock_downloader.download_and_install.assert_called_once()
+        # bundle_bytes must have been None — STRICT would have re-raised
+        # before this call.
+        kwargs = mock_downloader.download_and_install.call_args.kwargs
+        assert kwargs["bundle_bytes"] is None
+
+    def test_install_strict_mode_fails_when_signature_bundle_fails(self, cli_fs_runner):
+        """
+        GIVEN strict signature verification (default) and a broken
+              signature URL on the catalog response
+        WHEN running 'ggshield plugin install <plugin>'
+        THEN the install aborts; the wheel is never written.
+        """
+        from ggshield.core.plugin.client import PluginAPIError
+
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="tokenscanner",
+                    display_name="Token Scanner",
+                    description="Local secret scanning",
+                    available=True,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
+            sha256="abc123",
+            version="1.0.0",
+            size_bytes=100,
+            signature_url="https://api.example/v1/.../signature",
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b"wheel-data"])
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client.download_signature_bundle.side_effect = (
+                PluginAPIError("upstream 500")
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config_class.load.return_value = mock.MagicMock()
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "tokenscanner"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code != ExitCode.SUCCESS
+        mock_downloader.download_and_install.assert_not_called()
+
+    def test_install_plugins_not_enabled(self, cli_fs_runner):
+        """
+        GIVEN the platform has plugins disabled (feature flag OFF)
+        WHEN running 'ggshield plugin install tokenscanner'
+        THEN it shows a clean error message about workspace configuration
+        """
+        from ggshield.core.plugin.client import PluginsNotEnabledError
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.side_effect = (
+                PluginsNotEnabledError()
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            result = cli_fs_runner.invoke(cli, ["plugin", "install", "tokenscanner"])
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "not available" in result.output.lower()
+        assert "administrator" in result.output.lower()
+
+    def test_install_calls_report_installation_after_success(self, cli_fs_runner):
+        """
+        GIVEN a successful plugin install
+        WHEN running 'ggshield plugin install tokenscanner'
+        THEN report_installation is called (best-effort analytics)
+        """
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="tokenscanner",
+                    display_name="Token Scanner",
+                    description="Local secret scanning",
+                    available=True,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
+            sha256="abc123",
+            version="1.0.0",
+            size_bytes=100,
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "tokenscanner"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        mock_plugin_api_client.report_installation.assert_called_once_with(
+            "tokenscanner", "1.0.0", mock.ANY, mock.ANY
+        )
+
+    def test_install_unavailable_plugin(self, cli_fs_runner):
+        """
+        GIVEN a plugin exists but is not available
+        WHEN running 'ggshield plugin install <plugin>'
+        THEN it shows an error with reason
+        """
+        mock_catalog = PluginCatalog(
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -129,10 +454,9 @@ class TestPluginInstall:
                     description="Local secret scanning",
                     available=False,
                     latest_version="1.0.0",
-                    reason=reason,
+                    reason="Requires Business plan",
                 ),
             ],
-            features={},
         )
 
         with (
@@ -154,10 +478,7 @@ class TestPluginInstall:
 
         assert result.exit_code == ExitCode.USAGE_ERROR
         assert "not available" in result.output
-        if reason:
-            assert reason in result.output
-        else:
-            assert "Reason:" not in result.output
+        assert "Requires Business plan" in result.output
 
     def test_install_unknown_plugin(self, cli_fs_runner):
         """
@@ -166,9 +487,7 @@ class TestPluginInstall:
         THEN it shows an error
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[],
-            features={},
         )
 
         with (
@@ -199,7 +518,6 @@ class TestPluginInstall:
         THEN the specified version is requested
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -210,16 +528,19 @@ class TestPluginInstall:
                     reason=None,
                 ),
             ],
-            features={},
         )
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="plugin-1.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.5.0-py3-none-any.whl",
             sha256="abc123",
-            version="1.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            version="1.5.0",
+            size_bytes=100,
         )
+        captured_kwargs: dict = {}
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield mock_info, iter([b""])
 
         with (
             mock.patch(
@@ -235,12 +556,11 @@ class TestPluginInstall:
                 "ggshield.cmd.plugin.install.EnterpriseConfig"
             ) as mock_config_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_downloader = mock.MagicMock()
@@ -256,9 +576,7 @@ class TestPluginInstall:
             )
 
         assert result.exit_code == ExitCode.SUCCESS
-        mock_plugin_api_client.get_download_info.assert_called_once_with(
-            "tokenscanner", version="1.5.0"
-        )
+        assert captured_kwargs.get("version") == "1.5.0"
 
     def test_install_download_error(self, cli_fs_runner):
         """
@@ -266,8 +584,9 @@ class TestPluginInstall:
         WHEN running 'ggshield plugin install <plugin>'
         THEN it shows an error
         """
+        from ggshield.core.plugin.downloader import DownloadError
+
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -278,16 +597,18 @@ class TestPluginInstall:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-1.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
             sha256="abc123",
             version="1.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
 
         with (
             mock.patch(
@@ -303,12 +624,11 @@ class TestPluginInstall:
                 "ggshield.cmd.plugin.install.EnterpriseConfig"
             ) as mock_config_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_downloader = mock.MagicMock()
@@ -386,14 +706,13 @@ class TestPluginInstall:
 
     def test_install_plugin_not_available_error(self, cli_fs_runner):
         """
-        GIVEN getting download info fails with PluginNotAvailableError
+        GIVEN downloading raises PluginNotAvailableError
         WHEN running 'ggshield plugin install <plugin>'
         THEN it shows an error
         """
         from ggshield.core.plugin.client import PluginNotAvailableError
 
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -404,8 +723,12 @@ class TestPluginInstall:
                     reason=None,
                 ),
             ],
-            features={},
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            raise PluginNotAvailableError("tokenscanner", "Version not found")
+            yield  # make it a generator
 
         with (
             mock.patch(
@@ -421,14 +744,11 @@ class TestPluginInstall:
                 "ggshield.cmd.plugin.install.EnterpriseConfig"
             ) as mock_config_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.side_effect = (
-                PluginNotAvailableError("tokenscanner", "Version not found")
-            )
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_downloader = mock.MagicMock()
@@ -449,7 +769,6 @@ class TestPluginInstall:
         THEN it shows an error
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -460,16 +779,17 @@ class TestPluginInstall:
                     reason=None,
                 ),
             ],
-            features={},
         )
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-1.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-1.0.0-py3-none-any.whl",
             sha256="abc123",
             version="1.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
 
         with (
             mock.patch(
@@ -485,12 +805,11 @@ class TestPluginInstall:
                 "ggshield.cmd.plugin.install.EnterpriseConfig"
             ) as mock_config_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_downloader = mock.MagicMock()
@@ -506,6 +825,47 @@ class TestPluginInstall:
 
         assert result.exit_code == ExitCode.UNEXPECTED_ERROR
         assert "Failed to install tokenscanner" in result.output
+
+    def test_install_unavailable_plugin_without_reason(self, cli_fs_runner):
+        """
+        GIVEN a plugin exists but is not available (without reason)
+        WHEN running 'ggshield plugin install <plugin>'
+        THEN it shows an error without reason
+        """
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="tokenscanner",
+                    display_name="Token Scanner",
+                    description="Local secret scanning",
+                    available=False,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+        ):
+            mock_client = mock.MagicMock()
+            mock_create_client.return_value = mock_client
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            result = cli_fs_runner.invoke(cli, ["plugin", "install", "tokenscanner"])
+
+        assert result.exit_code == ExitCode.USAGE_ERROR
+        assert "not available" in result.output
+        # Should not show "Reason:" when reason is None
+        assert "Reason:" not in result.output
 
 
 class TestDetectSourceType:
@@ -549,8 +909,8 @@ class TestDetectSourceType:
 
     def test_detect_plugin_name(self) -> None:
         """Test plugin names default to GitGuardian API."""
-        assert detect_source_type("tokenscanner") == PluginSourceType.GITGUARDIAN_API
-        assert detect_source_type("my-plugin") == PluginSourceType.GITGUARDIAN_API
+        assert detect_source_type("tokenscanner") == PluginSourceType.PLATFORM
+        assert detect_source_type("my-plugin") == PluginSourceType.PLATFORM
 
 
 class TestInstallFromLocalWheel:
@@ -599,6 +959,105 @@ class TestInstallFromLocalWheel:
         mock_downloader.install_from_wheel.assert_called_once()
         mock_config.enable_plugin.assert_called_once_with("myplugin", version="1.0.0")
 
+    def test_install_local_wheel_uses_entry_point_name_for_config_key(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a wheel whose distribution name differs from its
+            ``ggshield.plugins`` entry-point name (the distribution is
+            ``package-name`` but the entry point declares ``my_plugin``)
+        WHEN ``ggshield plugin install <wheel>`` succeeds
+        THEN ``EnterpriseConfig.enable_plugin`` is called with
+            ``my_plugin`` — matching the key
+            ``PluginLoader.discover_plugins`` uses for enablement — so
+            the plugin is actually loaded after install instead of
+            silently disabled.
+        """
+        import zipfile
+
+        wheel_path = tmp_path / "package_name-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "package_name-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmy_plugin = package_name.plugin:Plugin\n",
+            )
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.LOCAL_FILE,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            # install_from_wheel returns the distribution name as the
+            # first tuple element (PEP 503-normalised), which is what the
+            # current code historically passed straight to enable_plugin.
+            mock_downloader.install_from_wheel.return_value = (
+                "package-name",
+                "1.0.0",
+                wheel_path,
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", str(wheel_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        mock_config.enable_plugin.assert_called_once_with("my_plugin", version="1.0.0")
+
+    def test_install_local_wheel_warning(self, cli_fs_runner, tmp_path: Path) -> None:
+        """
+        GIVEN a valid local wheel file without --force
+        WHEN running 'ggshield plugin install <path>'
+        THEN a warning is displayed
+        """
+        wheel_path = tmp_path / "myplugin-1.0.0.whl"
+        wheel_path.touch()
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.LOCAL_FILE,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.install_from_wheel.return_value = (
+                "myplugin",
+                "1.0.0",
+                wheel_path,
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", str(wheel_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed myplugin v1.0.0" in result.output
+
 
 class TestInstallFromUrl:
     """Tests for installing from URLs."""
@@ -646,9 +1105,49 @@ class TestInstallFromUrl:
 
         assert result.exit_code == ExitCode.SUCCESS
         assert "Installed urlplugin v2.0.0" in result.output
-        mock_downloader.download_from_url.assert_called_once()
-        call_args = mock_downloader.download_from_url.call_args
-        assert call_args[0] == ("https://example.com/plugin.whl", "abc123")
+        mock_downloader.download_from_url.assert_called_once_with(
+            "https://example.com/plugin.whl",
+            "abc123",
+            signature_mode=mock.ANY,
+        )
+
+    def test_install_url_warning_no_sha256(self, cli_fs_runner) -> None:
+        """
+        GIVEN a URL without SHA256 checksum
+        WHEN running 'ggshield plugin install <url>' without --force
+        THEN a warning about missing checksum is displayed
+        """
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.URL,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_url.return_value = (
+                "urlplugin",
+                "2.0.0",
+                Path("/fake/path.whl"),
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "https://example.com/plugin.whl"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed urlplugin v2.0.0" in result.output
 
     def test_install_http_url_rejected(self, cli_fs_runner) -> None:
         """
@@ -781,7 +1280,7 @@ class TestInstallFromGitHubArtifact:
 
     def test_install_github_artifact_warning(self, cli_fs_runner) -> None:
         """
-        GIVEN a GitHub artifact URL
+        GIVEN a GitHub artifact URL without --force
         WHEN running 'ggshield plugin install <url>'
         THEN a warning about ephemeral artifacts is displayed
         """
@@ -867,6 +1366,11 @@ class TestInstallErrorHandling:
     """Tests for error handling in various install scenarios."""
 
     def test_install_local_wheel_not_found(self, cli_fs_runner, tmp_path: Path) -> None:
+        """
+        GIVEN a non-existent wheel file path
+        WHEN running 'ggshield plugin install <path>'
+        THEN it shows a file not found error
+        """
         wheel_path = tmp_path / "nonexistent.whl"
 
         with mock.patch(
@@ -881,16 +1385,16 @@ class TestInstallErrorHandling:
         assert result.exit_code == ExitCode.USAGE_ERROR
         assert "Wheel file not found" in result.output
 
-    @pytest.mark.parametrize(
-        "error",
-        [
-            pytest.param(DownloadError("Invalid wheel"), id="download_error"),
-            pytest.param(Exception("Unexpected"), id="generic_error"),
-        ],
-    )
-    def test_install_local_wheel_error(
-        self, cli_fs_runner, tmp_path: Path, error: Exception
+    def test_install_local_wheel_download_error(
+        self, cli_fs_runner, tmp_path: Path
     ) -> None:
+        """
+        GIVEN a local wheel file that fails to install
+        WHEN running 'ggshield plugin install <path>'
+        THEN it shows an error
+        """
+        from ggshield.core.plugin.downloader import DownloadError
+
         wheel_path = tmp_path / "broken.whl"
         wheel_path.touch()
 
@@ -905,7 +1409,9 @@ class TestInstallErrorHandling:
             ),
         ):
             mock_downloader = mock.MagicMock()
-            mock_downloader.install_from_wheel.side_effect = error
+            mock_downloader.install_from_wheel.side_effect = DownloadError(
+                "Invalid wheel"
+            )
             mock_downloader_class.return_value = mock_downloader
 
             result = cli_fs_runner.invoke(
@@ -916,78 +1422,17 @@ class TestInstallErrorHandling:
         assert result.exit_code == ExitCode.UNEXPECTED_ERROR
         assert "Failed to install from wheel" in result.output
 
-    @pytest.mark.parametrize(
-        "source_type, method, cli_args, error, expected_msg",
-        [
-            pytest.param(
-                PluginSourceType.URL,
-                "download_from_url",
-                ["plugin", "install", "https://example.com/plugin.whl"],
-                DownloadError("Network error"),
-                "Failed to install from URL",
-                id="url-download_error",
-            ),
-            pytest.param(
-                PluginSourceType.URL,
-                "download_from_url",
-                ["plugin", "install", "https://example.com/plugin.whl"],
-                Exception("Unexpected"),
-                "Failed to install from URL",
-                id="url-generic_error",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_RELEASE,
-                "download_from_github_release",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/owner/repo/releases/download/v1/p.whl",
-                ],
-                DownloadError("Not found"),
-                "Failed to install from GitHub release",
-                id="github_release-download_error",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_RELEASE,
-                "download_from_github_release",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/owner/repo/releases/download/v1/p.whl",
-                ],
-                Exception("Unexpected"),
-                "Failed to install from GitHub release",
-                id="github_release-generic_error",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_ARTIFACT,
-                "download_from_github_artifact",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/owner/repo/actions/runs/123/artifacts/456",
-                ],
-                DownloadError("Failed to extract"),
-                "Failed to install from GitHub artifact",
-                id="github_artifact-download_error",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_ARTIFACT,
-                "download_from_github_artifact",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/owner/repo/actions/runs/123/artifacts/456",
-                ],
-                Exception("Unexpected"),
-                "Failed to install from GitHub artifact",
-                id="github_artifact-generic_error",
-            ),
-        ],
-    )
-    def test_install_error(
-        self, cli_fs_runner, source_type, method, cli_args, error, expected_msg
+    def test_install_local_wheel_generic_error(
+        self, cli_fs_runner, tmp_path: Path
     ) -> None:
+        """
+        GIVEN a local wheel file with unexpected error
+        WHEN running 'ggshield plugin install <path>'
+        THEN it shows an error
+        """
+        wheel_path = tmp_path / "problem.whl"
+        wheel_path.touch()
+
         with (
             mock.patch(
                 "ggshield.cmd.plugin.install.PluginDownloader"
@@ -995,24 +1440,47 @@ class TestInstallErrorHandling:
             mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
             mock.patch(
                 "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=source_type,
+                return_value=PluginSourceType.LOCAL_FILE,
             ),
         ):
             mock_downloader = mock.MagicMock()
-            getattr(mock_downloader, method).side_effect = error
+            mock_downloader.install_from_wheel.side_effect = Exception("Unexpected")
             mock_downloader_class.return_value = mock_downloader
 
-            result = cli_fs_runner.invoke(cli, cli_args)
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", str(wheel_path)],
+            )
 
         assert result.exit_code == ExitCode.UNEXPECTED_ERROR
-        assert expected_msg in result.output
+        assert "Failed to install from wheel" in result.output
 
-    @pytest.mark.parametrize(
-        "source_type, method, cli_args",
-        [
-            pytest.param(
-                PluginSourceType.URL,
-                "download_from_url",
+    def test_install_url_checksum_mismatch(self, cli_fs_runner) -> None:
+        """
+        GIVEN a URL with wrong checksum
+        WHEN running 'ggshield plugin install <url> --sha256 <hash>'
+        THEN it shows a checksum error
+        """
+        from ggshield.core.plugin.downloader import ChecksumMismatchError
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.URL,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_url.side_effect = ChecksumMismatchError(
+                "expected123", "actual456"
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
                 [
                     "plugin",
                     "install",
@@ -1020,25 +1488,19 @@ class TestInstallErrorHandling:
                     "--sha256",
                     "wrong",
                 ],
-                id="url",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_RELEASE,
-                "download_from_github_release",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/owner/repo/releases/download/v1/p.whl",
-                    "--sha256",
-                    "wrong",
-                ],
-                id="github_release",
-            ),
-        ],
-    )
-    def test_install_checksum_mismatch(
-        self, cli_fs_runner, source_type, method, cli_args
-    ) -> None:
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Checksum verification failed" in result.output
+
+    def test_install_url_download_error(self, cli_fs_runner) -> None:
+        """
+        GIVEN a URL that fails to download
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows a download error
+        """
+        from ggshield.core.plugin.downloader import DownloadError
+
         with (
             mock.patch(
                 "ggshield.cmd.plugin.install.PluginDownloader"
@@ -1046,265 +1508,225 @@ class TestInstallErrorHandling:
             mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
             mock.patch(
                 "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=source_type,
+                return_value=PluginSourceType.URL,
             ),
         ):
             mock_downloader = mock.MagicMock()
-            getattr(mock_downloader, method).side_effect = ChecksumMismatchError(
-                "expected123", "actual456"
+            mock_downloader.download_from_url.side_effect = DownloadError(
+                "Network error"
             )
             mock_downloader_class.return_value = mock_downloader
 
-            result = cli_fs_runner.invoke(cli, cli_args)
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "https://example.com/plugin.whl"],
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from URL" in result.output
+
+    def test_install_url_generic_error(self, cli_fs_runner) -> None:
+        """
+        GIVEN a URL with unexpected error
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows an error
+        """
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.URL,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_url.side_effect = Exception("Unexpected")
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", "https://example.com/plugin.whl"],
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from URL" in result.output
+
+    def test_install_github_release_checksum_mismatch(self, cli_fs_runner) -> None:
+        """
+        GIVEN a GitHub release URL with wrong checksum
+        WHEN running 'ggshield plugin install <url> --sha256 <hash>'
+        THEN it shows a checksum error
+        """
+        from ggshield.core.plugin.downloader import ChecksumMismatchError
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.GITHUB_RELEASE,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_github_release.side_effect = (
+                ChecksumMismatchError("expected", "actual")
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                [
+                    "plugin",
+                    "install",
+                    "https://github.com/owner/repo/releases/download/v1/p.whl",
+                    "--sha256",
+                    "wrong",
+                ],
+            )
 
         assert result.exit_code == ExitCode.UNEXPECTED_ERROR
         assert "Checksum verification failed" in result.output
 
-
-class TestSignatureVerificationHandling:
-    """Tests for signature verification error handling in install commands."""
-
-    def test_gitguardian_install_signature_error(self, cli_fs_runner) -> None:
+    def test_install_github_release_download_error(self, cli_fs_runner) -> None:
         """
-        GIVEN a plugin with invalid signature
-        WHEN installing from GitGuardian API
-        THEN signature error is shown with --allow-unsigned hint
+        GIVEN a GitHub release URL that fails to download
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows a download error
         """
-        mock_catalog = PluginCatalog(
-            plan="Enterprise",
-            plugins=[
-                PluginInfo(
-                    name="tokenscanner",
-                    display_name="Token Scanner",
-                    description="Local secret scanning",
-                    available=True,
-                    latest_version="1.0.0",
-                    reason=None,
-                ),
-            ],
-            features={},
-        )
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-1.0.0.whl",
-            sha256="abc123",
-            version="1.0.0",
-            expires_at="2099-12-31T23:59:59Z",
-        )
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.install.create_client_from_config"
-            ) as mock_create_client,
-            mock.patch(
-                "ggshield.cmd.plugin.install.PluginAPIClient"
-            ) as mock_plugin_api_client_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.PluginDownloader"
-            ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
-        ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
-
-            mock_plugin_api_client = mock.MagicMock()
-            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
-            mock_plugin_api_client_class.return_value = mock_plugin_api_client
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.download_and_install.side_effect = (
-                SignatureVerificationError(
-                    SignatureStatus.INVALID, "no trusted identity matched"
-                )
-            )
-            mock_downloader_class.return_value = mock_downloader
-
-            mock_config_class.load.return_value = mock.MagicMock()
-
-            result = cli_fs_runner.invoke(cli, ["plugin", "install", "tokenscanner"])
-
-        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
-        assert "Signature verification failed" in result.output
-        assert "--allow-unsigned" in result.output
-
-    def test_local_wheel_signature_error(self, cli_fs_runner, tmp_path: Path) -> None:
-        """
-        GIVEN a local wheel with invalid signature
-        WHEN installing from local wheel
-        THEN signature error is shown with --allow-unsigned hint
-        """
-        wheel_path = tmp_path / "plugin.whl"
-        wheel_path.touch()
+        from ggshield.core.plugin.downloader import DownloadError
 
         with (
             mock.patch(
                 "ggshield.cmd.plugin.install.PluginDownloader"
             ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
             mock.patch(
                 "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=PluginSourceType.LOCAL_FILE,
+                return_value=PluginSourceType.GITHUB_RELEASE,
             ),
         ):
             mock_downloader = mock.MagicMock()
-            mock_downloader.install_from_wheel.side_effect = SignatureVerificationError(
-                SignatureStatus.MISSING, "No bundle found"
+            mock_downloader.download_from_github_release.side_effect = DownloadError(
+                "Not found"
             )
             mock_downloader_class.return_value = mock_downloader
-
-            mock_config_class.load.return_value = mock.MagicMock()
-
-            result = cli_fs_runner.invoke(cli, ["plugin", "install", str(wheel_path)])
-
-        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
-        assert "Signature verification failed" in result.output
-        assert "--allow-unsigned" in result.output
-
-    @pytest.mark.parametrize(
-        "source_type, method, cli_args",
-        [
-            pytest.param(
-                PluginSourceType.URL,
-                "download_from_url",
-                ["plugin", "install", "https://example.com/plugin.whl"],
-                id="url",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_RELEASE,
-                "download_from_github_release",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/o/r/releases/download/v1/p.whl",
-                ],
-                id="github_release",
-            ),
-            pytest.param(
-                PluginSourceType.GITHUB_ARTIFACT,
-                "download_from_github_artifact",
-                [
-                    "plugin",
-                    "install",
-                    "https://github.com/o/r/actions/runs/1/artifacts/2",
-                ],
-                id="github_artifact",
-            ),
-        ],
-    )
-    def test_signature_error_all_sources(
-        self, cli_fs_runner, source_type, method, cli_args
-    ) -> None:
-        """Test that SignatureVerificationError is handled for all source types."""
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.install.PluginDownloader"
-            ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=source_type,
-            ),
-        ):
-            mock_downloader = mock.MagicMock()
-            getattr(mock_downloader, method).side_effect = SignatureVerificationError(
-                SignatureStatus.INVALID, "bad signature"
-            )
-            mock_downloader_class.return_value = mock_downloader
-
-            mock_config_class.load.return_value = mock.MagicMock()
-
-            result = cli_fs_runner.invoke(cli, cli_args)
-
-        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
-        assert "Signature verification failed" in result.output
-        assert "--allow-unsigned" in result.output
-
-    def test_default_signature_mode_is_strict(
-        self, cli_fs_runner, tmp_path: Path
-    ) -> None:
-        """
-        GIVEN no --allow-unsigned flag
-        WHEN installing a plugin
-        THEN signature mode is STRICT
-        """
-        wheel_path = tmp_path / "plugin.whl"
-        wheel_path.touch()
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.install.PluginDownloader"
-            ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=PluginSourceType.LOCAL_FILE,
-            ),
-        ):
-            mock_downloader = mock.MagicMock()
-            mock_downloader.install_from_wheel.return_value = (
-                "plugin",
-                "1.0.0",
-                wheel_path,
-            )
-            mock_downloader_class.return_value = mock_downloader
-            mock_config_class.load.return_value = mock.MagicMock()
 
             result = cli_fs_runner.invoke(
                 cli,
-                ["plugin", "install", str(wheel_path)],
-                catch_exceptions=False,
+                [
+                    "plugin",
+                    "install",
+                    "https://github.com/owner/repo/releases/download/v1/p.whl",
+                ],
             )
 
-        assert result.exit_code == ExitCode.SUCCESS
-        call_kwargs = mock_downloader.install_from_wheel.call_args[1]
-        assert call_kwargs["signature_mode"] == SignatureVerificationMode.STRICT
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from GitHub release" in result.output
 
-    def test_allow_unsigned_flag(self, cli_fs_runner, tmp_path: Path) -> None:
+    def test_install_github_release_generic_error(self, cli_fs_runner) -> None:
         """
-        GIVEN --allow-unsigned flag
-        WHEN installing a plugin
-        THEN signature mode is set to WARN (not STRICT)
+        GIVEN a GitHub release URL with unexpected error
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows an error
         """
-        wheel_path = tmp_path / "plugin.whl"
-        wheel_path.touch()
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.GITHUB_RELEASE,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_github_release.side_effect = Exception(
+                "Unexpected"
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                [
+                    "plugin",
+                    "install",
+                    "https://github.com/owner/repo/releases/download/v1/p.whl",
+                ],
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from GitHub release" in result.output
+
+    def test_install_github_artifact_download_error(self, cli_fs_runner) -> None:
+        """
+        GIVEN a GitHub artifact URL that fails to download
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows a download error
+        """
+        from ggshield.core.plugin.downloader import DownloadError
 
         with (
             mock.patch(
                 "ggshield.cmd.plugin.install.PluginDownloader"
             ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
             mock.patch(
                 "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=PluginSourceType.LOCAL_FILE,
+                return_value=PluginSourceType.GITHUB_ARTIFACT,
             ),
         ):
             mock_downloader = mock.MagicMock()
-            mock_downloader.install_from_wheel.return_value = (
-                "plugin",
-                "1.0.0",
-                wheel_path,
+            mock_downloader.download_from_github_artifact.side_effect = DownloadError(
+                "Failed to extract"
             )
             mock_downloader_class.return_value = mock_downloader
-            mock_config_class.load.return_value = mock.MagicMock()
 
             result = cli_fs_runner.invoke(
                 cli,
-                ["plugin", "install", str(wheel_path), "--allow-unsigned"],
-                catch_exceptions=False,
+                [
+                    "plugin",
+                    "install",
+                    "https://github.com/owner/repo/actions/runs/123/artifacts/456",
+                ],
             )
 
-        assert result.exit_code == ExitCode.SUCCESS
-        call_kwargs = mock_downloader.install_from_wheel.call_args[1]
-        assert call_kwargs["signature_mode"] == SignatureVerificationMode.WARN
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from GitHub artifact" in result.output
+
+    def test_install_github_artifact_generic_error(self, cli_fs_runner) -> None:
+        """
+        GIVEN a GitHub artifact URL with unexpected error
+        WHEN running 'ggshield plugin install <url>'
+        THEN it shows an error
+        """
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch("ggshield.cmd.plugin.install.EnterpriseConfig"),
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.GITHUB_ARTIFACT,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.download_from_github_artifact.side_effect = Exception(
+                "Unexpected"
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                [
+                    "plugin",
+                    "install",
+                    "https://github.com/owner/repo/actions/runs/123/artifacts/456",
+                ],
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "Failed to install from GitHub artifact" in result.output

--- a/tests/unit/cmd/plugin/test_list.py
+++ b/tests/unit/cmd/plugin/test_list.py
@@ -5,9 +5,40 @@ Tests for the enterprise list command.
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import ggshield.cmd.plugin.plugin_list as plugin_list_module
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
+from ggshield.core.plugin.client import PluginSource, PluginSourceType
+from ggshield.core.plugin.loader import DiscoveredPlugin
+
+
+def _run_list(cli_fs_runner, plugins, source_for_name=None, signature_label=None):
+    """Invoke `ggshield plugin list` with mocked loader + downloader.
+
+    ``source_for_name`` is a mapping of ``plugin name -> PluginSource | None``
+    returned by the patched ``PluginDownloader.get_plugin_source``.
+    """
+    source_for_name = source_for_name or {}
+    with (
+        mock.patch.object(plugin_list_module, "PluginLoader") as mock_loader_class,
+        mock.patch.object(
+            plugin_list_module, "PluginDownloader"
+        ) as mock_downloader_class,
+    ):
+        mock_loader = mock.MagicMock()
+        mock_loader.discover_plugins.return_value = plugins
+        mock_loader_class.return_value = mock_loader
+
+        mock_downloader = mock.MagicMock()
+        mock_downloader.get_plugin_source.side_effect = (
+            lambda name: source_for_name.get(name)
+        )
+        mock_downloader.get_installed_signature_label.return_value = signature_label
+        mock_downloader_class.return_value = mock_downloader
+
+        return cli_fs_runner.invoke(cli, ["plugin", "list"])
 
 
 class TestPluginList:
@@ -19,37 +50,21 @@ class TestPluginList:
         WHEN running 'ggshield plugin list'
         THEN it shows a message about no plugins
         """
-        # Mock the loader to return empty list
-        with (
-            mock.patch.object(plugin_list_module, "PluginLoader") as mock_loader_class,
-            mock.patch.object(
-                plugin_list_module, "PluginDownloader"
-            ) as mock_downloader_class,
-        ):
-            mock_loader = mock.MagicMock()
-            mock_loader.discover_plugins.return_value = []
-            mock_loader_class.return_value = mock_loader
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.get_installed_signature_label.return_value = None
-            mock_downloader_class.return_value = mock_downloader
-
-            result = cli_fs_runner.invoke(cli, ["plugin", "list"])
+        result = _run_list(cli_fs_runner, plugins=[])
 
         assert result.exit_code == ExitCode.SUCCESS
         assert "No plugins installed" in result.output
         assert "ggshield plugin status" in result.output
 
-    def test_list_with_plugins(self, cli_fs_runner):
+    def test_list_pip_plugin_without_wheel(self, cli_fs_runner):
         """
-        GIVEN plugins are installed
+        GIVEN a plugin discovered only via a Python entry point (pip-installed,
+              no on-disk wheel)
         WHEN running 'ggshield plugin list'
-        THEN it lists the plugins with their status
+        THEN the source column is "pip" — ``get_plugin_source`` is not called
+             because there's no wheel/manifest to consult.
         """
-        from ggshield.core.plugin.loader import DiscoveredPlugin
-
-        # Create mock discovered plugins
-        mock_plugins = [
+        plugins = [
             DiscoveredPlugin(
                 name="testplugin",
                 entry_point=mock.MagicMock(),
@@ -58,44 +73,89 @@ class TestPluginList:
                 is_enabled=True,
                 version="1.0.0",
             ),
+        ]
+
+        result = _run_list(cli_fs_runner, plugins)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "testplugin" in result.output
+        assert "enabled" in result.output
+        assert "pip" in result.output
+
+    @pytest.mark.parametrize(
+        "source_type, expected_label",
+        [
+            (PluginSourceType.PLATFORM, "platform"),
+            (PluginSourceType.LOCAL_FILE, "local file"),
+            (PluginSourceType.URL, "url"),
+            (PluginSourceType.GITHUB_RELEASE, "github release"),
+            (PluginSourceType.GITHUB_ARTIFACT, "github artifact"),
+        ],
+    )
+    def test_list_surfaces_manifest_source(
+        self, cli_fs_runner, source_type, expected_label
+    ):
+        """
+        GIVEN a wheel-installed plugin whose manifest records a ``source.type``
+        WHEN running 'ggshield plugin list'
+        THEN the source column mirrors the manifest value (with underscores
+             replaced by spaces for readability) — tells the user WHERE the
+             plugin came from, which the previous "local" label hid.
+        """
+        plugins = [
             DiscoveredPlugin(
-                name="otherplugin",
+                name="machine_scan",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="0.32.0",
+            ),
+        ]
+
+        result = _run_list(
+            cli_fs_runner,
+            plugins,
+            source_for_name={"machine_scan": PluginSource(type=source_type)},
+            signature_label="signed (GitGuardian/satori)",
+        )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "machine_scan" in result.output
+        assert expected_label in result.output
+        # The legacy label must not leak through for any recognised source type.
+        assert ", local," not in result.output
+        assert "signature: signed (GitGuardian/satori)" in result.output
+
+    def test_list_legacy_wheel_without_manifest_falls_back_to_on_disk(
+        self, cli_fs_runner
+    ):
+        """
+        GIVEN a wheel on disk with no readable manifest
+              (hand-dropped file — rare edge case)
+        WHEN running 'ggshield plugin list'
+        THEN the source column is "on-disk" rather than silently empty.
+        """
+        plugins = [
+            DiscoveredPlugin(
+                name="mystery_wheel",
                 entry_point=None,
                 wheel_path=Path("/path/to/wheel"),
                 is_installed=True,
                 is_enabled=False,
-                version="2.0.0",
+                version="0.1.0",
             ),
         ]
 
-        with (
-            mock.patch.object(plugin_list_module, "PluginLoader") as mock_loader_class,
-            mock.patch.object(
-                plugin_list_module, "PluginDownloader"
-            ) as mock_downloader_class,
-        ):
-            mock_loader = mock.MagicMock()
-            mock_loader.discover_plugins.return_value = mock_plugins
-            mock_loader_class.return_value = mock_loader
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.get_installed_signature_label.side_effect = [
-                None,
-                "unsigned (trusted)",
-            ]
-            mock_downloader_class.return_value = mock_downloader
-
-            result = cli_fs_runner.invoke(cli, ["plugin", "list"])
+        result = _run_list(
+            cli_fs_runner,
+            plugins,
+            # No entry for "mystery_wheel" → get_plugin_source returns None.
+        )
 
         assert result.exit_code == ExitCode.SUCCESS
-        assert "Installed Plugins" in result.output
-        assert "testplugin" in result.output
-        assert "enabled" in result.output
-        assert "pip" in result.output
-        assert "otherplugin" in result.output
-        assert "disabled" in result.output
-        assert "local" in result.output
-        assert "signature: unsigned (trusted)" in result.output
+        assert "mystery_wheel" in result.output
+        assert "on-disk" in result.output
 
     def test_list_plugin_versions(self, cli_fs_runner):
         """
@@ -103,9 +163,7 @@ class TestPluginList:
         WHEN running 'ggshield plugin list'
         THEN it shows the version numbers
         """
-        from ggshield.core.plugin.loader import DiscoveredPlugin
-
-        mock_plugins = [
+        plugins = [
             DiscoveredPlugin(
                 name="versioned",
                 entry_point=mock.MagicMock(),
@@ -116,21 +174,7 @@ class TestPluginList:
             ),
         ]
 
-        with (
-            mock.patch.object(plugin_list_module, "PluginLoader") as mock_loader_class,
-            mock.patch.object(
-                plugin_list_module, "PluginDownloader"
-            ) as mock_downloader_class,
-        ):
-            mock_loader = mock.MagicMock()
-            mock_loader.discover_plugins.return_value = mock_plugins
-            mock_loader_class.return_value = mock_loader
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.get_installed_signature_label.return_value = None
-            mock_downloader_class.return_value = mock_downloader
-
-            result = cli_fs_runner.invoke(cli, ["plugin", "list"])
+        result = _run_list(cli_fs_runner, plugins)
 
         assert result.exit_code == ExitCode.SUCCESS
         assert "v3.2.1" in result.output

--- a/tests/unit/cmd/plugin/test_status.py
+++ b/tests/unit/cmd/plugin/test_status.py
@@ -12,104 +12,13 @@ from ggshield.core.plugin.client import PluginCatalog, PluginInfo
 class TestPluginStatus:
     """Tests for 'ggshield plugin status' command."""
 
-    def test_status_shows_plan(self, cli_fs_runner):
-        """
-        GIVEN a user with an account
-        WHEN running 'ggshield plugin status'
-        THEN it shows the plan information
-        """
-        mock_catalog = PluginCatalog(
-            plan="Enterprise",
-            plugins=[],
-            features={},
-        )
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.status.create_client_from_config"
-            ) as mock_create_client,
-            mock.patch(
-                "ggshield.cmd.plugin.status.PluginAPIClient"
-            ) as mock_plugin_api_client_class,
-            mock.patch(
-                "ggshield.cmd.plugin.status.EnterpriseConfig"
-            ) as mock_config_class,
-        ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
-
-            mock_plugin_api_client = mock.MagicMock()
-            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client_class.return_value = mock_plugin_api_client
-
-            mock_config = mock.MagicMock()
-            mock_config.is_plugin_enabled.return_value = False
-            mock_config_class.load.return_value = mock_config
-
-            result = cli_fs_runner.invoke(
-                cli, ["plugin", "status"], catch_exceptions=False
-            )
-
-        assert result.exit_code == ExitCode.SUCCESS
-        assert "Account Status" in result.output
-        assert "Plan: Enterprise" in result.output
-
-    def test_status_shows_features(self, cli_fs_runner):
-        """
-        GIVEN a user with features enabled
-        WHEN running 'ggshield plugin status'
-        THEN it shows the features
-        """
-        mock_catalog = PluginCatalog(
-            plan="Business",
-            plugins=[],
-            features={
-                "local_scanning": True,
-                "advanced_detection": False,
-            },
-        )
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.status.create_client_from_config"
-            ) as mock_create_client,
-            mock.patch(
-                "ggshield.cmd.plugin.status.PluginAPIClient"
-            ) as mock_plugin_api_client_class,
-            mock.patch(
-                "ggshield.cmd.plugin.status.EnterpriseConfig"
-            ) as mock_config_class,
-        ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
-
-            mock_plugin_api_client = mock.MagicMock()
-            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client_class.return_value = mock_plugin_api_client
-
-            mock_config = mock.MagicMock()
-            mock_config.is_plugin_enabled.return_value = False
-            mock_config_class.load.return_value = mock_config
-
-            result = cli_fs_runner.invoke(
-                cli, ["plugin", "status"], catch_exceptions=False
-            )
-
-        assert result.exit_code == ExitCode.SUCCESS
-        assert "Features" in result.output
-        assert "local_scanning" in result.output
-        assert "enabled" in result.output
-        assert "advanced_detection" in result.output
-        assert "disabled" in result.output
-
     def test_status_shows_available_plugins(self, cli_fs_runner):
         """
-        GIVEN plugins are available
+        GIVEN plugins are available in the catalog
         WHEN running 'ggshield plugin status'
-        THEN it shows the available plugins
+        THEN it shows the 'Available Plugins' section without plan or features
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -119,16 +28,7 @@ class TestPluginStatus:
                     latest_version="1.0.0",
                     reason=None,
                 ),
-                PluginInfo(
-                    name="premium",
-                    display_name="Premium Plugin",
-                    description="Premium features",
-                    available=False,
-                    latest_version="2.0.0",
-                    reason="Requires Enterprise Plus plan",
-                ),
             ],
-            features={},
         )
 
         with (
@@ -145,8 +45,7 @@ class TestPluginStatus:
                 "ggshield.cmd.plugin.status.PluginDownloader"
             ) as mock_downloader_class,
         ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
+            mock_create_client.return_value = mock.MagicMock()
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
@@ -167,11 +66,40 @@ class TestPluginStatus:
         assert result.exit_code == ExitCode.SUCCESS
         assert "Available Plugins" in result.output
         assert "Token Scanner" in result.output
-        assert "tokenscanner" in result.output
-        assert "Local secret scanning" in result.output
-        assert "Premium Plugin" in result.output
-        assert "not available" in result.output
-        assert "Requires Enterprise Plus plan" in result.output
+        # No plan or features section
+        assert "Account Status" not in result.output
+        assert "Plan:" not in result.output
+        assert "Features" not in result.output
+
+    def test_status_plugins_not_enabled(self, cli_fs_runner):
+        """
+        GIVEN the platform has plugins disabled
+        WHEN running 'ggshield plugin status'
+        THEN it shows a clean error message
+        """
+        from ggshield.core.plugin.client import PluginsNotEnabledError
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.status.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.status.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.side_effect = (
+                PluginsNotEnabledError()
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            result = cli_fs_runner.invoke(cli, ["plugin", "status"])
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "not available" in result.output.lower()
+        assert "administrator" in result.output.lower()
 
     def test_status_shows_installed_plugins(self, cli_fs_runner):
         """
@@ -180,7 +108,6 @@ class TestPluginStatus:
         THEN it shows the installed version
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -191,7 +118,6 @@ class TestPluginStatus:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         with (
@@ -239,7 +165,6 @@ class TestPluginStatus:
         THEN it shows the human-readable signature label.
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -250,7 +175,6 @@ class TestPluginStatus:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         with (
@@ -357,7 +281,6 @@ class TestPluginStatus:
         THEN it shows the plugin as disabled
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -368,7 +291,6 @@ class TestPluginStatus:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         with (
@@ -416,7 +338,6 @@ class TestPluginStatus:
         THEN it shows the plugin as not available
         """
         mock_catalog = PluginCatalog(
-            plan="Free",
             plugins=[
                 PluginInfo(
                     name="premium",
@@ -427,7 +348,6 @@ class TestPluginStatus:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         with (

--- a/tests/unit/cmd/plugin/test_update.py
+++ b/tests/unit/cmd/plugin/test_update.py
@@ -2,14 +2,19 @@
 Tests for the enterprise update command.
 """
 
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
-from ggshield.core.plugin.client import PluginCatalog, PluginDownloadInfo, PluginInfo
+from ggshield.core.plugin.client import (
+    PluginCatalog,
+    PluginDownloadInfo,
+    PluginInfo,
+    PluginSourceType,
+)
 from ggshield.core.plugin.loader import DiscoveredPlugin
-from ggshield.core.plugin.signature import SignatureVerificationMode
 
 
 class TestPluginUpdate:
@@ -33,7 +38,6 @@ class TestPluginUpdate:
         THEN it shows the available update
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -44,7 +48,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -109,7 +112,6 @@ class TestPluginUpdate:
         THEN it shows everything is up to date
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -120,7 +122,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -183,7 +184,6 @@ class TestPluginUpdate:
         THEN the plugin is updated
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -194,7 +194,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -208,13 +207,16 @@ class TestPluginUpdate:
             ),
         ]
 
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-2.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-2.0.0-py3-none-any.whl",
             sha256="abc123",
             version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
 
         with (
             mock.patch(
@@ -236,7 +238,7 @@ class TestPluginUpdate:
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_config = mock.MagicMock()
@@ -263,6 +265,9 @@ class TestPluginUpdate:
         assert "Updated tokenscanner to v2.0.0" in result.output
         mock_downloader.download_and_install.assert_called_once()
         mock_config.save.assert_called_once()
+        mock_plugin_api_client.report_installation.assert_called_once_with(
+            "tokenscanner", "2.0.0", mock.ANY, mock.ANY
+        )
 
     def test_update_not_installed(self, cli_fs_runner):
         """
@@ -271,9 +276,7 @@ class TestPluginUpdate:
         THEN it shows an error
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[],
-            features={},
         )
 
         with (
@@ -314,7 +317,6 @@ class TestPluginUpdate:
         THEN all plugins are updated
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="plugin1",
@@ -333,7 +335,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -355,20 +356,23 @@ class TestPluginUpdate:
             ),
         ]
 
-        mock_download_info_1 = PluginDownloadInfo(
-            download_url="https://example.com/plugin1.whl",
-            filename="plugin1-2.0.0.whl",
-            sha256="abc123",
+        mock_info_1 = PluginDownloadInfo(
+            filename="plugin1-2.0.0-py3-none-any.whl",
+            sha256="hash1",
             version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
-        mock_download_info_2 = PluginDownloadInfo(
-            download_url="https://example.com/plugin2.whl",
-            filename="plugin2-3.0.0.whl",
-            sha256="def456",
+        mock_info_2 = PluginDownloadInfo(
+            filename="plugin2-3.0.0-py3-none-any.whl",
+            sha256="hash2",
             version="3.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=200,
         )
+        _infos = iter([mock_info_1, mock_info_2])
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield next(_infos), iter([b""])
 
         with (
             mock.patch(
@@ -390,10 +394,7 @@ class TestPluginUpdate:
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.side_effect = [
-                mock_download_info_1,
-                mock_download_info_2,
-            ]
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_config = mock.MagicMock()
@@ -419,6 +420,13 @@ class TestPluginUpdate:
         assert "Updating plugin2" in result.output
         assert "2 plugins updated successfully" in result.output
         assert mock_downloader.download_and_install.call_count == 2
+        assert mock_plugin_api_client.report_installation.call_count == 2
+        mock_plugin_api_client.report_installation.assert_any_call(
+            "plugin1", "2.0.0", mock.ANY, mock.ANY
+        )
+        mock_plugin_api_client.report_installation.assert_any_call(
+            "plugin2", "3.0.0", mock.ANY, mock.ANY
+        )
 
     def test_update_api_error(self, cli_fs_runner):
         """
@@ -543,9 +551,7 @@ class TestPluginUpdate:
         THEN it shows a message about no plugins
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[],
-            features={},
         )
 
         with (
@@ -590,7 +596,6 @@ class TestPluginUpdate:
         THEN it shows the plugin is up to date
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -601,7 +606,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -658,7 +662,6 @@ class TestPluginUpdate:
         THEN it does NOT show an update (no downgrade)
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -669,7 +672,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -735,7 +737,6 @@ class TestPluginUpdate:
         from ggshield.core.plugin.downloader import DownloadError
 
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -746,7 +747,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -760,13 +760,16 @@ class TestPluginUpdate:
             ),
         ]
 
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-2.0.0.whl",
+        mock_info = PluginDownloadInfo(
+            filename="tokenscanner-2.0.0-py3-none-any.whl",
             sha256="abc123",
             version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
+            size_bytes=100,
         )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
 
         with (
             mock.patch(
@@ -788,7 +791,7 @@ class TestPluginUpdate:
 
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_config = mock.MagicMock()
@@ -819,7 +822,6 @@ class TestPluginUpdate:
         from ggshield.core.plugin.client import PluginNotAvailableError
 
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -830,7 +832,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -862,11 +863,14 @@ class TestPluginUpdate:
             mock_client = mock.MagicMock()
             mock_create_client.return_value = mock_client
 
+            @contextmanager
+            def fake_download_plugin_raises(*args, **kwargs):
+                raise PluginNotAvailableError("tokenscanner", "Upgrade required")
+                yield  # make it a generator
+
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.side_effect = (
-                PluginNotAvailableError("tokenscanner", "Upgrade required")
-            )
+            mock_plugin_api_client.download_plugin = fake_download_plugin_raises
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_config = mock.MagicMock()
@@ -892,7 +896,6 @@ class TestPluginUpdate:
         THEN it shows an error
         """
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[
                 PluginInfo(
                     name="tokenscanner",
@@ -903,7 +906,6 @@ class TestPluginUpdate:
                     reason=None,
                 ),
             ],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -916,14 +918,6 @@ class TestPluginUpdate:
                 version="1.0.0",
             ),
         ]
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-2.0.0.whl",
-            sha256="abc123",
-            version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
-        )
 
         with (
             mock.patch(
@@ -943,9 +937,20 @@ class TestPluginUpdate:
             mock_client = mock.MagicMock()
             mock_create_client.return_value = mock_client
 
+            mock_info = PluginDownloadInfo(
+                filename="tokenscanner-2.0.0-py3-none-any.whl",
+                sha256="abc123",
+                version="2.0.0",
+                size_bytes=100,
+            )
+
+            @contextmanager
+            def fake_download_plugin(*args, **kwargs):
+                yield mock_info, iter([b""])
+
             mock_plugin_api_client = mock.MagicMock()
             mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
+            mock_plugin_api_client.download_plugin = fake_download_plugin
             mock_plugin_api_client_class.return_value = mock_plugin_api_client
 
             mock_config = mock.MagicMock()
@@ -1025,9 +1030,7 @@ class TestPluginUpdate:
         from ggshield.core.plugin.client import PluginSource, PluginSourceType
 
         mock_catalog = PluginCatalog(
-            plan="Enterprise",
             plugins=[],
-            features={},
         )
 
         mock_discovered_plugins = [
@@ -1088,189 +1091,25 @@ class TestPluginUpdate:
         assert result.exit_code == ExitCode.SUCCESS
         assert "Cannot Auto-Update" in result.output
         assert "localplugin" in result.output
-        assert "local_file" in result.output
+        # Humanised label, matching `ggshield plugin list`.
+        assert "local file" in result.output
+        assert "local_file" not in result.output
 
-    def test_update_default_signature_mode_is_strict(self, cli_fs_runner):
+    def test_update_all_lists_non_updatable_when_nothing_to_update(self, cli_fs_runner):
         """
-        GIVEN no --allow-unsigned flag
-        WHEN running 'ggshield plugin update <plugin>'
-        THEN download_and_install is called with signature_mode=STRICT
-        """
-        mock_catalog = PluginCatalog(
-            plan="Enterprise",
-            plugins=[
-                PluginInfo(
-                    name="tokenscanner",
-                    display_name="Token Scanner",
-                    description="Local secret scanning",
-                    available=True,
-                    latest_version="2.0.0",
-                    reason=None,
-                ),
-            ],
-            features={},
-        )
-
-        mock_discovered_plugins = [
-            DiscoveredPlugin(
-                name="tokenscanner",
-                entry_point=None,
-                wheel_path=Path("/path/to/wheel"),
-                is_installed=True,
-                is_enabled=True,
-                version="1.0.0",
-            ),
-        ]
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-2.0.0.whl",
-            sha256="abc123",
-            version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
-        )
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.update.create_client_from_config"
-            ) as mock_create_client,
-            mock.patch(
-                "ggshield.cmd.plugin.update.PluginAPIClient"
-            ) as mock_plugin_api_client_class,
-            mock.patch(
-                "ggshield.cmd.plugin.update.EnterpriseConfig"
-            ) as mock_config_class,
-            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.update.PluginDownloader"
-            ) as mock_downloader_class,
-        ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
-
-            mock_plugin_api_client = mock.MagicMock()
-            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
-            mock_plugin_api_client_class.return_value = mock_plugin_api_client
-
-            mock_config_class.load.return_value = mock.MagicMock()
-
-            mock_loader = mock.MagicMock()
-            mock_loader.discover_plugins.return_value = mock_discovered_plugins
-            mock_loader_class.return_value = mock_loader
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.get_plugin_source.return_value = None
-            mock_downloader_class.return_value = mock_downloader
-
-            result = cli_fs_runner.invoke(
-                cli,
-                ["plugin", "update", "tokenscanner"],
-                catch_exceptions=False,
-            )
-
-        assert result.exit_code == ExitCode.SUCCESS
-        mock_downloader.download_and_install.assert_called_once()
-        call_kwargs = mock_downloader.download_and_install.call_args
-        assert call_kwargs.kwargs["signature_mode"] == SignatureVerificationMode.STRICT
-
-    def test_update_allow_unsigned_overrides_to_warn(self, cli_fs_runner):
-        """
-        GIVEN --allow-unsigned
-        WHEN running 'ggshield plugin update --allow-unsigned <plugin>'
-        THEN download_and_install is called with signature_mode=WARN
-        """
-        mock_catalog = PluginCatalog(
-            plan="Enterprise",
-            plugins=[
-                PluginInfo(
-                    name="tokenscanner",
-                    display_name="Token Scanner",
-                    description="Local secret scanning",
-                    available=True,
-                    latest_version="2.0.0",
-                    reason=None,
-                ),
-            ],
-            features={},
-        )
-
-        mock_discovered_plugins = [
-            DiscoveredPlugin(
-                name="tokenscanner",
-                entry_point=None,
-                wheel_path=Path("/path/to/wheel"),
-                is_installed=True,
-                is_enabled=True,
-                version="1.0.0",
-            ),
-        ]
-
-        mock_download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="tokenscanner-2.0.0.whl",
-            sha256="abc123",
-            version="2.0.0",
-            expires_at="2099-12-31T23:59:59Z",
-        )
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.update.create_client_from_config"
-            ) as mock_create_client,
-            mock.patch(
-                "ggshield.cmd.plugin.update.PluginAPIClient"
-            ) as mock_plugin_api_client_class,
-            mock.patch(
-                "ggshield.cmd.plugin.update.EnterpriseConfig"
-            ) as mock_config_class,
-            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.update.PluginDownloader"
-            ) as mock_downloader_class,
-        ):
-            mock_client = mock.MagicMock()
-            mock_create_client.return_value = mock_client
-
-            mock_plugin_api_client = mock.MagicMock()
-            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
-            mock_plugin_api_client.get_download_info.return_value = mock_download_info
-            mock_plugin_api_client_class.return_value = mock_plugin_api_client
-
-            mock_config_class.load.return_value = mock.MagicMock()
-
-            mock_loader = mock.MagicMock()
-            mock_loader.discover_plugins.return_value = mock_discovered_plugins
-            mock_loader_class.return_value = mock_loader
-
-            mock_downloader = mock.MagicMock()
-            mock_downloader.get_plugin_source.return_value = None
-            mock_downloader_class.return_value = mock_downloader
-
-            result = cli_fs_runner.invoke(
-                cli,
-                ["plugin", "update", "--allow-unsigned", "tokenscanner"],
-                catch_exceptions=False,
-            )
-
-        assert result.exit_code == ExitCode.SUCCESS
-        mock_downloader.download_and_install.assert_called_once()
-        call_kwargs = mock_downloader.download_and_install.call_args
-        assert call_kwargs.kwargs["signature_mode"] == SignatureVerificationMode.WARN
-
-    def test_update_github_release_default_signature_mode_is_strict(
-        self, cli_fs_runner
-    ):
-        """
-        GIVEN a plugin from GitHub release with an update available
-        WHEN running 'ggshield plugin update <plugin>'
-        THEN download_from_github_release is called with signature_mode=STRICT
+        GIVEN only non-auto-updatable plugins are installed
+        WHEN running 'ggshield plugin update --all'
+        THEN the 'Cannot Auto-Update' footer still appears so the user
+             learns which plugins they need to reinstall manually,
+             instead of an opaque 'All updatable plugins are already up
+             to date' that hides the local-file installs.
         """
         from ggshield.core.plugin.client import PluginSource, PluginSourceType
 
+        mock_catalog = PluginCatalog(plugins=[])
         mock_discovered_plugins = [
             DiscoveredPlugin(
-                name="ghplugin",
+                name="localplugin",
                 entry_point=None,
                 wheel_path=Path("/path/to/wheel"),
                 is_installed=True,
@@ -1278,23 +1117,18 @@ class TestPluginUpdate:
                 version="1.0.0",
             ),
         ]
-
         mock_source = PluginSource(
-            type=PluginSourceType.GITHUB_RELEASE,
-            github_repo="owner/repo",
+            type=PluginSourceType.LOCAL_FILE,
+            local_path="/path/to/local.whl",
         )
 
-        mock_release = {
-            "tag_name": "v2.0.0",
-            "assets": [
-                {
-                    "name": "ghplugin-2.0.0-py3-none-any.whl",
-                    "browser_download_url": "https://github.com/owner/repo/releases/download/v2.0.0/ghplugin.whl",
-                },
-            ],
-        }
-
         with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
             mock.patch(
                 "ggshield.cmd.plugin.update.EnterpriseConfig"
             ) as mock_config_class,
@@ -1302,15 +1136,13 @@ class TestPluginUpdate:
             mock.patch(
                 "ggshield.cmd.plugin.update.PluginDownloader"
             ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.update._check_github_release_update",
-                return_value=mock_release,
-            ),
-            mock.patch(
-                "ggshield.cmd.plugin.update._find_wheel_asset",
-                return_value="https://github.com/owner/repo/releases/download/v2.0.0/ghplugin.whl",
-            ),
         ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
             mock_config_class.load.return_value = mock.MagicMock()
 
             mock_loader = mock.MagicMock()
@@ -1323,14 +1155,171 @@ class TestPluginUpdate:
 
             result = cli_fs_runner.invoke(
                 cli,
-                ["plugin", "update", "ghplugin"],
+                ["plugin", "update", "--all"],
                 catch_exceptions=False,
             )
 
         assert result.exit_code == ExitCode.SUCCESS
-        mock_downloader.download_from_github_release.assert_called_once()
-        call_kwargs = mock_downloader.download_from_github_release.call_args
-        assert call_kwargs.kwargs["signature_mode"] == SignatureVerificationMode.STRICT
+        assert "Cannot Auto-Update" in result.output
+        assert "localplugin" in result.output
+        assert "local file" in result.output
+
+    def test_update_plugins_not_enabled_exits_cleanly(self, cli_fs_runner):
+        """
+        GIVEN the platform has plugins disabled
+        WHEN running 'ggshield plugin update --all'
+        THEN it exits with a clean error (not a stack trace)
+        """
+        from ggshield.core.plugin.client import PluginsNotEnabledError
+
+        mock_discovered_plugins = [
+            DiscoveredPlugin(
+                name="tokenscanner",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.side_effect = (
+                PluginsNotEnabledError()
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config_class.load.return_value = mock.MagicMock()
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered_plugins
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.return_value = None
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(cli, ["plugin", "update", "--all"])
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "not available" in result.output.lower()
+        assert "administrator" in result.output.lower()
+
+    def test_update_catalog_failure_does_not_abort_github_release_check(
+        self, cli_fs_runner
+    ):
+        """
+        GIVEN one platform plugin and one github_release plugin installed,
+              and the GitGuardian catalog fetch fails
+        WHEN running 'ggshield plugin update --check'
+        THEN the github_release plugin is still checked for updates and the
+             command exits cleanly, instead of the platform-side failure
+             killing the whole invocation.
+        """
+        from ggshield.core.plugin.client import (
+            PluginAPIError,
+            PluginSource,
+            PluginSourceType,
+        )
+
+        mock_discovered_plugins = [
+            DiscoveredPlugin(
+                name="tokenscanner",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+            DiscoveredPlugin(
+                name="ghplugin",
+                entry_point=None,
+                wheel_path=Path("/path/to/gh.whl"),
+                is_installed=True,
+                is_enabled=True,
+                version="0.5.0",
+            ),
+        ]
+
+        def fake_get_plugin_source(name):
+            if name == "ghplugin":
+                return PluginSource(
+                    type=PluginSourceType.GITHUB_RELEASE,
+                    github_repo="owner/ghplugin",
+                )
+            return None
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update._check_github_release_update",
+                return_value={
+                    "tag_name": "v0.6.0",
+                    "assets": [
+                        {
+                            "name": "ghplugin-0.6.0-py3-none-any.whl",
+                            "browser_download_url": "https://example.com/gh.whl",
+                        }
+                    ],
+                },
+            ),
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.side_effect = PluginAPIError(
+                "catalog down"
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config_class.load.return_value = mock.MagicMock()
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered_plugins
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.side_effect = fake_get_plugin_source
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(cli, ["plugin", "update", "--check"])
+
+        assert result.exit_code == ExitCode.SUCCESS
+        # Catalog failure surfaced as a warning, not a fatal error
+        assert "catalog down" in result.output
+        assert "Skipping GitGuardian-hosted plugin updates" in result.output
+        # github_release plugin still produced an update entry
+        assert "ghplugin" in result.output
+        assert "0.5.0" in result.output and "0.6.0" in result.output
 
 
 class TestUpdateHelperFunctions:
@@ -1425,3 +1414,391 @@ class TestUpdateHelperFunctions:
         result = _find_wheel_asset(release)
 
         assert result is None
+
+
+class TestUpdateUsesEntryPointConfigKey:
+    """Regression for the round-3 follow-up: the update flow used to
+    write ``enable_plugin(name, ...)`` directly, where ``name`` is the
+    discover_plugins key (entry-point name when the wheel declares one,
+    distribution name otherwise). When the catalog reference / loader key
+    matched the entry-point name this was incidentally correct; when the
+    update went through the GITHUB_RELEASE branch (where ``name`` could
+    diverge from the wheel's actual entry-point name), the row written
+    to enterprise_config drifted away from the loader's lookup key and
+    the plugin was silently disabled after the upgrade.
+    """
+
+    def test_platform_update_keys_config_on_entry_point(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN an installed plugin whose catalog reference happens to
+            match the loader's discovered name (the common case for
+            satori-python where reference == entry-point name)
+            AND ``download_and_install`` writes a wheel whose embedded
+            entry-point name happens to match
+        WHEN the update flow completes
+        THEN ``enable_plugin`` is called with the entry-point name
+            extracted from the installed wheel — proving the wiring
+            goes through ``resolve_config_key`` rather than passing
+            ``name`` straight through.
+        """
+        import zipfile
+
+        installed_wheel = tmp_path / "satori_python-2.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(installed_wheel, "w") as zf:
+            zf.writestr(
+                "satori_python-2.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmachine_scan = satori_python.plugin:Plugin\n",
+            )
+
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="machine_scan",
+                    display_name="Machine Scan",
+                    description="",
+                    available=True,
+                    latest_version="2.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_discovered = [
+            DiscoveredPlugin(
+                name="machine_scan",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+        mock_info = PluginDownloadInfo(
+            filename="satori_python-2.0.0-py3-none-any.whl",
+            sha256="a" * 64,
+            version="2.0.0",
+            size_bytes=10,
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.return_value = None
+            # ``download_and_install`` returns the installed wheel path;
+            # this is what ``resolve_config_key`` reads the entry point
+            # from. Point it at a real wheel on disk with the divergent
+            # entry-point name.
+            mock_downloader.download_and_install.return_value = installed_wheel
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "update", "machine_scan"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        mock_config.enable_plugin.assert_called_once_with(
+            "machine_scan", version="2.0.0"
+        )
+
+    def test_github_release_update_keys_config_on_entry_point(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a plugin previously installed from a github_release and
+            its loader key (``ghplugin``) differs from the entry-point
+            name that the freshly downloaded wheel declares
+            (``new_entry_point``)
+        WHEN ``plugin update`` runs through the GITHUB_RELEASE branch
+        THEN ``enable_plugin`` is called with the wheel's entry-point
+            name — not with the loader key — so the row written matches
+            what discover_plugins will look up after the upgrade.
+        """
+        import zipfile
+
+        from ggshield.core.plugin.client import PluginSource
+
+        installed_wheel = tmp_path / "ghplugin-2.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(installed_wheel, "w") as zf:
+            zf.writestr(
+                "ghplugin-2.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nnew_entry_point = ghplugin.plugin:Plugin\n",
+            )
+
+        mock_discovered = [
+            DiscoveredPlugin(
+                name="ghplugin",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+
+        with (
+            mock.patch("ggshield.cmd.plugin.update.create_client_from_config"),
+            mock.patch("ggshield.cmd.plugin.update.PluginAPIClient"),
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update._check_github_release_update",
+                return_value={
+                    "tag_name": "v2.0.0",
+                    "assets": [
+                        {
+                            "name": "ghplugin-2.0.0-py3-none-any.whl",
+                            "browser_download_url": (
+                                "https://github.com/owner/repo/releases/download/"
+                                "v2.0.0/ghplugin-2.0.0-py3-none-any.whl"
+                            ),
+                        }
+                    ],
+                },
+            ),
+        ):
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.return_value = PluginSource(
+                type=PluginSourceType.GITHUB_RELEASE,
+                url="https://github.com/owner/repo/releases/download/v1.0.0/p.whl",
+                github_repo="owner/repo",
+            )
+            # Downloader returns the freshly installed wheel path; the
+            # update flow MUST read its entry-point name (rather than
+            # passing the loader key straight through).
+            mock_downloader.download_from_github_release.return_value = (
+                "ghplugin",
+                "2.0.0",
+                installed_wheel,
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "update", "ghplugin"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        # The point of the regression: ``enable_plugin`` must use the
+        # wheel's entry-point name (``new_entry_point``), NOT the loader
+        # key (``ghplugin``). If this assertion sees ``ghplugin``, the
+        # update path regressed back to passing ``name`` through verbatim
+        # and the plugin would be silently disabled after the upgrade.
+        mock_config.enable_plugin.assert_called_once_with(
+            "new_entry_point", version="2.0.0"
+        )
+
+
+class TestUpdateCheckSkippedPlatform:
+    """Regression for: when the catalog fetch fails and we degrade to
+    github-only checks, the empty-results message must not pretend all
+    plugins are up to date — platform plugins were never actually checked.
+    """
+
+    def test_check_acknowledges_skipped_platform(self, cli_fs_runner) -> None:
+        """
+        GIVEN one platform plugin and one github_release plugin, with a
+            failing catalog fetch that degrades to github-only checks,
+            and no GitHub-side updates available
+        WHEN running ``ggshield plugin update --check``
+        THEN the output explicitly says GitGuardian-hosted plugins were
+            skipped instead of claiming everything is up to date.
+        """
+        from ggshield.core.plugin.client import (
+            PluginAPIError,
+            PluginSource,
+            PluginSourceType,
+        )
+
+        mock_discovered_plugins = [
+            DiscoveredPlugin(
+                name="machine_scan",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+            DiscoveredPlugin(
+                name="ghplugin",
+                entry_point=None,
+                wheel_path=Path("/path/to/gh-wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+
+        def fake_get_plugin_source(name: str):
+            if name == "ghplugin":
+                return PluginSource(
+                    type=PluginSourceType.GITHUB_RELEASE,
+                    url="https://github.com/owner/repo/releases/download/v1.0.0/p.whl",
+                    github_repo="owner/repo",
+                )
+            # Platform plugin (no explicit source recorded)
+            return None
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update._check_github_release_update",
+                return_value=None,
+            ),
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.side_effect = PluginAPIError(
+                "catalog fetch failed"
+            )
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config_class.load.return_value = mock.MagicMock()
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered_plugins
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.side_effect = fake_get_plugin_source
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "update", "--check"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Skipping GitGuardian-hosted plugin updates" in result.output
+        assert "GitGuardian-hosted plugins were skipped" in result.output
+        # And we must NOT lie about state we didn't actually verify.
+        assert "All updatable plugins are up to date." not in result.output
+
+    def test_check_says_up_to_date_when_platform_actually_checked(
+        self, cli_fs_runner
+    ) -> None:
+        """Counter-test: when the catalog fetch succeeds and confirms no
+        updates, the message keeps the original wording so users with
+        healthy backends still get the familiar terse output."""
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="machine_scan",
+                    display_name="Machine Scan",
+                    description="",
+                    available=True,
+                    latest_version="1.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        mock_discovered_plugins = [
+            DiscoveredPlugin(
+                name="machine_scan",
+                entry_point=None,
+                wheel_path=Path("/path/to/wheel"),
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.update.create_client_from_config"
+            ) as mock_create_client,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+        ):
+            mock_create_client.return_value = mock.MagicMock()
+
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config_class.load.return_value = mock.MagicMock()
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered_plugins
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.return_value = None
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "update", "--check"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "All updatable plugins are up to date." in result.output
+        assert "skipped" not in result.output

--- a/tests/unit/core/plugin/test_client.py
+++ b/tests/unit/core/plugin/test_client.py
@@ -9,55 +9,23 @@ from ggshield.core.plugin.client import (
     PluginAPIClient,
     PluginAPIError,
     PluginCatalog,
-    PluginDownloadInfo,
-    PluginInfo,
     PluginNotAvailableError,
+    PluginsNotEnabledError,
+    PluginSourceType,
 )
 from ggshield.core.plugin.platform import PlatformInfo
 
 
-class TestPluginInfo:
-    """Tests for PluginInfo dataclass."""
+class TestPluginSourceType:
+    """Tests for PluginSourceType enum."""
 
-    def test_is_platform_supported_no_restrictions(self) -> None:
-        """Test platform support with no restrictions."""
-        info = PluginInfo(
-            name="test",
-            display_name="Test",
-            description="Test plugin",
-            available=True,
-            latest_version="1.0.0",
-            supported_platforms=[],
-        )
-        assert info.is_platform_supported("linux", "x86_64") is True
-        assert info.is_platform_supported("macosx", "arm64") is True
+    def test_platform_value(self) -> None:
+        """PLATFORM enum has value 'platform'."""
+        assert PluginSourceType.PLATFORM.value == "platform"
 
-    def test_is_platform_supported_exact_match(self) -> None:
-        """Test platform support with exact match."""
-        info = PluginInfo(
-            name="test",
-            display_name="Test",
-            description="Test plugin",
-            available=True,
-            latest_version="1.0.0",
-            supported_platforms=["linux-x86_64", "macosx-arm64"],
-        )
-        assert info.is_platform_supported("linux", "x86_64") is True
-        assert info.is_platform_supported("macosx", "arm64") is True
-        assert info.is_platform_supported("win", "amd64") is False
-
-    def test_is_platform_supported_any_any(self) -> None:
-        """Test platform support with any-any wildcard."""
-        info = PluginInfo(
-            name="test",
-            display_name="Test",
-            description="Test plugin",
-            available=True,
-            latest_version="1.0.0",
-            supported_platforms=["any-any"],
-        )
-        assert info.is_platform_supported("linux", "x86_64") is True
-        assert info.is_platform_supported("win", "amd64") is True
+    def test_backward_compat_gitguardian_api(self) -> None:
+        """Legacy manifest value 'gitguardian_api' maps to PLATFORM."""
+        assert PluginSourceType("gitguardian_api") == PluginSourceType.PLATFORM
 
 
 class TestPluginNotAvailableError:
@@ -103,35 +71,33 @@ class TestPluginAPIClient:
     def test_get_available_plugins_success(
         self, mock_platform: MagicMock, mock_gg_client: MagicMock
     ) -> None:
-        """Test successful plugin list fetch."""
+        """Test successful plugin list fetch returns PluginCatalog with plugins."""
         mock_platform.return_value = PlatformInfo(
             os="linux", arch="x86_64", python_abi="cp311"
         )
 
         mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "plan": "enterprise",
-            "features": {"local_scanning": True},
-            "plugins": [
-                {
-                    "name": "tokenscanner",
-                    "display_name": "Token Scanner",
-                    "description": "Local scanning",
-                    "available": True,
-                    "latest_version": "1.0.0",
-                }
-            ],
-        }
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "reference": "tokenscanner",
+                "display_name": "Token Scanner",
+                "description": "Local scanning",
+                "available": True,
+                "reason": None,
+                "releases": [{"version": "1.0.0"}],
+            }
+        ]
+        mock_response.__enter__.return_value = mock_response
         mock_gg_client.session.get.return_value = mock_response
 
         client = PluginAPIClient(mock_gg_client)
         catalog = client.get_available_plugins()
 
         assert isinstance(catalog, PluginCatalog)
-        assert catalog.plan == "enterprise"
-        assert catalog.features == {"local_scanning": True}
         assert len(catalog.plugins) == 1
         assert catalog.plugins[0].name == "tokenscanner"
+        assert catalog.plugins[0].latest_version == "1.0.0"
 
     @patch("ggshield.core.plugin.client.get_platform_info")
     def test_get_available_plugins_request_error(
@@ -154,163 +120,733 @@ class TestPluginAPIClient:
         assert "Failed to fetch plugins" in str(exc_info.value)
 
     @patch("ggshield.core.plugin.client.get_platform_info")
-    def test_get_download_info_success(
+    def test_get_available_plugins_new_endpoint(
         self, mock_platform: MagicMock, mock_gg_client: MagicMock
     ) -> None:
-        """Test successful download info fetch."""
+        """get_available_plugins calls /v1/endpoints/plugins and parses the list."""
         mock_platform.return_value = PlatformInfo(
             os="linux", arch="x86_64", python_abi="cp311"
         )
-
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "download_url": "https://example.com/plugin.whl",
-            "filename": "plugin-1.0.0.whl",
-            "sha256": "abc123",
-            "version": "1.0.0",
-            "expires_at": "2025-01-01T00:00:00Z",
-        }
+        mock_response.json.return_value = [
+            {
+                "reference": "tokenscanner",
+                "display_name": "Token Scanner",
+                "description": "Local scanning",
+                "available": True,
+                "reason": None,
+                "releases": [{"version": "2.0.0"}, {"version": "1.0.0"}],
+            }
+        ]
+        mock_response.__enter__.return_value = mock_response
         mock_gg_client.session.get.return_value = mock_response
 
         client = PluginAPIClient(mock_gg_client)
-        info = client.get_download_info("testplugin")
+        catalog = client.get_available_plugins()
 
-        assert isinstance(info, PluginDownloadInfo)
-        assert info.download_url == "https://example.com/plugin.whl"
-        assert info.filename == "plugin-1.0.0.whl"
-        assert info.sha256 == "abc123"
-        assert info.version == "1.0.0"
+        url_called = mock_gg_client.session.get.call_args[0][0]
+        assert "/v1/endpoints/plugins" in url_called
+        assert len(catalog.plugins) == 1
+        assert catalog.plugins[0].name == "tokenscanner"
+        assert catalog.plugins[0].latest_version == "2.0.0"
+        assert catalog.plugins[0].available is True
 
     @patch("ggshield.core.plugin.client.get_platform_info")
-    def test_get_download_info_with_version(
+    def test_get_available_plugins_malformed_row_raises_plugin_api_error(
         self, mock_platform: MagicMock, mock_gg_client: MagicMock
     ) -> None:
-        """Test download info fetch with specific version."""
+        """A catalog row missing ``reference`` surfaces as PluginAPIError.
+
+        Regression: the bare ``p["reference"]`` would raise ``KeyError`` past
+        the surrounding ``except RequestException``, leaking a raw traceback
+        instead of a typed error the caller can handle.
+        """
         mock_platform.return_value = PlatformInfo(
             os="linux", arch="x86_64", python_abi="cp311"
         )
-
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "download_url": "https://example.com/plugin.whl",
-            "filename": "plugin-0.9.0.whl",
-            "sha256": "def456",
-            "version": "0.9.0",
-            "expires_at": "2025-01-01T00:00:00Z",
-        }
+        # Missing "reference" — KeyError if parser is bare.
+        mock_response.json.return_value = [{"display_name": "no-ref"}]
+        mock_response.__enter__.return_value = mock_response
         mock_gg_client.session.get.return_value = mock_response
 
         client = PluginAPIClient(mock_gg_client)
-        info = client.get_download_info("testplugin", version="0.9.0")
+        with pytest.raises(PluginAPIError) as exc_info:
+            client.get_available_plugins()
 
-        assert info.version == "0.9.0"
-        mock_gg_client.session.get.assert_called_once()
-        call_kwargs = mock_gg_client.session.get.call_args[1]
-        assert call_kwargs["params"]["version"] == "0.9.0"
+        assert "Malformed plugin catalog response" in str(exc_info.value)
 
     @patch("ggshield.core.plugin.client.get_platform_info")
-    def test_get_download_info_forbidden(
+    def test_get_available_plugins_non_json_body_raises_plugin_api_error(
         self, mock_platform: MagicMock, mock_gg_client: MagicMock
     ) -> None:
-        """Test download info with 403 response."""
+        """A non-JSON body raises PluginAPIError (not a bare ValueError)."""
         mock_platform.return_value = PlatformInfo(
             os="linux", arch="x86_64", python_abi="cp311"
         )
-
         mock_response = MagicMock()
-        mock_response.status_code = 403
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Expecting value")
+        mock_response.__enter__.return_value = mock_response
         mock_gg_client.session.get.return_value = mock_response
 
         client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError) as exc_info:
+            client.get_available_plugins()
 
-        with pytest.raises(PluginNotAvailableError) as exc_info:
-            client.get_download_info("testplugin")
-
-        assert exc_info.value.plugin_name == "testplugin"
+        assert "Malformed plugin catalog response" in str(exc_info.value)
 
     @patch("ggshield.core.plugin.client.get_platform_info")
-    def test_get_download_info_not_found(
+    def test_get_available_plugins_raises_plugins_not_enabled_on_404(
         self, mock_platform: MagicMock, mock_gg_client: MagicMock
     ) -> None:
-        """Test download info with 404 response."""
+        """get_available_plugins raises PluginsNotEnabledError on 404."""
         mock_platform.return_value = PlatformInfo(
             os="linux", arch="x86_64", python_abi="cp311"
         )
-
         mock_response = MagicMock()
         mock_response.status_code = 404
+        mock_response.__enter__.return_value = mock_response
         mock_gg_client.session.get.return_value = mock_response
 
         client = PluginAPIClient(mock_gg_client)
 
+        with pytest.raises(PluginsNotEnabledError):
+            client.get_available_plugins()
+
+    @patch("ggshield.core.plugin.client.get_platform_info")
+    def test_download_plugin_yields_info_and_chunks(
+        self, mock_platform: MagicMock, mock_gg_client: MagicMock
+    ) -> None:
+        """download_plugin yields PluginDownloadInfo and chunk iterator."""
+        mock_platform.return_value = PlatformInfo(
+            os="linux", arch="x86_64", python_abi="cp311"
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "Content-Disposition": 'attachment; filename="tokenscanner-1.0.0.whl"',
+            "X-Plugin-SHA256": "abc123def456",
+            "X-Plugin-Version": "1.0.0",
+            "Content-Length": "12345",
+        }
+        mock_response.iter_content.return_value = iter([b"chunk1", b"chunk2"])
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
+        client = PluginAPIClient(mock_gg_client)
+        with client.download_plugin("tokenscanner") as (info, chunks):
+            assert info.filename == "tokenscanner-1.0.0.whl"
+            assert info.sha256 == "abc123def456"
+            assert info.version == "1.0.0"
+            assert info.size_bytes == 12345
+            data = list(chunks)
+
+        assert data == [b"chunk1", b"chunk2"]
+        mock_response.close.assert_called_once()
+
+    @patch("ggshield.core.plugin.client.get_platform_info")
+    def test_download_plugin_raises_on_403(
+        self, mock_platform: MagicMock, mock_gg_client: MagicMock
+    ) -> None:
+        """download_plugin raises PluginNotAvailableError on 403."""
+        mock_platform.return_value = PlatformInfo(
+            os="linux", arch="x86_64", python_abi="cp311"
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
+        client = PluginAPIClient(mock_gg_client)
         with pytest.raises(PluginNotAvailableError) as exc_info:
-            client.get_download_info("testplugin")
+            with client.download_plugin("tokenscanner"):
+                pass
+
+        assert exc_info.value.plugin_name == "tokenscanner"
+        mock_response.close.assert_called_once()
+
+    @patch("ggshield.core.plugin.client.get_platform_info")
+    def test_download_plugin_raises_on_404(
+        self, mock_platform: MagicMock, mock_gg_client: MagicMock
+    ) -> None:
+        """download_plugin raises PluginNotAvailableError on 404."""
+        mock_platform.return_value = PlatformInfo(
+            os="linux", arch="x86_64", python_abi="cp311"
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginNotAvailableError) as exc_info:
+            with client.download_plugin("tokenscanner"):
+                pass
 
         assert "not found" in exc_info.value.reason.lower()
+        mock_response.close.assert_called_once()
 
-    def test_is_plugin_available_explicit_false(
+    @patch("ggshield.core.plugin.client.get_platform_info")
+    def test_download_plugin_closes_response_on_mid_stream_error(
+        self, mock_platform: MagicMock, mock_gg_client: MagicMock
+    ) -> None:
+        """download_plugin closes the response even when caller raises inside the with block."""
+        mock_platform.return_value = PlatformInfo(
+            os="linux", arch="x86_64", python_abi="cp311"
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "Content-Disposition": 'attachment; filename="tokenscanner-1.0.0.whl"',
+            "X-Plugin-SHA256": "abc123",
+            "X-Plugin-Version": "1.0.0",
+            "Content-Length": "100",
+        }
+        mock_response.iter_content.return_value = iter([b"data"])
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(RuntimeError):
+            with client.download_plugin("tokenscanner"):
+                raise RuntimeError("mid-stream failure")
+
+        mock_response.close.assert_called_once()
+
+    def test_report_installation_posts_correct_body(
         self, mock_gg_client: MagicMock
     ) -> None:
-        """Test _is_plugin_available with explicit available=false."""
-        client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"available": False}
-        assert client._is_plugin_available(plugin_data, "linux-x86_64") is False
+        """report_installation POSTs to /installed with version, platform, arch."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_gg_client.session.post.return_value = mock_response
 
-    def test_is_plugin_available_no_platform_restrictions(
+        client = PluginAPIClient(mock_gg_client)
+        client.report_installation("tokenscanner", "1.0.0", "linux", "x86_64")
+
+        mock_gg_client.session.post.assert_called_once()
+        call_args = mock_gg_client.session.post.call_args
+        url = call_args[0][0]
+        body = call_args[1]["json"]
+        assert "/endpoints/plugins/tokenscanner/installed" in url
+        assert body == {"version": "1.0.0", "platform": "linux", "arch": "x86_64"}
+
+    def test_report_installation_swallows_network_error(
         self, mock_gg_client: MagicMock
     ) -> None:
-        """Test _is_plugin_available with no platform restrictions."""
-        client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"available": True, "supported_platforms": []}
-        assert client._is_plugin_available(plugin_data, "linux-x86_64") is True
+        """report_installation does not raise when the network call fails."""
+        mock_gg_client.session.post.side_effect = Exception("network failure")
 
-    def test_is_plugin_available_platform_match(
-        self, mock_gg_client: MagicMock
-    ) -> None:
-        """Test _is_plugin_available with matching platform."""
         client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"available": True, "supported_platforms": ["linux-x86_64"]}
-        assert client._is_plugin_available(plugin_data, "linux-x86_64") is True
-        assert client._is_plugin_available(plugin_data, "win-amd64") is False
+        # Must not raise
+        client.report_installation("tokenscanner", "1.0.0", "linux", "x86_64")
 
-    def test_is_plugin_available_any_any(self, mock_gg_client: MagicMock) -> None:
-        """Test _is_plugin_available with any-any wildcard."""
-        client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"available": True, "supported_platforms": ["any-any"]}
-        assert client._is_plugin_available(plugin_data, "linux-x86_64") is True
-        assert client._is_plugin_available(plugin_data, "win-amd64") is True
 
-    def test_get_unavailable_reason_explicit(self, mock_gg_client: MagicMock) -> None:
-        """Test _get_unavailable_reason with explicit reason."""
+class TestDownloadSignatureBundle:
+    """Tests for PluginAPIClient.download_signature_bundle."""
+
+    @pytest.fixture
+    def mock_gg_client(self) -> MagicMock:
+        client = MagicMock()
+        client.base_uri = "https://api.gitguardian.com/"
+        client.api_key = "test-api-key"
+        client.session = MagicMock()
+        return client
+
+    def test_returns_bundle_bytes(self, mock_gg_client: MagicMock) -> None:
+        """A normal HTTPS bundle download returns the body bytes."""
+        body = b"sigstore bundle bytes"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.history = []
+        mock_response.url = (
+            "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        )
+        mock_response.headers = {"Content-Length": str(len(body))}
+        mock_response.iter_content.return_value = iter([body])
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
         client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"reason": "Requires enterprise plan"}
-        assert (
-            client._get_unavailable_reason(plugin_data, "linux-x86_64")
-            == "Requires enterprise plan"
+        result = client.download_signature_bundle(
+            "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
         )
 
-    def test_get_unavailable_reason_platform_mismatch(
+        assert result == body
+
+    def test_rejects_foreign_origin(self, mock_gg_client: MagicMock) -> None:
+        """A signature URL on a different origin is rejected before sending the request."""
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError, match="foreign origin"):
+            client.download_signature_bundle("https://evil.example.com/bundle.sigstore")
+        mock_gg_client.session.get.assert_not_called()
+
+    def test_rejects_oversize_bundle_via_content_length(
         self, mock_gg_client: MagicMock
     ) -> None:
-        """Test _get_unavailable_reason with platform mismatch."""
-        client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"supported_platforms": ["macosx-arm64"]}
-        reason = client._get_unavailable_reason(plugin_data, "linux-x86_64")
-        assert reason is not None
-        assert "linux-x86_64" in reason
-        assert "macosx-arm64" in reason
+        """A Content-Length above the cap is rejected before reading the body."""
+        from ggshield.core.plugin.client import MAX_BUNDLE_SIZE_BYTES
 
-    def test_get_unavailable_reason_none(self, mock_gg_client: MagicMock) -> None:
-        """Test _get_unavailable_reason returns None when available."""
-        client = PluginAPIClient(mock_gg_client)
-        plugin_data = {"supported_platforms": ["linux-x86_64"]}
-        assert client._get_unavailable_reason(plugin_data, "linux-x86_64") is None
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.history = []
+        mock_response.url = (
+            "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        )
+        mock_response.headers = {"Content-Length": str(MAX_BUNDLE_SIZE_BYTES + 1)}
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
 
-    def test_get_headers(self, mock_gg_client: MagicMock) -> None:
-        """Test _get_headers returns correct headers."""
         client = PluginAPIClient(mock_gg_client)
-        headers = client._get_headers()
-        assert headers["Authorization"] == "Token test-api-key"
-        assert headers["Content-Type"] == "application/json"
+        with pytest.raises(PluginAPIError, match="exceeds maximum"):
+            client.download_signature_bundle(
+                "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+            )
+
+    def test_rejects_oversize_streaming_body(self, mock_gg_client: MagicMock) -> None:
+        """If Content-Length lies, the streaming-read cap still kicks in."""
+        from ggshield.core.plugin.client import MAX_BUNDLE_SIZE_BYTES
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.history = []
+        mock_response.url = (
+            "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        )
+        mock_response.headers = {"Content-Length": "0"}  # lie about size
+        # Stream more bytes than the cap allows.
+        mock_response.iter_content.return_value = iter(
+            [b"x" * (MAX_BUNDLE_SIZE_BYTES + 1)]
+        )
+        mock_response.__enter__.return_value = mock_response
+        mock_gg_client.session.get.return_value = mock_response
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError, match="exceeded maximum"):
+            client.download_signature_bundle(
+                "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+            )
+
+    def test_wraps_network_error(self, mock_gg_client: MagicMock) -> None:
+        """A requests exception is re-raised as PluginAPIError."""
+        mock_gg_client.session.get.side_effect = requests.RequestException("boom")
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError, match="Failed to download signature bundle"):
+            client.download_signature_bundle(
+                "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+            )
+
+
+class TestExtractServerDetail:
+    """Tests for the ``_extract_server_detail`` helper used to surface DRF
+    error-detail strings to the user."""
+
+    def test_returns_detail_when_present(self) -> None:
+        from ggshield.core.plugin.client import _extract_server_detail
+
+        response = MagicMock()
+        response.json.return_value = {"detail": "Plugin disabled"}
+        assert _extract_server_detail(response) == "Plugin disabled"
+
+    def test_returns_none_for_non_json_body(self) -> None:
+        from ggshield.core.plugin.client import _extract_server_detail
+
+        response = MagicMock()
+        response.json.side_effect = ValueError("not json")
+        assert _extract_server_detail(response) is None
+
+    def test_returns_none_for_request_exception(self) -> None:
+        from ggshield.core.plugin.client import _extract_server_detail
+
+        response = MagicMock()
+        response.json.side_effect = requests.RequestException("network")
+        assert _extract_server_detail(response) is None
+
+    def test_returns_none_when_detail_missing_or_non_string(self) -> None:
+        from ggshield.core.plugin.client import _extract_server_detail
+
+        response = MagicMock()
+        response.json.return_value = {"detail": 42}  # non-string
+        assert _extract_server_detail(response) is None
+
+        response.json.return_value = {"other": "field"}
+        assert _extract_server_detail(response) is None
+
+        response.json.return_value = ["just", "a", "list"]
+        assert _extract_server_detail(response) is None
+
+
+class TestDownloadPluginErrorPaths:
+    """Tests for ``PluginAPIClient.download_plugin``'s validation branches."""
+
+    @pytest.fixture
+    def mock_gg_client(self) -> MagicMock:
+        client = MagicMock()
+        client.base_uri = "https://api.gitguardian.com/"
+        client.api_key = "test-api-key"
+        client.session = MagicMock()
+        return client
+
+    def _make_response(self, headers: dict, status_code: int = 200) -> MagicMock:
+        response = MagicMock()
+        response.status_code = status_code
+        response.history = []
+        response.url = "https://api.gitguardian.com/v1/endpoints/plugins/p/download"
+        response.headers = headers
+        response.iter_content.return_value = iter([b"wheel-bytes"])
+        return response
+
+    def test_raises_on_missing_sha256_header(self, mock_gg_client: MagicMock) -> None:
+        """Server response without X-Plugin-SHA256 yields a PluginAPIError."""
+        mock_gg_client.session.get.return_value = self._make_response(
+            {
+                "Content-Disposition": 'attachment; filename="p-1.0.0.whl"',
+                "X-Plugin-Version": "1.0.0",
+                "Content-Length": "10",
+            }
+        )
+
+        client = PluginAPIClient(mock_gg_client)
+        from ggshield.core.plugin.platform import PlatformInfo
+
+        with pytest.raises(PluginAPIError, match="X-Plugin-SHA256"):
+            with client.download_plugin(
+                "p", platform_info=PlatformInfo("linux", "x86_64", "cp311")
+            ):
+                pass
+
+    def test_raises_on_missing_version_header(self, mock_gg_client: MagicMock) -> None:
+        """Server response without X-Plugin-Version yields a PluginAPIError."""
+        mock_gg_client.session.get.return_value = self._make_response(
+            {
+                "Content-Disposition": 'attachment; filename="p-1.0.0.whl"',
+                "X-Plugin-SHA256": "a" * 64,
+                "Content-Length": "10",
+            }
+        )
+
+        client = PluginAPIClient(mock_gg_client)
+        from ggshield.core.plugin.platform import PlatformInfo
+
+        with pytest.raises(PluginAPIError, match="X-Plugin-Version"):
+            with client.download_plugin(
+                "p", platform_info=PlatformInfo("linux", "x86_64", "cp311")
+            ):
+                pass
+
+    def test_raises_when_content_length_exceeds_cap(
+        self, mock_gg_client: MagicMock
+    ) -> None:
+        """Content-Length above MAX_WHEEL_SIZE_BYTES is rejected upfront."""
+        from ggshield.core.plugin.client import MAX_WHEEL_SIZE_BYTES
+
+        mock_gg_client.session.get.return_value = self._make_response(
+            {
+                "Content-Disposition": 'attachment; filename="p-1.0.0.whl"',
+                "X-Plugin-SHA256": "a" * 64,
+                "X-Plugin-Version": "1.0.0",
+                "Content-Length": str(MAX_WHEEL_SIZE_BYTES + 1),
+            }
+        )
+
+        client = PluginAPIClient(mock_gg_client)
+        from ggshield.core.plugin.platform import PlatformInfo
+
+        with pytest.raises(PluginAPIError, match="exceeds maximum"):
+            with client.download_plugin(
+                "p", platform_info=PlatformInfo("linux", "x86_64", "cp311")
+            ):
+                pass
+
+    def test_wraps_request_exception(self, mock_gg_client: MagicMock) -> None:
+        """A requests.RequestException becomes a PluginAPIError."""
+        mock_gg_client.session.get.side_effect = requests.RequestException("boom")
+
+        client = PluginAPIClient(mock_gg_client)
+        from ggshield.core.plugin.platform import PlatformInfo
+
+        with pytest.raises(PluginAPIError, match="Failed to download plugin"):
+            with client.download_plugin(
+                "p", platform_info=PlatformInfo("linux", "x86_64", "cp311")
+            ):
+                pass
+
+    def test_passes_version_in_query(self, mock_gg_client: MagicMock) -> None:
+        """``version=`` argument is forwarded as a query param."""
+        mock_gg_client.session.get.return_value = self._make_response(
+            {
+                "Content-Disposition": 'attachment; filename="p-0.5.0.whl"',
+                "X-Plugin-SHA256": "a" * 64,
+                "X-Plugin-Version": "0.5.0",
+                "Content-Length": "10",
+            }
+        )
+
+        client = PluginAPIClient(mock_gg_client)
+        from ggshield.core.plugin.platform import PlatformInfo
+
+        with client.download_plugin(
+            "p", platform_info=PlatformInfo("linux", "x86_64", "cp311"), version="0.5.0"
+        ):
+            pass
+
+        call = mock_gg_client.session.get.call_args
+        params = call.kwargs.get("params") or {}
+        assert params.get("version") == "0.5.0"
+
+
+class TestSecurityHelpers:
+    """Tests for module-level security helpers.
+
+    Coverage for ``assert_all_https`` and ``sanitize_wheel_filename``
+    lives in ``test_http_security.py`` and ``test_wheel_utils.py``
+    respectively, since both helpers were extracted out of this module.
+    """
+
+    def test_iter_with_size_cap_raises_on_overflow(self) -> None:
+        """Total bytes exceeding the cap raise PluginAPIError mid-stream."""
+        from ggshield.core.plugin.client import _iter_with_size_cap
+
+        gen = _iter_with_size_cap(iter([b"a" * 100, b"b" * 100]), max_bytes=150)
+        # First chunk fits.
+        next(gen)
+        # Second chunk pushes total past the cap.
+        with pytest.raises(PluginAPIError, match="exceeded maximum"):
+            next(gen)
+
+
+class TestPluginSourceTypeMissingFallback:
+    """``_missing_`` only handles the legacy 'gitguardian_api' name; any
+    other unknown value should hit the ``return None`` fallback (which
+    coerces the constructor to raise ValueError)."""
+
+    def test_unknown_value_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            PluginSourceType("definitely-not-a-real-source")
+
+
+class TestAssertBaseUrlHttps:
+    """Pre-validation that the authenticated client's base URL is HTTPS.
+
+    Regression for: token leaks in cleartext on the very first request
+    when the instance URL is misconfigured to http://. ``validate_instance_url``
+    catches this at ``auth login`` time except for loopback; this is the
+    defense-in-depth backstop for hand-edited configs and the missing
+    ``assert_all_https`` coverage on ``get_available_plugins`` /
+    ``report_installation``.
+    """
+
+    def test_accepts_https(self) -> None:
+        from ggshield.core.plugin.client import _assert_base_url_https
+
+        _assert_base_url_https("https://api.gitguardian.com")
+
+    def test_rejects_http_non_loopback(self) -> None:
+        from ggshield.core.plugin.client import _assert_base_url_https
+
+        with pytest.raises(PluginAPIError, match="non-HTTPS"):
+            _assert_base_url_https("http://api.example.com")
+
+    def test_rejects_loopback_without_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ggshield.core.plugin.client import _assert_base_url_https
+
+        monkeypatch.delenv("GITGUARDIAN_ALLOW_INSECURE_LOOPBACK", raising=False)
+        with pytest.raises(PluginAPIError, match="non-HTTPS"):
+            _assert_base_url_https("http://localhost:3000")
+
+    def test_accepts_loopback_with_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ggshield.core.plugin.client import _assert_base_url_https
+
+        monkeypatch.setenv("GITGUARDIAN_ALLOW_INSECURE_LOOPBACK", "1")
+        _assert_base_url_https("http://localhost:3000")
+
+    def test_get_available_plugins_rejects_http_base(self) -> None:
+        """Pre-check fires before any HTTP traffic — token never leaves."""
+        gg = MagicMock()
+        gg.base_uri = "http://api.example.com/"
+        gg.session = MagicMock()
+        client = PluginAPIClient(gg)
+
+        with pytest.raises(PluginAPIError, match="non-HTTPS"):
+            client.get_available_plugins()
+
+        gg.session.get.assert_not_called()
+
+    def test_report_installation_swallows_http_base(self) -> None:
+        """``report_installation`` is best-effort; HTTPS check failure is logged,
+        not raised, and the POST is never sent."""
+        gg = MagicMock()
+        gg.base_uri = "http://api.example.com/"
+        gg.session = MagicMock()
+        client = PluginAPIClient(gg)
+
+        # Must not raise.
+        client.report_installation("tokenscanner", "1.0.0", "linux", "x86_64")
+
+        gg.session.post.assert_not_called()
+
+
+class TestParseContentLength:
+    """Malformed Content-Length must surface as PluginAPIError, not a raw
+    ValueError that bypasses the typed-error contract."""
+
+    @pytest.fixture
+    def mock_gg_client(self) -> MagicMock:
+        client = MagicMock()
+        client.base_uri = "https://api.gitguardian.com/"
+        client.api_key = "test-api-key"
+        client.session = MagicMock()
+        return client
+
+    @patch("ggshield.core.plugin.client.get_platform_info")
+    def test_download_plugin_malformed_content_length(
+        self, mock_platform: MagicMock, mock_gg_client: MagicMock
+    ) -> None:
+        mock_platform.return_value = PlatformInfo(
+            os="linux", arch="x86_64", python_abi="cp311"
+        )
+        response = MagicMock()
+        response.status_code = 200
+        response.history = []
+        response.url = "https://api.gitguardian.com/v1/endpoints/plugins/p/download"
+        response.headers = {
+            "Content-Disposition": 'attachment; filename="p-1.0.0.whl"',
+            "X-Plugin-SHA256": "a" * 64,
+            "X-Plugin-Version": "1.0.0",
+            "Content-Length": "not-a-number",
+        }
+        mock_gg_client.session.get.return_value = response
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError, match="Malformed Content-Length"):
+            with client.download_plugin(
+                "p", platform_info=PlatformInfo("linux", "x86_64", "cp311")
+            ):
+                pass
+
+    def test_signature_bundle_malformed_content_length(
+        self, mock_gg_client: MagicMock
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 200
+        response.history = []
+        response.url = "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        response.headers = {"Content-Length": "garbage"}
+        response.__enter__.return_value = response
+        mock_gg_client.session.get.return_value = response
+
+        client = PluginAPIClient(mock_gg_client)
+        with pytest.raises(PluginAPIError, match="Malformed Content-Length"):
+            client.download_signature_bundle(
+                "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+            )
+
+
+class TestSameOriginPortNormalization:
+    """Regression: implicit vs explicit default port (e.g. ``:443``) used
+    to flip the same-origin check in ``download_signature_bundle`` even
+    though the URLs are semantically the same origin.
+    """
+
+    @pytest.fixture
+    def mock_gg_client_explicit_port(self) -> MagicMock:
+        client = MagicMock()
+        # Explicit ":443" in the base URL.
+        client.base_uri = "https://api.gitguardian.com:443/"
+        client.session = MagicMock()
+        return client
+
+    def test_implicit_default_port_matches_explicit(
+        self, mock_gg_client_explicit_port: MagicMock
+    ) -> None:
+        """Bundle URL omits the port; base URL has explicit ``:443``."""
+        body = b"sigstore bundle bytes"
+        response = MagicMock()
+        response.status_code = 200
+        response.history = []
+        response.url = "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        response.headers = {"Content-Length": str(len(body))}
+        response.iter_content.return_value = iter([body])
+        response.__enter__.return_value = response
+        mock_gg_client_explicit_port.session.get.return_value = response
+
+        client = PluginAPIClient(mock_gg_client_explicit_port)
+        # Must not raise "foreign origin".
+        result = client.download_signature_bundle(
+            "https://api.gitguardian.com/v1/endpoints/plugins/p/signature"
+        )
+        assert result == body
+
+    def test_explicit_default_port_matches_implicit(self) -> None:
+        """Mirror case: base URL omits port, bundle URL has explicit ``:443``."""
+        gg = MagicMock()
+        gg.base_uri = "https://api.gitguardian.com/"
+        gg.session = MagicMock()
+
+        body = b"sigstore bundle bytes"
+        response = MagicMock()
+        response.status_code = 200
+        response.history = []
+        response.url = (
+            "https://api.gitguardian.com:443/v1/endpoints/plugins/p/signature"
+        )
+        response.headers = {"Content-Length": str(len(body))}
+        response.iter_content.return_value = iter([body])
+        response.__enter__.return_value = response
+        gg.session.get.return_value = response
+
+        client = PluginAPIClient(gg)
+        result = client.download_signature_bundle(
+            "https://api.gitguardian.com:443/v1/endpoints/plugins/p/signature"
+        )
+        assert result == body
+
+    def test_genuinely_different_port_still_rejected(self) -> None:
+        """A different non-default port IS a foreign origin — don't over-rotate."""
+        gg = MagicMock()
+        gg.base_uri = "https://api.gitguardian.com/"
+        gg.session = MagicMock()
+
+        client = PluginAPIClient(gg)
+        with pytest.raises(PluginAPIError, match="foreign origin"):
+            client.download_signature_bundle(
+                "https://api.gitguardian.com:8443/v1/endpoints/plugins/p/signature"
+            )
+        gg.session.get.assert_not_called()
+
+
+class TestReportInstallationContract:
+    """Regressions for the ``report_installation`` hardening."""
+
+    @pytest.fixture
+    def mock_gg_client(self) -> MagicMock:
+        client = MagicMock()
+        client.base_uri = "https://api.gitguardian.com/"
+        client.api_key = "test-api-key"
+        client.session = MagicMock()
+        return client
+
+    def test_passes_explicit_timeout(self, mock_gg_client: MagicMock) -> None:
+        """A stalled ``/installed`` POST must not hang the command — update.py
+        relied on the report happening before the final config save before
+        the timeout was added, so the wheel could be on disk with the
+        version still pointing at the previous release."""
+        from ggshield.core.plugin.client import HTTP_TIMEOUT_SECONDS
+
+        response = MagicMock()
+        response.history = []
+        response.url = "https://api.gitguardian.com/v1/endpoints/plugins/p/installed"
+        response.raise_for_status.return_value = None
+        mock_gg_client.session.post.return_value = response
+
+        client = PluginAPIClient(mock_gg_client)
+        client.report_installation("p", "1.0.0", "linux", "x86_64")
+
+        kwargs = mock_gg_client.session.post.call_args.kwargs
+        assert kwargs.get("timeout") == HTTP_TIMEOUT_SECONDS

--- a/tests/unit/core/plugin/test_downloader.py
+++ b/tests/unit/core/plugin/test_downloader.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import zipfile
 from pathlib import Path
+from typing import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,6 +29,7 @@ from ggshield.core.plugin.signature import (
     SignatureStatus,
     SignatureVerificationMode,
 )
+from ggshield.core.plugin.trust import compute_file_sha256
 
 
 MOCK_SIG_INFO = SignatureInfo(status=SignatureStatus.SKIPPED)
@@ -179,29 +181,25 @@ class TestPluginDownloader:
         sha256 = hashlib.sha256(wheel_content).hexdigest()
 
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256=sha256,
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=len(wheel_content),
         )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [wheel_content]
-        mock_response.raise_for_status = MagicMock()
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get", return_value=mock_response):
-                with patch(
-                    "ggshield.core.plugin.downloader.verify_wheel_signature",
-                    return_value=MOCK_SIG_INFO,
-                ):
-                    downloader = PluginDownloader()
-                    wheel_path = downloader.download_and_install(
-                        download_info, "testplugin"
-                    )
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=MOCK_SIG_INFO,
+            ):
+                downloader = PluginDownloader()
+                wheel_path = downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "testplugin",
+                )
 
         assert wheel_path.exists()
         assert wheel_path.name == "testplugin-1.0.0.whl"
@@ -220,34 +218,29 @@ class TestPluginDownloader:
         sha256 = hashlib.sha256(wheel_content).hexdigest()
 
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256=sha256,
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=len(wheel_content),
         )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [wheel_content]
-        mock_response.raise_for_status = MagicMock()
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get", return_value=mock_response):
-                with patch(
-                    "ggshield.core.plugin.downloader.verify_wheel_signature",
-                    return_value=SignatureInfo(
-                        status=SignatureStatus.MISSING,
-                        message="No bundle found",
-                    ),
-                ):
-                    downloader = PluginDownloader()
-                    downloader.download_and_install(
-                        download_info,
-                        "testplugin",
-                        signature_mode=SignatureVerificationMode.WARN,
-                    )
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=SignatureInfo(
+                    status=SignatureStatus.MISSING,
+                    message="No bundle found",
+                ),
+            ):
+                downloader = PluginDownloader()
+                downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "testplugin",
+                    signature_mode=SignatureVerificationMode.WARN,
+                )
 
         record = downloader.trust_store.get_record("testplugin")
         assert record is not None
@@ -262,35 +255,33 @@ class TestPluginDownloader:
         sha256 = hashlib.sha256(wheel_content).hexdigest()
 
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256=sha256,
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=len(wheel_content),
         )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [wheel_content]
-        mock_response.raise_for_status = MagicMock()
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get", return_value=mock_response):
-                with patch(
-                    "ggshield.core.plugin.downloader.verify_wheel_signature",
-                    return_value=SignatureInfo(
-                        status=SignatureStatus.VALID,
-                        identity="GitGuardian/satori",
-                    ),
-                ):
-                    downloader = PluginDownloader()
-                    downloader.trust_store.trust_plugin(
-                        "testplugin",
-                        sha256,
-                        "missing",
-                    )
-                    downloader.download_and_install(download_info, "testplugin")
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=SignatureInfo(
+                    status=SignatureStatus.VALID,
+                    identity="GitGuardian/satori",
+                ),
+            ):
+                downloader = PluginDownloader()
+                downloader.trust_store.trust_plugin(
+                    "testplugin",
+                    sha256,
+                    "missing",
+                )
+                downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "testplugin",
+                )
 
         assert downloader.trust_store.get_record("testplugin") is None
 
@@ -300,114 +291,120 @@ class TestPluginDownloader:
         wrong_sha256 = "0" * 64  # Wrong checksum
 
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256=wrong_sha256,
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=len(wheel_content),
         )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [wheel_content]
-        mock_response.raise_for_status = MagicMock()
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get", return_value=mock_response):
-                downloader = PluginDownloader()
+            downloader = PluginDownloader()
 
-                with pytest.raises(ChecksumMismatchError):
-                    downloader.download_and_install(download_info, "testplugin")
+            with pytest.raises(ChecksumMismatchError):
+                downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "testplugin",
+                )
 
     def test_download_and_install_network_error(self, tmp_path: Path) -> None:
-        """Test download fails with network error."""
+        """Test download fails with network error (simulated via raising iterator)."""
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256="abc123",
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=10,
         )
+
+        def raising_chunks() -> Iterator[bytes]:
+            raise OSError("Network error")
+            yield b""  # make it a generator
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch(
-                "requests.get", side_effect=requests.RequestException("Network error")
-            ):
-                downloader = PluginDownloader()
+            downloader = PluginDownloader()
 
-                with pytest.raises(DownloadError) as exc_info:
-                    downloader.download_and_install(download_info, "testplugin")
+            with pytest.raises(OSError) as exc_info:
+                downloader.download_and_install(
+                    download_info,
+                    raising_chunks(),
+                    "testplugin",
+                )
 
-                assert "Failed to download plugin" in str(exc_info.value)
+            assert "Network error" in str(exc_info.value)
 
     def test_download_and_install_rejects_invalid_plugin_name(
         self, tmp_path: Path
     ) -> None:
         """Test install rejects unsafe plugin names."""
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256="abc123",
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=100,
         )
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get") as mock_get:
-                downloader = PluginDownloader()
+            downloader = PluginDownloader()
 
-                with pytest.raises(DownloadError) as exc_info:
-                    downloader.download_and_install(download_info, "../../outside")
+            with pytest.raises(DownloadError) as exc_info:
+                downloader.download_and_install(
+                    download_info,
+                    iter([b""]),
+                    "../../outside",
+                )
 
-                assert "Invalid plugin name" in str(exc_info.value)
-                mock_get.assert_not_called()
+            assert "Invalid plugin name" in str(exc_info.value)
 
-    def test_download_and_install_manifest_failure_cleans_temp_file(
+    def test_download_and_install_manifest_failure_keeps_verified_wheel(
         self, tmp_path: Path
     ) -> None:
-        """Test temp file is cleaned up if manifest write fails."""
+        """A manifest write failure after the swap must leave the new wheel.
+
+        The swap happens AFTER signature verification, so wheel_path holds
+        verified bytes. Deleting them would strand the user with neither
+        the old nor the new wheel (same-filename reinstall scenario);
+        leaving them lets a retry rewrite manifest/trust.
+        """
         wheel_content = b"fake wheel content"
         sha256 = hashlib.sha256(wheel_content).hexdigest()
 
         download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
             filename="testplugin-1.0.0.whl",
             sha256=sha256,
             version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
+            size_bytes=len(wheel_content),
         )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [wheel_content]
-        mock_response.raise_for_status = MagicMock()
 
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
         ):
-            with patch("requests.get", return_value=mock_response):
-                with patch(
-                    "ggshield.core.plugin.downloader.verify_wheel_signature",
-                    return_value=MOCK_SIG_INFO,
-                ):
-                    downloader = PluginDownloader()
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=MOCK_SIG_INFO,
+            ):
+                downloader = PluginDownloader()
 
-                    with patch.object(
-                        downloader, "_write_manifest", side_effect=OSError("disk full")
-                    ):
-                        with pytest.raises(OSError):
-                            downloader.download_and_install(download_info, "testplugin")
+                with patch.object(
+                    downloader, "_write_manifest", side_effect=OSError("disk full")
+                ):
+                    with pytest.raises(OSError):
+                        downloader.download_and_install(
+                            download_info,
+                            iter([wheel_content]),
+                            "testplugin",
+                        )
 
         temp_path = tmp_path / "testplugin" / "testplugin-1.0.0.whl.tmp"
         assert not temp_path.exists()
-        # The post-rename OSError from _write_manifest must trigger cleanup,
-        # otherwise a half-installed wheel would be left on disk.
         wheel_path = tmp_path / "testplugin" / "testplugin-1.0.0.whl"
-        assert not wheel_path.exists()
+        assert wheel_path.exists()
+        assert not (tmp_path / "testplugin" / "manifest.json").exists()
 
     def test_is_installed_by_entry_point_name(self, tmp_path: Path) -> None:
         """Test is_installed finds plugin by entry point name."""
@@ -485,10 +482,12 @@ class TestPluginDownloader:
                 "[ggshield.plugins]\nmy_plugin = package_name.plugin:Plugin\n",
             )
 
+        wheel_sha256 = compute_file_sha256(wheel_path)
         manifest = {
             "plugin_name": "package-name",
             "version": "1.0.0",
             "wheel_filename": "package_name-1.0.0.whl",
+            "sha256": wheel_sha256,
             "signature": {
                 "status": "missing",
                 "message": "No bundle found",
@@ -503,7 +502,7 @@ class TestPluginDownloader:
 
         downloader.trust_store.trust_plugin(
             plugin_dir.name,
-            downloader._compute_sha256(wheel_path),
+            wheel_sha256,
             "missing",
         )
 
@@ -512,6 +511,44 @@ class TestPluginDownloader:
             downloader.get_installed_signature_label("my_plugin")
             == "unsigned (trusted)"
         )
+
+    def test_signature_label_drops_trusted_when_wheel_tampered(
+        self, tmp_path: Path
+    ) -> None:
+        """Tampering the on-disk wheel must drop the trusted-unsigned label.
+
+        The label compares the trust record to the wheel hash recomputed
+        from disk, so a post-install rewrite of the wheel bytes (leaving
+        manifest and trust record intact) breaks the trust chain.
+        """
+        plugin_dir = tmp_path / "tamper-test"
+        plugin_dir.mkdir()
+        wheel_path = plugin_dir / "tamper_test-1.0.0.whl"
+        wheel_path.write_bytes(b"original wheel bytes")
+        original_sha = compute_file_sha256(wheel_path)
+
+        manifest = {
+            "plugin_name": "tamper-test",
+            "version": "1.0.0",
+            "wheel_filename": "tamper_test-1.0.0.whl",
+            "sha256": original_sha,
+            "signature": {"status": "missing", "message": "No bundle found"},
+        }
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        downloader.trust_store.trust_plugin(plugin_dir.name, original_sha, "missing")
+        assert (
+            downloader.get_installed_signature_label("tamper-test")
+            == "unsigned (trusted)"
+        )
+
+        wheel_path.write_bytes(b"tampered wheel bytes")
+        assert downloader.get_installed_signature_label("tamper-test") == "missing"
 
     def test_uninstall_by_entry_point_name(self, tmp_path: Path) -> None:
         """Test uninstall can remove plugin by entry point name."""
@@ -594,6 +631,68 @@ class TestPluginDownloader:
             downloader = PluginDownloader()
 
         assert downloader._read_entry_point_name_from_wheel(invalid_file) is None
+
+    def test_download_and_install_from_chunks(self, tmp_path: Path) -> None:
+        """
+        GIVEN a PluginDownloadInfo and an iterator of bytes
+        WHEN download_and_install is called
+        THEN it writes the wheel and verifies SHA256
+        """
+        # Build a minimal valid wheel zip
+        wheel_bytes = b"fake wheel content for sha test"
+        sha256 = hashlib.sha256(wheel_bytes).hexdigest()
+
+        download_info = PluginDownloadInfo(
+            filename="testplugin-1.0.0-py3-none-any.whl",
+            sha256=sha256,
+            version="1.0.0",
+            size_bytes=len(wheel_bytes),
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ), patch(
+            "ggshield.core.plugin.downloader.verify_wheel_signature",
+            return_value=MOCK_SIG_INFO,
+        ):
+            downloader = PluginDownloader()
+            result = downloader.download_and_install(
+                download_info,
+                iter([wheel_bytes]),
+                "testplugin",
+            )
+
+        assert result == tmp_path / "testplugin" / "testplugin-1.0.0-py3-none-any.whl"
+        assert result.read_bytes() == wheel_bytes
+
+    def test_download_and_install_raises_on_sha256_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a download info with wrong SHA256
+        WHEN download_and_install is called
+        THEN it raises ChecksumMismatchError and cleans up the temp file
+        """
+        download_info = PluginDownloadInfo(
+            filename="testplugin-1.0.0-py3-none-any.whl",
+            sha256="a" * 64,  # 64-char hex string (SHA256 length), wrong hash
+            version="1.0.0",
+            size_bytes=10,
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            with pytest.raises(ChecksumMismatchError):
+                downloader.download_and_install(
+                    download_info,
+                    iter([b"actual content"]),
+                    "testplugin",
+                )
+
+        # temp file must be cleaned up
+        assert not list((tmp_path / "testplugin").glob("*.tmp"))
 
 
 class TestChecksumMismatchError:
@@ -683,6 +782,39 @@ class TestInstallFromWheel:
         assert manifest["version"] == "2.0.0"
         assert manifest["source"]["type"] == "local_file"
 
+    def test_install_from_wheel_canonicalises_distribution_name(
+        self, tmp_path: Path
+    ) -> None:
+        """Install dir uses the PEP 503-canonical name, matching the platform flow.
+
+        A wheel whose METADATA ``Name`` is ``Foo_Bar`` must land under
+        ``plugins_dir/foo-bar/`` (the same place ``download_and_install``
+        would write the catalog wheel) so the two flows converge instead
+        of creating side-by-side directories for the same package.
+        """
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        wheel_path = create_test_wheel(source_dir, "Foo_Bar", "1.0.0")
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=MOCK_SIG_INFO,
+            ):
+                downloader = PluginDownloader()
+                plugin_name, _, installed_path = downloader.install_from_wheel(
+                    wheel_path
+                )
+
+        assert plugin_name == "foo-bar"
+        assert installed_path.parent == plugins_dir / "foo-bar"
+        assert not (plugins_dir / "Foo_Bar").exists()
+
     def test_install_from_wheel_removes_stale_bundle_sidecars(
         self, tmp_path: Path
     ) -> None:
@@ -700,18 +832,12 @@ class TestInstallFromWheel:
         stale_sigstore_json = plugin_dir / f"{wheel_path.name}.sigstore.json"
         stale_sigstore_json.write_bytes(b"stale-bundle-json")
 
-        def _verify_without_stale_sidecars(dest_wheel_path: Path, *_args):
-            assert dest_wheel_path == plugin_dir / wheel_path.name
-            assert not stale_sigstore.exists()
-            assert not stale_sigstore_json.exists()
-            return MOCK_SIG_INFO
-
         with patch(
             "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
         ):
             with patch(
                 "ggshield.core.plugin.downloader.verify_wheel_signature",
-                side_effect=_verify_without_stale_sidecars,
+                return_value=MOCK_SIG_INFO,
             ):
                 downloader = PluginDownloader()
                 _, _, installed_path = downloader.install_from_wheel(wheel_path)
@@ -927,7 +1053,7 @@ class TestGetPluginSource:
             source = downloader.get_plugin_source("testplugin")
 
         assert source is not None
-        assert source.type == PluginSourceType.GITGUARDIAN_API
+        assert source.type == PluginSourceType.PLATFORM
 
     def test_get_source_url(self, tmp_path: Path) -> None:
         """Test getting source for URL-installed plugin."""
@@ -1002,7 +1128,7 @@ class TestGetPluginSource:
             source = downloader.get_plugin_source("legacyplugin")
 
         assert source is not None
-        assert source.type == PluginSourceType.GITGUARDIAN_API
+        assert source.type == PluginSourceType.PLATFORM
 
     def test_get_source_not_installed(self, tmp_path: Path) -> None:
         """Test getting source for non-installed plugin."""
@@ -1050,11 +1176,11 @@ class TestPluginSourceTypes:
 
     def test_source_minimal(self) -> None:
         """Test PluginSource with minimal fields."""
-        source = PluginSource(type=PluginSourceType.GITGUARDIAN_API)
+        source = PluginSource(type=PluginSourceType.PLATFORM)
 
         data = source.to_dict()
 
-        assert data == {"type": "gitguardian_api"}
+        assert data == {"type": "platform"}
 
 
 class TestDownloadFromUrlEdgeCases:
@@ -1349,106 +1475,6 @@ class TestGetSignatureLabel:
         assert get_signature_label(manifest) == "unknown (org/repo)"
 
 
-class TestDownloadBundle:
-    """Tests for _download_bundle method."""
-
-    def test_returns_none_when_no_signature_url(self, tmp_path: Path) -> None:
-        download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="plugin-1.0.0.whl",
-            sha256="abc",
-            version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
-            signature_url=None,
-        )
-
-        with patch(
-            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
-        ):
-            downloader = PluginDownloader()
-
-        result = downloader._download_bundle(download_info, tmp_path)
-        assert result is None
-
-    def test_downloads_bundle_successfully(self, tmp_path: Path) -> None:
-        download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="plugin-1.0.0.whl",
-            sha256="abc",
-            version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
-            signature_url="https://example.com/plugin.whl.sigstore",
-        )
-
-        mock_response = MagicMock()
-        mock_response.iter_content.return_value = [b"bundle-content"]
-        mock_response.raise_for_status = MagicMock()
-
-        with patch(
-            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
-        ):
-            downloader = PluginDownloader()
-
-        with patch("requests.get", return_value=mock_response):
-            result = downloader._download_bundle(download_info, tmp_path)
-
-        assert result is not None
-        assert result.name == "plugin-1.0.0.whl.sigstore"
-        assert result.read_bytes() == b"bundle-content"
-
-    def test_returns_none_on_network_error(self, tmp_path: Path) -> None:
-        download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="plugin-1.0.0.whl",
-            sha256="abc",
-            version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
-            signature_url="https://example.com/plugin.whl.sigstore",
-        )
-
-        with patch(
-            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
-        ):
-            downloader = PluginDownloader()
-
-        with patch(
-            "requests.get", side_effect=requests.RequestException("Network error")
-        ):
-            result = downloader._download_bundle(download_info, tmp_path)
-
-        assert result is None
-
-    def test_removes_partial_bundle_on_mid_stream_error(self, tmp_path: Path) -> None:
-        """If iter_content raises after open(), the partial file is unlinked."""
-        download_info = PluginDownloadInfo(
-            download_url="https://example.com/plugin.whl",
-            filename="plugin-1.0.0.whl",
-            sha256="abc",
-            version="1.0.0",
-            expires_at="2025-01-01T00:00:00Z",
-            signature_url="https://example.com/plugin.whl.sigstore",
-        )
-
-        def iter_boom(*_args, **_kwargs):
-            yield b"partial"
-            raise OSError("connection reset")
-
-        mock_response = MagicMock()
-        mock_response.iter_content.side_effect = iter_boom
-        mock_response.raise_for_status = MagicMock()
-
-        with patch(
-            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
-        ):
-            downloader = PluginDownloader()
-
-        with patch("requests.get", return_value=mock_response):
-            with pytest.raises(OSError):
-                downloader._download_bundle(download_info, tmp_path)
-
-        assert not (tmp_path / "plugin-1.0.0.whl.sigstore").exists()
-
-
 class TestDownloadUrlBundle:
     """Tests for _download_url_bundle method."""
 
@@ -1671,3 +1697,1003 @@ def _create_artifact_zip(content: bytes, filename: str) -> bytes:
     with zipfile.ZipFile(buffer, "w") as zf:
         zf.writestr(filename, content)
     return buffer.getvalue()
+
+
+class TestCleanupLegacyInstallDir:
+    """Tests for PluginDownloader._cleanup_legacy_install_dir.
+
+    Covers the upgrade path from older ggshield builds that named the
+    plugin directory after the catalog reference instead of the wheel's
+    distribution name.
+    """
+
+    def _downloader(self, tmp_path: Path) -> "PluginDownloader":
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            return PluginDownloader()
+
+    @staticmethod
+    def _write_manifest(plugin_dir: Path, source_type: str) -> None:
+        manifest = {"source": {"type": source_type}}
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    def test_removes_legacy_platform_dir(self, tmp_path: Path) -> None:
+        """Legacy ``plugins_dir/<reference>/`` from a platform install is removed."""
+        downloader = self._downloader(tmp_path)
+        legacy = tmp_path / "machine_scan"
+        legacy.mkdir()
+        self._write_manifest(legacy, "platform")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+        assert not legacy.exists()
+        assert new_install.exists()
+
+    def test_removes_legacy_gitguardian_api_dir(self, tmp_path: Path) -> None:
+        """Manifests written by ggshield < 1.50 use the old ``gitguardian_api``
+        value but still represent a platform install — accept them too."""
+        downloader = self._downloader(tmp_path)
+        legacy = tmp_path / "machine_scan"
+        legacy.mkdir()
+        self._write_manifest(legacy, "gitguardian_api")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+        assert not legacy.exists()
+
+    @pytest.mark.parametrize(
+        "user_source_type",
+        ["local_file", "url", "github_release", "github_artifact"],
+    )
+    def test_preserves_user_managed_dir(
+        self, tmp_path: Path, user_source_type: str
+    ) -> None:
+        """A directory whose name collides with the catalog reference but whose
+        manifest says it was user-installed (local_file / url / github_*) must
+        not be wiped by the platform-install cleanup path.
+        """
+        downloader = self._downloader(tmp_path)
+        collider = tmp_path / "tokenscanner"
+        collider.mkdir()
+        self._write_manifest(collider, user_source_type)
+        new_install = tmp_path / "ggshield-tokenscanner"
+        new_install.mkdir()
+        downloader.trust_store = MagicMock()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="tokenscanner", current_dir=new_install
+        )
+
+        assert (
+            collider.exists()
+        ), f"cleanup deleted a user-managed {user_source_type} install"
+        assert (collider / "manifest.json").exists()
+        downloader.trust_store.revoke_plugin.assert_not_called()
+
+    def test_preserves_dir_with_unparseable_manifest(self, tmp_path: Path) -> None:
+        """A malformed manifest is ambiguous evidence; don't risk wiping
+        a legitimate user-managed directory."""
+        downloader = self._downloader(tmp_path)
+        legacy = tmp_path / "machine_scan"
+        legacy.mkdir()
+        (legacy / "manifest.json").write_text("{not json")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+        assert legacy.exists()
+
+    def test_keeps_dir_when_same_as_current(self, tmp_path: Path) -> None:
+        """When wheel-distribution-name == catalog-reference, no migration."""
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "tokenscanner"
+        plugin_dir.mkdir()
+        self._write_manifest(plugin_dir, "platform")
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="tokenscanner", current_dir=plugin_dir
+        )
+
+        assert plugin_dir.exists()
+
+    def test_skips_dir_without_manifest(self, tmp_path: Path) -> None:
+        """A bare directory without a manifest isn't a plugin install — leave it alone."""
+        downloader = self._downloader(tmp_path)
+        not_a_plugin = tmp_path / "machine_scan"
+        not_a_plugin.mkdir()
+        (not_a_plugin / "random.txt").write_text("hi")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+        assert not_a_plugin.exists()
+
+    def test_skips_when_legacy_dir_missing(self, tmp_path: Path) -> None:
+        """No-op when the catalog-reference directory doesn't exist."""
+        downloader = self._downloader(tmp_path)
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        # Should not raise.
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+    def test_rejects_invalid_catalog_reference(self, tmp_path: Path) -> None:
+        """An invalid name (path-traversal etc.) is silently ignored."""
+        downloader = self._downloader(tmp_path)
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        # Should not raise even though "../etc" is bogus.
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="../etc", current_dir=new_install
+        )
+
+    def test_swallows_oserror_during_rmtree(self, tmp_path: Path) -> None:
+        """Filesystem error during rmtree is logged, not raised."""
+        downloader = self._downloader(tmp_path)
+        legacy = tmp_path / "machine_scan"
+        legacy.mkdir()
+        self._write_manifest(legacy, "platform")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+
+        with patch(
+            "ggshield.core.plugin.downloader.shutil.rmtree",
+            side_effect=OSError("permission denied"),
+        ):
+            downloader._cleanup_legacy_install_dir(
+                catalog_reference="machine_scan", current_dir=new_install
+            )
+
+        # Did not crash. The legacy dir is still there because rmtree raised.
+        assert legacy.exists()
+
+    def test_revokes_trust_record_after_removal(self, tmp_path: Path) -> None:
+        """After removing the legacy dir, the trust record keyed on the
+        catalog reference is revoked so a fresh install under that key
+        doesn't inherit a stale SHA."""
+        downloader = self._downloader(tmp_path)
+        legacy = tmp_path / "machine_scan"
+        legacy.mkdir()
+        self._write_manifest(legacy, "platform")
+        new_install = tmp_path / "satori-python"
+        new_install.mkdir()
+        downloader.trust_store = MagicMock()
+
+        downloader._cleanup_legacy_install_dir(
+            catalog_reference="machine_scan", current_dir=new_install
+        )
+
+        downloader.trust_store.revoke_plugin.assert_called_once_with("machine_scan")
+
+
+class TestRemoveStaleWheels:
+    """Regression: upgrading from foo-1.0.whl to foo-2.0.whl used to leave
+    the old wheel + sidecar on disk. The plugin directory accumulated one
+    stale wheel per upgrade; the manifest pointed at the new one so
+    function still worked but disk usage grew and audits were noisy.
+    """
+
+    def _downloader(self, tmp_path: Path) -> "PluginDownloader":
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            return PluginDownloader()
+
+    def test_removes_other_wheels_and_their_sidecars(self, tmp_path: Path) -> None:
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "foo"
+        plugin_dir.mkdir()
+        # Old wheel + its sidecars (the stale install).
+        (plugin_dir / "foo-1.0.whl").write_bytes(b"old")
+        (plugin_dir / "foo-1.0.whl.sigstore").write_bytes(b"old-sig")
+        (plugin_dir / "foo-1.0.whl.sigstore.json").write_bytes(b"old-sig-json")
+        # New wheel + its sidecar.
+        (plugin_dir / "foo-2.0.whl").write_bytes(b"new")
+        (plugin_dir / "foo-2.0.whl.sigstore").write_bytes(b"new-sig")
+        # Unrelated file that must survive.
+        (plugin_dir / "manifest.json").write_bytes(b"{}")
+
+        downloader._remove_stale_wheels(plugin_dir, keep_filename="foo-2.0.whl")
+
+        names = {p.name for p in plugin_dir.iterdir()}
+        assert names == {
+            "foo-2.0.whl",
+            "foo-2.0.whl.sigstore",
+            "manifest.json",
+        }
+
+    def test_keeps_target_wheel(self, tmp_path: Path) -> None:
+        """The kept wheel and its sidecars must not be touched."""
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "foo"
+        plugin_dir.mkdir()
+        (plugin_dir / "foo-2.0.whl").write_bytes(b"new")
+        (plugin_dir / "foo-2.0.whl.sigstore").write_bytes(b"new-sig")
+
+        downloader._remove_stale_wheels(plugin_dir, keep_filename="foo-2.0.whl")
+
+        assert (plugin_dir / "foo-2.0.whl").exists()
+        assert (plugin_dir / "foo-2.0.whl.sigstore").exists()
+
+    def test_no_op_when_no_other_wheels(self, tmp_path: Path) -> None:
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "foo"
+        plugin_dir.mkdir()
+        (plugin_dir / "foo-1.0.whl").write_bytes(b"only")
+        (plugin_dir / "manifest.json").write_bytes(b"{}")
+
+        downloader._remove_stale_wheels(plugin_dir, keep_filename="foo-1.0.whl")
+
+        assert (plugin_dir / "foo-1.0.whl").exists()
+        assert (plugin_dir / "manifest.json").exists()
+
+    def test_skips_non_wheel_files(self, tmp_path: Path) -> None:
+        """Random files that happen to share the plugin dir aren't wheels;
+        leave them alone even though they look like cruft."""
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "foo"
+        plugin_dir.mkdir()
+        (plugin_dir / "foo-2.0.whl").write_bytes(b"new")
+        (plugin_dir / "README.txt").write_bytes(b"docs")
+        (plugin_dir / "fake.whl.bak").write_bytes(b"backup")
+
+        downloader._remove_stale_wheels(plugin_dir, keep_filename="foo-2.0.whl")
+
+        assert (plugin_dir / "README.txt").exists()
+        assert (plugin_dir / "fake.whl.bak").exists()
+
+    def test_swallows_unlink_oserror(self, tmp_path: Path) -> None:
+        """A read-only filesystem mustn't abort the install — log and move on."""
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "foo"
+        plugin_dir.mkdir()
+        (plugin_dir / "foo-1.0.whl").write_bytes(b"old")
+        (plugin_dir / "foo-2.0.whl").write_bytes(b"new")
+
+        with patch.object(Path, "unlink", side_effect=OSError("read-only")):
+            # Must not raise.
+            downloader._remove_stale_wheels(plugin_dir, keep_filename="foo-2.0.whl")
+
+
+class TestResolvePluginDirFallback:
+    """Regression: a bare ``plugins_dir/<name>/`` without a manifest must
+    not block resolution of the real install that lives under the
+    wheel's distribution-name directory.
+    """
+
+    def _downloader(self, tmp_path: Path) -> "PluginDownloader":
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            return PluginDownloader()
+
+    def test_direct_path_with_manifest_returns_direct(self, tmp_path: Path) -> None:
+        downloader = self._downloader(tmp_path)
+        plugin_dir = tmp_path / "tokenscanner"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{}")
+
+        assert downloader._resolve_plugin_dir("tokenscanner") == plugin_dir
+
+    def test_direct_path_without_manifest_falls_through(self, tmp_path: Path) -> None:
+        """Stale ``plugins_dir/<catalog_ref>/`` (no manifest) must not be
+        returned — fall through to the entry-point scan so the real install
+        under the wheel's distribution name still resolves."""
+        downloader = self._downloader(tmp_path)
+
+        # Bare residue dir (no manifest) named after the catalog reference.
+        bare = tmp_path / "machine_scan"
+        bare.mkdir()
+        (bare / "stray.txt").write_text("not a plugin")
+
+        # Real install lives under the wheel distribution name and has a
+        # wheel with an entry point named "machine_scan".
+        real_dir = tmp_path / "satori-python"
+        real_dir.mkdir()
+        wheel_path = real_dir / "satori_python-1.0.0.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "satori_python-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmachine_scan = satori_python.plugin:Plugin\n",
+            )
+        manifest = {
+            "plugin_name": "satori-python",
+            "version": "1.0.0",
+            "wheel_filename": "satori_python-1.0.0.whl",
+        }
+        (real_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        assert downloader._resolve_plugin_dir("machine_scan") == real_dir
+
+    def test_no_direct_no_entry_point_returns_none(self, tmp_path: Path) -> None:
+        downloader = self._downloader(tmp_path)
+        assert downloader._resolve_plugin_dir("absent") is None
+
+
+class TestWheelDistributionName:
+    """Tests for _wheel_distribution_name (PEP 427 → PEP 503)."""
+
+    def test_normalises_underscores(self) -> None:
+        from ggshield.core.plugin.downloader import _wheel_distribution_name
+
+        assert (
+            _wheel_distribution_name(
+                "satori_python-0.38.1-cp37-abi3-manylinux_2_28_x86_64.whl"
+            )
+            == "satori-python"
+        )
+
+    def test_lowercases(self) -> None:
+        from ggshield.core.plugin.downloader import _wheel_distribution_name
+
+        assert _wheel_distribution_name("Foo-1.0.0-py3-none-any.whl") == "foo"
+
+    def test_rejects_non_wheel_extension(self) -> None:
+        from ggshield.core.plugin.downloader import _wheel_distribution_name
+
+        with pytest.raises(DownloadError, match="Not a wheel filename"):
+            _wheel_distribution_name("plugin-1.0.0.tar.gz")
+
+    def test_rejects_invalid_format(self) -> None:
+        """A wheel filename without version/python segments is rejected."""
+        from ggshield.core.plugin.downloader import _wheel_distribution_name
+
+        # No '-' at all → bad format.
+        with pytest.raises(DownloadError, match="Invalid wheel filename"):
+            _wheel_distribution_name("plugin.whl")
+
+
+class TestDownloadAndInstallBundle:
+    """Tests for the bundle_bytes path of download_and_install."""
+
+    def test_writes_bundle_alongside_wheel(self, tmp_path: Path) -> None:
+        """bundle_bytes is persisted as ``<wheel>.sigstore`` next to the
+        wheel in the install dir."""
+        wheel_content = b"fake wheel content"
+        sha256 = hashlib.sha256(wheel_content).hexdigest()
+        bundle_bytes = b'{"fake": "bundle"}'
+        download_info = PluginDownloadInfo(
+            filename="plug-1.0.0.whl",
+            sha256=sha256,
+            version="1.0.0",
+            size_bytes=len(wheel_content),
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ), patch(
+            "ggshield.core.plugin.downloader.verify_wheel_signature",
+            return_value=MOCK_SIG_INFO,
+        ):
+            downloader = PluginDownloader()
+            wheel_path = downloader.download_and_install(
+                download_info,
+                iter([wheel_content]),
+                "plug",
+                bundle_bytes=bundle_bytes,
+            )
+
+        bundle_path = wheel_path.parent / (wheel_path.name + ".sigstore")
+        assert bundle_path.exists()
+        assert bundle_path.read_bytes() == bundle_bytes
+
+    def test_signature_failure_leaves_existing_install_intact(
+        self, tmp_path: Path
+    ) -> None:
+        """When STRICT verification fails on update, the previous install
+        (wheel + manifest) is untouched."""
+        # Pre-populate the install dir as if a prior version is already
+        # installed (matches the real upgrade scenario).
+        install_dir = tmp_path / "plug"
+        install_dir.mkdir()
+        previous_wheel_bytes = b"previous good wheel"
+        previous_wheel_path = install_dir / "plug-0.9.0.whl"
+        previous_wheel_path.write_bytes(previous_wheel_bytes)
+        previous_manifest = install_dir / "manifest.json"
+        previous_manifest.write_text('{"plugin_name":"plug","version":"0.9.0"}')
+
+        wheel_content = b"new (unsigned) wheel"
+        sha256 = hashlib.sha256(wheel_content).hexdigest()
+        download_info = PluginDownloadInfo(
+            filename="plug-1.0.0.whl",
+            sha256=sha256,
+            version="1.0.0",
+            size_bytes=len(wheel_content),
+        )
+
+        from ggshield.core.plugin.signature import (
+            SignatureStatus,
+            SignatureVerificationError,
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ), patch(
+            "ggshield.core.plugin.downloader.verify_wheel_signature",
+            side_effect=SignatureVerificationError(SignatureStatus.MISSING, "missing"),
+        ):
+            downloader = PluginDownloader()
+            with pytest.raises(SignatureVerificationError):
+                downloader.download_and_install(
+                    download_info, iter([wheel_content]), "plug"
+                )
+
+        # Previous install untouched.
+        assert previous_wheel_path.exists()
+        assert previous_wheel_path.read_bytes() == previous_wheel_bytes
+        assert previous_manifest.exists()
+        # And the temp file got cleaned up.
+        assert not (install_dir / "plug-1.0.0.whl.tmp").exists()
+
+
+class TestGetSignatureLabelExtra:
+    """Additional get_signature_label coverage."""
+
+    def test_signed_without_identity(self) -> None:
+        """A valid signature without identity returns plain 'signed'."""
+        manifest = {"signature": {"status": "valid"}}
+        assert get_signature_label(manifest) == "signed"
+
+
+class TestDownloadAndInstallBundleCleanup:
+    """Tests for the finally-clause bundle cleanup in download_and_install."""
+
+    def test_temp_bundle_cleaned_up_when_signature_fails(self, tmp_path: Path) -> None:
+        """Temp bundle file written before signature verification is
+        removed when verification fails (the only path that exercises
+        the temp bundle's finally-clause unlink)."""
+        wheel_content = b"actual bytes"
+        sha256 = hashlib.sha256(wheel_content).hexdigest()
+        download_info = PluginDownloadInfo(
+            filename="plug-1.0.0.whl",
+            sha256=sha256,
+            version="1.0.0",
+            size_bytes=len(wheel_content),
+        )
+        from ggshield.core.plugin.signature import (
+            SignatureStatus,
+            SignatureVerificationError,
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ), patch(
+            "ggshield.core.plugin.downloader.verify_wheel_signature",
+            side_effect=SignatureVerificationError(
+                SignatureStatus.MISSING, "no bundle"
+            ),
+        ):
+            downloader = PluginDownloader()
+            with pytest.raises(SignatureVerificationError):
+                downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "plug",
+                    bundle_bytes=b"some bundle",
+                )
+
+        # Temp wheel and temp bundle both gone after the failure.
+        plugin_dir = tmp_path / "plug"
+        if plugin_dir.exists():
+            for entry in plugin_dir.iterdir():
+                assert not entry.name.endswith(".tmp")
+                assert not entry.name.endswith(".tmp.sigstore")
+
+    def test_temp_bundle_cleaned_up_on_sha_mismatch(self, tmp_path: Path) -> None:
+        """Temp bundle file written before SHA verification is removed
+        when the install fails downstream."""
+        wheel_content = b"actual bytes"
+        wrong_sha = "0" * 64
+        download_info = PluginDownloadInfo(
+            filename="plug-1.0.0.whl",
+            sha256=wrong_sha,
+            version="1.0.0",
+            size_bytes=len(wheel_content),
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            with pytest.raises(ChecksumMismatchError):
+                downloader.download_and_install(
+                    download_info,
+                    iter([wheel_content]),
+                    "plug",
+                    bundle_bytes=b"some bundle",
+                )
+
+        # Neither the temp wheel nor the temp bundle should remain.
+        plugin_dir = tmp_path / "plug"
+        for name in plugin_dir.iterdir() if plugin_dir.exists() else []:
+            assert not name.name.endswith(".tmp")
+            assert not name.name.endswith(".tmp.sigstore")
+
+
+class TestStreamToFile:
+    """Tests for the module-level _stream_to_file helper."""
+
+    def test_skips_empty_chunks_and_caps_oversized_body(self, tmp_path: Path) -> None:
+        """Empty chunks (line 94 ``continue``) and the size cap (line 97
+        ``raise``) are both exercised here."""
+        from ggshield.core.plugin.downloader import _stream_to_file
+
+        response = MagicMock()
+        # Empty chunk (skipped), then a chunk that exceeds the cap.
+        response.iter_content.return_value = iter([b"", b"x" * 100])
+
+        dest = tmp_path / "out.bin"
+        with pytest.raises(DownloadError, match="exceeded maximum"):
+            _stream_to_file(response, dest, max_bytes=50)
+
+        # Partial file removed before re-raise.
+        assert not dest.exists()
+
+
+class TestExtractGithubRepo:
+    """Tests for the _extract_github_repo helper."""
+
+    def _downloader(self, tmp_path: Path) -> "PluginDownloader":
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            return PluginDownloader()
+
+    def test_returns_owner_repo_for_valid_url(self, tmp_path: Path) -> None:
+        d = self._downloader(tmp_path)
+        assert d._extract_github_repo("https://github.com/owner/repo") == "owner/repo"
+
+    def test_strips_dotgit_suffix(self, tmp_path: Path) -> None:
+        d = self._downloader(tmp_path)
+        assert (
+            d._extract_github_repo("https://github.com/owner/repo.git") == "owner/repo"
+        )
+
+    def test_returns_none_for_non_github_url(self, tmp_path: Path) -> None:
+        d = self._downloader(tmp_path)
+        assert d._extract_github_repo("https://example.com/owner/repo") is None
+
+    def test_rejects_path_traversal_segments(self, tmp_path: Path) -> None:
+        d = self._downloader(tmp_path)
+        assert d._extract_github_repo("https://github.com/../repo") is None
+        assert d._extract_github_repo("https://github.com/owner/..") is None
+        assert d._extract_github_repo("https://github.com/./repo") is None
+
+    def test_rejects_slash_in_segment(self, tmp_path: Path) -> None:
+        """Slash and backslash within the segment are rejected — they
+        could escape the api.github.com URL the value gets interpolated
+        into. Trigger the path via a regex that allows them through.
+        """
+        d = self._downloader(tmp_path)
+        # urlparse-driven regex captures up to the next '/', so slashes
+        # don't naturally get into the segment from a real URL. Force
+        # it via a direct match: backslash inside a segment.
+        # Construct a URL that allows ``\`` to land inside one segment.
+        # The current regex is ``([^/]+)/([^/]+)`` — non-slash chars,
+        # so backslash sneaks in.
+        assert d._extract_github_repo("https://github.com/owner\\evil/repo") is None
+
+
+class TestDownloadFromUrlFinally:
+    """Tests for the temp-file cleanup in download_from_url."""
+
+    def test_cleans_up_temp_file_on_request_error(self, tmp_path: Path) -> None:
+        """A request exception during streaming should leave no temp file
+        behind in the staging area."""
+        from ggshield.core.plugin.downloader import _stream_to_file
+
+        # Easier path: drive _stream_to_file directly to assert the
+        # finally branch in download_from_url's caller. The wrapper's
+        # finally clause unlinks the temp file regardless of why
+        # _stream_to_file raised.
+        response = MagicMock()
+        response.iter_content.return_value = iter([b"x" * 50])
+        dest = tmp_path / "stage.tmp"
+        with pytest.raises(DownloadError):
+            _stream_to_file(response, dest, max_bytes=10)
+        assert not dest.exists()
+
+
+class TestDownloadFromGithubReleaseFinally:
+    """Cover the finally-clause manifest-tmp cleanup in download_from_github_release."""
+
+    def test_cleans_up_tmp_manifest_when_replace_fails(self, tmp_path: Path) -> None:
+        """If atomic replace of manifest.json fails, the leftover .tmp
+        file is removed by the finally clause."""
+        plugin_dir = tmp_path / "p"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "manifest.json"
+        manifest_path.write_text(
+            '{"plugin_name": "p", "version": "1.0", "sha256": "abc"}'
+        )
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        # Stub download_from_url to skip the actual download work.
+        downloader.download_from_url = MagicMock(  # type: ignore[method-assign]
+            return_value=("p", "1.0", plugin_dir / "p-1.0.whl")
+        )
+
+        # Make Path.replace raise so the .tmp file lingers and the
+        # finally clause has to clean it up.
+        from pathlib import Path as _PathCls
+
+        with patch.object(_PathCls, "replace", side_effect=OSError("rename failed")):
+            with pytest.raises(OSError):
+                downloader.download_from_github_release(
+                    "https://github.com/owner/repo/releases/download/v1/p-1.0.whl"
+                )
+
+        # No leftover .tmp manifest.
+        assert not (plugin_dir / "manifest.json.tmp").exists()
+
+
+class TestInstallFromWheelBundleCopy:
+    """Cover install_from_wheel copying a co-located bundle (line 372)."""
+
+    def test_install_from_wheel_copies_bundle_when_present(
+        self, tmp_path: Path
+    ) -> None:
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        wheel_path = create_test_wheel(source_dir, "bundleplugin", "1.0.0")
+        bundle_path = source_dir / f"{wheel_path.name}.sigstore"
+        bundle_path.write_bytes(b"fake-bundle")
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch(
+                "ggshield.core.plugin.downloader.verify_wheel_signature",
+                return_value=MOCK_SIG_INFO,
+            ):
+                with patch(
+                    "ggshield.core.plugin.signature.get_bundle_path",
+                    return_value=bundle_path,
+                ):
+                    downloader = PluginDownloader()
+                    downloader.install_from_wheel(wheel_path)
+
+        installed_bundle = plugins_dir / "bundleplugin" / bundle_path.name
+        assert installed_bundle.exists()
+        assert installed_bundle.read_bytes() == b"fake-bundle"
+
+
+class TestGitHubArtifactExtraEdgeCases:
+    """Cover remaining download_from_github_artifact branches.
+
+    Lines 629-630 (safe_unpack failure), 642 (multiple wheels warning),
+    652-653 (WheelError), 675-676 (bundle copy).
+    """
+
+    def test_safe_unpack_failure_raises_artifact_error(self, tmp_path: Path) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        artifact_content = _create_artifact_zip(b"x", "ignored.txt")
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [artifact_content]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch("requests.get", return_value=mock_response):
+                with patch(
+                    "ggshield.utils.archive.safe_unpack",
+                    side_effect=RuntimeError("zip slip"),
+                ):
+                    with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+                        downloader = PluginDownloader()
+                        with pytest.raises(GitHubArtifactError) as exc:
+                            downloader.download_from_github_artifact(
+                                "https://github.com/o/r/actions/runs/1/artifacts/2"
+                            )
+        assert "Failed to extract artifact" in str(exc.value)
+
+    def test_multiple_wheels_logs_warning_and_picks_first(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        wheel_a = create_test_wheel(wheel_dir, "alpha", "1.0.0")
+        wheel_b = create_test_wheel(wheel_dir, "beta", "2.0.0")
+
+        import io
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr(wheel_a.name, wheel_a.read_bytes())
+            zf.writestr(wheel_b.name, wheel_b.read_bytes())
+        artifact_content = buffer.getvalue()
+
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [artifact_content]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch("requests.get", return_value=mock_response):
+                with patch(
+                    "ggshield.core.plugin.downloader.verify_wheel_signature",
+                    return_value=MOCK_SIG_INFO,
+                ):
+                    with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+                        with caplog.at_level("WARNING"):
+                            downloader = PluginDownloader()
+                            plugin_name, _, _ = (
+                                downloader.download_from_github_artifact(
+                                    "https://github.com/o/r/actions/runs/1/artifacts/2"
+                                )
+                            )
+
+        assert plugin_name == "alpha"
+        assert any("Multiple wheel files" in rec.message for rec in caplog.records)
+
+    def test_invalid_wheel_in_artifact_raises_download_error(
+        self, tmp_path: Path
+    ) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        artifact_content = _create_artifact_zip(
+            b"not-a-zip", "broken-1.0.0-py3-none-any.whl"
+        )
+
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [artifact_content]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch("requests.get", return_value=mock_response):
+                with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+                    downloader = PluginDownloader()
+                    with pytest.raises(DownloadError) as exc:
+                        downloader.download_from_github_artifact(
+                            "https://github.com/o/r/actions/runs/1/artifacts/2"
+                        )
+        assert "Invalid wheel in artifact" in str(exc.value)
+
+    def test_artifact_copies_sigstore_bundle_when_present(self, tmp_path: Path) -> None:
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        wheel_path = create_test_wheel(wheel_dir, "sigplugin", "1.0.0")
+        wheel_bytes = wheel_path.read_bytes()
+
+        import io
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr(wheel_path.name, wheel_bytes)
+            zf.writestr(wheel_path.name + ".sigstore", b"bundle-bytes")
+        artifact_content = buffer.getvalue()
+
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [artifact_content]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=plugins_dir
+        ):
+            with patch("requests.get", return_value=mock_response):
+                with patch(
+                    "ggshield.core.plugin.downloader.verify_wheel_signature",
+                    return_value=MOCK_SIG_INFO,
+                ):
+                    with patch.dict("os.environ", {"GITHUB_TOKEN": "tok"}):
+                        downloader = PluginDownloader()
+                        downloader.download_from_github_artifact(
+                            "https://github.com/o/r/actions/runs/1/artifacts/2"
+                        )
+
+        installed_bundle = plugins_dir / "sigplugin" / (wheel_path.name + ".sigstore")
+        assert installed_bundle.exists()
+        assert installed_bundle.read_bytes() == b"bundle-bytes"
+
+
+class TestUninstallInvalidName:
+    """Cover uninstall rejecting unsafe plugin names (lines 703-704)."""
+
+    def test_uninstall_rejects_invalid_name(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            with caplog.at_level("WARNING"):
+                assert downloader.uninstall("../escape") is False
+        assert any("Invalid plugin name" in rec.message for rec in caplog.records)
+
+
+class TestManifestPathErrors:
+    """Cover _get_manifest_path branches via public callers."""
+
+    def test_get_manifest_invalid_name_returns_none(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Lines 737-738: invalid plugin name path."""
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            with caplog.at_level("WARNING"):
+                assert downloader.get_manifest("../escape") is None
+        assert any("Invalid plugin name" in rec.message for rec in caplog.records)
+
+    def test_get_manifest_dir_without_manifest_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Line 746: plugin dir exists but has no manifest.json."""
+        plugin_dir = tmp_path / "noManifestPlugin"
+        plugin_dir.mkdir()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_manifest("noManifestPlugin") is None
+
+
+class TestFindPluginDirByEntryPointBranches:
+    """Cover defensive branches in _find_plugin_dir_by_entry_point."""
+
+    def test_skips_files_in_plugins_dir(self, tmp_path: Path) -> None:
+        """Line 756: plain file in plugins_dir is skipped."""
+        (tmp_path / "stray.txt").write_text("hi")
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            # Lookup by entry-point name with no matching dirs returns None
+            # without crashing on the stray file.
+            assert downloader.get_manifest("anyplugin") is None
+
+    def test_skips_dirs_without_manifest(self, tmp_path: Path) -> None:
+        """Line 760: directory without manifest.json is skipped."""
+        (tmp_path / "emptydir").mkdir()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_manifest("anyplugin") is None
+
+    def test_handles_invalid_manifest_json(self, tmp_path: Path) -> None:
+        """Lines 772-773: dir with invalid JSON manifest is skipped."""
+        plugin_dir = tmp_path / "broken"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{not-json}")
+        # Different lookup name so we exercise entry-point traversal.
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_manifest("entrypointname") is None
+
+
+class TestGetWheelPathInvalidJson:
+    """Cover get_wheel_path JSON decode fallthrough (lines 797-800)."""
+
+    def test_invalid_json_manifest_returns_none(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "badjson"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{not-valid-json}")
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_wheel_path("badjson") is None
+
+
+class TestGetManifestInvalidJson:
+    """Cover get_manifest JSON decode fallthrough (lines 810-811)."""
+
+    def test_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "badjson2"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{not-valid-json}")
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_manifest("badjson2") is None
+
+
+class TestGetInstalledSignatureLabelMissingPlugin:
+    """Cover get_installed_signature_label early-return (line 817)."""
+
+    def test_returns_none_for_missing_plugin(self, tmp_path: Path) -> None:
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_installed_signature_label("nope") is None
+
+
+class TestGetPluginSourceInvalidSourceDict:
+    """Cover get_plugin_source PluginSource.from_dict failure (lines 842-843)."""
+
+    def test_source_missing_type_returns_none(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "bad_source"
+        plugin_dir.mkdir()
+        manifest = {
+            "plugin_name": "bad_source",
+            "version": "1.0.0",
+            "wheel_filename": "bad_source-1.0.0.whl",
+            "sha256": "deadbeef",
+            "source": {"url": "https://example.com"},  # missing "type"
+        }
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_plugin_source("bad_source") is None
+
+    def test_source_unknown_type_returns_none(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "weird_source"
+        plugin_dir.mkdir()
+        manifest = {
+            "plugin_name": "weird_source",
+            "version": "1.0.0",
+            "wheel_filename": "weird_source-1.0.0.whl",
+            "sha256": "deadbeef",
+            "source": {"type": "wormhole"},  # unknown enum value
+        }
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.get_plugin_source("weird_source") is None
+
+
+class TestIsValidPluginNameRejections:
+    """Cover _is_valid_plugin_name reject branches (lines 849, 853)."""
+
+    @pytest.mark.parametrize("name", ["", ".", ".."])
+    def test_rejects_empty_or_dot_segments(self, tmp_path: Path, name: str) -> None:
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.uninstall(name) is False
+
+    def test_rejects_null_byte(self, tmp_path: Path) -> None:
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+            assert downloader.uninstall("foo\x00bar") is False

--- a/tests/unit/core/plugin/test_http_security.py
+++ b/tests/unit/core/plugin/test_http_security.py
@@ -1,0 +1,141 @@
+"""Tests for ggshield.core.plugin.http_security."""
+
+import pytest
+import requests
+
+from ggshield.core.plugin.http_security import (
+    INSECURE_LOOPBACK_ENV_VAR,
+    LOOPBACK_HOSTS,
+    assert_all_https,
+    is_insecure_loopback_allowed,
+    is_loopback,
+)
+
+
+class _CustomError(Exception):
+    """Stand-in for the domain exceptions client.py / downloader.py raise."""
+
+
+def _resp(*urls: str) -> requests.Response:
+    """Build a Response whose history+url chain matches ``urls``.
+
+    ``urls[-1]`` is the final response; everything before is a redirect hop.
+    """
+    final = requests.Response()
+    final.url = urls[-1]
+    final.history = []
+    for u in urls[:-1]:
+        hop = requests.Response()
+        hop.url = u
+        final.history.append(hop)
+    return final
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/",
+        "http://localhost:3000/x",
+        "http://127.0.0.1:3000/x",
+        "http://[::1]/x",
+        "https://localhost/x",
+    ],
+)
+def test_is_loopback_true(url: str) -> None:
+    """is_loopback recognises every documented loopback host."""
+    assert is_loopback(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/",
+        "http://192.168.1.1/",
+        "https://localhost.example.com/",  # subdomain attack
+        "https://127.0.0.1.example.com/",
+    ],
+)
+def test_is_loopback_false(url: str) -> None:
+    """is_loopback rejects non-loopback hosts including lookalikes."""
+    assert is_loopback(url) is False
+
+
+def test_is_loopback_malformed_returns_false() -> None:
+    """A non-URL string must not raise — just return False."""
+    assert is_loopback("not a url") is False
+    assert is_loopback("") is False
+
+
+def test_loopback_hosts_constant_includes_v4_and_v6() -> None:
+    assert "localhost" in LOOPBACK_HOSTS
+    assert "127.0.0.1" in LOOPBACK_HOSTS
+    assert "::1" in LOOPBACK_HOSTS
+
+
+def test_is_insecure_loopback_allowed_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(INSECURE_LOOPBACK_ENV_VAR, raising=False)
+    assert is_insecure_loopback_allowed() is False
+
+
+def test_is_insecure_loopback_allowed_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(INSECURE_LOOPBACK_ENV_VAR, "1")
+    assert is_insecure_loopback_allowed() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "true", "yes", "TRUE"])
+def test_is_insecure_loopback_allowed_only_accepts_one(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Only the literal string ``"1"`` enables the bypass."""
+    monkeypatch.setenv(INSECURE_LOOPBACK_ENV_VAR, value)
+    assert is_insecure_loopback_allowed() is False
+
+
+def test_assert_all_https_passes_for_https_only() -> None:
+    response = _resp("https://example.com/a", "https://example.com/b")
+    assert_all_https(response, exc_factory=_CustomError)  # no raise
+
+
+def test_assert_all_https_rejects_http_final_hop() -> None:
+    response = _resp("https://example.com/a", "http://example.com/b")
+    with pytest.raises(_CustomError, match="Refusing insecure redirect"):
+        assert_all_https(response, exc_factory=_CustomError)
+
+
+def test_assert_all_https_rejects_http_intermediate_hop() -> None:
+    response = _resp(
+        "https://example.com/a",
+        "http://evil.example.com/b",
+        "https://example.com/c",
+    )
+    with pytest.raises(_CustomError):
+        assert_all_https(response, exc_factory=_CustomError)
+
+
+def test_assert_all_https_rejects_loopback_http_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(INSECURE_LOOPBACK_ENV_VAR, raising=False)
+    response = _resp("https://example.com/a", "http://localhost:3000/b")
+    with pytest.raises(_CustomError):
+        assert_all_https(response, exc_factory=_CustomError)
+
+
+def test_assert_all_https_allows_loopback_http_when_envvar_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(INSECURE_LOOPBACK_ENV_VAR, "1")
+    response = _resp("https://example.com/a", "http://localhost:3000/b")
+    assert_all_https(response, exc_factory=_CustomError)  # no raise
+
+
+def test_assert_all_https_envvar_does_not_allow_arbitrary_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env var must only widen loopback — not all of HTTP."""
+    monkeypatch.setenv(INSECURE_LOOPBACK_ENV_VAR, "1")
+    response = _resp("https://example.com/a", "http://example.com/b")
+    with pytest.raises(_CustomError):
+        assert_all_https(response, exc_factory=_CustomError)

--- a/tests/unit/core/plugin/test_wheel_utils.py
+++ b/tests/unit/core/plugin/test_wheel_utils.py
@@ -204,3 +204,56 @@ class TestWheelMetadata:
         assert metadata.summary is None
         assert metadata.author is None
         assert metadata.license is None
+
+
+class TestSanitizeWheelFilename:
+    """Tests for sanitize_wheel_filename."""
+
+    def test_accepts_normal_wheel(self) -> None:
+        from ggshield.core.plugin.wheel_utils import sanitize_wheel_filename
+
+        assert (
+            sanitize_wheel_filename("foo-1.0.0-py3-none-any.whl")
+            == "foo-1.0.0-py3-none-any.whl"
+        )
+
+    def test_strips_path_components(self) -> None:
+        """Server may include path components; we keep only the basename."""
+        from ggshield.core.plugin.wheel_utils import sanitize_wheel_filename
+
+        assert (
+            sanitize_wheel_filename("evil/path/foo-1.0.0-py3-none-any.whl")
+            == "foo-1.0.0-py3-none-any.whl"
+        )
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            ".",
+            "..",
+            "foo\x00.whl",
+            "foo\\bar.whl",  # backslash forbidden
+            "D:evil-1.0-py3-none-any.whl",  # Windows drive prefix
+            "\\\\?\\C:\\evil-1.0.whl",  # Windows extended-length prefix
+            "\\\\share\\evil-1.0.whl",  # Windows UNC path
+        ],
+    )
+    def test_rejects_unsafe(self, raw: str) -> None:
+        from ggshield.core.plugin.wheel_utils import sanitize_wheel_filename
+
+        with pytest.raises(InvalidWheelError):
+            sanitize_wheel_filename(raw)
+
+    def test_rejects_missing_whl_suffix(self) -> None:
+        from ggshield.core.plugin.wheel_utils import sanitize_wheel_filename
+
+        with pytest.raises(InvalidWheelError, match=r"\.whl"):
+            sanitize_wheel_filename("foo-1.0.0-py3-none-any.tar.gz")
+
+    def test_rejects_traversal_to_empty_basename(self) -> None:
+        """``../`` resolves to ``""`` after PurePosixPath(...).name."""
+        from ggshield.core.plugin.wheel_utils import sanitize_wheel_filename
+
+        with pytest.raises(InvalidWheelError):
+            sanitize_wheel_filename("../")


### PR DESCRIPTION
## Context

This PR is the ggshield side of the GitGuardian-platform plugin install flow. With the matching backend deployed, `ggshield plugin install/update/status` discover and pull plugins from the user's GitGuardian instance instead of a hard-coded GitHub release URL.

## What has been done

**Core install flow**
- `PluginAPIClient` rewritten to call `/v1/endpoints/plugins` (list / detail / streaming download / signature) with API-key auth. The client no longer sees the upstream wheel URL: the platform proxies bytes from a GitGuardian-hosted repository and exposes `X-Plugin-SHA256`, `X-Plugin-Version`, `Content-Length` (and `X-Plugin-Signature-URL`) on the download response.
- `download_and_install` accepts a byte stream rather than fetching a URL — keeps the verify-sha256 / extract pipeline pure.
- `install` / `update` / `status` commands wired to the new client surface. `update` calls the new `installed` endpoint best-effort. `status` surfaces a dedicated `PluginsNotEnabledError` when the workspace doesn't have the feature.

**Install-directory naming**
- `download_and_install` (catalog flow) now names the on-disk plugin directory after the wheel's PEP 503-normalised distribution name, the same way `install_from_wheel` (local-file flow) already does. The catalog reference is still passed in as `plugin_name` and stored in the manifest, but the on-disk dir comes from the wheel filename.
- Convergent naming means a user who installed the local wheel and then runs `plugin install <ref>` ends up with **one** plugin directory flipped from `source.type=local_file` to `platform` in place — not two side-by-side directories backed by the same wheel bytes.
- `update --check` pairing keys on entry-point name = catalog reference (independent of the on-disk dir name), so the rename above doesn't change the pairing logic. `_resolve_plugin_dir`'s wheel-based entry-point fallback already handles the dir-name / reference divergence for `plugin uninstall`.

**Manifest**
- New `PluginSourceType.PLATFORM` (value `"platform"`) replaces `GITGUARDIAN_API`. A `_missing_` classmethod accepts the legacy `"gitguardian_api"` value so manifests written by pre-1.50 ggshield keep parsing.
- `ggshield plugin list` now reads the install source from the manifest and renders it verbatim (`platform`, `local file`, `url`, `github release`, `github artifact`); falls back to `pip` for entry-point-only plugins and `on-disk` for the wheel-without-manifest case.

**Smaller fixes**
- variable shadowing in `download_plugin` (`version` → `resolved_version`)
- missing `return` after `ctx.exit()` in `update.py` error handlers (was hitting `UnboundLocalError`)
- removed redundant try/except around `report_installation` (method already swallows + logs)
- `.worktrees/` added to `.gitignore`

## Validation

Unit and functional tests in `tests/unit/cmd/plugin/` and `tests/unit/core/plugin/` cover the new client, the rewritten command flows, and the source-type compat layer (parametrized matrix across all PluginSourceType values plus the two fallback paths).

End-to-end against a live backend: a separate harness drives ggshield as a real user would against a GitGuardian instance with the plugin feature enabled, then asserts on real CLI output and on-disk manifests. 14 scenarios passing as of the latest push:

\`\`\`
status / install pinned / install latest / list /
status post-install (update available) / update --check / update --all /
re-install / uninstall / unknown-plugin error / unknown-version error /
strict-sig install (sigstore bundle proxied + verified) /
local→local wheel upgrade / local-wheel-then-platform install (in-place)
\`\`\`

Manual smoke test against a GitGuardian instance with the plugin feature enabled:

1. \`ggshield auth login --instance <instance-url>\`.
2. \`ggshield plugin status\` → catalog plugins listed as available.
3. \`ggshield plugin install <ref>\` → wheel + sigstore bundle streamed via the platform; manifest records \`source.type == platform\`.
4. \`ggshield plugin list\` → \`<entry-point-name>: v…, enabled, platform, signature: signed (…)\`.
5. \`ggshield plugin update --check\` then \`--all\` → upgrades to the catalog's latest.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the \`skip-changelog\` label has been added to the PR.
