### PR TITLE
Improve MCP detection in Codex

### DIFF
--- a/changelog.d/20260520_113259_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260520_113259_paul.petit.ext_HEAD.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- MCP configuration parsing improved for VSCode and Copilot CLI.
+- MCP configuration parsing improved for VSCode, Copilot CLI and Codex.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -71,6 +71,10 @@ class Claude(Agent):
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".claude") / "settings.json"
 
+    @property
+    def user_mcp_file(self) -> Path:
+        return get_user_home_dir() / ".claude.json"
+
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".mcp.json"
 
@@ -83,8 +87,8 @@ class Claude(Agent):
     def _get_dot_claude_json_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         """Look into ~/.claude.json for both user-level and project-level MCP server entries."""
         # Load config file
-        filepath = get_user_home_dir() / ".claude.json"
-        if not (data := self._load_json_file(filepath)):
+        data = self._load_file(self.user_mcp_file)
+        if not data:
             return
 
         # User-level mcpServers
@@ -110,7 +114,7 @@ class Claude(Agent):
         ``<installPath>/.claude-plugin/plugin.json``.
         """
         installed_path = self.config_folder / "plugins" / "installed_plugins.json"
-        if not (data := self._load_json_file(installed_path)):
+        if not (data := self._load_file(installed_path)):
             return
 
         plugins = data.get("plugins", {})
@@ -148,7 +152,7 @@ class Claude(Agent):
         # Preferred location: .mcp.json at the plugin root. The file may use
         # either the wrapped {"mcpServers": {...}} layout or the bare
         # {"name": {...}} layout, so we normalize before parsing.
-        mcp_data = self._load_json_file(install_dir / ".mcp.json")
+        mcp_data = self._load_file(install_dir / ".mcp.json")
         if mcp_data is not None:
             if "mcpServers" not in mcp_data and "servers" not in mcp_data:
                 mcp_data = {"mcpServers": mcp_data}
@@ -156,7 +160,7 @@ class Claude(Agent):
             return
 
         # Fallback: inline mcpServers in the plugin manifest.
-        manifest = self._load_json_file(install_dir / ".claude-plugin" / "plugin.json")
+        manifest = self._load_file(install_dir / ".claude-plugin" / "plugin.json")
         if not manifest:
             return
         inline = manifest.get("mcpServers")
@@ -183,14 +187,12 @@ class Claude(Agent):
             seen.add(name)
             names.append(name)
 
-        claude_json = self._load_json_file(get_user_home_dir() / ".claude.json")
+        claude_json = self._load_file(get_user_home_dir() / ".claude.json")
         if claude_json:
             for name in claude_json.get("claudeAiMcpEverConnected", []) or []:
                 _add(name)
 
-        auth_cache = self._load_json_file(
-            self.config_folder / "mcp-needs-auth-cache.json"
-        )
+        auth_cache = self._load_file(self.config_folder / "mcp-needs-auth-cache.json")
         if auth_cache:
             for name in auth_cache.keys():
                 _add(name)

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -61,6 +61,10 @@ class Codex(Agent):
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".codex" / "config.toml"
 
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "config.toml"
+
     def discover_project_directories(self) -> Iterator[Path]:
         yield from []
 

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -7,7 +7,7 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookPayload, HookResult
+from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration, Scope
 from .claude_code import _mangle_server_name
 
 
@@ -66,7 +66,40 @@ class Codex(Agent):
         return self.config_folder / "config.toml"
 
     def discover_project_directories(self) -> Iterator[Path]:
-        yield from []
+        data = self._load_file(self.config_folder / "config.toml")
+        if not data:
+            return
+        for project in data.get("projects", {}).keys():
+            yield Path(project)
+
+    def _get_project_mcp_configurations(
+        self, directory: Path
+    ) -> Iterator[MCPConfiguration]:
+        # Standard project-level MCP servers
+        yield from super()._get_project_mcp_configurations(directory)
+        # Detect local plugin
+        yield from self._get_codex_plugin_mcp_configurations(
+            directory / ".codex-plugin", Scope.PROJECT
+        )
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        # Standard user-level MCP servers
+        yield from super()._get_user_mcp_configurations()
+        # Detect plugins
+        # (arborescence is plugins/cache/<marketplace>/<plugin>/<hash>/)
+        for plugin_dir in self.config_folder.glob("plugins/cache/*/*/*"):
+            yield from self._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+
+    def _get_codex_plugin_mcp_configurations(
+        self, plugin_dir: Path, scope: Scope
+    ) -> Iterator[MCPConfiguration]:
+        if not plugin_dir.is_dir():
+            return
+        if not (data := self._load_file(plugin_dir / ".mcp.json")):
+            return
+        yield from self._parse_servers_block(
+            data, scope, None if scope == Scope.USER else plugin_dir
+        )
 
     def parse_mcp_activity(
         self, payload: HookPayload, ai_config: AIDiscovery

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -37,12 +37,13 @@ class Copilot(VSCode):
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".mcp.json"
 
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "mcp-config.json"
+
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
-        # Load config file
-        filepath = self.config_folder / "mcp-config.json"
-        if not (data := self._load_json_file(filepath)):
-            return
-        yield from self._parse_servers_block(data, Scope.USER, None)
+        # Standard user-level MCP servers
+        yield from super()._get_user_mcp_configurations()
         # Search in installed plugins
         for plugin_folder in self.config_folder.glob("installed-plugins/*/*/"):
             for config in self._get_project_mcp_configurations(plugin_folder):

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -88,6 +88,10 @@ class Cursor(Agent):
                 return obj
         return None
 
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "mcp.json"
+
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".cursor" / "mcp.json"
 
@@ -123,7 +127,7 @@ class Cursor(Agent):
         # file may use either the wrapped {"mcpServers": {...}} layout or the
         # bare {"name": {...}} layout, so we normalize before parsing.
         for filename in ("mcp.json", ".mcp.json"):
-            mcp_data = self._load_json_file(install_dir / filename)
+            mcp_data = self._load_file(install_dir / filename)
             if mcp_data is not None:
                 if "mcpServers" not in mcp_data and "servers" not in mcp_data:
                     mcp_data = {"mcpServers": mcp_data}
@@ -131,7 +135,7 @@ class Cursor(Agent):
                 return
 
         # Fallback: inline mcpServers in the plugin manifest.
-        manifest = self._load_json_file(install_dir / ".cursor-plugin" / "plugin.json")
+        manifest = self._load_file(install_dir / ".cursor-plugin" / "plugin.json")
         if not manifest:
             return
         inline = manifest.get("mcpServers")
@@ -152,7 +156,7 @@ class Cursor(Agent):
         """
         packages = self.config_folder.glob("extensions/*/package.json")
         for package_path in packages:
