### PR TITLE
fix(ai): include command in notification

### DIFF
--- a/changelog.d/20260513_172255_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260513_172255_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- (AI hooks): the command that leaked a secret is now shown in the notification message.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -107,6 +107,8 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
 
     elif event_type == EventType.PRE_TOOL_USE:
         tool = _parse_tool(data)
+        # NOTE: if we ever support agents that use another field than "tool_input.command",
+        # remember to update the line that reads the command to fill the notification message.
         tool_input = data.get("tool_input", {})
         # Select the content based on the tool
         if tool == Tool.BASH:
@@ -231,11 +233,7 @@ class AIHookScanner:
 
         # Sometimes the secret has already leaked to the agent. Notify the user.
         if result.block and payload.agent.has_secret_already_leaked(payload):
-            self._send_secret_notification(
-                result.nbr_secrets,
-                payload.tool or Tool.OTHER,
-                payload.agent.display_name,
-            )
+            self._send_secret_notification(result)
 
         return payload.agent.output_result(result)
 
@@ -356,7 +354,7 @@ class AIHookScanner:
 
     @staticmethod
     def _send_secret_notification(
-        nbr_secrets: int, tool: Tool, agent_name: str
+        result: HookResult,
     ) -> None:
         """
         Send desktop notification when secrets are detected.
@@ -366,16 +364,21 @@ class AIHookScanner:
             tool: Tool used to detect the secrets
             agent_name: Name of the agent that detected the secrets
         """
+        tool = result.payload.tool
         source = "using a tool"
         if tool == Tool.READ:
             source = "reading a file"
         elif tool == Tool.BASH:
-            source = "running a command"
+            # This should always be present, unless agents changed their payload in an update.
+            command = result.payload.raw.get("tool_input", {}).get("command", "")
+            source = (
+                f"running the command `{command}`" if command else "running a command"
+            )
         notification = Notify()
         notification.title = "ggshield - Secrets Detected"
         notification.message = (
-            f"{agent_name} got access to {nbr_secrets}"
-            f" {pluralize('secret', nbr_secrets)} by {source}"
+            f"{result.payload.agent.display_name} got access to {result.nbr_secrets}"
+            f" {pluralize('secret', result.nbr_secrets)} by {source}"
         )
         notification.application_name = "ggshield"
         try:

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -9,7 +9,7 @@ from pygitguardian import GGClient
 from pygitguardian.models import MCPActivityResponse
 
 from ggshield.utils.git_shell import Filemode
-from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor, VSCode
+from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
 from ggshield.verticals.ai.hooks import AIHookScanner, find_filepaths, parse_hook_input
 from ggshield.verticals.ai.mcp import send_mcp_activity
 from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
@@ -161,9 +161,9 @@ class TestAIHookScannerScan:
         code = scanner.scan(json.dumps(data))
         assert code == 0
         mock_notify.assert_called_once()
-        args = mock_notify.call_args[0]
-        assert args[0] == 1  # nbr_secrets
-        assert args[1] == Tool.BASH  # tool
+        result = mock_notify.call_args[0][0]
+        assert result.nbr_secrets == 1  # nbr_secrets
+        assert result.payload.tool == Tool.BASH  # tool
 
     def test_scan_pre_tool_use_with_secrets_blocks(self):
         """scan() on PRE_TOOL_USE with secrets returns block result."""
@@ -316,19 +316,43 @@ class TestMessageFromSecrets:
 class TestSendSecretNotification:
     """Unit tests for AIHookScanner._send_secret_notification."""
 
+    def _result(
+        self,
+        nbr_secrets: int,
+        tool: Tool,
+        agent: Agent,
+        input_command: str = "",
+    ) -> HookResult:
+        return HookResult(
+            block=True,
+            message="",
+            nbr_secrets=nbr_secrets,
+            payload=HookPayload(
+                event_type=EventType.PRE_TOOL_USE,
+                tool=tool,
+                content="",
+                identifier="",
+                agent=agent,
+                raw={"tool_input": {"command": input_command}},
+            ),
+        )
+
     @patch("ggshield.verticals.ai.hooks.Notify")
     def test_notification_for_bash_tool(self, mock_notify_cls: MagicMock):
-        """Notification for BASH tool says 'running a command'."""
-        AIHookScanner._send_secret_notification(1, Tool.BASH, "Claude Code")
+        """Notification for BASH tool says 'running the command'
+        and contains the command run."""
+        AIHookScanner._send_secret_notification(
+            self._result(1, Tool.BASH, Claude(), input_command="ls -la")
+        )
         instance = mock_notify_cls.return_value
-        assert "running a command" in instance.message
+        assert "running the command `ls -la`" in instance.message
         assert "Claude Code" in instance.message
         instance.send.assert_called_once()
 
     @patch("ggshield.verticals.ai.hooks.Notify")
     def test_notification_for_read_tool(self, mock_notify_cls: MagicMock):
         """Notification for READ tool says 'reading a file'."""
-        AIHookScanner._send_secret_notification(2, Tool.READ, "Cursor")
+        AIHookScanner._send_secret_notification(self._result(2, Tool.READ, Cursor()))
         instance = mock_notify_cls.return_value
         assert "reading a file" in instance.message
         assert "2" in instance.message
@@ -337,7 +361,7 @@ class TestSendSecretNotification:
     @patch("ggshield.verticals.ai.hooks.Notify")
     def test_notification_for_other_tool(self, mock_notify_cls: MagicMock):
         """Notification for OTHER tool says 'using a tool'."""
-        AIHookScanner._send_secret_notification(1, Tool.OTHER, "Copilot")
+        AIHookScanner._send_secret_notification(self._result(1, Tool.OTHER, Copilot()))
         instance = mock_notify_cls.return_value
         assert "using a tool" in instance.message
         instance.send.assert_called_once()


### PR DESCRIPTION
# Context

GitGuardian's Claude Code hook notifies users when the assistant runs a command that exposes secrets. Today the notification reads:

"Claude Code got access to 3 secrets by running a command"

User feedback:

> Hey there,
Claude ran a command and got secrets from it. I got the notification Claude Code got access to 3 secrets by running a command. I'd assume this creates an incident somewhere but I see no actionable thing in either Claude or on the Dashboard.
Any insights on where I can find the detected leaked secrets? (I have them in my Claude transcript)"

## Expected behavior

- The notification should include the exact command that led to the secret access. This lets the user:
  - Identify what Claude Code ran
  - Judge whether the exposure is a concern
  - Take local action (rotate, redact transcript, etc.)

## Scope (for now)

- Notification message only.
- We are explicitly not creating incidents from these detections at this stage.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
