### PR TITLE
Improve MCP parsing for VSCode and Copilot CLI

### DIFF
--- a/changelog.d/20260520_113259_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260520_113259_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- MCP configuration parsing improved for VSCode and Copilot CLI.

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -9,6 +9,7 @@ from ggshield.verticals.ai.models import (
     HookPayload,
     MCPConfiguration,
     Scope,
+    Tool,
 )
 
 from .vscode import VSCode
@@ -61,6 +62,18 @@ class Copilot(VSCode):
         if payload.event_type == EventType.USER_PROMPT and payload.tool is None:
             return True
         return super().has_secret_already_leaked(payload)
+
+    def post_process_payload(self, payload: HookPayload):
+        # Copilot CLI doesn't prefix the MCP tools by any specific string,
+        # so we need to identify them by elimination.
+        if payload.tool == Tool.OTHER:
+            tool_name = payload.raw.get("tool_name", "")
+            # The list of tools provided in the official documentation is not exhaustive,
+            # (they don't list "report_intent" for instance), so I have no confidence in having
+            # a whitelist/blacklist. Instead, we rely on the fact that Copilot separates the server
+            # and tool names by a "-", which is never used in other tool names (they are snake_cased).
+            if "-" in tool_name:
+                payload.tool = Tool.MCP
 
     def _lookup_server_name(
         self, raw_tool_name: str, ai_config: AIDiscovery

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,4 +1,8 @@
-from ggshield.verticals.ai.models import EventType, HookPayload
+from pathlib import Path
+from typing import Iterator
+
+from ggshield.core.dirs import get_user_home_dir
+from ggshield.verticals.ai.models import EventType, HookPayload, MCPConfiguration, Scope
 
 from .vscode import VSCode
 
@@ -16,6 +20,26 @@ class Copilot(VSCode):
     @property
     def display_name(self) -> str:
         return "Copilot CLI"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".copilot"
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".mcp.json"
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        # Load config file
+        filepath = self.config_folder / "mcp-config.json"
+        if not (data := self._load_json_file(filepath)):
+            return
+        yield from self._parse_servers_block(data, Scope.USER, None)
+        # Search in installed plugins
+        for plugin_folder in self.config_folder.glob("installed-plugins/*/*/"):
+            for config in self._get_project_mcp_configurations(plugin_folder):
+                config.scope = Scope.USER
+                config.project = None
+                yield config
 
     def is_caller(self, hook_payload: dict[str, str]) -> bool:
         # Copilot CLI only emits the default fields in all hooks, which in a way identifies it.

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,8 +1,15 @@
+import re
 from pathlib import Path
-from typing import Iterator
+from typing import Dict, Iterator, Tuple
 
 from ggshield.core.dirs import get_user_home_dir
-from ggshield.verticals.ai.models import EventType, HookPayload, MCPConfiguration, Scope
+from ggshield.verticals.ai.models import (
+    AIDiscovery,
+    EventType,
+    HookPayload,
+    MCPConfiguration,
+    Scope,
+)
 
 from .vscode import VSCode
 
@@ -54,3 +61,38 @@ class Copilot(VSCode):
         if payload.event_type == EventType.USER_PROMPT and payload.tool is None:
             return True
         return super().has_secret_already_leaked(payload)
+
+    def _lookup_server_name(
+        self, raw_tool_name: str, ai_config: AIDiscovery
+    ) -> Tuple[str, str]:
+        # Copilot's hook tool name is "{server}-{tool}"
+        # which is unfortunate because server names can contain "-" in their name.
+        # It also mangles the config name (replaces spaces, uses punycode encoding, ...).
+        # It doesn't look like it can import MCP servers from other agents, so we filter them to avoid
+        # false positives.
+        # We look for the longest chain of parts separated by "-" that is a valid server configuration name.
+
+        # Build a map of mangled server configuration names to server names.
+        mangled_to_server: Dict[str, str] = {
+            _mangle_name(configuration.name): server.name
+            for server in ai_config.servers
+            for configuration in server.configurations
+            if configuration.agent == self.name
+        }
+
+        parts = raw_tool_name.split("-")
+
+        # At each separation point (starting from the biggest name possible), check if the mangled name is in the map.
+        for i in range(len(parts)):
+            # lower() because of IDNA encoding, whereas Copilot preserves the case.
+            mangled_name = "-".join(parts[:-i]).lower()
+            if mangled_name in mangled_to_server:
+                return mangled_to_server[mangled_name], "-".join(parts[-i:])
+
+        # If no match is found, fallback to use the last part as the tool name.
+        return "-".join(parts[:-1]), parts[-1]
+
+
+def _mangle_name(name: str) -> str:
+    """Mangle a name in the same way Copilot does."""
+    return re.sub(r"\W", "-", name.lower()).encode("idna").decode()

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -10,6 +10,7 @@ from ggshield.verticals.ai.models import (
     MCPConfiguration,
     Scope,
     Tool,
+    Transport,
 )
 
 from .vscode import VSCode
@@ -48,6 +49,15 @@ class Copilot(VSCode):
                 config.scope = Scope.USER
                 config.project = None
                 yield config
+        # Hard-coded Github MCP server
+        yield MCPConfiguration(
+            name="github-mcp-server",
+            agent=self.name,
+            scope=Scope.USER,
+            project=None,
+            transport=Transport.HTTP,
+            url="https://api.individual.githubcopilot.com/mcp/readonly",
+        )
 
     def is_caller(self, hook_payload: dict[str, str]) -> bool:
         # Copilot CLI only emits the default fields in all hooks, which in a way identifies it.

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, Iterator, Literal, Tuple
 
@@ -7,7 +8,7 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
+from ..models import Agent, EventType, HookPayload, HookResult
 
 
 class VSCode(Agent):
@@ -65,16 +66,13 @@ class VSCode(Agent):
                 if path.is_dir():
                     yield path.resolve()
 
-    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
-        yield from Agent._get_user_mcp_configurations(self)
-
     def parse_mcp_activity(
         self, payload: HookPayload, ai_config: AIDiscovery
     ) -> MCPActivityRequest:
         """Parse the MCP activity from an MCP hook payload."""
 
         raw_tool_name: str = payload.raw.get("tool_name", "")
-        server_name, tool_name = _lookup_server_name(raw_tool_name, ai_config)
+        server_name, tool_name = self._lookup_server_name(raw_tool_name, ai_config)
 
         return MCPActivityRequest(
             user=ai_config.user,
@@ -86,20 +84,40 @@ class VSCode(Agent):
             input=payload.raw.get("tool_input", {}),
         )
 
+    def _lookup_server_name(
+        self, raw_tool_name: str, ai_config: AIDiscovery
+    ) -> Tuple[str, str]:
+        # VSCode's hook tool name is "mcp_{server}_{tool}"
+        # which is unfortunate because a lot of tools have a "_" in their name.
+        # It also mangles the config name (lowercase, groups of non-alphanumeric
+        # characters are replaced by a single "_", and only the first 13 characters are kept).
+        # We may not have the list of tools available and VSCode can use MCP servers
+        # from other agents (like Claude Code), so for now as a best effort attempt,
+        # we look for the longest chain of parts separated by "_" that is a valid server configuration name.
 
-def _lookup_server_name(raw_tool_name: str, ai_config: AIDiscovery) -> Tuple[str, str]:
-    # Copilot's hook tool name is "mcp_{server}_{tool}"
-    # which is unfortunate because a lot of tools have a "_" in their name.
-    # For now we hope there won't be "_" in the server configuration name
-    # (this is less likely than in the tool name but very brittle).
-    # TODO: test this more thoroughly and implement a better lookup.
-    _, server_cfg_name, *tool_parts = raw_tool_name.split("_")
-    tool = "_".join(tool_parts)
+        # Build a map of mangled server configuration names to server names.
+        mangled_to_server: Dict[str, str] = {
+            _mangle_name(configuration.name): server.name
+            for server in ai_config.servers
+            for configuration in server.configurations
+        }
 
-    # Lookup the server name based on its configuration name
-    # Fallback to the configuration name if not found
-    for server in ai_config.servers:
-        for configuration in server.configurations:
-            if configuration.name == server_cfg_name:
-                return server.name, tool
-    return server_cfg_name, tool
+        # This get rid of the "mcp_" prefix.
+        _, *parts = raw_tool_name.split("_")
+
+        # At each separation point (starting from the biggest name possible), check if the mangled name is in the map.
+        for i in range(len(parts)):
+            mangled_name = "_".join(parts[:-i])
+            if mangled_name in mangled_to_server:
+                return mangled_to_server[mangled_name], "_".join(parts[-i:])
+
+        # If no match is found, fallback to use the first part as the server name.
+        return parts[0], "_".join(parts[1:])
+
+
+MANGLING_PATTERN = re.compile(r"[^A-Za-z0-9-]+")
+
+
+def _mangle_name(name: str) -> str:
+    """Mangle a name in the same way VSCode does."""
+    return MANGLING_PATTERN.sub("_", name).lower()[:13]

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -141,6 +141,11 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             raw=data,
         )
     )
