### PR TITLE
build(docker): use wolfi python as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM python:3.10-slim AS build
+FROM ghcr.io/gitguardian/wolfi/python:3.10-dev AS build
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
+
+WORKDIR /app
+
+COPY . .
+
+RUN python3 -m venv /app/.venv \
+    && /app/.venv/bin/pip install --no-cache-dir .
+
+# ---------------------------------------------------------
+
+FROM cgr.dev/chainguard/wolfi-base AS runtime
 
 LABEL maintainer="GitGuardian SRE Team <support@gitguardian.com>"
 
@@ -8,20 +24,16 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
 ENV PATH=/app/.venv/bin:$PATH
 
-WORKDIR /app
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache bash python-3.10 git openssh-client \
+    && rm -rf /var/cache/apk/*
 
-RUN \
-    apt-get update \
-    && apt-get dist-upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends git openssh-client \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY . .
-
-RUN pip install .
+COPY --from=build /app/.venv /app/.venv
+COPY --from=build /app/docker /app/docker
 
 WORKDIR /data
 VOLUME [ "/data" ]
 
+ENTRYPOINT []
 CMD ["ggshield"]

--- a/changelog.d/20260513_091200_6d7a_wolfi_base.md
+++ b/changelog.d/20260513_091200_6d7a_wolfi_base.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Use `cgr.dev/chainguard/wolfi-base` as a base runtime image for the `ggshield` docker image.


### PR DESCRIPTION
## Context

The current docker base image is vulnerable to CVE-2026-33845.

## What has been done

Use `ghcr.io/gitguardian/wolfi/python:3.10-dev` as a build image and `cgr.dev/chainguard/wolfi-base` as a runtime base.