### PR TITLE
Split VSCode/Copilot CLI and fix hooks

### DIFF
--- a/changelog.d/20260430_000000_add_codex_ai_hooks.md
+++ b/changelog.d/20260430_000000_add_codex_ai_hooks.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Add Codex support to `ggshield secret scan ai-hook` and `ggshield install -t codex`.
+- Add Codex support to `ggshield secret scan ai-hook` and `ggshield install -t codex`. (thanks to trickyfalcon)

--- a/changelog.d/20260512_122415_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260512_122415_paul.petit.ext_HEAD.md
@@ -1,0 +1,7 @@
+### Added
+
+- New `vscode` alias to "copilot" for hook installation.
+
+### Fixed
+
+- fixed AI hooks support for Copilot CLI.

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -5,11 +5,12 @@ from .claude_code import Claude
 from .codex import Codex
 from .copilot import Copilot
 from .cursor import Cursor
+from .vscode import VSCode
 
 
 AGENTS: Dict[str, Agent] = {
-    agent.name: agent for agent in [Cursor(), Claude(), Copilot(), Codex()]
+    agent.name: agent for agent in [Claude(), Codex(), Copilot(), Cursor(), VSCode()]
 }
 
 
-__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor"]
+__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "VSCode"]

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional
+from typing import Any, Dict, Iterator, List, Literal
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -63,64 +63,13 @@ class Claude(Agent):
         # We don't use the return 2 convention to make sure our JSON output is read.
         return 0
 
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return "session_id" in hook_payload and "claude" in hook_payload.get(
+            "transcript_path", ""
+        )
+
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".claude") / "settings.json"
-
-    @property
-    def settings_template(self) -> Dict[str, Any]:
-        return {
-            "hooks": {
-                "PreToolUse": [
-                    {
-                        "matcher": ".*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-                "PostToolUse": [
-                    {
-                        "matcher": ".*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-                "UserPromptSubmit": [
-                    {
-                        "matcher": ".*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-            }
-        }
-
-    def settings_locate(
-        self, candidates: List[Dict[str, Any]], template: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
-        # We have two kind of lists: at the root of each hook (with a matcher)
-        # and in each hook (with a list of commands).
-        if "matcher" in template:
-            for obj in candidates:
-                if obj.get("matcher") == template["matcher"]:
-                    return obj
-            return None
-        for obj in candidates:
-            command = obj.get("command", "")
-            if "ggshield" in command or "<COMMAND>" in command:
-                return obj
-        return None
 
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".mcp.json"

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional
+from typing import Any, Dict, Iterator, Literal
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -49,66 +49,14 @@ class Codex(Agent):
         click.echo(json.dumps(response))
         return 0
 
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return (
+            "turn_id" in hook_payload
+            or ".codex" in hook_payload.get("transcript_path", "").lower()
+        )
+
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".codex") / "hooks.json"
-
-    @property
-    def settings_template(self) -> Dict[str, Any]:
-        return {
-            "hooks": {
-                "PreToolUse": [
-                    {
-                        "matcher": ".*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-                "PostToolUse": [
-                    {
-                        "matcher": ".*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-                "UserPromptSubmit": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "<COMMAND>",
-                            }
-                        ],
-                    }
-                ],
-            }
-        }
-
-    def settings_locate(
-        self, candidates: List[Dict[str, Any]], template: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
-        if "matcher" in template:
-            for obj in candidates:
-                if obj.get("matcher") == template["matcher"]:
-                    return obj
-            return None
-        for obj in candidates:
-            command = obj.get("command", "")
-            if "ggshield" in command or "<COMMAND>" in command:
-                return obj
-        for obj in candidates:
-            for hook in obj.get("hooks", []):
-                command = hook.get("command", "")
-                if "ggshield" in command or "<COMMAND>" in command:
-                    return obj
-        return None
 
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".codex" / "config.toml"

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,19 +1,10 @@
-import json
-from pathlib import Path
-from typing import Any, Dict, Iterator, Literal, Tuple
-
-import click
-from pygitguardian.models import AIDiscovery, MCPActivityRequest
-
-from ggshield.core.dirs import get_user_home_dir
-
-from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
+from .vscode import VSCode
 
 
-class Copilot(Agent):
-    """Behavior specific to Copilot Chat.
+class Copilot(VSCode):
+    """Behavior specific to Copilot CLI.
 
-    Inherits most of its behavior from Claude Code.
+    Inherits most of its behavior from VSCode.
     """
 
     @property
@@ -22,87 +13,4 @@ class Copilot(Agent):
 
     @property
     def display_name(self) -> str:
-        return "Copilot Chat"
-
-    @property
-    def config_folder(self) -> Path:
-        return get_user_home_dir() / ".config" / "Code" / "User"
-
-    def output_result(self, result: HookResult) -> int:
-        response = {}
-        if result.block:
-            if result.payload.event_type == EventType.PRE_TOOL_USE:
-                response["hookSpecificOutput"] = {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": result.message,
-                }
-            elif result.payload.event_type == EventType.POST_TOOL_USE:
-                response["decision"] = "block"
-                response["reason"] = result.message
-            else:
-                response["continue"] = False
-                response["stopReason"] = result.message
-        else:
-            response["continue"] = True
-
-        click.echo(json.dumps(response))
-        return 0
-
-    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
-        return "github.copilot-chat" in hook_payload.get("transcript_path", "").lower()
-
-    def settings_path(self, mode: Literal["local", "global"]) -> Path:
-        return (
-            Path(".github" if mode == "local" else ".copilot") / "hooks" / "hooks.json"
-        )
-
-    def project_mcp_file(self, directory: Path) -> Path:
-        return directory / ".vscode" / "mcp.json"
-
-    def discover_project_directories(self) -> Iterator[Path]:
-        # Try to parse workspaces settings.
-        for file in self.config_folder.glob("workspaceStorage/*/workspace.json"):
-            if (data := self._load_json_file(file)) and "folder" in data:
-                path = Path(data["folder"].removeprefix("file://"))
-                if path.is_dir():
-                    yield path.resolve()
-
-    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
-        yield from Agent._get_user_mcp_configurations(self)
-
-    def parse_mcp_activity(
-        self, payload: HookPayload, ai_config: AIDiscovery
-    ) -> MCPActivityRequest:
-        """Parse the MCP activity from an MCP hook payload."""
-
-        raw_tool_name: str = payload.raw.get("tool_name", "")
-        server_name, tool_name = _lookup_server_name(raw_tool_name, ai_config)
-
-        return MCPActivityRequest(
-            user=ai_config.user,
-            tool=tool_name,
-            server=server_name,
-            agent=self.name,
-            model="",
-            cwd=payload.raw.get("cwd", ""),
-            input=payload.raw.get("tool_input", {}),
-        )
-
-
-def _lookup_server_name(raw_tool_name: str, ai_config: AIDiscovery) -> Tuple[str, str]:
-    # Copilot's hook tool name is "mcp_{server}_{tool}"
-    # which is unfortunate because a lot of tools have a "_" in their name.
-    # For now we hope there won't be "_" in the server configuration name
-    # (this is less likely than in the tool name but very brittle).
-    # TODO: test this more thoroughly and implement a better lookup.
-    _, server_cfg_name, *tool_parts = raw_tool_name.split("_")
-    tool = "_".join(tool_parts)
-
-    # Lookup the server name based on its configuration name
-    # Fallback to the configuration name if not found
-    for server in ai_config.servers:
-        for configuration in server.configurations:
-            if configuration.name == server_cfg_name:
-                return server.name, tool
-    return server_cfg_name, tool
+        return "Copilot CLI"

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,3 +1,5 @@
+from ggshield.verticals.ai.models import EventType, HookPayload
+
 from .vscode import VSCode
 
 
@@ -14,3 +16,17 @@ class Copilot(VSCode):
     @property
     def display_name(self) -> str:
         return "Copilot CLI"
+
+    def is_caller(self, hook_payload: dict[str, str]) -> bool:
+        # Copilot CLI only emits the default fields in all hooks, which in a way identifies it.
+        default_fields = {"hook_event_name", "session_id", "timestamp", "cwd"}
+        optional_fields = {"prompt", "tool_name", "tool_input", "tool_result"}
+        return set(hook_payload.keys()) - optional_fields == default_fields
+
+    def has_secret_already_leaked(self, payload: HookPayload) -> bool:
+        # Copilot CLI doesn't allow blocking on UserPromptSubmit.
+        # Special case: if we found a secret because we read a file that was "@" in a prompt,
+        # then we did prevent the leak.
+        if payload.event_type == EventType.USER_PROMPT and payload.tool is None:
+            return True
+        return super().has_secret_already_leaked(payload)

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Iterator, Literal, Tuple
+from typing import Any, Dict, Iterator, Literal, Tuple
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -8,10 +8,9 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from ggshield.core.dirs import get_user_home_dir
 
 from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
-from .claude_code import Claude
 
 
-class Copilot(Claude):
+class Copilot(Agent):
     """Behavior specific to Copilot Chat.
 
     Inherits most of its behavior from Claude Code.
@@ -49,6 +48,9 @@ class Copilot(Claude):
 
         click.echo(json.dumps(response))
         return 0
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return "github.copilot-chat" in hook_payload.get("transcript_path", "").lower()
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return (

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -61,6 +61,9 @@ class Cursor(Agent):
         # We don't use the return 2 convention to make sure our JSON output is read.
         return 0
 
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return "cursor_version" in hook_payload
+
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".cursor") / "hooks.json"
 

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, Literal, Tuple
+
+import click
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
+
+from ggshield.core.dirs import get_user_home_dir
+
+from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
+
+
+class VSCode(Agent):
+    """Behavior specific to VSCode."""
+
+    @property
+    def name(self) -> str:
+        return "vscode"
+
+    @property
+    def display_name(self) -> str:
+        return "VSCode"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".config" / "Code" / "User"
+
+    def output_result(self, result: HookResult) -> int:
+        response = {}
+        if result.block:
+            if result.payload.event_type == EventType.PRE_TOOL_USE:
+                response["hookSpecificOutput"] = {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": result.message,
+                }
+            elif result.payload.event_type == EventType.POST_TOOL_USE:
+                response["decision"] = "block"
+                response["reason"] = result.message
+            else:
+                response["continue"] = False
+                response["stopReason"] = result.message
+        else:
+            response["continue"] = True
+
+        click.echo(json.dumps(response))
+        return 0
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return "github.copilot-chat" in hook_payload.get("transcript_path", "").lower()
+
+    def settings_path(self, mode: Literal["local", "global"]) -> Path:
+        return (
+            Path(".github" if mode == "local" else ".copilot") / "hooks" / "hooks.json"
+        )
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".vscode" / "mcp.json"
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        # Try to parse workspaces settings.
+        for file in self.config_folder.glob("workspaceStorage/*/workspace.json"):
+            if (data := self._load_json_file(file)) and "folder" in data:
+                path = Path(data["folder"].removeprefix("file://"))
+                if path.is_dir():
+                    yield path.resolve()
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        yield from Agent._get_user_mcp_configurations(self)
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        """Parse the MCP activity from an MCP hook payload."""
+
+        raw_tool_name: str = payload.raw.get("tool_name", "")
+        server_name, tool_name = _lookup_server_name(raw_tool_name, ai_config)
+
+        return MCPActivityRequest(
+            user=ai_config.user,
+            tool=tool_name,
+            server=server_name,
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+        )
+
+
+def _lookup_server_name(raw_tool_name: str, ai_config: AIDiscovery) -> Tuple[str, str]:
+    # Copilot's hook tool name is "mcp_{server}_{tool}"
+    # which is unfortunate because a lot of tools have a "_" in their name.
+    # For now we hope there won't be "_" in the server configuration name
+    # (this is less likely than in the tool name but very brittle).
+    # TODO: test this more thoroughly and implement a better lookup.
+    _, server_cfg_name, *tool_parts = raw_tool_name.split("_")
+    tool = "_".join(tool_parts)
+
+    # Lookup the server name based on its configuration name
+    # Fallback to the configuration name if not found
+    for server in ai_config.servers:
+        for configuration in server.configurations:
+            if configuration.name == server_cfg_name:
+                return server.name, tool
+    return server_cfg_name, tool

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -46,7 +46,9 @@ def lookup(data: Dict[str, Any], keys: Sequence[str], default: Any = None) -> An
 _FILE_PATH_REGEX = re.compile(
     r'@"((?:[^"\\]|\\.)*)"'  # quoted: @"..."
     r"|"
-    r"(?:\W|^)@([\w/\\.-]+)",  # unquoted: @path
+    r"(?:\W|^)@"  # unquoted: @path
+    r"(?:file:)?"  # some agents add a "file:" prefix
+    r"([\w/\\.-]+)",
     re.MULTILINE,
 )
 
@@ -112,7 +114,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             identifier = content
         elif tool == Tool.READ:
             # We only need to deal with the identifier, the content will be read by the Scannable
-            identifier = lookup(tool_input, ["file_path", "filePath"], "")
+            identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
 
     elif event_type == EventType.POST_TOOL_USE:
         tool = _parse_tool(data)

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -12,7 +12,7 @@ from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
 from ggshield.verticals.ai.mcp import send_mcp_activity
 
-from .agents import Claude, Codex, Copilot, Cursor
+from .agents import AGENTS
 from .models import Agent, EventType, HookPayload, HookResult, Tool
 
 
@@ -147,17 +147,10 @@ def _parse_tool(data: Dict[str, Any]) -> Tool:
 
 def _detect_agent(data: Dict[str, Any]) -> Agent:
     """Detect the AI code assistant."""
-    if "cursor_version" in data:
-        return Cursor()
-    elif "github.copilot-chat" in data.get("transcript_path", "").lower():
-        return Copilot()
-    # no .lower() here to reduce the risk of false positives (this is also why this check is last)
-    elif "session_id" in data and "claude" in data.get("transcript_path", ""):
-        return Claude()
-    elif "turn_id" in data or ".codex" in data.get("transcript_path", "").lower():
-        return Codex()
-    # No other agent is supported yet
-    raise ValueError("Unsupported agent")
+    for agent in AGENTS.values():
+        if agent.is_caller(data):
+            return agent
+    raise ValueError("Unrecognized agent")
 
 
 def _parse_user_prompt(
@@ -207,8 +200,8 @@ class AIHookScanner:
         result = self._scan_payloads(payloads)
         payload = result.payload
 
-        # Special case: in post-tool use, the action is already done: at least notify the user
-        if result.block and payload.event_type == EventType.POST_TOOL_USE:
+        # Sometimes the secret has already leaked to the agent. Notify the user.
+        if result.block and payload.agent.has_secret_already_leaked(payload):
             self._send_secret_notification(
                 result.nbr_secrets,
                 payload.tool or Tool.OTHER,

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -29,6 +29,7 @@ TOOL_NAME_TO_TOOL = {
     "run_in_terminal": Tool.BASH,  # Copilot
     "read": Tool.READ,  # Claude/Cursor
     "read_file": Tool.READ,  # Copilot
+    "view": Tool.READ,  # Copilot CLI
 }
 
 
@@ -115,8 +116,8 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
 
     elif event_type == EventType.POST_TOOL_USE:
         tool = _parse_tool(data)
-        content = data.get("tool_output", "") or data.get("tool_response", {})
-        # Claude Code returns a dict for the tool output
+        content = lookup(data, ["tool_output", "tool_response", "tool_result"], {})
+        # Some agents return a dict for the tool output. Also support lists just in case.
         if isinstance(content, (dict, list)):
             content = json.dumps(content)
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -117,6 +117,17 @@ class Agent(ABC):
         Returns: the exit code.
         """
 
+    @abstractmethod
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        """Whether the agent is the caller of the hook."""
+
+    def has_secret_already_leaked(self, payload: HookPayload) -> bool:
+        """Whether the secret has already been leaked to the agent.
+
+        By default, this is in PostToolUse hooks, but it can depend on the agent.
+        """
+        return payload.event_type == EventType.POST_TOOL_USE
+
     # Settings
 
     @abstractmethod
@@ -124,14 +135,49 @@ class Agent(ABC):
         """Path to the settings file for this AI coding tool."""
 
     @property
-    @abstractmethod
     def settings_template(self) -> Dict[str, Any]:
         """
         Template for the settings file for this AI coding tool.
         Use the sentinel "<COMMAND>" for the places where the command should be inserted.
         """
+        return {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "<COMMAND>",
+                            }
+                        ],
+                    }
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "<COMMAND>",
+                            }
+                        ],
+                    }
+                ],
+                "UserPromptSubmit": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "<COMMAND>",
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
 
-    @abstractmethod
     def settings_locate(
         self, candidates: List[Dict[str, Any]], template: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
@@ -147,6 +193,17 @@ class Agent(ABC):
 
         Returns: the object to update, or None if no object was found.
         """
+        # We have two kind of lists: at the root of each hook (with a matcher)
+        # and in each hook (with a list of commands).
+        if "matcher" in template:
+            for obj in candidates:
+                if obj.get("matcher") == template["matcher"]:
+                    return obj
+            return None
+        for obj in candidates:
+            command = obj.get("command", "")
+            if "ggshield" in command or "<COMMAND>" in command:
+                return obj
         return None
 
     # Discovery

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -9,7 +9,7 @@ from pygitguardian import GGClient
 from pygitguardian.models import MCPActivityResponse
 
 from ggshield.utils.git_shell import Filemode
-from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor
+from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor, VSCode
 from ggshield.verticals.ai.hooks import AIHookScanner, find_filepaths, parse_hook_input
 from ggshield.verticals.ai.mcp import send_mcp_activity
 from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
@@ -561,12 +561,12 @@ class TestAIHookScannerParseInput:
         assert payload.tool is None
         assert isinstance(payload.agent, Claude)
 
-    def test_copilot_user_prompt(self):
-        """Test Copilot UserPromptSubmit parsing."""
+    def test_vscode_user_prompt(self):
+        """Test VSCode UserPromptSubmit parsing."""
         data = {
             "timestamp": "2026-02-26T11:28:53.112Z",
-            "hookEventName": "UserPromptSubmit",
-            "sessionId": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
             "transcript_path": (
                 "/home/user1/.config/Code/User/workspaceStorage/"
                 "abc123/GitHub.copilot-chat/transcripts/69cc6a03.jsonl"
@@ -578,15 +578,15 @@ class TestAIHookScannerParseInput:
         assert payload.event_type == EventType.USER_PROMPT
         assert "hello world" in payload.content
         assert payload.tool is None
-        assert isinstance(payload.agent, Copilot)
+        assert isinstance(payload.agent, VSCode)
 
-    def test_copilot_pre_tool_use_run_in_terminal(self):
-        """Test Copilot PreToolUse with run_in_terminal (shell) parsing."""
+    def test_vscode_pre_tool_use_run_in_terminal(self):
+        """Test VSCode PreToolUse with run_in_terminal (shell) parsing."""
         # From raw_hooks_logs: Copilot PreToolUse run_in_terminal
         data = {
             "timestamp": "2026-02-26T11:29:05.821Z",
-            "hookEventName": "PreToolUse",
-            "sessionId": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
             "transcript_path": (
                 "/home/user1/.config/Code/User/workspaceStorage/"
                 "abc123/GitHub.copilot-chat/transcripts/69cc6a03.jsonl"
@@ -606,15 +606,15 @@ class TestAIHookScannerParseInput:
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.BASH
         assert "whoami" in payload.content
-        assert isinstance(payload.agent, Copilot)
+        assert isinstance(payload.agent, VSCode)
 
-    def test_copilot_pre_tool_use_read_file(self, tmp_file: Path):
-        """Test Copilot PreToolUse with read_file parsing."""
-        # From raw_hooks_logs: Copilot PreToolUse read_file (nonexistent path for deterministic test)
+    def test_vscode_pre_tool_use_read_file(self, tmp_file: Path):
+        """Test VSCode PreToolUse with read_file parsing."""
+        # From raw_hooks_logs: VSCode PreToolUse read_file (nonexistent path for deterministic test)
         data = {
             "timestamp": "2026-02-26T11:53:49.593Z",
-            "hookEventName": "PreToolUse",
-            "sessionId": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
             "transcript_path": (
                 "/home/user1/.config/Code/User/workspaceStorage/"
                 "abc123/GitHub.copilot-chat/transcripts/69cc6a03.jsonl"
@@ -634,15 +634,15 @@ class TestAIHookScannerParseInput:
         assert payload.identifier == tmp_file.as_posix()
         assert payload.content == ""
         assert payload.scannable.content == "this is the content"
-        assert isinstance(payload.agent, Copilot)
+        assert isinstance(payload.agent, VSCode)
 
-    def test_copilot_post_tool_use_run_in_terminal(self):
-        """Test Copilot PostToolUse with run_in_terminal (simulated cat result)."""
+    def test_vscode_post_tool_use_run_in_terminal(self):
+        """Test VSCode PostToolUse with run_in_terminal (simulated cat result)."""
         # From raw_hooks_logs: Copilot PostToolUse run_in_terminal - tool_response is string
         data = {
             "timestamp": "2026-02-26T11:53:47.392Z",
-            "hookEventName": "PostToolUse",
-            "sessionId": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "hook_event_name": "PostToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
             "transcript_path": (
                 "/home/user1/.config/Code/User/workspaceStorage/"
                 "abc123/GitHub.copilot-chat/transcripts/69cc6a03.jsonl"
@@ -663,7 +663,99 @@ class TestAIHookScannerParseInput:
         assert payload.event_type == EventType.POST_TOOL_USE
         assert payload.tool == Tool.BASH
         assert "user1" in payload.content
+        assert isinstance(payload.agent, VSCode)
+
+    def test_copilot_user_prompt(self):
+        """Test Copilot UserPromptSubmit parsing."""
+        data = {
+            "timestamp": "2026-02-26T11:28:53.112Z",
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "prompt": "hello world",
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.USER_PROMPT
+        assert "hello world" in payload.content
+        assert payload.tool is None
         assert isinstance(payload.agent, Copilot)
+
+    def test_copilot_pre_tool_use_run_in_terminal(self):
+        """Test Copilot PreToolUse with bash parsing."""
+        data = {
+            "timestamp": "2026-02-26T11:29:05.821Z",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "tool_name": "bash",
+            "tool_input": {
+                "command": "whoami",
+                "description": "whoami to test preToolUse hook",
+                "mode": "sync",
+                "initial_wait": 30,
+            },
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.BASH
+        assert "whoami" in payload.content
+        assert isinstance(payload.agent, Copilot)
+
+    def test_copilot_pre_tool_use_read_file(self, tmp_file: Path):
+        """Test Copilot PreToolUse with read_file parsing."""
+        # From raw_hooks_logs: Copilot PreToolUse read_file (nonexistent path for deterministic test)
+        data = {
+            "timestamp": "2026-02-26T11:53:49.593Z",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "tool_name": "view",
+            "tool_input": {
+                "path": tmp_file.as_posix(),
+            },
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.READ
+        assert payload.identifier == tmp_file.as_posix()
+        assert payload.content == ""
+        assert payload.scannable.content == "this is the content"
+        assert isinstance(payload.agent, Copilot)
+
+    def test_copilot_post_tool_use_run_in_terminal(self):
+        """Test Copilot PostToolUse with bash"""
+        data = {
+            "timestamp": "2026-02-26T11:53:47.392Z",
+            "hook_event_name": "PostToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "tool_name": "run_in_terminal",
+            "tool_input": {
+                "command": "whoami",
+                "explanation": "whoami to test postToolUse hook",
+                "goal": "whoami to test postToolUse hook",
+                "isBackground": False,
+                "timeout": 0,
+            },
+            "tool_result": {
+                "result_type": "success",
+                "text_result_for_llm": "user1\n<exited with exit code 0>",
+            },
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.POST_TOOL_USE
+        assert payload.tool == Tool.BASH
+        assert "user1" in payload.content
+        assert isinstance(payload.agent, Copilot)
+
+    def test_raises_if_no_agent_recognized(self):
+        """Test raises if no agent can be recognized."""
+        data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "hello world",
+        }
+        with pytest.raises(ValueError, match="Unrecognized agent"):
+            parse_hook_input(json.dumps(data))
 
     def test_codex_user_prompt(self):
         """Test Codex UserPromptSubmit parsing."""

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1105,6 +1105,7 @@ class TestFlavorOutputResult:
         ("@filename.txt", {"filename.txt"}),
         ("same @file @file twice", {"file"}),
         ("File can start with a dot: @.env", {".env"}),
+        ("File can contain underscores: @my_file.txt", {"my_file.txt"}),
         (
             "Files simply mentioned without @ prefix are not matched: foo.txt bar.txt.",
             set(),
@@ -1138,6 +1139,8 @@ class TestFlavorOutputResult:
             {"config.json", "big file.txt"},
         ),
         ("Newline before @: line1\n@file.txt", {"file.txt"}),
+        ("VSCode-style path: @file:file.txt", {"file.txt"}),
+        ("VSCode-style path with folder: @file:folder/file.txt", {"folder/file.txt"}),
     ],
 )
 def test_find_filepaths(prompt: str, filepaths: Set[str]):

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -305,36 +305,6 @@ class TestFlavorSettingsProperties:
     def test_codex_settings_template(self):
         assert isinstance(Codex().settings_template, dict)
 
-    def test_codex_settings_locate_finds_nested_ggshield_hook(self):
-        codex = Codex()
-        candidates = [
-            {"hooks": [{"type": "command", "command": "other-tool"}]},
-            {"hooks": [{"type": "command", "command": "ggshield secret scan ai-hook"}]},
-        ]
-        template = {"hooks": [{"type": "command", "command": "<COMMAND>"}]}
-        result = codex.settings_locate(candidates, template)
-        assert result is candidates[1]
-
-    def test_codex_settings_locate_finds_command_hook(self):
-        codex = Codex()
-        candidates = [
-            {"type": "command", "command": "other-tool"},
-            {"type": "command", "command": "ggshield secret scan ai-hook"},
-        ]
-        template = {"type": "command", "command": "<COMMAND>"}
-        result = codex.settings_locate(candidates, template)
-        assert result is candidates[1]
-
-    def test_codex_settings_locate_finds_matching_matcher(self):
-        codex = Codex()
-        candidates = [
-            {"matcher": "Bash", "hooks": []},
-            {"matcher": ".*", "hooks": []},
-        ]
-        template = {"matcher": ".*", "hooks": []}
-        result = codex.settings_locate(candidates, template)
-        assert result is candidates[1]
-
 
 class TestInstallHooks:
     """Unit tests for the install_hooks function."""


### PR DESCRIPTION
## Context

Some customers notified us that the hooks weren't working for their developpers.

After some investigation, it turned out that they were using "Copilot CLI", which is a distinct product than VSCode with Copilot Chat.

Although their configuration is mostly interchangeable, they behave differently (distinct payloads, not the same response to hook results, etc.). Most notably, Copilot CLI currently doesn't allow blocking a user prompt, only a tool use.

Some more work will be needed to properly support MCP servers and their differences between VSCode and Copilot CLI, which will be for a subsequent PR.

## What has been done

- the first commit is a small refactoring to have more custom-logic in `Agent`, and remove the inheritance between `Copilot` and `Claude`.
- then a new `VSCode` class replaces what was `Copilot`, which becomes a very light subclass.
  - because they can share the same configuration, from a UX perspective this is like simply having `vscode` and `copilot` being two aliases for the same hook installation
- then Copilot specifics are added so that it is properly recognized and hooks work
- while doing tests, I noticed that VSCode changed its behavior when files were "@-ed" in a prompt. This is fixed in another commit
- add changelog

## Validation

```
ggshield install -t copilot -m global
copilot -p "read the content of this-file-contains-secrets.txt"
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