+
+    # Allow the agent to post-process the payloads (e.g overriding the tool)
+    for payload in payloads:
+        agent.post_process_payload(payload)
+
     return payloads
 
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -128,6 +128,12 @@ class Agent(ABC):
         """
         return payload.event_type == EventType.POST_TOOL_USE
 
+    def post_process_payload(self, payload: HookPayload):
+        """Post-process the payload.
+
+        This method is called after the payload has been parsed, but before it is scanned.
+        """
+
     # Settings
 
     @abstractmethod

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -9,6 +9,7 @@ from pygitguardian.models import MCPToolInfo, UserInfo
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.codex import Codex
+from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
 from ggshield.verticals.ai.agents.vscode import VSCode
 from ggshield.verticals.ai.models import (
@@ -1051,6 +1052,108 @@ class TestVSCodeParseMcpActivity:
         req = vscode.parse_mcp_activity(payload, discovery)
 
         assert req.server == "unknown"
+        assert req.tool == "tool_name"
+
+
+# ===========================================================================
+# Copilot
+# ===========================================================================
+
+
+class TestCopilotParseMcpActivity:
+    @pytest.mark.parametrize(
+        "tool_name, config_name, expected_tool",
+        [
+            pytest.param("myserver-mytool", "myserver", "mytool", id="simple"),
+            pytest.param(
+                "server-tool_name",
+                "server",
+                "tool_name",
+                id="underscores_in_tool",
+            ),
+            pytest.param(
+                "server-name-tool-name",
+                "server-name",
+                "tool-name",
+                id="multiple_dashes_in_tool_and_config",
+            ),
+            pytest.param(
+                "xn--Foob_ar_s--Prod--twb-tool_name",
+                "Foob_ar_ös (Prod)",
+                "tool_name",
+                id="special_chars_in_config_name",
+            ),
+            pytest.param(
+                "xn--Fo-bar_bz--Spam---Toto-----T-ta------Tutu-42-2vd5e46b-tool_name",
+                "Fôo-bar_bäz (Spam) [Toto]   <Tâ/ta> -  (Tutu 42",
+                "tool_name",
+                id="special_chars_in_config_name_2",
+            ),
+            pytest.param(
+                "FooVeryLong-NameWithCapsInCamelCase-tool_name",
+                "FooVeryLong-NameWithCapsInCamelCase",
+                "tool_name",
+                id="long_server_name",
+            ),
+            pytest.param(
+                "Server-MCP-With-Spaces-tool_name",
+                "Server MCP With Spaces",
+                "tool_name",
+                id="server_name_with_spaces",
+            ),
+        ],
+    )
+    def test_identify_server_tool_split(
+        self, tool_name: str, config_name: str, expected_tool: str
+    ):
+        """Test that the server and tool names are split correctly."""
+        copilot = Copilot()
+        cfg = _cfg(name=config_name, agent="copilot")
+        server = MCPServer(name="identified", configurations=[cfg])
+        discovery = _ai_discovery(servers=[server])
+        payload = _payload(
+            copilot,
+            raw={"tool_name": tool_name, "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == expected_tool
+        assert req.server == "identified"
+
+    def test_identify_from_multiple_servers(self):
+        """Test that the server and tool names are split correctly."""
+        copilot = Copilot()
+        cfg1 = _cfg(name="foo", agent="copilot")
+        cfg2 = _cfg(name="foo-bar", agent="copilot")
+        server = MCPServer(name="server1", configurations=[cfg1])
+        server2 = MCPServer(name="server2", configurations=[cfg2])
+        discovery = _ai_discovery(servers=[server, server2])
+        payload = _payload(
+            copilot,
+            raw={"tool_name": "foo-bar-tool-name", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "tool-name"
+        assert req.server == "server2"
+
+    def test_unknown_server_falls_back_to_cfg_name(self):
+        copilot = Copilot()
+        discovery = _ai_discovery(servers=[])
+        payload = _payload(
+            copilot,
+            raw={
+                "tool_name": "unknown-server-tool_name",
+                "cwd": "/tmp",
+                "tool_input": {},
+            },
+        )
+
+        req = copilot.parse_mcp_activity(payload, discovery)
+
+        assert req.server == "unknown-server"
         assert req.tool == "tool_name"
 
 

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -9,8 +9,8 @@ from pygitguardian.models import MCPToolInfo, UserInfo
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.codex import Codex
-from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
+from ggshield.verticals.ai.agents.vscode import VSCode
 from ggshield.verticals.ai.models import (
     Agent,
     AIDiscovery,
@@ -969,55 +969,89 @@ class TestCodex:
 
 
 # ===========================================================================
-# Copilot
+# VSCode
 # ===========================================================================
 
 
-class TestCopilotParseMcpActivity:
-    def test_simple_server_tool_split(self):
-        copilot = Copilot()
-        cfg = _cfg(name="myserver", agent="copilot")
-        server = MCPServer(name="othername", configurations=[cfg])
+class TestVSCodeParseMcpActivity:
+    @pytest.mark.parametrize(
+        "tool_name, config_name, expected_tool",
+        [
+            pytest.param("mcp_myserver_mytool", "myserver", "mytool", id="simple"),
+            pytest.param(
+                "mcp_server_tool_name_extra",
+                "server",
+                "tool_name_extra",
+                id="multiple_underscores_in_tool",
+            ),
+            pytest.param(
+                "mcp_server_name_tool_name",
+                "server_name",
+                "tool_name",
+                id="multiple_underscores_in_tool_and_config",
+            ),
+            pytest.param(
+                "mcp_foo_b_r__tool_name",
+                "Foo (Bâr)",
+                "tool_name",
+                id="special_chars_in_config_name",
+            ),
+            pytest.param(
+                "mcp_verylongserve_tool_name",
+                "VeryLongServerName",
+                "tool_name",
+                id="long_server_name",
+            ),
+        ],
+    )
+    def test_identify_server_tool_split(
+        self, tool_name: str, config_name: str, expected_tool: str
+    ):
+        """Test that the server and tool names are split correctly."""
+        vscode = VSCode()
+        cfg = _cfg(name=config_name, agent="vscode")
+        server = MCPServer(name="identified", configurations=[cfg])
         discovery = _ai_discovery(servers=[server])
         payload = _payload(
-            copilot,
-            raw={"tool_name": "mcp_myserver_mytool", "cwd": "/tmp", "tool_input": {}},
+            vscode,
+            raw={"tool_name": tool_name, "cwd": "/tmp", "tool_input": {}},
         )
 
-        req = copilot.parse_mcp_activity(payload, discovery)
+        req = vscode.parse_mcp_activity(payload, discovery)
 
-        assert req.tool == "mytool"
-        assert req.server == "othername"
+        assert req.tool == expected_tool
+        assert req.server == "identified"
 
-    def test_multiple_underscores(self):
-        """Tools with underscores in their name are supported."""
-        copilot = Copilot()
-        discovery = _ai_discovery(servers=[])
+    def test_identify_from_multiple_servers(self):
+        """Test that the server and tool names are split correctly."""
+        vscode = VSCode()
+        cfg1 = _cfg(name="foo", agent="vscode")
+        cfg2 = _cfg(name="foo_bar", agent="cursor")
+        server = MCPServer(name="server1", configurations=[cfg1])
+        server2 = MCPServer(name="server2", configurations=[cfg2])
+        discovery = _ai_discovery(servers=[server, server2])
         payload = _payload(
-            copilot,
-            raw={
-                "tool_name": "mcp_server_tool_name_extra",
-                "cwd": "/tmp",
-                "tool_input": {},
-            },
+            vscode,
+            raw={"tool_name": "mcp_foo_bar_tool_name", "cwd": "/tmp", "tool_input": {}},
         )
 
-        req = copilot.parse_mcp_activity(payload, discovery)
-        assert req.server == "server"
-        assert req.tool == "tool_name_extra"
+        req = vscode.parse_mcp_activity(payload, discovery)
+
+        assert req.tool == "tool_name"
+        assert req.server == "server2"
 
     def test_unknown_server_falls_back_to_cfg_name(self):
-        copilot = Copilot()
+        vscode = VSCode()
         discovery = _ai_discovery(servers=[])
         payload = _payload(
-            copilot,
-            raw={"tool_name": "mcp_unknown_tool", "cwd": "/tmp", "tool_input": {}},
+            vscode,
+            raw={"tool_name": "mcp_unknown_tool_name", "cwd": "/tmp", "tool_input": {}},
         )
 
-        req = copilot.parse_mcp_activity(payload, discovery)
+        req = vscode.parse_mcp_activity(payload, discovery)
 
         assert req.server == "unknown"
-        assert req.tool == "tool"
+        assert req.tool == "tool_name"
 
 
 # ===========================================================================

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -746,6 +746,23 @@ class TestAIHookScannerParseInput:
         assert payload.scannable.content == "this is the content"
         assert isinstance(payload.agent, Copilot)
 
+    def test_copilot_pre_tool_use_mcp(self):
+        """Test Copilot PreToolUse is correctly overriden to MCP."""
+        data = {
+            "timestamp": "2026-02-26T11:53:49.593Z",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "tool_name": "server-name-tool-name",
+            "tool_input": {
+                "arg": "value",
+            },
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.MCP
+        assert isinstance(payload.agent, Copilot)
+
     def test_copilot_post_tool_use_run_in_terminal(self):
         """Test Copilot PostToolUse with bash"""
         data = {


### PR DESCRIPTION
## Context

We recently split an Agent integration into two: VSCode and Copilot.

This PR improves how MCP configurations are detected, and MCP activity parsed, for these two agents.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