-            package = self._load_json_file(package_path)
+            package = self._load_file(package_path)
             if not package:
                 continue
             providers = package.get("contributes", {}).get(
@@ -181,7 +185,7 @@ class Cursor(Agent):
         # Because Cursor is based on VS Code, we can reuse the same logic than Copilot.
         user_folder = get_user_home_dir() / ".config" / "Cursor" / "User"
         for file in user_folder.glob("workspaceStorage/*/workspace.json"):
-            if (data := self._load_json_file(file)) and "folder" in data:
+            if (data := self._load_file(file)) and "folder" in data:
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()
@@ -207,7 +211,7 @@ class Cursor(Agent):
             for file in self.config_folder.glob(
                 f"projects/*/mcps/*{configuration_name}/SERVER_METADATA.json"
             ):
-                metadata = self._load_json_file(file)
+                metadata = self._load_file(file)
                 if self._server_name_matches(metadata, configuration_name):
                     # Found it! Update the folder
                     folder = file.parent
@@ -226,7 +230,7 @@ class Cursor(Agent):
             filled = False
             # Tools
             for file in folder.glob("tools/*.json"):
-                tool = self._load_json_file(file)
+                tool = self._load_file(file)
                 if not isinstance(tool, dict) or "name" not in tool:
                     continue
                 server.tools.append(
@@ -239,7 +243,7 @@ class Cursor(Agent):
                 filled = True
             # Resources
             for file in folder.glob("resources/*.json"):
-                resource = self._load_json_file(file)
+                resource = self._load_file(file)
                 if not isinstance(resource, dict) or "uri" not in resource:
                     continue
                 server.resources.append(
@@ -253,7 +257,7 @@ class Cursor(Agent):
                 filled = True
             # Prompts
             for file in folder.glob("prompts/*.json"):
-                prompt = self._load_json_file(file)
+                prompt = self._load_file(file)
                 if not isinstance(prompt, dict) or "name" not in prompt:
                     continue
                 server.prompts.append(

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -58,10 +58,14 @@ class VSCode(Agent):
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".vscode" / "mcp.json"
 
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "mcp.json"
+
     def discover_project_directories(self) -> Iterator[Path]:
         # Try to parse workspaces settings.
         for file in self.config_folder.glob("workspaceStorage/*/workspace.json"):
-            if (data := self._load_json_file(file)) and "folder" in data:
+            if (data := self._load_file(file)) and "folder" in data:
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+import tomli
 from pygitguardian.models import (
     AIDiscovery,
     MCPActivityRequest,
@@ -218,6 +219,11 @@ class Agent(ABC):
     def project_mcp_file(self, directory: Path) -> Path:
         """The file where MCP servers are configured at the project level."""
 
+    @property
+    @abstractmethod
+    def user_mcp_file(self) -> Path:
+        """The file where MCP servers are configured at the user level."""
+
     @abstractmethod
     def discover_project_directories(self) -> Iterator[Path]:
         """Discover project directories by scraping config or history files."""
@@ -233,7 +239,9 @@ class Agent(ABC):
         The format is standard across all assistants.
         """
         # Lookup the two usual conventions
-        servers = data.get("mcpServers", data.get("servers", {}))
+        servers = data.get(
+            "mcpServers", data.get("servers", data.get("mcp_servers", {}))
+        )
         for name, entry in servers.items():
             if "url" in entry:
                 if entry.get("transport") == "sse":
@@ -259,11 +267,10 @@ class Agent(ABC):
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         """Return the MCP server entries for user-level (global) config files.
 
-        Default implementation looks in the config folder for a file named "mcp.json".
+        Default implementation loads the user's config file.
         """
         # Load config file
-        filepath = self.config_folder / "mcp.json"
-        if not (data := self._load_json_file(filepath)):
+        if not (data := self._load_file(self.user_mcp_file)):
             return
         yield from self._parse_servers_block(data, Scope.USER, None)
 
@@ -271,7 +278,7 @@ class Agent(ABC):
         self, directory: Path
     ) -> Iterator[MCPConfiguration]:
         """Return the MCP server entries for project-level config files."""
-        if data := self._load_json_file(self.project_mcp_file(directory)):
+        if data := self._load_file(self.project_mcp_file(directory)):
             yield from self._parse_servers_block(data, Scope.PROJECT, directory)
 
     def discover_mcp_configurations(
@@ -311,17 +318,22 @@ class Agent(ABC):
 
     # Helper methods
 
-    def _load_json_file(self, path: Path) -> Optional[Dict[str, Any]]:
-        """Load a JSON file and return the data, or None if the file doesn't exist (or is not a JSON object)."""
+    def _load_file(self, path: Path) -> Optional[Dict[str, Any]]:
+        """Load a file and return the data, or None if the file doesn't exist."""
         if not path.is_file():
             return None
         try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
+            raw = path.read_text()
+            # Fallback to JSON
+            if path.suffix == ".toml":
+                data = tomli.loads(raw)
+            else:
+                data = json.loads(raw)
+            if not isinstance(data, dict):
+                return None
+            return data
+        except (OSError, ValueError):
             return None
-        if not isinstance(data, dict):
-            return None
-        return data
 
     def _load_jsonl_file(self, path: Path) -> Iterator[Dict[str, Any]]:
         """Load a JSONL file and return the data line by line,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "truststore>=0.10.1; python_version >= \"3.10\"",
     "notify-py>=0.3.43",
     "keyring>=24.0.0,<26",
+    "tomli>=2.4.0",
 ]
 
 [project.urls]

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -938,9 +938,6 @@ class TestCodex:
             Path("/tmp/project") / ".codex" / "config.toml"
         )
 
-    def test_discover_project_directories_empty(self):
-        assert list(Codex().discover_project_directories()) == []
-
     def test_parse_mcp_activity(self):
         codex = Codex()
         cfg = _cfg(name="my.server", agent="codex")
@@ -967,6 +964,248 @@ class TestCodex:
         assert req.model == "gpt-5.4"
         assert req.cwd == "/tmp/project"
         assert req.input == {"query": "hello"}
+
+
+class TestCodexDiscoverProjectDirectories:
+    def _patch(self, codex: Codex, config_folder: Path):
+        return patch.object(
+            type(codex),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def test_yields_project_keys_from_config_toml(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        config_folder.mkdir()
+        (config_folder / "config.toml").write_text(
+            "[projects]\n"
+            '"/home/user/project-a" = {}\n'
+            '"/home/user/project-b" = {}\n'
+        )
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            dirs = list(codex.discover_project_directories())
+
+        assert Path("/home/user/project-a") in dirs
+        assert Path("/home/user/project-b") in dirs
+
+    def test_missing_config_toml_yields_nothing(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        config_folder.mkdir()
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            dirs = list(codex.discover_project_directories())
+
+        assert dirs == []
+
+    def test_config_toml_without_projects_key_yields_nothing(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        config_folder.mkdir()
+        (config_folder / "config.toml").write_text('model = "gpt-5"\n')
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            dirs = list(codex.discover_project_directories())
+
+        assert dirs == []
+
+
+class TestCodexGetProjectMcpConfigurations:
+    def _patch(self, codex: Codex, config_folder: Path):
+        return patch.object(
+            type(codex),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def test_includes_standard_project_config(self, tmp_path: Path):
+        """The parent's project-level config (.codex/config.toml) is included."""
+        project = tmp_path / "myproject"
+        project.mkdir()
+        codex_dir = project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            "[mcpServers.proj-srv]\n" 'command = "node"\n' 'args = ["index.js"]\n'
+        )
+
+        codex = Codex()
+        configs = list(codex._get_project_mcp_configurations(project))
+
+        assert len(configs) == 1
+        assert configs[0].name == "proj-srv"
+        assert configs[0].scope == Scope.PROJECT
+
+    def test_includes_local_codex_plugin(self, tmp_path: Path):
+        """A .codex-plugin directory with .mcp.json at project root is discovered."""
+        project = tmp_path / "myproject"
+        plugin_dir = project / ".codex-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "plugin-srv": {"command": "npx", "args": ["-y", "srv"]}
+                    }
+                }
+            )
+        )
+
+        codex = Codex()
+        configs = list(codex._get_project_mcp_configurations(project))
+
+        plugin_configs = [c for c in configs if c.name == "plugin-srv"]
+        assert len(plugin_configs) == 1
+        assert plugin_configs[0].scope == Scope.PROJECT
+        assert plugin_configs[0].project == str(plugin_dir)
+        assert plugin_configs[0].transport == Transport.STDIO
+        assert plugin_configs[0].command == "npx"
+
+    def test_no_plugin_dir_yields_only_standard(self, tmp_path: Path):
+        """When .codex-plugin doesn't exist, only standard config is considered."""
+        project = tmp_path / "myproject"
+        project.mkdir()
+
+        codex = Codex()
+        configs = list(codex._get_project_mcp_configurations(project))
+
+        assert configs == []
+
+
+class TestCodexGetUserMcpConfigurations:
+    def _patch(self, codex: Codex, config_folder: Path):
+        return patch.object(
+            type(codex),
+            "config_folder",
+            new_callable=lambda: property(lambda self: config_folder),
+        )
+
+    def test_includes_standard_user_config(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        config_folder.mkdir()
+        (config_folder / "config.toml").write_text(
+            "[mcpServers.global-srv]\n" 'command = "npx"\n' 'args = ["-y", "mcp"]\n'
+        )
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            configs = list(codex._get_user_mcp_configurations())
+
+        assert any(c.name == "global-srv" for c in configs)
+
+    def test_includes_marketplace_plugins(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        install_dir = (
+            config_folder / "plugins" / "cache" / "codex-public" / "sentry" / "abc123"
+        )
+        install_dir.mkdir(parents=True)
+        (install_dir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "sentry": {"type": "http", "url": "https://mcp.sentry.dev/mcp"}
+                    }
+                }
+            )
+        )
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            configs = list(codex._get_user_mcp_configurations())
+
+        plugin_configs = [c for c in configs if c.name == "sentry"]
+        assert len(plugin_configs) == 1
+        assert plugin_configs[0].scope == Scope.USER
+        assert plugin_configs[0].project is None
+        assert plugin_configs[0].transport == Transport.HTTP
+        assert plugin_configs[0].url == "https://mcp.sentry.dev/mcp"
+
+    def test_missing_plugins_folder_yields_only_standard(self, tmp_path: Path):
+        config_folder = tmp_path / ".codex"
+        config_folder.mkdir()
+
+        codex = Codex()
+        with self._patch(codex, config_folder):
+            configs = list(codex._get_user_mcp_configurations())
+
+        assert configs == []
+
+
+class TestCodexGetCodexPluginMcpConfigurations:
+    def test_missing_dir_yields_nothing(self, tmp_path: Path):
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(
+                tmp_path / "nonexistent", Scope.USER
+            )
+        )
+        assert configs == []
+
+    def test_dir_without_mcp_json_yields_nothing(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+        assert configs == []
+
+    def test_user_scope_sets_no_project(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"my-srv": {"command": "node", "args": ["s.js"]}}}
+            )
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "my-srv"
+        assert configs[0].scope == Scope.USER
+        assert configs[0].project is None
+        assert configs[0].transport == Transport.STDIO
+
+    def test_project_scope_sets_project_to_plugin_dir(self, tmp_path: Path):
+        plugin_dir = tmp_path / "myproject" / ".codex-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"local-srv": {"command": "python", "args": ["srv.py"]}}}
+            )
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.PROJECT)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "local-srv"
+        assert configs[0].scope == Scope.PROJECT
+        assert configs[0].project == str(plugin_dir)
+
+    def test_http_transport_detected(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"remote": {"url": "https://example.com/mcp"}}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].transport == Transport.HTTP
+        assert configs[0].url == "https://example.com/mcp"
 
 
 # ===========================================================================

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -180,28 +180,28 @@ class TestParseServersBlock:
 
 
 # ---------------------------------------------------------------------------
