### PR TITLE
fix(plugins): skip TUF update on --allow-unsigned

### DIFF
--- a/changelog.d/20260507_6d7a_skip_tuf_update_on_allow_unsigned.md
+++ b/changelog.d/20260507_6d7a_skip_tuf_update_on_allow_unsigned.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield plugin install --allow-unsigned` and `ggshield plugin update --allow-unsigned` now verify plugin signatures using the embedded / cached sigstore trust root instead of refreshing it over the network, so plugins can still be installed when the sigstore TUF endpoints are unreachable.

--- a/ggshield/core/plugin/signature.py
+++ b/ggshield/core/plugin/signature.py
@@ -7,7 +7,9 @@ of GitHub Actions workflow identities (OIDC).
 
 Verification modes:
 - STRICT: block unsigned or invalid plugins
-- WARN: log a warning but allow loading
+- WARN: log a warning but allow loading. Verification still runs against the
+  embedded / cached sigstore trust root (offline=True) so the TUF metadata
+  refresh, which can fail in restricted networks, is skipped.
 - DISABLED: skip verification entirely
 """
 
@@ -131,10 +133,13 @@ def verify_wheel_signature(
         logger.warning("%s", msg)
         return SignatureInfo(status=SignatureStatus.MISSING, message=msg)
 
-    # Verify bundle
+    # Verify bundle. In WARN mode (--allow-unsigned) we use the embedded /
+    # cached sigstore trust root via offline=True so that the TUF metadata
+    # refresh -- which can fail in restricted networks -- is skipped.
     bundle = Bundle.from_json(bundle_path.read_bytes())
     wheel_bytes = wheel_path.read_bytes()
-    verifier = Verifier.production()
+    offline = mode == SignatureVerificationMode.WARN
+    verifier = Verifier.production(offline=offline)
 
     for trusted in trusted_identities:
         policy = AllOf(

--- a/tests/unit/core/plugin/test_signature.py
+++ b/tests/unit/core/plugin/test_signature.py
@@ -92,6 +92,70 @@ class TestMissingBundle:
         assert result.status == SignatureStatus.MISSING
 
 
+class TestSignatureVerificationModeWarn:
+    """WARN mode verifies offline so the sigstore TUF refresh is skipped."""
+
+    def test_warn_mode_uses_offline_verifier(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "plugin-1.0.0.whl"
+        wheel.write_bytes(b"fake wheel content")
+        bundle = tmp_path / "plugin-1.0.0.whl.sigstore"
+        bundle.write_bytes(b'{"fake": "bundle"}')
+
+        mock_verifier_cls = MagicMock()
+        mock_bundle_cls = MagicMock()
+        mock_all_of_cls = MagicMock()
+        mock_oidc_issuer_cls = MagicMock()
+        mock_gh_repo_cls = MagicMock()
+
+        mock_verifier_cls.production.return_value.verify_artifact.return_value = None
+        mock_bundle_cls.from_json.return_value = MagicMock()
+
+        with (
+            patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
+            patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
+            patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
+            patch("ggshield.core.plugin.signature.OIDCIssuer", mock_oidc_issuer_cls),
+            patch(
+                "ggshield.core.plugin.signature.GitHubWorkflowRepository",
+                mock_gh_repo_cls,
+            ),
+        ):
+            verify_wheel_signature(wheel, SignatureVerificationMode.WARN)
+
+        # The TUF refresh runs inside Verifier.production() unless offline=True
+        # is passed; --allow-unsigned must opt into offline verification.
+        mock_verifier_cls.production.assert_called_once_with(offline=True)
+
+    def test_strict_mode_uses_online_verifier(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "plugin-1.0.0.whl"
+        wheel.write_bytes(b"fake wheel content")
+        bundle = tmp_path / "plugin-1.0.0.whl.sigstore"
+        bundle.write_bytes(b'{"fake": "bundle"}')
+
+        mock_verifier_cls = MagicMock()
+        mock_bundle_cls = MagicMock()
+        mock_all_of_cls = MagicMock()
+        mock_oidc_issuer_cls = MagicMock()
+        mock_gh_repo_cls = MagicMock()
+
+        mock_verifier_cls.production.return_value.verify_artifact.return_value = None
+        mock_bundle_cls.from_json.return_value = MagicMock()
+
+        with (
+            patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
+            patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
+            patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
+            patch("ggshield.core.plugin.signature.OIDCIssuer", mock_oidc_issuer_cls),
+            patch(
+                "ggshield.core.plugin.signature.GitHubWorkflowRepository",
+                mock_gh_repo_cls,
+            ),
+        ):
+            verify_wheel_signature(wheel, SignatureVerificationMode.STRICT)
+
+        mock_verifier_cls.production.assert_called_once_with(offline=False)
+
+
 class TestBundleVerification:
     """Tests for bundle verification with mocked sigstore."""
 


### PR DESCRIPTION
## Context

`ggshield plugin install --allow-unsigned` and `ggshield plugin update --allow-unsigned` currently fail if TUF metadata cannot be successfully updated. This blocks plugin installation for the user entirely.

## What has been done

When passing `--allow-unsigned`, the verifier is now built with `offline=True`, which makes `sigstore-python` use the embedded/cached trust root and skip the TUF metadata refresh. `STRICT` mode is unchanged: it continues to refresh TUF and fail closed on network errors.

## Validation

- block egress to `tuf-repo-cdn.sigstore.dev` (e.g. `127.0.0.1 tuf-repo-cdn.sigstore.dev` in `/etc/hosts`)
- `uv run ggshield plugin install <wheel> --allow-unsigned` should now succeed (previously failed with a TUF refresh error)
- `uv run ggshield plugin install <wheel>` (no flag, STRICT) should still fail with a TUF refresh error — verifying the offline opt-in is gated on `--allow-unsigned`
- `uv run pytest tests/unit/core/plugin/test_signature.py`

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
