### PR TITLE
Pbeslin/parse mcp history

### DIFF
--- a/changelog.d/20260512_132545_paul.beslin.ext_nhi_1628.md
+++ b/changelog.d/20260512_132545_paul.beslin.ext_nhi_1628.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- `ggshield ai discover --history` backfills historical MCP tool calls to GitGuardian (parsed from `~/.claude/projects/*/*.jsonl`). The API deduplicates events via idempotency keys, so reruns are safe.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -21,6 +21,7 @@ from ggshield.verticals.ai.discovery import (
     save_discovery_cache,
     submit_ai_discovery,
 )
+from ggshield.verticals.ai.history import BackfillReport, backfill_mcp_history
 from ggshield.verticals.ai.models import Scope
 
 
@@ -32,11 +33,19 @@ from ggshield.verticals.ai.models import Scope
     default=False,
     help="Output as JSON",
 )
+@click.option(
+    "--history",
+    "scan_history",
+    is_flag=True,
+    default=False,
+    help="Also backfill historical MCP tool calls parsed from agent transcripts.",
+)
 @add_common_options()
 @click.pass_context
 def discover_cmd(
     ctx: click.Context,
     use_json: bool,
+    scan_history: bool,
     **kwargs: Any,
 ) -> None:
     """
@@ -47,6 +56,7 @@ def discover_cmd(
     Examples:
       ggshield ai discover
       ggshield ai discover --json
+      ggshield ai discover --history
     """
 
     config = discover_ai_configuration()
@@ -61,9 +71,12 @@ def discover_cmd(
         )
         return
 
+    backfill_report = BackfillReport()
     try:
         config = submit_ai_discovery(client, config)
         save_discovery_cache(config)
+        if scan_history:
+            backfill_report = backfill_mcp_history(client, config)
     except Exception as exc:
         if "missing the following scope:" in str(exc):
             scope = str(exc).split("missing the following scope:")[1].strip()