-# Agent._load_json_file
+# Agent._load_file
 # ---------------------------------------------------------------------------
 
 
-class TestLoadJsonFile:
+class TestLoadFile:
     def test_returns_dict_for_valid_json(self, tmp_path: Path):
         f = tmp_path / "ok.json"
         f.write_text(json.dumps({"key": "value"}))
-        assert Cursor()._load_json_file(f) == {"key": "value"}
+        assert Cursor()._load_file(f) == {"key": "value"}
 
     def test_returns_none_for_missing_file(self, tmp_path: Path):
-        assert Cursor()._load_json_file(tmp_path / "missing.json") is None
+        assert Cursor()._load_file(tmp_path / "missing.json") is None
 
     def test_returns_none_for_invalid_json(self, tmp_path: Path):
         f = tmp_path / "bad.json"
         f.write_text("{not valid json")
-        assert Cursor()._load_json_file(f) is None
+        assert Cursor()._load_file(f) is None
 
     def test_returns_none_for_non_dict_json(self, tmp_path: Path):
         f = tmp_path / "list.json"
         f.write_text(json.dumps([1, 2, 3]))
-        assert Cursor()._load_json_file(f) is None
+        assert Cursor()._load_file(f) is None
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-26T09:37:06.118565Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -870,6 +870,7 @@ dependencies = [
     { name = "rich" },
     { name = "sigstore", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sigstore", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tomli" },
     { name = "truststore", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions" },
     { name = "urllib3" },
@@ -938,6 +939,7 @@ requires-dist = [
     { name = "requests", specifier = "~=2.32.0" },
     { name = "rich", specifier = "~=13.0" },
     { name = "sigstore", specifier = ">=4.0.0,<5" },
+    { name = "tomli", specifier = ">=2.4.0" },
     { name = "truststore", marker = "python_full_version >= '3.10'", specifier = ">=0.10.1" },
     { name = "typing-extensions", specifier = "~=4.14" },
     { name = "urllib3", specifier = ">=2.2.2,<3" },


### PR DESCRIPTION
## Context

After merging hook support for Codex, this PR improves MCP configuration detection.

## What has been done
3 commits:

- add `tomli` as dependency (becomes the standard package `tomllib` starting from Python3.11)
- a first refactoring commit to seamlessly parse both json and toml config files
- the actual changes to Codex

Commits should probably be reviewed independently for an easier review.

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
