### PR TITLE
AI hook basic command parsing

### DIFF
--- a/changelog.d/20260513_155719_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260513_155719_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Changed
+
+- AI hooks naively try to detect file read by shell commands.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -112,6 +112,8 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         if tool == Tool.BASH:
             content = tool_input.get("command", "")
             identifier = content
+            # Try to detect a command that could be used to read a file.
+            payloads.extend(_parse_command(content, event_type, agent))
         elif tool == Tool.READ:
             # We only need to deal with the identifier, the content will be read by the Scannable
             identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
@@ -172,6 +174,30 @@ def _parse_user_prompt(
                 tool=Tool.READ,
                 content="",
                 identifier=match,
+                agent=agent,
+                raw={},
+            )
+        )
+    return payloads
+
+
+def _parse_command(
+    content: str, event_type: EventType, agent: Agent
+) -> List[HookPayload]:
+    """Parse the command for additional payloads that we may miss."""
+    # In Windows, some agents (at least Codex) use the Get-Content command to read a file.
+    # We might as well try to detect other commands like "cat".
+    payloads = []
+
+    if content.startswith(("Get-Content ", "cat ")):
+        # Extract the filename (remove the command)
+        identifier = content.partition(" ")[2].strip()
+        payloads.append(
+            HookPayload(
+                event_type=event_type,
+                tool=Tool.READ,
+                content="",
+                identifier=identifier,
                 agent=agent,
                 raw={},
             )

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -834,6 +834,25 @@ class TestAIHookScannerParseInput:
         assert payload.content == ""
         assert payload.tool is None
 
+    def test_windows_GetContent_parsing(self):
+        """The Bash/Get-Content tool use in windows is parsed as file reading."""
+        # This case was observed with Codex on Windows.
+        data = {
+            "session_id": "273ad859-3608-4799-9971-fa15ecb1a65c",
+            "transcript_path": "/home/user/.codex/sessions/2026/04/30/session.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "PreToolUse",
+            "turn_id": "turn_123",
+            "model": "gpt-5.4",
+            "tool_name": "Bash",
+            "tool_input": {"command": "Get-Content README.md"},
+            "tool_use_id": "call_123",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.READ
+        assert payload.identifier == "README.md"
+
 
 class TestFlavorOutputResult:
     """Unit tests for Cursor, Claude, Copilot output_result with Result objects.


### PR DESCRIPTION
## Context

Some users raised the concern that we may not detect secrets leaked to AI agents in PostTool if the Agent uses bash command instead of a proper "Read" tool to access a file's content.

Our first stance was that trying to perfectly do that is probably a lost battle, and that agents prefer using a "Read" tool anyway.

After some testing with the recent Codex support, we noticed that, at least in Windows, it favors the Powershell "Get-Content" command over an agent-specific "Read" tool.

This PR adds basic support for detecting file reads in bash commands.

## What has been done

- In PreToolUse hooks, detect if the command is of the form `{read_command} {filename}`.
- Two "read_commands" supported for now: `Get-Content` and `cat`.

## Validation

- Explicitly making an agent use a bash command instead of simply prompting "use this file"
- Reading a file with Codex on a Windows computer.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