@@ -73,7 +86,7 @@ def discover_cmd(
         ui.display_warning(f"Could not upload AI discovery to GitGuardian: {reason}")
 
     # Summarize after sending to GIM, so we can benefit from its fixes.
-    summary = _summarize_discovery(config)
+    summary = _summarize_discovery(config, backfill_report)
 
     if use_json:
         click.echo(json.dumps(summary, indent=2))
@@ -81,7 +94,7 @@ def discover_cmd(
         print_summary(summary)
 
 
-def _summarize_discovery(config: AIDiscovery) -> Dict[str, Any]:
+def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[str, Any]:
     """Summarize what we want to show of the discovery."""
     agent_names = set()
     servers = []
@@ -110,6 +123,12 @@ def _summarize_discovery(config: AIDiscovery) -> Dict[str, Any]:
     return {
         "agents": [AGENTS[name].display_name for name in agent_names],
         "servers": servers,
+        "history": {
+            "parsed": report.parsed,
+            "ingested": report.ingested,
+            "duplicates": report.duplicates,
+            "skipped": report.skipped,
+        },
     }
 
 
@@ -158,3 +177,13 @@ def print_summary(summary: Dict[str, Any]) -> None:
                 click.echo(f"{indent}{connector} {project}")
 
     click.echo()
+
+    history = summary.get("history")
+    if history and history.get("parsed"):
+        click.echo(f"{format_text('Backfilling MCP usage history…', STYLE['key'])}")
+        click.echo(f"  • Parsed {history['parsed']:,} events")
+        click.echo(
+            f"  • Recorded {history['ingested']:,} events "
+            f"({history['duplicates']:,} already known, "
+            f"{history.get('skipped', 0):,} skipped)"
+        )

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -1,7 +1,8 @@
 import json
 import re
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, Literal
+from typing import Any, Dict, Iterator, Literal, Optional
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -229,14 +230,7 @@ class Claude(Agent):
         # Remove the optional "claude_ai_" prefix
         server_cfg_name = server_cfg_name.removeprefix("claude_ai_")
 
-        # Lookup the server name based on its configuration name
-        # Fallback to the server name if not found
-        server_name = server_cfg_name
-        for server in ai_config.servers:
-            for configuration in server.configurations:
-                if _mangle_server_name(configuration.name) == server_cfg_name:
-                    server_name = server.name
-                    break
+        server_name = self._resolve_server_name(server_cfg_name, ai_config)
 
         return MCPActivityRequest(
             user=ai_config.user,
@@ -247,6 +241,79 @@ class Claude(Agent):
             cwd=payload.raw.get("cwd", ""),
             input=payload.raw.get("tool_input", {}),
         )
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Walk every Claude session transcript and yield its MCP tool_use events."""
+        for path in self._history_files():
+            for entry in self._load_jsonl_file(path):
+                yield from self._parse_history_entry(entry, ai_config)
+
+    def _history_files(self) -> Iterator[Path]:
+        """Yield every Claude Code session transcript file we know about."""
+        yield from sorted(self.config_folder.glob("projects/*/*.jsonl"))
+
+    def _parse_history_entry(
+        self,
+        entry: Dict[str, Any],
+        ai_config: Optional[AIDiscovery],
+    ) -> Iterator[MCPActivityRequest]:
+        """Turn one parsed transcript entry into zero-or-more MCPActivityRequest events.
+
+        Returns nothing for non-MCP tool uses or sidechain entries.
+        Server names are resolved against ai_config when available.
+        """
+        if not isinstance(entry, dict) or entry.get("isSidechain"):
+            return
+
+        message = entry.get("message") or {}
+        content = message.get("content") or []
+        if not isinstance(content, list):
+            return
+
+        try:
+            ts = datetime.fromisoformat(entry["timestamp"].replace("Z", "+00:00"))
+        except (KeyError, AttributeError, ValueError):
+            return
+
+        cwd = entry.get("cwd", "")
+        model = message.get("model", "")
+
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            raw_name = block.get("name", "")
+            if not raw_name.startswith("mcp__"):
+                continue
+            parts = raw_name.split("__")
+            tool = parts[-1]
+            server_cfg_name = "__".join(parts[1:-1]).removeprefix("claude_ai_")
+            server_name = self._resolve_server_name(server_cfg_name, ai_config)
+            yield MCPActivityRequest(
+                user=self._user_or_default(ai_config),
+                tool=tool,
+                server=server_name,
+                agent=self.name,
+                model=model,
+                cwd=cwd,
+                input=block.get("input") or {},
+                timestamp=ts,
+            )
+
+    def _resolve_server_name(
+        self, cfg_name: str, ai_config: Optional[AIDiscovery]
+    ) -> str:
+        """Look up the canonical server name; fall back to the configuration name."""
+        if ai_config is None:
+            return cfg_name
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if _mangle_server_name(configuration.name) == cfg_name:
+                    return server.name
+        return cfg_name
 
 
 MANGLING_PATTERN = re.compile(r"[^A-Za-z0-9-]")

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -240,6 +240,7 @@ class Claude(Agent):
             model="",
             cwd=payload.raw.get("cwd", ""),
             input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
         )
 
     def iter_history_events(

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -130,4 +130,5 @@ class Codex(Agent):
             model=payload.raw.get("model", ""),
             cwd=payload.raw.get("cwd", ""),
             input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
         )

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -1,6 +1,7 @@
 import json
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, Literal
+from typing import Any, Dict, Iterator, Literal, Optional
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -115,20 +116,106 @@ class Codex(Agent):
         tool = parts[-1]
         server_cfg_name = "__".join(parts[1:-1])
 
-        server_name = server_cfg_name
-        for server in ai_config.servers:
-            for configuration in server.configurations:
-                if _mangle_server_name(configuration.name) == server_cfg_name:
-                    server_name = server.name
-                    break
-
         return MCPActivityRequest(
             user=ai_config.user,
             tool=tool,
-            server=server_name,
+            server=self._resolve_server_name(server_cfg_name, ai_config),
             agent=self.name,
             model=payload.raw.get("model", ""),
             cwd=payload.raw.get("cwd", ""),
             input=payload.raw.get("tool_input", {}),
             timestamp=payload.timestamp,
         )
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Walk every Codex session rollout and yield its MCP tool_use events."""
+        for path in self._history_files():
+            yield from self._parse_session_file(path, ai_config)
+
+    def _history_files(self) -> Iterator[Path]:
+        """Yield every Codex session rollout file we know about."""
+        yield from sorted(self.config_folder.glob("sessions/*/*/*/rollout-*.jsonl"))
+
+    def _parse_session_file(
+        self, path: Path, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Yield MCPActivityRequest events from a single Codex session rollout."""
+        cwd = ""
+        model = ""
+        for entry in self._load_jsonl_file(path):
+            if not isinstance(entry, dict):
+                continue
+            payload = entry.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            entry_type = entry.get("type")
+            if entry_type == "session_meta":
+                cwd = payload.get("cwd") or cwd
+                continue
+            if entry_type == "turn_context":
+                cwd = payload.get("cwd") or cwd
+                model = payload.get("model") or model
+                continue
+            if entry_type != "response_item":
+                continue
+            if payload.get("type") != "function_call":
+                continue
+            namespace = payload.get("namespace") or ""
+            if not namespace.startswith("mcp__"):
+                continue
+            event = self._build_activity_from_function_call(
+                entry, payload, namespace, cwd, model, ai_config
+            )
+            if event is not None:
+                yield event
+
+    def _build_activity_from_function_call(
+        self,
+        entry: Dict[str, Any],
+        payload: Dict[str, Any],
+        namespace: str,
+        cwd: str,
+        model: str,
+        ai_config: Optional[AIDiscovery],
+    ) -> Optional[MCPActivityRequest]:
+        """Turn one function_call response_item into an MCPActivityRequest."""
+        tool = payload.get("name") or ""
+        if not tool:
+            return None
+        server_cfg_name = namespace.removeprefix("mcp__").removesuffix("__")
+        try:
+            tool_input = json.loads(payload.get("arguments") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            tool_input = {}
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        try:
+            ts = datetime.fromisoformat(
+                str(entry.get("timestamp", "")).replace("Z", "+00:00")
+            )
+        except ValueError:
+            return None
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool,
+            server=self._resolve_server_name(server_cfg_name, ai_config),
+            agent=self.name,
+            model=model,
+            cwd=cwd,
+            input=tool_input,
+            timestamp=ts,
+        )
+
+    def _resolve_server_name(
+        self, cfg_name: str, ai_config: Optional[AIDiscovery]
+    ) -> str:
+        """Look up the canonical server name; fall back to the configuration name."""
+        if ai_config is None:
+            return cfg_name
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if _mangle_server_name(configuration.name) == cfg_name:
+                    return server.name
+        return cfg_name

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,7 +1,8 @@
 import logging
 import re
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.models import (
@@ -16,6 +17,7 @@ from ggshield.verticals.ai.models import (
 )
 
 from .vscode import VSCode
+
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +129,75 @@ class Copilot(VSCode):
     def iter_history_events(
         self, ai_config: Optional[AIDiscovery]
     ) -> Iterator[MCPActivityRequest]:
-        return iter(())
+        """Walk every Copilot CLI session and yield MCP tool calls.
+
+        Sessions live under ``~/.copilot/session-state/<uuid>/events.jsonl``.
+        """
+        history_root = self.config_folder / "session-state"
+        for session_dir in sorted(history_root.glob("*")):
+            events_path = session_dir / "events.jsonl"
+            if not events_path.is_file():
+                continue
+            yield from self._parse_events_file(events_path, ai_config)
+
+    def _parse_events_file(
+        self, path: Path, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Yield MCP events from a single Copilot CLI events file."""
+        cwd = ""
+        for line in self._load_jsonl_file(path):
+            if not isinstance(line, dict):
+                continue
+            event_type = line.get("type")
+            data = line.get("data") or {}
+            if event_type == "session.start":
+                folder = (data.get("context") or {}).get("cwd")
+                if isinstance(folder, str):
+                    cwd = folder
+                continue
+            if event_type != "tool.execution_start":
+                continue
+            event = self._build_event(line, data, cwd, ai_config)
+            if event is not None:
+                yield event
+
+    def _build_event(
+        self,
+        line: Dict[str, Any],
+        data: Dict[str, Any],
+        cwd: str,
+        ai_config: Optional[AIDiscovery],
+    ) -> Optional[MCPActivityRequest]:
+        server_cfg_name = data.get("mcpServerName") or ""
+        tool_name = data.get("mcpToolName") or ""
+        if not server_cfg_name or not tool_name:
+            return None
+        timestamp = _parse_iso_timestamp(line.get("timestamp"))
+        if timestamp is None:
+            return None
+        arguments = data.get("arguments")
+        if not isinstance(arguments, dict):
+            arguments = {}
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool_name,
+            server=self._resolve_server_name(server_cfg_name, ai_config),
+            agent=self.name,
+            model="",
+            cwd=cwd,
+            input=arguments,
+            timestamp=timestamp,
+        )
+
+
+def _parse_iso_timestamp(raw: Any) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp string, tolerating a trailing ``Z``."""
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _mangle_name(name: str) -> str:

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,12 +1,14 @@
+import logging
 import re
 from pathlib import Path
-from typing import Dict, Iterator, Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.models import (
     AIDiscovery,
     EventType,
     HookPayload,
+    MCPActivityRequest,
     MCPConfiguration,
     Scope,
     Tool,
@@ -14,6 +16,8 @@ from ggshield.verticals.ai.models import (
 )
 
 from .vscode import VSCode
+
+logger = logging.getLogger(__name__)
 
 
 class Copilot(VSCode):
@@ -87,7 +91,7 @@ class Copilot(VSCode):
                 payload.tool = Tool.MCP
 
     def _lookup_server_name(
-        self, raw_tool_name: str, ai_config: AIDiscovery
+        self, raw_tool_name: str, ai_config: Optional[AIDiscovery]
     ) -> Tuple[str, str]:
         # Copilot's hook tool name is "{server}-{tool}"
         # which is unfortunate because server names can contain "-" in their name.
@@ -97,12 +101,16 @@ class Copilot(VSCode):
         # We look for the longest chain of parts separated by "-" that is a valid server configuration name.
 
         # Build a map of mangled server configuration names to server names.
-        mangled_to_server: Dict[str, str] = {
-            _mangle_name(configuration.name): server.name
-            for server in ai_config.servers
-            for configuration in server.configurations
-            if configuration.agent == self.name
-        }
+        mangled_to_server: Dict[str, str] = (
+            {
+                _mangle_name(configuration.name): server.name
+                for server in ai_config.servers
+                for configuration in server.configurations
+                if configuration.agent == self.name
+            }
+            if ai_config is not None
+            else {}
+        )
 
         parts = raw_tool_name.split("-")
 
@@ -115,6 +123,11 @@ class Copilot(VSCode):
 
         # If no match is found, fallback to use the last part as the tool name.
         return "-".join(parts[:-1]), parts[-1]
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        return iter(())
 
 
 def _mangle_name(name: str) -> str:

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -1,4 +1,7 @@
 import json
+import logging
+import sqlite3
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional
 
@@ -23,6 +26,18 @@ from ..models import (
     MCPServer,
     Scope,
     Transport,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Cursor tags every tool call in cursorDiskKV bubbles with a numeric "tool" kind
+# under $.toolFormerData.tool. 19 is the MCP kind. Brittle — bump if Cursor
+# renumbers tool kinds in a future release.
+MCP_TOOL_KIND = 19
+
+CHAT_DB_RELATIVE_PATH = (
+    Path(".config") / "Cursor" / "User" / "globalStorage" / "state.vscdb"
 )
 
 
@@ -310,6 +325,183 @@ class Cursor(Agent):
             cwd=payload.raw.get("workspace_roots", [""])[0],
             input=payload.raw.get("tool_input", {}),
         )
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Read past MCP tool calls from Cursor's chat database.
+
+        Each chat message is a row keyed ``bubbleId:<composerId>:<bubbleId>`` in
+        ``cursorDiskKV``.
+        """
+        db_path = get_user_home_dir() / CHAT_DB_RELATIVE_PATH
+        if not db_path.is_file():
+            return
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error as exc:
+            logger.warning("Cursor: could not open chat database %s: %s", db_path, exc)
+            return
+        try:
+            cwd_by_composer = self._load_composer_cwd_map(conn)
+            model_by_composer: Dict[str, str] = {}
+            rows = conn.execute(
+                "SELECT substr(key, 10, 36) AS composer_id, value "
+                "FROM cursorDiskKV "
+                "WHERE key LIKE 'bubbleId:%' "
+                "AND json_extract(value, '$.toolFormerData.tool') = ?",
+                (MCP_TOOL_KIND,),
+            )
+            for composer_id, raw in rows:
+                if composer_id not in cwd_by_composer:
+                    cwd_by_composer[composer_id] = self._lookup_composer_cwd(
+                        conn, composer_id
+                    )
+                if composer_id not in model_by_composer:
+                    model_by_composer[composer_id] = self._lookup_composer_model(
+                        conn, composer_id
+                    )
+                event = self._parse_bubble(
+                    raw,
+                    ai_config,
+                    cwd_by_composer[composer_id],
+                    model_by_composer[composer_id],
+                )
+                if event is not None:
+                    yield event
+        except sqlite3.Error as exc:
+            logger.warning("Cursor: read failed on %s: %s", db_path, exc)
+        finally:
+            conn.close()
+
+    def _parse_bubble(
+        self,
+        raw: str,
+        ai_config: Optional[AIDiscovery],
+        cwd: str,
+        model: str,
+    ) -> Optional[MCPActivityRequest]:
+        """Turn a cursorDiskKV bubble row into an MCPActivityRequest, or None."""
+        try:
+            bubble = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(bubble, dict):
+            return None
+
+        tfd = bubble.get("toolFormerData") or {}
+        if not isinstance(tfd, dict):
+            return None
+
+        # params is a stringified JSON object — the only field that reliably
+        # carries the server name across the 3 toolFormerData.name conventions.
+        try:
+            params = json.loads(tfd.get("params") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return None
+        tools = params.get("tools") if isinstance(params, dict) else None
+        if not (isinstance(tools, list) and tools and isinstance(tools[0], dict)):
+            return None
+        tool_name = tools[0].get("name") or ""
+        server_cfg_name = tools[0].get("serverName") or ""
+        if not tool_name or not server_cfg_name:
+            return None
+
+        try:
+            envelope = json.loads(tfd.get("rawArgs") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            envelope = {}
+        args = envelope.get("args") if isinstance(envelope, dict) else None
+        tool_input = args if isinstance(args, dict) else {}
+
+        try:
+            ts = datetime.fromisoformat(
+                str(bubble.get("createdAt", "")).replace("Z", "+00:00")
+            )
+        except ValueError:
+            return None
+
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool_name,
+            server=self._resolve_server_name(server_cfg_name, ai_config),
+            agent=self.name,
+            model=model,
+            cwd=cwd,
+            input=tool_input,
+            timestamp=ts,
+        )
+
+    def _resolve_server_name(
+        self, cfg_name: str, ai_config: Optional[AIDiscovery]
+    ) -> str:
+        """Look up the canonical server name; fall back to the configuration name."""
+        if ai_config is None:
+            return cfg_name
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if configuration.name == cfg_name:
+                    return server.name
+        return cfg_name
+
+    def _load_composer_cwd_map(self, conn: sqlite3.Connection) -> Dict[str, str]:
+        """Read ``composer.composerHeaders`` once and map composerId → workspace path."""
+        try:
+            row = conn.execute(
+                "SELECT value FROM ItemTable WHERE key = 'composer.composerHeaders'"
+            ).fetchone()
+        except sqlite3.Error:
+            return {}
+        if not row or not row[0]:
+            return {}
+        try:
+            headers = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        composers = headers.get("allComposers") if isinstance(headers, dict) else None
+        if not isinstance(composers, list):
+            return {}
+        result: Dict[str, str] = {}
+        for header in composers:
+            if not isinstance(header, dict):
+                continue
+            composer_id = header.get("composerId")
+            if not isinstance(composer_id, str):
+                continue
+            uri = (header.get("workspaceIdentifier") or {}).get("uri") or {}
+            path = uri.get("path") if isinstance(uri, dict) else None
+            if isinstance(path, str) and path:
+                result[composer_id] = path
+        return result
+
+    def _lookup_composer_cwd(self, conn: sqlite3.Connection, composer_id: str) -> str:
+        """Fallback: pull the workspace path from any user bubble in this composer."""
+        row = conn.execute(
+            "SELECT json_extract(value, '$.workspaceUris') FROM cursorDiskKV "
+            "WHERE key LIKE ? "
+            "AND json_extract(value, '$.type') = 1 "
+            "AND json_extract(value, '$.workspaceUris') != '[]' "
+            "LIMIT 1",
+            (f"bubbleId:{composer_id}:%",),
+        ).fetchone()
+        if not row or not row[0]:
+            return ""
+        try:
+            uris = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            return ""
+        if isinstance(uris, list) and uris and isinstance(uris[0], str):
+            return uris[0].removeprefix("file://")
+        return ""
+
+    def _lookup_composer_model(self, conn: sqlite3.Connection, composer_id: str) -> str:
+        """Return ``modelConfig.modelName`` for the composer (e.g. ``composer-2``)."""
+        row = conn.execute(
+            "SELECT json_extract(value, '$.modelConfig.modelName') "
+            "FROM cursorDiskKV WHERE key = ?",
+            (f"composerData:{composer_id}",),
+        ).fetchone()
+        return row[0] if row and isinstance(row[0], str) else ""
 
 
 def _parse_tool_arguments(

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -28,6 +28,7 @@ from ..models import (
     Transport,
 )
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -324,6 +325,7 @@ class Cursor(Agent):
             model=payload.raw.get("model", ""),
             cwd=payload.raw.get("workspace_roots", [""])[0],
             input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
         )
 
     def iter_history_events(

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import re
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterator, Literal, Tuple
+from typing import Any, Dict, Iterator, Literal, Optional, Tuple
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -9,6 +11,9 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from ggshield.core.dirs import get_user_home_dir
 
 from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
+
+
+logger = logging.getLogger(__name__)
 
 
 class VSCode(Agent):
@@ -111,7 +116,7 @@ class VSCode(Agent):
         )
 
     def _lookup_server_name(
-        self, raw_tool_name: str, ai_config: AIDiscovery
+        self, raw_tool_name: str, ai_config: Optional[AIDiscovery]
     ) -> Tuple[str, str]:
         # VSCode's hook tool name is "mcp_{server}_{tool}"
         # which is unfortunate because a lot of tools have a "_" in their name.
@@ -122,11 +127,15 @@ class VSCode(Agent):
         # we look for the longest chain of parts separated by "_" that is a valid server configuration name.
 
         # Build a map of mangled server configuration names to server names.
-        mangled_to_server: Dict[str, str] = {
-            _mangle_name(configuration.name): server.name
-            for server in ai_config.servers
-            for configuration in server.configurations
-        }
+        mangled_to_server: Dict[str, str] = (
+            {
+                _mangle_name(configuration.name): server.name
+                for server in ai_config.servers
+                for configuration in server.configurations
+            }
+            if ai_config is not None
+            else {}
+        )
 
         # This get rid of the "mcp_" prefix.
         _, *parts = raw_tool_name.split("_")
@@ -139,6 +148,133 @@ class VSCode(Agent):
 
         # If no match is found, fallback to use the first part as the server name.
         return parts[0], "_".join(parts[1:])
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Walk every Copilot Chat session and yield MCP tool calls.
+
+        Sessions live under
+        ``/workspaceStorage/<hash>/chatSessions/<id>.jsonl``.
+        Iterating per-workspace lets us read each ``workspace.json`` once.
+        """
+        for workspace_dir in sorted(self.config_folder.glob("workspaceStorage/*")):
+            cwd = self._workspace_cwd(workspace_dir)
+            for session in sorted(workspace_dir.glob("chatSessions/*.jsonl")):
+                try:
+                    yield from self._parse_session_file(session, cwd, ai_config)
+                except OSError as exc:
+                    logger.warning("VSCode: skipping %s: %s", session, exc)
+
+    def _workspace_cwd(self, workspace_dir: Path) -> str:
+        """Return the project folder backing a ``workspaceStorage/<hash>`` directory."""
+        data = self._load_file(workspace_dir / "workspace.json")
+        folder = (data or {}).get("folder", "") if data else ""
+        return folder.removeprefix("file://") if isinstance(folder, str) else ""
+
+    def _parse_session_file(
+        self, path: Path, cwd: str, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Yield deduped MCP events from a single Copilot Chat session file."""
+        seen: set = set()
+        last_ts: Optional[datetime] = None
+        with path.open("r", encoding="utf-8", errors="ignore") as history_file:
+            for raw in history_file:
+                try:
+                    line = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                content = line.get("v") if isinstance(line, dict) else None
+                # toolInvocation lines have no timestamp, try finding one around them
+                line_max = max(_iter_timestamps(content), default=None)
+                if line_max is not None:
+                    try:
+                        candidate = datetime.fromtimestamp(
+                            line_max / 1000, tz=timezone.utc
+                        )
+                    except (ValueError, OSError, OverflowError):
+                        candidate = None
+                    if candidate is not None and (
+                        last_ts is None or candidate > last_ts
+                    ):
+                        last_ts = candidate
+                for inv in _find_mcp_invocations(content):
+                    tool_call_id = inv.get("toolCallId")
+                    if not tool_call_id or tool_call_id in seen:
+                        continue
+                    event = self._build_activity(inv, cwd, last_ts, ai_config)
+                    if event is None:
+                        continue
+                    seen.add(tool_call_id)
+                    yield event
+
+    def _build_activity(
+        self,
+        invocation: Dict[str, Any],
+        cwd: str,
+        timestamp: Optional[datetime],
+        ai_config: Optional[AIDiscovery],
+    ) -> Optional[MCPActivityRequest]:
+        if timestamp is None:
+            return None
+        source = invocation.get("source") or {}
+        server_cfg_name = source.get("label") or ""
+        tool_id = invocation.get("toolId") or ""
+        if not server_cfg_name or not tool_id:
+            return None
+        tool_input = (invocation.get("toolSpecificData") or {}).get("rawInput") or {}
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        _, tool_name = self._lookup_server_name(tool_id, ai_config)
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool_name,
+            server=self._resolve_server_name(server_cfg_name, ai_config),
+            agent=self.name,
+            model="",
+            cwd=cwd,
+            input=tool_input,
+            timestamp=timestamp,
+        )
+
+    def _resolve_server_name(
+        self, cfg_name: str, ai_config: Optional[AIDiscovery]
+    ) -> str:
+        """Resolve a bubble's ``source.label`` to the canonical server name."""
+        if ai_config is None or not cfg_name:
+            return cfg_name
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if configuration.name == cfg_name:
+                    return server.name
+        return cfg_name
+
+
+def _iter_timestamps(obj: Any) -> Iterator[int]:
+    """Yield every numeric ``timestamp`` (unix ms) nested anywhere in ``obj``."""
+    if isinstance(obj, dict):
+        ts = obj.get("timestamp")
+        if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+            yield int(ts)
+        for value in obj.values():
+            yield from _iter_timestamps(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from _iter_timestamps(value)
+
+
+def _find_mcp_invocations(obj: Any) -> Iterator[Dict[str, Any]]:
+    """Yield every ``toolInvocationSerialized`` dict with ``source.type == "mcp"``."""
+    if isinstance(obj, dict):
+        if obj.get("kind") == "toolInvocationSerialized":
+            source = obj.get("source") or {}
+            if isinstance(source, dict) and source.get("type") == "mcp":
+                yield obj
+        for value in obj.values():
+            yield from _find_mcp_invocations(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from _find_mcp_invocations(value)
 
 
 MANGLING_PATTERN = re.compile(r"[^A-Za-z0-9-]+")

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -113,6 +113,7 @@ class VSCode(Agent):
             model="",
             cwd=payload.raw.get("cwd", ""),
             input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
         )
 
     def _lookup_server_name(

--- a/ggshield/verticals/ai/history.py
+++ b/ggshield/verticals/ai/history.py
@@ -1,0 +1,61 @@
+"""Backfill of historical MCP activities, parsed from each agent's local state."""
+
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+from pygitguardian import GGClient
+from pygitguardian.models import AIDiscovery, Detail, MCPActivityRequest
+
+from .agents import AGENTS
+
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+
+@dataclass
+class BackfillReport:
+    parsed: int = 0
+    ingested: int = 0
+    duplicates: int = 0
+    skipped: int = 0
+    error: Optional[str] = None
+
+
+def backfill_mcp_history(client: GGClient, ai_config: AIDiscovery) -> BackfillReport:
+    """Stream each agent's historical MCP events and ship them to the GitGuardian API."""
+    report = BackfillReport()
+    activities: List[MCPActivityRequest] = []
+
+    def send_activities_batch() -> bool:
+        if not activities:
+            return True
+        try:
+            response = client.log_mcp_activities_bulk(list(activities))
+        except Exception as exc:
+            logger.warning("Bulk MCP activity upload failed: %s", exc)
+            report.error = str(exc)
+            return False
+        if isinstance(response, Detail):
+            logger.warning("Bulk MCP activity upload returned an error: %s", response)
+            report.error = response.detail
+            return False
+        report.ingested += response.ingested
+        report.duplicates += response.duplicates
+        report.skipped += response.skipped
+        activities.clear()
+        return True
+
+    for agent in AGENTS.values():
+        for event in agent.iter_history_events(ai_config):
+            activities.append(event)
+            report.parsed += 1
+            if len(activities) >= BATCH_SIZE:
+                success = send_activities_batch()
+                if not success:
+                    return report
+
+    send_activities_batch()
+    return report

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Sequence, Set
 
 import filelock
@@ -103,6 +104,8 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         but in some cases files mentioned in the prompt will be read but the
         PreToolUse event will not be called. So we need to handle this case ourselves.
     """
+    timestamp = datetime.now(timezone.utc)
+
     # Parse the content as JSON
     if not raw_content.strip():
         raise ValueError("Error: No input received on stdin")
@@ -131,7 +134,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         content = data.get("prompt", "")
         # Look for files mentioned in the prompt that could be read
         # without triggering a PRE_TOOL_USE event.
-        payloads.extend(_parse_user_prompt(content, event_type, agent))
+        payloads.extend(_parse_user_prompt(content, event_type, agent, timestamp))
 
     elif event_type == EventType.PRE_TOOL_USE:
         tool = _parse_tool(data)
@@ -143,7 +146,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             content = tool_input.get("command", "")
             identifier = content
             # Try to detect a command that could be used to read a file.
-            payloads.extend(_parse_command(content, event_type, agent))
+            payloads.extend(_parse_command(content, event_type, agent, timestamp))
         elif tool == Tool.READ:
             # We only need to deal with the identifier, the content will be read by the Scannable
             identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
@@ -167,6 +170,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             identifier=identifier,
             agent=agent,
             raw=data,
+            timestamp=timestamp,
         )
     )
 
@@ -194,7 +198,7 @@ def _detect_agent(data: Dict[str, Any]) -> Agent:
 
 
 def _parse_user_prompt(
-    content: str, event_type: EventType, agent: Agent
+    content: str, event_type: EventType, agent: Agent, timestamp: datetime
 ) -> List[HookPayload]:
     """Parse the user prompt for additional payloads that we may miss."""
     payloads = []
@@ -211,13 +215,14 @@ def _parse_user_prompt(
                 identifier=match,
                 agent=agent,
                 raw={},
+                timestamp=timestamp,
             )
         )
     return payloads
 
 
 def _parse_command(
-    content: str, event_type: EventType, agent: Agent
+    content: str, event_type: EventType, agent: Agent, timestamp: datetime
 ) -> List[HookPayload]:
     """Parse the command for additional payloads that we may miss."""
     # In Windows, some agents (at least Codex) use the Get-Content command to read a file.
@@ -235,6 +240,7 @@ def _parse_command(
                 identifier=identifier,
                 agent=agent,
                 raw={},
+                timestamp=timestamp,
             )
         )
     return payloads

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional
 import tomli
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from pygitguardian.models import MCPConfiguration as BaseMCPConfiguration
-from pygitguardian.models import MCPServer
+from pygitguardian.models import MCPServer, UserInfo
 
 from ggshield.core.scan import File, Scannable, StringScannable
 from ggshield.utils.files import is_path_binary
@@ -321,6 +321,25 @@ class Agent(ABC):
 
         Implementations can assume that the payload is an MCP pre-tool use.
         """
+
+    # History parsing — agents that can find past MCP usage on disk override this.
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Yield historical MCP tool calls this agent can recover from its on-disk state.
+
+        Default: empty (this agent does not know how to surface its history).
+        Implementations decide how to source the events: JSONL transcripts,
+        SQLite databases, etc.
+        """
+        return iter(())
+
+    def _user_or_default(self, ai_config: Optional[AIDiscovery]) -> UserInfo:
+        """Return ``ai_config.user`` or a blank ``UserInfo`` if no config is provided."""
+        if ai_config is not None:
+            return ai_config.user
+        return UserInfo(hostname="", username="", machine_id="")
 
     # Helper methods
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -1,7 +1,8 @@
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
@@ -70,6 +71,7 @@ class HookPayload:
     identifier: str
     agent: "Agent"
     raw: Dict[str, Any]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     @property
     def scannable(self) -> Scannable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
     "packaging>=22.0",
-    "pygitguardian~=1.30.0",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@d3152b7bf33077fd17a8ea692d658dd428c73ac3",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",
@@ -67,6 +67,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 path = "ggshield/__init__.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.uv]
 # Exclude packages released in the last 3 days to avoid pulling a freshly

--- a/tests/unit/verticals/ai/test_claude_history.py
+++ b/tests/unit/verticals/ai/test_claude_history.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+
+from ggshield.verticals.ai.agents.claude_code import Claude
+
+
+def _entry(**overrides) -> dict:
+    base = {
+        "type": "assistant",
+        "sessionId": "session-1",
+        "cwd": "/home/u/repo",
+        "isSidechain": False,
+        "timestamp": "2026-04-01T09:00:00.000Z",
+        "message": {
+            "model": "claude-opus-4-7",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_AAA",
+                    "name": "mcp__linear__get_issue",
+                    "input": {"id": "NHI-1"},
+                }
+            ],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def empty_ai_config() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+class TestClaudeParseHistoryEntry:
+    def test_extracts_mcp_tool_use(self, empty_ai_config) -> None:
+        events = list(Claude()._parse_history_entry(_entry(), empty_ai_config))
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tool == "get_issue"
+        assert ev.server == "linear"
+        assert ev.agent == "claude-code"
+        assert ev.model == "claude-opus-4-7"
+        assert ev.cwd == "/home/u/repo"
+        assert ev.timestamp == datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc)
+        assert ev.input == {"id": "NHI-1"}
+
+    def test_ignores_non_mcp_tools(self, empty_ai_config) -> None:
+        entry = _entry(
+            message={
+                "model": "claude-opus-4-7",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_X", "name": "Read", "input": {}}
+                ],
+            }
+        )
+        assert list(Claude()._parse_history_entry(entry, empty_ai_config)) == []
+
+    def test_ignores_sidechain_entries(self, empty_ai_config) -> None:
+        entry = _entry(isSidechain=True)
+        assert list(Claude()._parse_history_entry(entry, empty_ai_config)) == []
+
+    def test_skips_non_dict_entries(self, empty_ai_config) -> None:
+        assert list(Claude()._parse_history_entry("not-a-dict", empty_ai_config)) == []
+
+    def test_resolves_server_display_name_from_discovery(self) -> None:
+        config = AIDiscovery(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            servers=[
+                MCPServer(
+                    name="LinearDisplay",
+                    configurations=[
+                        MCPConfiguration(
+                            name="linear",
+                            agent="claude-code",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.STDIO,
+                            project=None,
+                        )
+                    ],
+                ),
+            ],
+            discovery_duration=0.0,
+        )
+        events = list(Claude()._parse_history_entry(_entry(), config))
+        assert events[0].server == "LinearDisplay"
+
+
+class TestClaudeHistoryFiles:
+    def test_globs_jsonl_under_projects_dir(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude" / "projects" / "p1").mkdir(parents=True)
+        (tmp_path / ".claude" / "projects" / "p1" / "s1.jsonl").write_text("{}\n")
+        (tmp_path / ".claude" / "projects" / "p2").mkdir(parents=True)
+        (tmp_path / ".claude" / "projects" / "p2" / "s2.jsonl").write_text("{}\n")
+        # Should ignore non-jsonl
+        (tmp_path / ".claude" / "projects" / "p2" / "ignore.txt").write_text("x")
+
+        with patch(
+            "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            files = sorted(Claude()._history_files())
+
+        assert [f.name for f in files] == ["s1.jsonl", "s2.jsonl"]

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -9,6 +9,7 @@ from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserI
 from ggshield.__main__ import cli
 from ggshield.cmd.ai.discover import print_summary
 from ggshield.core.errors import APIKeyCheckError
+from ggshield.verticals.ai.history import BackfillReport
 from ggshield.verticals.ai.models import Scope, Transport
 
 
@@ -311,6 +312,104 @@ class TestDiscoverCmd:
         assert len(parsed["servers"]) == 1
         assert parsed["servers"][0]["name"] == "My MCP"
         assert parsed["servers"][0]["installed_globally"] is True
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch(
+        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        return_value=BackfillReport(parsed=3, ingested=3, duplicates=0),
+    )
+    def test_history_flag_invokes_backfill_and_surfaces_summary(
+        self,
+        mock_backfill: MagicMock,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        discovery = _discovery(
+            servers=[
+                _server(
+                    "my-mcp",
+                    display_name="My MCP",
+                    configurations=[
+                        _config(agent="cursor", scope=Scope.USER),
+                    ],
+                ),
+            ]
+        )
+        mock_submit.return_value = discovery
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--history"])
+
+        assert result.exit_code == 0
+        mock_backfill.assert_called_once()
+        # Human-readable summary should reflect the parsed count.
+        assert "3" in result.output and "MCP" in result.output
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.cmd.ai.discover.backfill_mcp_history")
+    def test_history_skipped_without_flag(
+        self,
+        mock_backfill: MagicMock,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        mock_submit.return_value = _discovery()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover"])
+
+        assert result.exit_code == 0
+        mock_backfill.assert_not_called()
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch(
+        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch(
+        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        return_value=BackfillReport(parsed=4, ingested=2, duplicates=1, skipped=1),
+    )
+    def test_json_output_includes_history_block(
+        self,
+        mock_backfill: MagicMock,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--json", "--history"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["history"] == {
+            "parsed": 4,
+            "ingested": 2,
+            "duplicates": 1,
+            "skipped": 1,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/ai/test_codex_history.py
+++ b/tests/unit/verticals/ai/test_codex_history.py
@@ -1,0 +1,183 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+
+from ggshield.verticals.ai.agents.codex import Codex
+
+
+def _function_call_entry(
+    *,
+    name: str = "get_issue",
+    namespace: str = "mcp__linear__",
+    arguments: str = '{"id": "NHI-1"}',
+    timestamp: str = "2026-04-01T09:00:00.000Z",
+) -> dict:
+    """Build a Codex JSONL response_item line carrying an MCP function_call."""
+    return {
+        "timestamp": timestamp,
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "name": name,
+            "namespace": namespace,
+            "arguments": arguments,
+            "call_id": "call_AAA",
+        },
+    }
+
+
+def _session_meta(cwd: str = "/home/u/repo") -> dict:
+    return {
+        "timestamp": "2026-04-01T08:55:00.000Z",
+        "type": "session_meta",
+        "payload": {"id": "sess-1", "cwd": cwd, "cli_version": "0.130.0"},
+    }
+
+
+def _turn_context(cwd: str = "/home/u/repo", model: str = "gpt-5.5") -> dict:
+    return {
+        "timestamp": "2026-04-01T08:56:00.000Z",
+        "type": "turn_context",
+        "payload": {"turn_id": "turn-1", "cwd": cwd, "model": model},
+    }
+
+
+def _write_session(path: Path, entries: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+@pytest.fixture
+def empty_ai_config() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+class TestCodexParseSessionFile:
+    def test_extracts_mcp_tool_use(self, tmp_path: Path, empty_ai_config) -> None:
+        path = tmp_path / "rollout.jsonl"
+        _write_session(
+            path,
+            [
+                _session_meta(),
+                _turn_context(model="gpt-5.5"),
+                _function_call_entry(),
+            ],
+        )
+
+        events = list(Codex()._parse_session_file(path, empty_ai_config))
+
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tool == "get_issue"
+        assert ev.server == "linear"
+        assert ev.agent == "codex"
+        assert ev.model == "gpt-5.5"
+        assert ev.cwd == "/home/u/repo"
+        assert ev.input == {"id": "NHI-1"}
+        assert ev.timestamp == datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc)
+
+    def test_ignores_non_mcp_function_calls(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        path = tmp_path / "rollout.jsonl"
+        _write_session(
+            path,
+            [
+                _session_meta(),
+                _turn_context(),
+                # Built-in shell tool: no namespace.
+                {
+                    "timestamp": "2026-04-01T09:00:01.000Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "function_call",
+                        "name": "exec_command",
+                        "arguments": '{"cmd": "ls"}',
+                        "call_id": "x",
+                    },
+                },
+                # A non-function_call response_item.
+                {
+                    "timestamp": "2026-04-01T09:00:02.000Z",
+                    "type": "response_item",
+                    "payload": {"type": "message", "role": "assistant"},
+                },
+            ],
+        )
+        assert list(Codex()._parse_session_file(path, empty_ai_config)) == []
+
+    def test_tracks_cwd_and_model_across_turns(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        path = tmp_path / "rollout.jsonl"
+        _write_session(
+            path,
+            [
+                _session_meta(cwd="/home/u/initial"),
+                _turn_context(cwd="/home/u/turn1", model="gpt-5.5"),
+                _function_call_entry(timestamp="2026-04-01T09:00:01.000Z"),
+                _turn_context(cwd="/home/u/turn2", model="gpt-5.6"),
+                _function_call_entry(timestamp="2026-04-01T09:00:02.000Z"),
+            ],
+        )
+
+        events = list(Codex()._parse_session_file(path, empty_ai_config))
+
+        assert [(e.cwd, e.model) for e in events] == [
+            ("/home/u/turn1", "gpt-5.5"),
+            ("/home/u/turn2", "gpt-5.6"),
+        ]
+
+    def test_resolves_server_display_name_from_discovery(self, tmp_path: Path) -> None:
+        config = AIDiscovery(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            servers=[
+                MCPServer(
+                    name="LinearDisplay",
+                    configurations=[
+                        MCPConfiguration(
+                            name="linear",
+                            agent="codex",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.HTTP,
+                            project=None,
+                        )
+                    ],
+                ),
+            ],
+            discovery_duration=0.0,
+        )
+        path = tmp_path / "rollout.jsonl"
+        _write_session(path, [_session_meta(), _turn_context(), _function_call_entry()])
+
+        events = list(Codex()._parse_session_file(path, config))
+
+        assert events[0].server == "LinearDisplay"
+
+
+class TestCodexHistoryFiles:
+    def test_globs_rollouts_under_dated_dirs(self, tmp_path: Path) -> None:
+        sessions = tmp_path / ".codex" / "sessions"
+        (sessions / "2026" / "04" / "01").mkdir(parents=True)
+        (sessions / "2026" / "04" / "01" / "rollout-1.jsonl").write_text("{}\n")
+        (sessions / "2026" / "04" / "02").mkdir(parents=True)
+        (sessions / "2026" / "04" / "02" / "rollout-2.jsonl").write_text("{}\n")
+        # Wrong depth — should be ignored.
+        (sessions / "loose.jsonl").write_text("{}\n")
+        # Wrong prefix — should be ignored.
+        (sessions / "2026" / "04" / "02" / "other.jsonl").write_text("{}\n")
+
+        with patch(
+            "ggshield.verticals.ai.agents.codex.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            files = sorted(Codex()._history_files())
+
+        assert [f.name for f in files] == ["rollout-1.jsonl", "rollout-2.jsonl"]

--- a/tests/unit/verticals/ai/test_copilot_history.py
+++ b/tests/unit/verticals/ai/test_copilot_history.py
@@ -1,0 +1,227 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+
+from ggshield.verticals.ai.agents.copilot import Copilot
+
+
+def _session_start(cwd: str = "/repo", session_id: str = "sess-1") -> str:
+    return json.dumps(
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": session_id,
+                "context": {"cwd": cwd},
+            },
+            "id": "evt-start",
+            "timestamp": "2026-05-18T14:09:37.678Z",
+        }
+    )
+
+
+def _tool_execution_start(
+    tool_call_id: str = "call-1",
+    mcp_server_name: str = "github-mcp-server",
+    mcp_tool_name: str = "get_file_contents",
+    arguments=None,
+    timestamp: str = "2026-05-18T14:10:46.052Z",
+) -> str:
+    data: dict = {
+        "toolCallId": tool_call_id,
+        "toolName": f"{mcp_server_name}-{mcp_tool_name}",
+        "arguments": arguments if arguments is not None else {"owner": "GitGuardian"},
+        "turnId": "0",
+    }
+    if mcp_server_name:
+        data["mcpServerName"] = mcp_server_name
+    if mcp_tool_name:
+        data["mcpToolName"] = mcp_tool_name
+    return json.dumps(
+        {
+            "type": "tool.execution_start",
+            "data": data,
+            "id": f"evt-{tool_call_id}",
+            "timestamp": timestamp,
+        }
+    )
+
+
+def _seed_session(tmp_path: Path, lines: list, session_id: str = "sess-1") -> Path:
+    session_dir = tmp_path / ".copilot" / "session-state" / session_id
+    session_dir.mkdir(parents=True)
+    events = session_dir / "events.jsonl"
+    events.write_text("\n".join(lines) + "\n")
+    return events
+
+
+@pytest.fixture
+def empty_ai_config() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+class TestCopilotIterHistoryEvents:
+    def test_extracts_mcp_call(self, tmp_path: Path, empty_ai_config) -> None:
+        _seed_session(
+            tmp_path,
+            [
+                _session_start(cwd="/repo"),
+                _tool_execution_start(
+                    tool_call_id="call_abc",
+                    mcp_server_name="github-mcp-server",
+                    mcp_tool_name="get_file_contents",
+                    arguments={"owner": "GitGuardian", "repo": "ggshield"},
+                    timestamp="2026-05-18T14:10:46.052Z",
+                ),
+            ],
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tool == "get_file_contents"
+        assert ev.server == "github-mcp-server"
+        assert ev.agent == "copilot"
+        assert ev.cwd == "/repo"
+        assert ev.timestamp == datetime(
+            2026, 5, 18, 14, 10, 46, 52000, tzinfo=timezone.utc
+        )
+        assert ev.input == {"owner": "GitGuardian", "repo": "ggshield"}
+
+    def test_skips_non_mcp_tool_calls(self, tmp_path: Path, empty_ai_config) -> None:
+        """``tool.execution_start`` events without ``mcpServerName`` are not MCP calls."""
+        builtin = json.dumps(
+            {
+                "type": "tool.execution_start",
+                "data": {
+                    "toolCallId": "call_builtin",
+                    "toolName": "report_intent",
+                    "arguments": {"intent": "Searching"},
+                    "turnId": "0",
+                },
+                "id": "evt-builtin",
+                "timestamp": "2026-05-18T14:10:46.052Z",
+            }
+        )
+        _seed_session(tmp_path, [_session_start(), builtin])
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert events == []
+
+    def test_drops_event_with_unparseable_timestamp(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        _seed_session(
+            tmp_path,
+            [
+                _session_start(),
+                _tool_execution_start(timestamp="not-a-date"),
+            ],
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert events == []
+
+    def test_resolves_server_name_via_configuration(self, tmp_path: Path) -> None:
+        """``mcpServerName`` matches ``MCPConfiguration.name`` byte-for-byte."""
+        _seed_session(
+            tmp_path,
+            [
+                _session_start(),
+                _tool_execution_start(mcp_server_name="github-mcp-server"),
+            ],
+        )
+
+        config = AIDiscovery(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            servers=[
+                MCPServer(
+                    name="GitHub",
+                    configurations=[
+                        MCPConfiguration(
+                            name="github-mcp-server",
+                            agent="copilot",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.STDIO,
+                            project=None,
+                        )
+                    ],
+                )
+            ],
+            discovery_duration=0.0,
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(config))
+
+        assert events[0].server == "GitHub"
+
+    def test_walks_multiple_sessions(self, tmp_path: Path, empty_ai_config) -> None:
+        _seed_session(
+            tmp_path,
+            [_session_start(cwd="/repo-a"), _tool_execution_start(tool_call_id="a")],
+            session_id="sess-a",
+        )
+        _seed_session(
+            tmp_path,
+            [_session_start(cwd="/repo-b"), _tool_execution_start(tool_call_id="b")],
+            session_id="sess-b",
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert {ev.cwd for ev in events} == {"/repo-a", "/repo-b"}
+
+    def test_missing_history_root_yields_nothing(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """A user who has never run Copilot CLI has no ``~/.copilot/session-state``."""
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert events == []
+
+    def test_session_without_events_file_is_skipped(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        (tmp_path / ".copilot" / "session-state" / "empty").mkdir(parents=True)
+
+        with patch(
+            "ggshield.verticals.ai.agents.copilot.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert events == []

--- a/tests/unit/verticals/ai/test_cursor_history.py
+++ b/tests/unit/verticals/ai/test_cursor_history.py
@@ -1,0 +1,367 @@
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+
+from ggshield.verticals.ai.agents.cursor import (
+    CHAT_DB_RELATIVE_PATH,
+    MCP_TOOL_KIND,
+    Cursor,
+)
+
+
+def _bubble(**overrides) -> str:
+    base = {
+        "type": 2,
+        "bubbleId": "b1",
+        "createdAt": "2026-04-01T09:00:00.000Z",
+        "workspaceUris": [],
+        "toolFormerData": {
+            "tool": MCP_TOOL_KIND,
+            "toolCallId": "tool_AAA",
+            "name": "mcp_linear_get_issue",
+            "rawArgs": json.dumps(
+                {
+                    "name": "user-linear-get_issue",
+                    "args": {"id": "NHI-1"},
+                    "toolCallId": "tool_AAA",
+                    "providerIdentifier": "linear",
+                    "toolName": "get_issue",
+                }
+            ),
+            "params": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "get_issue",
+                            "parameters": '{"id":"NHI-1"}',
+                            "serverName": "linear",
+                        }
+                    ]
+                }
+            ),
+        },
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+@pytest.fixture
+def empty_ai_config() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+class TestCursorParseBubble:
+    def test_extracts_mcp_tool_use(self, empty_ai_config) -> None:
+        event = Cursor()._parse_bubble(
+            _bubble(), empty_ai_config, "/home/u/repo", "composer-2"
+        )
+        assert event is not None
+        assert event.tool == "get_issue"
+        assert event.server == "linear"
+        assert event.agent == "cursor"
+        assert event.cwd == "/home/u/repo"
+        assert event.model == "composer-2"
+        assert event.timestamp == datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc)
+        assert event.input == {"id": "NHI-1"}
+
+    def test_unwraps_rawargs_envelope(self, empty_ai_config) -> None:
+        """``rawArgs`` is a stringified envelope; only its ``args`` field is the live input."""
+        raw = _bubble(
+            toolFormerData={
+                "tool": MCP_TOOL_KIND,
+                "toolCallId": "tool_X",
+                "rawArgs": json.dumps(
+                    {
+                        "name": "user-Notion-notion-get-users",
+                        "args": {"user_id": "self"},
+                        "toolCallId": "tool_X",
+                        "providerIdentifier": "Notion",
+                        "toolName": "notion-get-users",
+                    }
+                ),
+                "params": json.dumps(
+                    {
+                        "tools": [
+                            {
+                                "name": "notion-get-users",
+                                "parameters": '{"user_id":"self"}',
+                                "serverName": "Notion",
+                            }
+                        ]
+                    }
+                ),
+            }
+        )
+        event = Cursor()._parse_bubble(raw, empty_ai_config, "", "")
+        assert event is not None
+        assert event.input == {"user_id": "self"}
+
+    def test_skips_malformed_json(self, empty_ai_config) -> None:
+        assert Cursor()._parse_bubble("not-json", empty_ai_config, "", "") is None
+
+    def test_skips_missing_tool_former_data(self, empty_ai_config) -> None:
+        raw = json.dumps({"type": 2, "createdAt": "2026-04-01T09:00:00Z"})
+        assert Cursor()._parse_bubble(raw, empty_ai_config, "", "") is None
+
+    def test_skips_when_params_lacks_tools(self, empty_ai_config) -> None:
+        raw = _bubble(
+            toolFormerData={
+                "tool": MCP_TOOL_KIND,
+                "toolCallId": "x",
+                "params": "{}",
+                "rawArgs": "{}",
+            }
+        )
+        assert Cursor()._parse_bubble(raw, empty_ai_config, "", "") is None
+
+    def test_skips_when_timestamp_invalid(self, empty_ai_config) -> None:
+        raw = _bubble(createdAt="not-a-date")
+        assert Cursor()._parse_bubble(raw, empty_ai_config, "", "") is None
+
+    def test_handles_dash_form_name(self, empty_ai_config) -> None:
+        """Newer name layout (mcp-<server>-<tool>) still parses via params.tools[0]."""
+        raw = _bubble(
+            toolFormerData={
+                "tool": MCP_TOOL_KIND,
+                "toolCallId": "tool_X",
+                "name": "mcp-ward-runs-app-linear-get_issue",
+                "rawArgs": json.dumps(
+                    {
+                        "name": "user-linear-get_issue",
+                        "args": {"id": "NHI-9"},
+                        "toolCallId": "tool_X",
+                        "providerIdentifier": "linear",
+                        "toolName": "get_issue",
+                    }
+                ),
+                "params": json.dumps(
+                    {
+                        "tools": [
+                            {
+                                "name": "get_issue",
+                                "parameters": '{"id":"NHI-9"}',
+                                "serverName": "ward-runs-app-linear",
+                            }
+                        ]
+                    }
+                ),
+            }
+        )
+        event = Cursor()._parse_bubble(raw, empty_ai_config, "", "")
+        assert event is not None
+        assert event.tool == "get_issue"
+        assert event.server == "ward-runs-app-linear"
+        assert event.input == {"id": "NHI-9"}
+
+    def test_resolves_server_display_name_from_discovery(self) -> None:
+        config = AIDiscovery(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            servers=[
+                MCPServer(
+                    name="LinearDisplay",
+                    configurations=[
+                        MCPConfiguration(
+                            name="linear",
+                            agent="cursor",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.STDIO,
+                            project=None,
+                        )
+                    ],
+                ),
+            ],
+            discovery_duration=0.0,
+        )
+        event = Cursor()._parse_bubble(_bubble(), config, "", "")
+        assert event is not None
+        assert event.server == "LinearDisplay"
+
+
+class TestCursorIterHistoryEvents:
+    def _make_db(self, tmp_path: Path) -> Path:
+        db_dir = tmp_path / CHAT_DB_RELATIVE_PATH.parent
+        db_dir.mkdir(parents=True)
+        return db_dir / CHAT_DB_RELATIVE_PATH.name
+
+    def _seed(
+        self,
+        db_path: Path,
+        rows: list[tuple[str, str]],
+        item_table_rows: Optional[list[tuple[str, str]]] = None,
+    ) -> None:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE ItemTable (key TEXT UNIQUE, value BLOB)")
+        conn.executemany("INSERT INTO cursorDiskKV VALUES (?, ?)", rows)
+        if item_table_rows:
+            conn.executemany("INSERT INTO ItemTable VALUES (?, ?)", item_table_rows)
+        conn.commit()
+        conn.close()
+
+    @staticmethod
+    def _composer_headers(*entries: tuple[str, str]) -> str:
+        """Build a ``composer.composerHeaders`` JSON blob for the given (id, path) pairs."""
+        return json.dumps(
+            {
+                "allComposers": [
+                    {
+                        "composerId": composer_id,
+                        "workspaceIdentifier": {
+                            "uri": {
+                                "path": path,
+                                "fsPath": path,
+                                "external": f"file://{path}",
+                                "scheme": "file",
+                            }
+                        },
+                    }
+                    for composer_id, path in entries
+                ]
+            }
+        )
+
+    def test_yields_events_resolves_cwd_via_item_table_and_model(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        composer = "11111111-2222-3333-4444-555555555555"
+        rows = [
+            (f"bubbleId:{composer}:tool-1", _bubble()),
+            (
+                f"bubbleId:{composer}:tool-2",
+                _bubble(
+                    toolFormerData={
+                        "tool": MCP_TOOL_KIND,
+                        "toolCallId": "tool_BBB",
+                        "rawArgs": json.dumps(
+                            {
+                                "name": "user-linear-get_issue",
+                                "args": {"id": "NHI-2"},
+                                "toolCallId": "tool_BBB",
+                                "providerIdentifier": "linear",
+                                "toolName": "get_issue",
+                            }
+                        ),
+                        "params": json.dumps(
+                            {
+                                "tools": [
+                                    {
+                                        "name": "get_issue",
+                                        "parameters": "",
+                                        "serverName": "linear",
+                                    }
+                                ]
+                            }
+                        ),
+                    }
+                ),
+            ),
+            (
+                f"composerData:{composer}",
+                json.dumps({"modelConfig": {"modelName": "composer-2"}}),
+            ),
+            # Non-MCP tool — should be filtered out at SQL level.
+            (
+                f"bubbleId:{composer}:other-1",
+                json.dumps(
+                    {
+                        "type": 2,
+                        "toolFormerData": {"tool": 9, "name": "codebase_search"},
+                    }
+                ),
+            ),
+        ]
+        item_table_rows = [
+            (
+                "composer.composerHeaders",
+                self._composer_headers((composer, "/home/u/repo")),
+            )
+        ]
+
+        db_path = self._make_db(tmp_path)
+        self._seed(db_path, rows, item_table_rows)
+
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Cursor().iter_history_events(empty_ai_config))
+
+        assert len(events) == 2
+        assert all(e.cwd == "/home/u/repo" for e in events)
+        assert all(e.model == "composer-2" for e in events)
+        assert events[0].input == {"id": "NHI-1"}
+        assert events[1].input == {"id": "NHI-2"}
+
+    def test_falls_back_to_bubble_workspace_when_not_in_item_table(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """No ItemTable header for this composer → fall back to the user bubble."""
+        composer = "11111111-2222-3333-4444-555555555555"
+        user_bubble = json.dumps(
+            {
+                "type": 1,
+                "createdAt": "2026-04-01T08:59:00Z",
+                "workspaceUris": ["file:///home/u/repo"],
+            }
+        )
+        rows = [
+            (f"bubbleId:{composer}:user-1", user_bubble),
+            (f"bubbleId:{composer}:tool-1", _bubble()),
+        ]
+        db_path = self._make_db(tmp_path)
+        self._seed(db_path, rows)  # no ItemTable rows seeded
+
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Cursor().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        assert events[0].cwd == "/home/u/repo"
+        assert events[0].model == ""
+
+    def test_missing_db_yields_nothing(self, tmp_path: Path, empty_ai_config) -> None:
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Cursor().iter_history_events(empty_ai_config))
+        assert events == []
+
+    def test_empty_cwd_when_no_workspace_anywhere(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        composer = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        user_bubble = json.dumps(
+            {
+                "type": 1,
+                "createdAt": "2026-04-01T08:59:00Z",
+                "workspaceUris": [],
+            }
+        )
+        rows = [
+            (f"bubbleId:{composer}:user-1", user_bubble),
+            (f"bubbleId:{composer}:tool-1", _bubble()),
+        ]
+        db_path = self._make_db(tmp_path)
+        self._seed(db_path, rows)  # no ItemTable rows seeded
+
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Cursor().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        assert events[0].cwd == ""

--- a/tests/unit/verticals/ai/test_history.py
+++ b/tests/unit/verticals/ai/test_history.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPActivityBulkResponse, UserInfo
+
+from ggshield.verticals.ai.history import backfill_mcp_history
+
+
+def _make_discovery() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+def _claude_transcript_dir(tmp_path: Path) -> Path:
+    p = tmp_path / ".claude" / "projects" / "myrepo"
+    p.mkdir(parents=True)
+    return p
+
+
+def _mcp_line(ts: str = "2026-04-01T09:00:00.000Z") -> str:
+    return (
+        json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": "s1",
+                "cwd": "/repo",
+                "isSidechain": False,
+                "timestamp": ts,
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "mcp__linear__get_issue",
+                            "input": {},
+                        }
+                    ],
+                },
+            }
+        )
+        + "\n"
+    )
+
+
+class TestBackfillMCPHistory:
+    @pytest.fixture(autouse=True)
+    def _patch_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "ggshield.verticals.ai.agents.claude_code.get_user_home_dir",
+            lambda: tmp_path,
+        )
+
+    def test_uploads_all_events(self, tmp_path) -> None:
+        session = _claude_transcript_dir(tmp_path) / "session1.jsonl"
+        session.write_text(_mcp_line() + _mcp_line())
+
+        client = MagicMock()
+        client.log_mcp_activities_bulk.return_value = MCPActivityBulkResponse(
+            ingested=2, duplicates=0, skipped=0
+        )
+
+        report = backfill_mcp_history(client, _make_discovery())
+
+        assert client.log_mcp_activities_bulk.call_count == 1
+        sent = client.log_mcp_activities_bulk.call_args.args[0]
+        assert len(sent) == 2
+        assert report.parsed == 2
+        assert report.ingested == 2
+        assert report.duplicates == 0
+        assert report.skipped == 0
+
+    def test_runs_every_time(self, tmp_path) -> None:
+        """No cache: each invocation re-walks transcripts and re-sends events."""
+        session = _claude_transcript_dir(tmp_path) / "session1.jsonl"
+        session.write_text(_mcp_line())
+
+        client = MagicMock()
+        client.log_mcp_activities_bulk.return_value = MCPActivityBulkResponse(
+            ingested=0, duplicates=1, skipped=0
+        )
+
+        first = backfill_mcp_history(client, _make_discovery())
+        second = backfill_mcp_history(client, _make_discovery())
+
+        assert client.log_mcp_activities_bulk.call_count == 2
+        assert first.parsed == 1
+        assert second.parsed == 1
+
+    def test_upload_failure_reports_error(self, tmp_path) -> None:
+        session = _claude_transcript_dir(tmp_path) / "session1.jsonl"
+        session.write_text(_mcp_line())
+
+        client = MagicMock()
+        client.log_mcp_activities_bulk.side_effect = RuntimeError("network down")
+
+        report = backfill_mcp_history(client, _make_discovery())
+        assert report.ingested == 0
+        assert report.error is not None

--- a/tests/unit/verticals/ai/test_vscode_history.py
+++ b/tests/unit/verticals/ai/test_vscode_history.py
@@ -1,0 +1,315 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+
+from ggshield.verticals.ai.agents.vscode import VSCode, _find_mcp_invocations
+
+
+def _invocation(
+    tool_call_id: str = "tc-1",
+    tool_id: str = "mcp_makenotion_no_notion-search",
+    server_label: str = "Notion MCP",
+    label: str = "makenotion/notion-mcp-server",
+    raw_input=None,
+) -> dict:
+    return {
+        "kind": "toolInvocationSerialized",
+        "source": {
+            "type": "mcp",
+            "serverLabel": server_label,
+            "label": label,
+            "collectionId": "mcp.config.usrlocal",
+        },
+        "toolCallId": tool_call_id,
+        "toolId": tool_id,
+        "isComplete": True,
+        "toolSpecificData": {
+            "kind": "input",
+            "rawInput": raw_input if raw_input is not None else {"q": "x"},
+        },
+    }
+
+
+def _request_line(timestamp_ms: int, response: list, request_id: str = "req-1") -> str:
+    return json.dumps(
+        {
+            "kind": 2,
+            "v": [
+                {
+                    "requestId": request_id,
+                    "timestamp": timestamp_ms,
+                    "response": response,
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def empty_ai_config() -> AIDiscovery:
+    return AIDiscovery(
+        user=UserInfo(hostname="h", username="u", machine_id="m"),
+        servers=[],
+        discovery_duration=0.0,
+    )
+
+
+class TestFindMCPInvocations:
+    def test_finds_nested_mcp_invocations(self) -> None:
+        obj = {
+            "v": [
+                {"response": [_invocation("a"), {"kind": "thinking"}]},
+                {"response": [_invocation("b", server_label="Other", label="other/x")]},
+            ]
+        }
+        found = list(_find_mcp_invocations(obj))
+        assert [i["toolCallId"] for i in found] == ["a", "b"]
+
+    def test_skips_internal_tools(self) -> None:
+        obj = {
+            "kind": "toolInvocationSerialized",
+            "source": {"type": "internal"},
+            "toolCallId": "x",
+        }
+        assert list(_find_mcp_invocations(obj)) == []
+
+
+class TestCopilotIterHistoryEvents:
+    """Copilot CLI sessions are not in workspaceStorage — the parser must not pick them up."""
+
+    def test_returns_empty(self, tmp_path: Path, empty_ai_config) -> None:
+        from ggshield.verticals.ai.agents.copilot import Copilot
+
+        # Even with VSCode-shaped data on disk, the Copilot CLI agent should yield nothing.
+        workspace_hash = (
+            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
+        )
+        sessions = workspace_hash / "chatSessions"
+        sessions.mkdir(parents=True)
+        (workspace_hash / "workspace.json").write_text(
+            json.dumps({"folder": "file:///repo"})
+        )
+        (sessions / "session.jsonl").write_text(
+            _request_line(1_778_855_521_780, [_invocation("call-1")]) + "\n"
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(Copilot().iter_history_events(empty_ai_config))
+
+        assert events == []
+
+
+class TestVSCodeIterHistoryEvents:
+    def _seed_session(
+        self, tmp_path: Path, lines: list[str], workspace_folder: str
+    ) -> Path:
+        workspace_hash = (
+            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
+        )
+        sessions = workspace_hash / "chatSessions"
+        sessions.mkdir(parents=True)
+        (workspace_hash / "workspace.json").write_text(
+            json.dumps({"folder": f"file://{workspace_folder}"})
+        )
+        session = sessions / "session.jsonl"
+        session.write_text("\n".join(lines) + "\n")
+        return session
+
+    def test_extracts_mcp_calls_with_request_timestamp(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        ts_ms = 1_778_855_521_780
+        line = _request_line(ts_ms, [_invocation("call-1")])
+        self._seed_session(tmp_path, [line], "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.tool == "no_notion-search"
+        assert ev.server == "makenotion/notion-mcp-server"
+        assert ev.agent == "vscode"
+        assert ev.cwd == "/repo"
+        assert ev.timestamp == datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        assert ev.input == {"q": "x"}
+
+    def test_dedupes_by_tool_call_id(self, tmp_path: Path, empty_ai_config) -> None:
+        """Same toolCallId across delta lines should yield exactly one event."""
+        ts_ms = 1_778_855_521_780
+        # First snapshot: invocation partial. Second snapshot: invocation again.
+        lines = [
+            _request_line(ts_ms, [_invocation("dup", raw_input={"q": "partial"})]),
+            _request_line(ts_ms, [_invocation("dup", raw_input={"q": "final"})]),
+        ]
+        self._seed_session(tmp_path, lines, "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+
+    def test_bare_invocation_uses_last_request_timestamp(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """A delta line carrying just a toolInvocation (no request envelope)
+        should inherit the most-recently-seen request timestamp."""
+        ts_ms = 1_778_855_521_780
+        bare_line = json.dumps({"kind": 2, "v": [_invocation("bare")]})
+        lines = [
+            _request_line(ts_ms, []),  # establishes last_ts
+            bare_line,
+        ]
+        self._seed_session(tmp_path, lines, "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        assert events[0].timestamp == datetime.fromtimestamp(
+            ts_ms / 1000, tz=timezone.utc
+        )
+
+    def test_uses_snapshot_request_timestamp_for_later_invocation(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """The ``kind:0`` snapshot stores the request timestamp inside a dict
+        (``v.requests[].timestamp``), not a top-level list. A later delta line
+        carrying the MCP invocation must still inherit that timestamp."""
+        ts_ms = 1_778_855_521_780
+        snapshot = json.dumps(
+            {
+                "kind": 0,
+                "v": {
+                    "version": 3,
+                    "requests": [
+                        {"requestId": "req-1", "timestamp": ts_ms, "response": []}
+                    ],
+                },
+            }
+        )
+        bare_line = json.dumps({"kind": 2, "v": [_invocation("late")]})
+        self._seed_session(tmp_path, [snapshot, bare_line], "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        assert events[0].timestamp == datetime.fromtimestamp(
+            ts_ms / 1000, tz=timezone.utc
+        )
+
+    def test_uses_nested_tool_call_round_timestamp(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """Some delta lines carry the timestamp nested under
+        ``v.metadata.toolCallRounds[].timestamp`` rather than at the top level."""
+        ts_ms = 1_778_855_521_780
+        round_line = json.dumps(
+            {
+                "kind": 1,
+                "v": {"metadata": {"toolCallRounds": [{"timestamp": ts_ms}]}},
+            }
+        )
+        bare_line = json.dumps({"kind": 2, "v": [_invocation("nested")]})
+        self._seed_session(tmp_path, [round_line, bare_line], "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert len(events) == 1
+        assert events[0].timestamp == datetime.fromtimestamp(
+            ts_ms / 1000, tz=timezone.utc
+        )
+
+    def test_drops_invocation_without_timestamp(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        """If no request snapshot has been seen yet, there's no timestamp to attach."""
+        bare_line = json.dumps({"kind": 2, "v": [_invocation("orphan")]})
+        self._seed_session(tmp_path, [bare_line], "/repo")
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert events == []
+
+    def test_resolves_server_name_via_configuration(self, tmp_path: Path) -> None:
+        """``source.label`` matches ``MCPConfiguration.name`` byte-for-byte."""
+        ts_ms = 1_778_855_521_780
+        line = _request_line(ts_ms, [_invocation("c")])
+        self._seed_session(tmp_path, [line], "/repo")
+
+        config = AIDiscovery(
+            user=UserInfo(hostname="h", username="u", machine_id="m"),
+            servers=[
+                MCPServer(
+                    name="Notion",
+                    configurations=[
+                        MCPConfiguration(
+                            name="makenotion/notion-mcp-server",
+                            agent="vscode",
+                            scope=MCPConfiguration.Scope.USER,
+                            transport=MCPConfiguration.Transport.HTTP,
+                            project=None,
+                        )
+                    ],
+                )
+            ],
+            discovery_duration=0.0,
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(config))
+
+        assert events[0].server == "Notion"
+        assert events[0].tool == "notion-search"
+
+    def test_ignores_legacy_json_sessions(
+        self, tmp_path: Path, empty_ai_config
+    ) -> None:
+        workspace_hash = (
+            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
+        )
+        sessions = workspace_hash / "chatSessions"
+        sessions.mkdir(parents=True)
+        (workspace_hash / "workspace.json").write_text(
+            json.dumps({"folder": "file:///repo"})
+        )
+        (sessions / "legacy.json").write_text(json.dumps({"requests": []}))
+
+        with patch(
+            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            events = list(VSCode().iter_history_events(empty_ai_config))
+
+        assert events == []

--- a/tests/unit/verticals/ai/test_vscode_history.py
+++ b/tests/unit/verticals/ai/test_vscode_history.py
@@ -78,34 +78,6 @@ class TestFindMCPInvocations:
         assert list(_find_mcp_invocations(obj)) == []
 
 
-class TestCopilotIterHistoryEvents:
-    """Copilot CLI sessions are not in workspaceStorage — the parser must not pick them up."""
-
-    def test_returns_empty(self, tmp_path: Path, empty_ai_config) -> None:
-        from ggshield.verticals.ai.agents.copilot import Copilot
-
-        # Even with VSCode-shaped data on disk, the Copilot CLI agent should yield nothing.
-        workspace_hash = (
-            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
-        )
-        sessions = workspace_hash / "chatSessions"
-        sessions.mkdir(parents=True)
-        (workspace_hash / "workspace.json").write_text(
-            json.dumps({"folder": "file:///repo"})
-        )
-        (sessions / "session.jsonl").write_text(
-            _request_line(1_778_855_521_780, [_invocation("call-1")]) + "\n"
-        )
-
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(Copilot().iter_history_events(empty_ai_config))
-
-        assert events == []
-
-
 class TestVSCodeIterHistoryEvents:
     def _seed_session(
         self, tmp_path: Path, lines: list[str], workspace_folder: str

--- a/uv.lock
+++ b/uv.lock
@@ -935,7 +935,7 @@ requires-dist = [
     { name = "oauthlib", specifier = "~=3.2.1" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", specifier = "~=1.30.0" },
+    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d3152b7bf33077fd17a8ea692d658dd428c73ac3" },
     { name = "pyjwt", specifier = "~=2.6.0" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
@@ -2608,17 +2608,13 @@ wheels = [
 [[package]]
 name = "pygitguardian"
 version = "1.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d3152b7bf33077fd17a8ea692d658dd428c73ac3#d3152b7bf33077fd17a8ea692d658dd428c73ac3" }
 dependencies = [
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },
     { name = "requests" },
     { name = "setuptools" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/d9/15e6d313c47c1e8753d7c0a274717b8841f34e9e187ba8a9f5b9598096f4/pygitguardian-1.30.0.tar.gz", hash = "sha256:fd6a43a2650d181c06d3e0a5c38b7a9ed9e4868bdd1997ce4e6c5863c94de9fe", size = 56271, upload-time = "2026-04-28T12:02:32.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/3e/aefd6fcc2fcb88dfe5fd1a026a3ca5d5ba87eb7baba3feea70ce4db117c4/pygitguardian-1.30.0-py3-none-any.whl", hash = "sha256:9ff6acb3e6a47ddc96fb4fc7f70dbe058ccb828c5cef67097ab5cef897c88219", size = 23518, upload-time = "2026-04-28T12:02:31.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

New option in `ggshield ai discover`: `--history` allows parsing and sending MCP calls found in agent transcripts, in order to obtain insight on calls made before installing the hook.  
:warning: Requires py-gitguardian changes: https://github.com/GitGuardian/py-gitguardian/pull/173

<img width="546" height="79" alt="image" src="https://github.com/user-attachments/assets/c50e70ef-56e8-4afb-ad1f-3a69771eab1b" />



## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

- `ggshield ai discover` takes a new optional flag option: `--history`. Not passing the flag results in the same behavior as before.  
- Passing the flag runs the history parsing in addition to the default behavior
- Transcript files are parsed for all supported agents: Claude Code, Copilot, Cursor
  - Claude Code and VSCode Chat store them in .jsonl files
  - Cursor uses a database
- Each agent implements its own way of iterating over the past events
- All activities are sent to the GitGuardian API in batches (500). The GitGuardian API handles idempotency.

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

1. Wire py-gitguardian correct version (https://github.com/GitGuardian/py-gitguardian/pull/173)
2. Wire the local GitGuardian API with the new route (if not deployed yet)
3. Run `ggshield ai discover --history`
4. Go to the Agentic AI dashboard

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
