### PR TITLE
fix(client): scope retry policy by command

### DIFF
--- a/changelog.d/20260507_140000_brigaud_tune_retry_backoff.md
+++ b/changelog.d/20260507_140000_brigaud_tune_retry_backoff.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Scans no longer fail on a single transient network glitch. ggshield retries connection errors (e.g. `ConnectionResetError`) and 502/503/504 responses with bounded exponential backoff (~15 s budget with jitter). `ggshield secret scan pre-receive` uses a minimal retry policy instead so it stays inside GitHub Enterprise Server's fixed 5 s pre-receive hook timeout.

--- a/ggshield/cmd/secret/scan/prereceive.py
+++ b/ggshield/cmd/secret/scan/prereceive.py
@@ -16,7 +16,7 @@ from ggshield.cmd.utils.common_decorators import fail_on_server_error_option
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.cache import ReadOnlyCache
-from ggshield.core.client import create_client_from_config
+from ggshield.core.client import RetryProfile, create_client_from_config
 from ggshield.core.config import Config
 from ggshield.core.errors import ExitCode, handle_exception
 from ggshield.core.git_hooks.prereceive import (
@@ -93,7 +93,11 @@ def prereceive_cmd(
     configuration.
     """
     ctx_obj = ContextObj.get(ctx)
-    ctx_obj.client = create_client_from_config(ctx_obj.config)
+    # GitHub Enterprise Server enforces a fixed 5 s timeout shared across all
+    # pre-receive hooks. Use a minimal retry profile to stay inside it.
+    ctx_obj.client = create_client_from_config(
+        ctx_obj.config, retry_profile=RetryProfile.PRE_RECEIVE
+    )
     config = ctx_obj.config
     output_handler = create_output_handler(ctx)
     if os.getenv("GL_PROTOCOL") == "web":

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from enum import Enum
 from typing import Optional
 
 import requests
@@ -25,7 +26,52 @@ from .ui.client_callbacks import ClientCallbacks
 logger = logging.getLogger(__name__)
 
 
-def create_client_from_config(config: Config) -> GGClient:
+_RETRY_ALLOWED_METHODS = frozenset(
+    {"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"}
+)
+_RETRY_STATUS_FORCELIST = frozenset({502, 503, 504})
+
+
+class RetryProfile(Enum):
+    """HTTP retry policy applied to the requests Session."""
+
+    # ~15s wall-clock budget with jitter. Used by every command except
+    # pre-receive. Sleep schedule before each retry: 0, 1, 2, 4, 8 s, each
+    # (except the first) jittered by up to 0.5 s; the 8 s sleep is capped by
+    # backoff_max.
+    DEFAULT = "default"
+
+    # One immediate retry, no backoff. Used by `ggshield secret scan
+    # pre-receive`: GitHub Enterprise Server enforces a fixed 5 s timeout
+    # shared across all pre-receive hooks, so any retry budget that adds
+    # measurable wall clock risks exceeding it.
+    PRE_RECEIVE = "pre_receive"
+
+
+def _build_retry(profile: RetryProfile) -> urllib3.Retry:
+    if profile is RetryProfile.PRE_RECEIVE:
+        return urllib3.Retry(
+            total=1,
+            backoff_factor=0,
+            backoff_jitter=0,
+            status_forcelist=_RETRY_STATUS_FORCELIST,
+            allowed_methods=_RETRY_ALLOWED_METHODS,
+        )
+    return urllib3.Retry(
+        total=5,
+        backoff_factor=0.5,
+        backoff_max=8,
+        backoff_jitter=0.5,
+        status_forcelist=_RETRY_STATUS_FORCELIST,
+        allowed_methods=_RETRY_ALLOWED_METHODS,
+    )
+
+
+def create_client_from_config(
+    config: Config,
+    *,
+    retry_profile: RetryProfile = RetryProfile.DEFAULT,
+) -> GGClient:
     """
     Create a GGClient using parameters from Config.
     """
@@ -58,6 +104,7 @@ https://docs.gitguardian.com/ggshield-docs/reference/auth/login""",
         api_url,
         allow_self_signed=config.user_config.insecure,
         callbacks=callbacks,
+        retry_profile=retry_profile,
     )
 
 
@@ -67,12 +114,16 @@ def create_client(
     *,
     allow_self_signed: bool = False,
     callbacks: Optional[GGClientCallbacks] = None,
+    retry_profile: RetryProfile = RetryProfile.DEFAULT,
 ) -> GGClient:
     """
     Implementation of create_client_from_config(). Exposed as a function for specific
     cases such as needing a GGClient instance while defining the config account.
     """
-    session = create_session(allow_self_signed=allow_self_signed)
+    session = create_session(
+        allow_self_signed=allow_self_signed,
+        retry_profile=retry_profile,
+    )
     try:
         return GGClient(
             api_key=api_key,
@@ -87,7 +138,10 @@ def create_client(
         raise UnexpectedError(f"Failed to create API client. {e}")
 
 
-def create_session(allow_self_signed: bool = False) -> Session:
+def create_session(
+    allow_self_signed: bool = False,
+    retry_profile: RetryProfile = RetryProfile.DEFAULT,
+) -> Session:
     session = Session()
     if allow_self_signed:
         ui.display_warning(
@@ -102,22 +156,11 @@ def create_session(allow_self_signed: bool = False) -> Session:
         )
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         session.verify = False
-    # Retry on transient connection errors (e.g. ConnectionResetError when a
-    # load balancer drops a long-lived connection during a large scan) and on
-    # transient 5xx responses. POST is included because our scan endpoints are
-    # POST-based.
-    retries = urllib3.Retry(
-        total=5,
-        backoff_factor=0.2,
-        status_forcelist=[502, 503, 504],
-        allowed_methods=frozenset(
-            {"HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"}
-        ),
-    )
-    # Mount HTTPAdapter with larger pool sizes for better concurrency
+    # Mount HTTPAdapter with larger pool sizes for better concurrency and a
+    # retry policy selected per command. See RetryProfile for the rationale.
     adapter = HTTPAdapter(
         pool_maxsize=100,  # default 10
-        max_retries=retries,
+        max_retries=_build_retry(retry_profile),
     )
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/tests/unit/cmd/scan/test_prereceive.py
+++ b/tests/unit/cmd/scan/test_prereceive.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 from pygitguardian.models import Detail
 
 from ggshield.__main__ import cli
+from ggshield.core.client import RetryProfile
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.errors import ExitCode
 from ggshield.core.scan import StringScannable
@@ -88,6 +89,39 @@ class TestPreReceive:
         assert_invoke_ok(result)
         scan_commit_range_mock.assert_called_once()
         assert "Commits to scan: 3" in result.output
+
+    @patch("ggshield.cmd.secret.scan.prereceive.create_client_from_config")
+    @patch("ggshield.cmd.secret.scan.prereceive.scan_commit_range")
+    def test_uses_pre_receive_retry_profile(
+        self,
+        scan_commit_range_mock: Mock,
+        create_client_from_config_mock: Mock,
+        tmp_path,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN the pre-receive command is invoked
+        WHEN it builds the GGClient
+        THEN it requests the PRE_RECEIVE retry profile so the client stays
+        inside GHES's fixed pre-receive hook timeout
+        """
+        scan_commit_range_mock.return_value = ExitCode.SUCCESS
+
+        repo = create_pre_receive_repo(tmp_path)
+        old_sha = repo.get_top_sha()
+        shas = [repo.create_commit() for _ in range(3)]
+        with cd(repo.path):
+            cli_fs_runner.invoke(
+                cli,
+                ["-v", "secret", "scan", "pre-receive"],
+                input=f"{old_sha} {shas[-1]} origin/main\n",
+            )
+
+        create_client_from_config_mock.assert_called_once()
+        assert (
+            create_client_from_config_mock.call_args.kwargs["retry_profile"]
+            is RetryProfile.PRE_RECEIVE
+        )
 
     @patch("ggshield.cmd.secret.scan.prereceive.scan_commit_range")
     def test_stdin_input_secret(

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -10,6 +10,7 @@ from pygitguardian import GGClient
 from pygitguardian.models import APITokensResponse, Detail, TokenScope
 
 from ggshield.core.client import (
+    RetryProfile,
     check_client_api_key,
     create_client_from_config,
     create_session,
@@ -261,12 +262,11 @@ def test_create_session_pool_configuration():
     assert getattr(adapter, "_pool_maxsize", None) == 100
 
 
-def test_create_session_retry_configuration():
+def test_create_session_default_retry_profile():
     """
-    GIVEN create_session is called
+    GIVEN create_session is called without retry_profile
     WHEN the session is created
-    THEN the HTTPAdapter retries transient connection errors and 5xx responses,
-    including for POST requests used by scan endpoints
+    THEN the HTTPAdapter uses the DEFAULT retry profile (~15s budget)
     """
     session = create_session()
 
@@ -274,9 +274,74 @@ def test_create_session_retry_configuration():
     retries = adapter.max_retries
 
     assert retries.total == 5
-    assert retries.backoff_factor == 0.2
+    assert retries.backoff_factor == 0.5
+    assert retries.backoff_max == 8
+    assert retries.backoff_jitter == 0.5
     assert set(retries.status_forcelist) == {502, 503, 504}
     assert "POST" in retries.allowed_methods
+
+
+def test_create_session_pre_receive_retry_profile():
+    """
+    GIVEN create_session is called with PRE_RECEIVE profile
+    WHEN the session is created
+    THEN the HTTPAdapter uses a minimal retry policy that fits inside GitHub
+    Enterprise Server's 5s pre-receive hook timeout: one immediate retry, no
+    backoff
+    """
+    session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
+
+    adapter = session.get_adapter("https://example.com")
+    retries = adapter.max_retries
+
+    assert retries.total == 1
+    assert retries.backoff_factor == 0
+    assert retries.backoff_jitter == 0
+    assert set(retries.status_forcelist) == {502, 503, 504}
+    assert "POST" in retries.allowed_methods
+
+
+def test_create_client_threads_retry_profile():
+    """
+    GIVEN create_client is called with a retry_profile
+    WHEN the underlying session is created
+    THEN the session's HTTPAdapter uses that profile
+
+    Tests the low-level entry point, which is what create_client_from_config
+    forwards to.
+    """
+    from ggshield.core.client import create_client
+
+    client = create_client(
+        api_key="test-api-key",
+        api_url="https://api.example.com",
+        retry_profile=RetryProfile.PRE_RECEIVE,
+    )
+
+    adapter = client.session.get_adapter("https://example.com")
+    assert adapter.max_retries.total == 1
+    assert adapter.max_retries.backoff_factor == 0
+
+
+def test_create_client_from_config_forwards_retry_profile():
+    """
+    GIVEN create_client_from_config is called with a retry_profile
+    WHEN it delegates to create_client
+    THEN it passes the retry_profile through unchanged
+    """
+    config = Mock(spec=Config)
+    config.api_key = "test-api-key"
+    config.api_url = "https://api.example.com"
+    config.user_config = Mock()
+    config.user_config.insecure = False
+
+    with patch("ggshield.core.client.create_client") as create_client_mock:
+        create_client_from_config(config, retry_profile=RetryProfile.PRE_RECEIVE)
+
+    create_client_mock.assert_called_once()
+    assert (
+        create_client_mock.call_args.kwargs["retry_profile"] is RetryProfile.PRE_RECEIVE
+    )
 
 
 @pytest.mark.parametrize("allow_self_signed", [True, False])


### PR DESCRIPTION
## Context

Follow-up to #1218 ([END-176](https://linear.app/gitguardian/issue/END-176/ggshield-connection-aborted-error-message)). The retry policy restored in #1218 (`total=5, backoff_factor=0.2`, ~6 s worst case, no jitter) is too short to outlast a typical SaaS edge incident on large multi-batch scans, and customers kept reporting `Connection aborted / ConnectionResetError` failures after it shipped.

An earlier draft of this PR bumped the policy to a single, session-wide `total=8, backoff_factor=0.3, backoff_jitter=0.5, backoff_max=20` (~58 s worst case). Code review caught that **GitHub Enterprise Server enforces a fixed 5 s timeout shared across all pre-receive hooks** ([docs](https://docs.github.com/en/enterprise-server@3.17/admin/enforcing-policies/enforcing-policy-with-pre-receive-hooks/about-pre-receive-hooks)), so any retry budget that adds measurable wall clock would break `secret scan pre-receive` on GHES — exactly the customers most reliant on it.

## What has been done

Introduce two named retry profiles and select per command via a keyword-only argument threaded through `create_session` / `create_client` / `create_client_from_config`. The retry policy lives in one place (`ggshield/core/client.py`) and the only command that opts out of the default is `prereceive.py`.

```python
class RetryProfile(Enum):
    DEFAULT = "default"           # ~15 s budget, jittered
    PRE_RECEIVE = "pre_receive"   # 1 immediate retry, no backoff
```

- **`DEFAULT`** — `total=5, backoff_factor=0.5, backoff_max=8, backoff_jitter=0.5`. Sleep schedule before each retry: `0, 1, 2, 4, 8 s`, each (after the first) jittered by up to 0.5 s; the 8 s sleep is capped by `backoff_max`. Worst case wall clock ≈ 15 s (≈ 16.5 s with maximum jitter). Long enough to absorb a typical SaaS edge blip; jitter de-synchronizes the up-to-`pool_maxsize=100` batches that can fail together when a load balancer aborts many in-flight POSTs at once. Used by every command **except** pre-receive.
- **`PRE_RECEIVE`** — `total=1, backoff_factor=0, backoff_jitter=0`. One immediate retry, no backoff, ~0 s added wall clock. Recovers the instant `ConnectionResetError` that motivated the original ticket without eating into GHES's 5 s budget. Used by `secret scan pre-receive` only.
- `status_forcelist=[502, 503, 504]` and `allowed_methods` (with POST, since scan endpoints are POST-based) are unchanged from #1218.
- `pool_maxsize=100` is unchanged.

`urllib3 >= 2.2.2` (already a hard dependency in `pyproject.toml`) exposes `backoff_max` and `backoff_jitter`, so no dependency change is needed.

## Why scope per command instead of a single policy

A single ~15 s session-wide policy would still risk exceeding GHES's 5 s pre-receive timeout in the worst case (initial attempt + first retry + connection time). A single ~0 s policy regresses #1218 for all other commands. The two-profile split keeps the policy decision local to where it's set (one line in `prereceive.py`), with `DEFAULT` covering every other call site (including `pre-commit`, `pre-push`, `ai_hook`, and the entire CLI surface for `auth`, `quota`, `status`, etc., which run on developer machines with no hard server-side timeout).

## Validation

- `tests/unit/core/test_client.py` — replaced the single retry-config test with three: `test_create_session_default_retry_profile`, `test_create_session_pre_receive_retry_profile`, `test_create_client_threads_retry_profile`. All pass.
- `tests/unit/cmd/scan/test_prereceive.py` (10 tests) — all pass; pre-receive command still behaves correctly with the minimal profile.
- Wider sweep across `tests/unit/cmd/scan/` and `tests/unit/core/test_client.py` shows 153 passes (8 pre-existing pyfakefs teardown E's, unrelated and reproduced on the unchanged baseline).

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)