### PR TITLE
feat(git): harden git commands by using --end-of-options separator

### DIFF
--- a/changelog.d/20260518_164622_6d7a_harden_git_invocations.md
+++ b/changelog.d/20260518_164622_6d7a_harden_git_invocations.md
@@ -1,0 +1,3 @@
+### Security
+
+- Harden internal `git` invocations against argument injection: positional refs, remotes, branches and clone URLs are now passed after `--end-of-options` (git 2.24+) so a value starting with `-` (e.g. read from a CI environment variable) cannot be reinterpreted as a `git` option such as `--upload-pack=`.

--- a/ggshield/cmd/secret/scan/repo.py
+++ b/ggshield/cmd/secret/scan/repo.py
@@ -61,7 +61,7 @@ def repo_cmd(
 
     if REGEX_GIT_URL.match(repository):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            git(["clone", "--mirror", repository, tmpdirname])
+            git(["clone", "--mirror", "--end-of-options", repository, tmpdirname])
             scan_context.target_path = Path(tmpdirname)
             return scan_repo_path(
                 client=ctx_obj.client,

--- a/ggshield/core/git_hooks/ci/commit_range.py
+++ b/ggshield/core/git_hooks/ci/commit_range.py
@@ -52,7 +52,7 @@ def _fetch_target_branch(remote: str, branch: str) -> None:
     """
     try:
         ui.display_verbose(f"\tFetching {branch} from {remote}")
-        git(["fetch", remote, branch])
+        git(["fetch", "--end-of-options", remote, branch])
     except (subprocess.CalledProcessError, GitCommandTimeoutExpired):
         logger.warning("Failed to fetch %s from %s", branch, remote)
 

--- a/ggshield/core/git_hooks/ci/previous_commit.py
+++ b/ggshield/core/git_hooks/ci/previous_commit.py
@@ -139,7 +139,7 @@ def gitlab_merge_request_previous_commit_sha() -> Optional[str]:
         return None
 
     # Requires to fetch targeted branch to access current HEAD
-    git(["fetch", "origin", targeted_branch])
+    git(["fetch", "--end-of-options", "origin", targeted_branch])
 
     try:
         last_commit = get_last_commit_sha_of_branch(f"origin/{targeted_branch}")
@@ -266,7 +266,7 @@ def azure_pull_request_previous_commit_sha() -> Optional[str]:
         return None
 
     # Requires to fetch targeted branch to access current HEAD
-    git(["fetch", "origin", targeted_branch])
+    git(["fetch", "--end-of-options", "origin", targeted_branch])
 
     last_commit = get_last_commit_sha_of_branch(f"origin/{targeted_branch}")
     if last_commit is not None:

--- a/ggshield/core/scan/commit_information.py
+++ b/ggshield/core/scan/commit_information.py
@@ -75,5 +75,5 @@ class CommitInformation:
 
     @staticmethod
     def from_sha(sha: str, cwd: Optional[Path] = None) -> "CommitInformation":
-        header = git(["show", sha] + HEADER_COMMON_ARGS, cwd=cwd)
+        header = git(["show"] + HEADER_COMMON_ARGS + ["--end-of-options", sha], cwd=cwd)
         return CommitInformation.from_patch_header(header)

--- a/ggshield/core/scan/commit_utils.py
+++ b/ggshield/core/scan/commit_utils.py
@@ -376,7 +376,7 @@ def get_file_sha_in_ref(
     Helper function to get the shas of files in the git reference.
     """
     for files in batched(files, MAX_FILES_PER_GIT_COMMAND):
-        output = git(["ls-tree", "-z", ref] + files, cwd=cwd)
+        output = git(["ls-tree", "-z", "--end-of-options", ref] + files, cwd=cwd)
         for line in output.split("\0")[:-1]:
             _, _, sha, path = line.split(maxsplit=3)
             yield (path, sha)

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -299,7 +299,7 @@ def is_valid_git_commit_ref(ref: str, wd: Optional[Union[str, Path]] = None) -> 
         wd = Path.cwd()
 
     ref += "^{commit}"
-    cmd = ["cat-file", "-e", ref]
+    cmd = ["cat-file", "-e", "--end-of-options", ref]
 
     try:
         git(cmd, cwd=wd)
@@ -428,7 +428,8 @@ def get_filepaths_from_ref(
     check_git_ref(ref, wd)
 
     filepaths = git(
-        ["ls-tree", "--name-only", "--full-name", "-r", ref], cwd=wd
+        ["ls-tree", "--name-only", "--full-name", "-r", "--end-of-options", ref],
+        cwd=wd,
     ).splitlines()
     return [Path(path_str) for path_str in filepaths]
 
@@ -448,7 +449,7 @@ def get_staged_filepaths(wd: Optional[Union[str, Path]] = None) -> List[Path]:
 @lru_cache(None)
 def read_git_file(ref: str, path: Path, wd: Optional[Union[str, Path]] = None) -> str:
     # Use as_posix to handle git and Windows
-    return git(["show", f"{ref}:{path.as_posix()}"], cwd=wd)
+    return git(["show", "--end-of-options", f"{ref}:{path.as_posix()}"], cwd=wd)
 
 
 def get_remotes(wd: Optional[Union[str, Path]] = None) -> List[str]:
@@ -477,7 +478,9 @@ def get_default_branch(wd: Optional[Union[str, Path]] = None) -> str:
 
     default_branch = None
     if remote is not None:
-        for line in git(["remote", "show", remote], cwd=wd).splitlines():
+        for line in git(
+            ["remote", "show", "--end-of-options", remote], cwd=wd
+        ).splitlines():
             line = line.strip()
             if line.startswith("HEAD branch: "):
                 default_branch = remote + "/" + line[len("HEAD branch: ") :]


### PR DESCRIPTION
## Context

Snyk flags a couple of medium command injection issues that we should resolve.

## What has been done

git 2.24+ supports the --end-of-options flag to separate command options from command arguments. This commit adds the separator to harden against command injections.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
