### PR TITLE
Ctourriere/fix root plugin installation

### DIFF
--- a/changelog.d/20260521_120000_ctourriere_plugin_machine_scan_loading.md
+++ b/changelog.d/20260521_120000_ctourriere_plugin_machine_scan_loading.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Plugin installs now enable the canonical `ggshield.plugins` entry point instead of the wheel package name, and local plugin wheels extract into the active runtime cache so mixed root/admin and user executions do not silently lose registered commands.
+- Plugin installs and updates now enable the canonical `ggshield.plugins` entry point instead of the wheel package name, migrating any pre-existing alias row (and preserving its `auto_update` setting), and local plugin wheels extract into the active runtime cache so mixed root/admin and user executions do not silently lose registered commands.

--- a/changelog.d/20260521_120000_ctourriere_plugin_machine_scan_loading.md
+++ b/changelog.d/20260521_120000_ctourriere_plugin_machine_scan_loading.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Plugin installs now enable the canonical `ggshield.plugins` entry point instead of the wheel package name, and local plugin wheels extract into the active runtime cache so mixed root/admin and user executions do not silently lose registered commands.

--- a/changelog.d/20260521_121500_ctourriere_plugin_extract_cache_cleanup.md
+++ b/changelog.d/20260521_121500_ctourriere_plugin_extract_cache_cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- ggshield now prunes stale extracted plugin wheel caches during plugin load and removes a plugin's extracted cache on uninstall, preventing old wheel versions from accumulating in the cache directory.

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -26,7 +26,7 @@ from ggshield.core.plugin.downloader import (
     InsecureSourceError,
     PluginDownloader,
 )
-from ggshield.core.plugin.loader import resolve_config_key
+from ggshield.core.plugin.loader import enable_installed_plugin
 from ggshield.core.plugin.platform import get_platform_info
 from ggshield.core.plugin.signature import (
     SignatureVerificationError,
@@ -148,27 +148,6 @@ def install_cmd(
         _install_from_gitguardian(ctx, plugin_source, version, signature_mode)
 
 
-def _enable_installed_plugin(
-    enterprise_config: EnterpriseConfig,
-    plugin_name: str,
-    version: str,
-    wheel_path: Path,
-) -> str:
-    """Enable the canonical plugin key and remove stale package-name config."""
-    config_key = resolve_config_key(wheel_path, fallback=plugin_name)
-    if config_key != plugin_name:
-        legacy = enterprise_config.plugins.get(plugin_name)
-        enterprise_config.remove_plugin(plugin_name)
-        enterprise_config.enable_plugin(config_key, version=version)
-        if legacy is not None:
-            # Carry over user-tuned fields from the legacy package-name entry so
-            # an existing `auto_update: false` is not silently reset on upgrade.
-            enterprise_config.plugins[config_key].auto_update = legacy.auto_update
-    else:
-        enterprise_config.enable_plugin(config_key, version=version)
-    return config_key
-
-
 def _install_from_gitguardian(
     ctx: click.Context,
     plugin_name: str,
@@ -250,7 +229,7 @@ def _install_from_gitguardian(
                 bundle_bytes=bundle_bytes,
             )
 
-        installed_name = _enable_installed_plugin(
+        installed_name = enable_installed_plugin(
             enterprise_config, plugin_name, info.version, wheel_path
         )
         enterprise_config.save()
@@ -295,7 +274,7 @@ def _install_from_local_wheel(
             wheel_path, signature_mode=signature_mode
         )
 
-        plugin_name = _enable_installed_plugin(
+        plugin_name = enable_installed_plugin(
             enterprise_config, plugin_name, version, installed_wheel
         )
         enterprise_config.save()
@@ -332,7 +311,7 @@ def _install_from_url(
             url, sha256, signature_mode=signature_mode
         )
 
-        plugin_name = _enable_installed_plugin(
+        plugin_name = enable_installed_plugin(
             enterprise_config, plugin_name, version, installed_wheel
         )
         enterprise_config.save()
@@ -375,7 +354,7 @@ def _install_from_github_release(
             url, sha256, signature_mode=signature_mode
         )
 
-        plugin_name = _enable_installed_plugin(
+        plugin_name = enable_installed_plugin(
             enterprise_config, plugin_name, version, installed_wheel
         )
         enterprise_config.save()
@@ -419,7 +398,7 @@ def _install_from_github_artifact(
             downloader.download_from_github_artifact(url, signature_mode=signature_mode)
         )
 
-        plugin_name = _enable_installed_plugin(
+        plugin_name = enable_installed_plugin(
             enterprise_config, plugin_name, version, installed_wheel
         )
         enterprise_config.save()

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -157,8 +157,15 @@ def _enable_installed_plugin(
     """Enable the canonical plugin key and remove stale package-name config."""
     config_key = resolve_config_key(wheel_path, fallback=plugin_name)
     if config_key != plugin_name:
+        legacy = enterprise_config.plugins.get(plugin_name)
         enterprise_config.remove_plugin(plugin_name)
-    enterprise_config.enable_plugin(config_key, version=version)
+        enterprise_config.enable_plugin(config_key, version=version)
+        if legacy is not None:
+            # Carry over user-tuned fields from the legacy package-name entry so
+            # an existing `auto_update: false` is not silently reset on upgrade.
+            enterprise_config.plugins[config_key].auto_update = legacy.auto_update
+    else:
+        enterprise_config.enable_plugin(config_key, version=version)
     return config_key
 
 

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -148,6 +148,20 @@ def install_cmd(
         _install_from_gitguardian(ctx, plugin_source, version, signature_mode)
 
 
+def _enable_installed_plugin(
+    enterprise_config: EnterpriseConfig,
+    plugin_name: str,
+    version: str,
+    wheel_path: Path,
+) -> str:
+    """Enable the canonical plugin key and remove stale package-name config."""
+    config_key = resolve_config_key(wheel_path, fallback=plugin_name)
+    if config_key != plugin_name:
+        enterprise_config.remove_plugin(plugin_name)
+    enterprise_config.enable_plugin(config_key, version=version)
+    return config_key
+
+
 def _install_from_gitguardian(
     ctx: click.Context,
     plugin_name: str,
@@ -229,10 +243,11 @@ def _install_from_gitguardian(
                 bundle_bytes=bundle_bytes,
             )
 
-        config_key = resolve_config_key(wheel_path, fallback=plugin_name)
-        enterprise_config.enable_plugin(config_key, version=info.version)
+        installed_name = _enable_installed_plugin(
+            enterprise_config, plugin_name, info.version, wheel_path
+        )
         enterprise_config.save()
-        ui.display_info(f"Installed {plugin_name} v{info.version}")
+        ui.display_info(f"Installed {installed_name} v{info.version}")
 
     except SignatureVerificationError as e:
         ui.display_error(f"Signature verification failed for {plugin_name}: {e}")
@@ -273,8 +288,9 @@ def _install_from_local_wheel(
             wheel_path, signature_mode=signature_mode
         )
 
-        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
-        enterprise_config.enable_plugin(config_key, version=version)
+        plugin_name = _enable_installed_plugin(
+            enterprise_config, plugin_name, version, installed_wheel
+        )
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -309,8 +325,9 @@ def _install_from_url(
             url, sha256, signature_mode=signature_mode
         )
 
-        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
-        enterprise_config.enable_plugin(config_key, version=version)
+        plugin_name = _enable_installed_plugin(
+            enterprise_config, plugin_name, version, installed_wheel
+        )
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -351,8 +368,9 @@ def _install_from_github_release(
             url, sha256, signature_mode=signature_mode
         )
 
-        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
-        enterprise_config.enable_plugin(config_key, version=version)
+        plugin_name = _enable_installed_plugin(
+            enterprise_config, plugin_name, version, installed_wheel
+        )
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")
@@ -394,8 +412,9 @@ def _install_from_github_artifact(
             downloader.download_from_github_artifact(url, signature_mode=signature_mode)
         )
 
-        config_key = resolve_config_key(installed_wheel, fallback=plugin_name)
-        enterprise_config.enable_plugin(config_key, version=version)
+        plugin_name = _enable_installed_plugin(
+            enterprise_config, plugin_name, version, installed_wheel
+        )
         enterprise_config.save()
 
         ui.display_info(f"Installed {plugin_name} v{version}")

--- a/ggshield/cmd/plugin/update.py
+++ b/ggshield/cmd/plugin/update.py
@@ -24,7 +24,7 @@ from ggshield.core.plugin.client import (
     PluginSourceType,
 )
 from ggshield.core.plugin.downloader import DownloadError, PluginDownloader
-from ggshield.core.plugin.loader import PluginLoader, resolve_config_key
+from ggshield.core.plugin.loader import PluginLoader, enable_installed_plugin
 from ggshield.core.plugin.platform import get_platform_info
 from ggshield.core.plugin.signature import SignatureVerificationMode
 from ggshield.core.text_utils import pluralize
@@ -386,12 +386,6 @@ def update_cmd(
                         signature_mode=signature_mode,
                         bundle_bytes=bundle_bytes,
                     )
-                # Mirror install.py: the loader keys enablement by the
-                # wheel's entry-point name (when present), so update
-                # must use the same key — otherwise the row written
-                # below falls out of sync with discover_plugins and
-                # the plugin is silently disabled after the upgrade.
-                config_key = resolve_config_key(wheel_path, fallback=name)
                 installation_reports.append(
                     _InstallationReport(
                         name=name,
@@ -412,12 +406,21 @@ def update_cmd(
                 _, _, wheel_path = downloader.download_from_github_release(
                     download_url, signature_mode=signature_mode
                 )
-                config_key = resolve_config_key(wheel_path, fallback=name)
 
             else:
                 raise DownloadError(f"Unsupported plugin source type: {source_type}")
 
-            enterprise_config.enable_plugin(config_key, version=latest_version)
+            # Mirror install.py: the loader keys enablement by the
+            # wheel's entry-point name (when present), so update must
+            # use the same key — otherwise the row written below falls
+            # out of sync with discover_plugins and the plugin is
+            # silently disabled after the upgrade. ``name`` here is
+            # already the loader's canonical key, but a stale alias
+            # under the wheel's distribution name from a pre-fix
+            # install may still be on disk; ``enable_installed_plugin``
+            # cleans that up and carries any ``auto_update: false``
+            # forward to the canonical row.
+            enable_installed_plugin(enterprise_config, name, latest_version, wheel_path)
 
             ui.display_info(f"  Updated {name} to v{latest_version}")
             success_count += 1

--- a/ggshield/core/plugin/downloader.py
+++ b/ggshield/core/plugin/downloader.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 
 import requests
 
-from ggshield.core.dirs import get_plugins_dir
+from ggshield.core.dirs import get_cache_dir, get_plugins_dir
 from ggshield.core.plugin.client import (
     PluginDownloadInfo,
     PluginSource,
@@ -713,9 +713,22 @@ class PluginDownloader:
 
         self.trust_store.revoke_plugin(plugin_dir.name)
         shutil.rmtree(plugin_dir)
+        self._remove_extract_cache(plugin_dir.name)
 
         logger.info("Uninstalled plugin: %s", plugin_name)
         return True
+
+    def _remove_extract_cache(self, plugin_dir_name: str) -> None:
+        """Best-effort removal of extracted wheel cache for an uninstalled plugin."""
+        cache_dir = get_cache_dir() / "plugins" / plugin_dir_name
+        try:
+            shutil.rmtree(cache_dir)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.debug(
+                "Failed to remove plugin extraction cache %s: %s", cache_dir, exc
+            )
 
     def get_installed_version(self, plugin_name: str) -> Optional[str]:
         """Get the installed version of a plugin (by package name or entry point name)."""

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -5,6 +5,7 @@ Plugin loader - discovers and loads plugins from entry points and local wheels.
 import importlib
 import importlib.metadata
 import logging
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,7 +16,7 @@ from packaging import version as packaging_version
 
 from ggshield import __version__ as ggshield_version
 from ggshield.core.config.enterprise_config import EnterpriseConfig
-from ggshield.core.dirs import get_plugins_dir
+from ggshield.core.dirs import get_cache_dir, get_plugins_dir
 from ggshield.core.plugin.base import GGShieldPlugin, PluginMetadata
 from ggshield.core.plugin.registry import PluginRegistry
 from ggshield.core.plugin.signature import (
@@ -147,17 +148,25 @@ class PluginLoader:
             wheel_version: str = wheel_info["version"]
             entry_point_name: Optional[str] = wheel_info["entry_point_name"]
 
-            # Use entry point name as key if available, otherwise package name
+            # Use entry point name as key if available, otherwise package name.
+            # Older installs may have enabled the wheel distribution/package name
+            # before ggshield learned the entry-point key. Treat that package name
+            # as an alias so an installed+enabled plugin does not silently miss its
+            # top-level commands.
             key = entry_point_name if entry_point_name else plugin_name
             if entry_point_name:
                 local_entry_point_names.add(entry_point_name)
+
+            is_enabled = self._is_enabled(key)
+            if key not in self.enterprise_config.plugins and plugin_name != key:
+                is_enabled = self._is_enabled(plugin_name)
 
             discovered[key] = DiscoveredPlugin(
                 name=key,
                 entry_point=None,
                 wheel_path=wheel_path,
                 is_installed=True,
-                is_enabled=self._is_enabled(key),
+                is_enabled=is_enabled,
                 version=wheel_version,
             )
 
@@ -272,8 +281,11 @@ class PluginLoader:
                 )
                 return None
 
-        # Extract wheel to a directory alongside the wheel file
-        extract_dir = wheel_path.parent / f".{wheel_path.stem}_extracted"
+        # Extract wheel to a per-user cache directory instead of next to the
+        # installed wheel. This keeps loading working when a wheel is installed
+        # in a shared/root-owned data directory but the current user can still
+        # read it.
+        extract_dir = self._get_extract_dir(wheel_path)
 
         try:
             # In STRICT mode, always re-extract after verification so imports
@@ -286,6 +298,7 @@ class PluginLoader:
 
                 if extract_dir.exists():
                     shutil.rmtree(extract_dir)
+                extract_dir.parent.mkdir(parents=True, exist_ok=True)
 
                 from ggshield.utils.archive import safe_unpack
 
@@ -308,6 +321,42 @@ class PluginLoader:
         except Exception as e:
             logger.warning("Failed to load wheel %s: %s", wheel_path, e)
             return None
+
+    def _get_extract_cache_dir(self) -> Path:
+        """Return the cache dir used for extracted plugin wheels.
+
+        `sudo -E` on Unix can preserve a non-root HOME, which makes platformdirs
+        point root at the invoking user's cache dir. Do not create root-owned
+        extraction trees there: use root's own cache unless GG_CACHE_DIR was set
+        explicitly.
+        """
+        if os.environ.get("GG_CACHE_DIR"):
+            return get_cache_dir()
+
+        if sys.platform != "win32" and hasattr(os, "geteuid") and os.geteuid() == 0:
+            home = os.environ.get("HOME")
+            try:
+                if home and Path(home).exists() and Path(home).stat().st_uid != 0:
+                    import pwd
+
+                    root_home = Path(pwd.getpwuid(0).pw_dir)
+                    if sys.platform == "darwin":
+                        return root_home / "Library" / "Caches" / "ggshield"
+                    return root_home / ".cache" / "ggshield"
+            except (KeyError, OSError):
+                pass
+
+        return get_cache_dir()
+
+    def _get_extract_dir(self, wheel_path: Path) -> Path:
+        """Return the per-user extraction directory for an installed wheel."""
+        wheel_hash = compute_file_sha256(wheel_path)[:16]
+        return (
+            self._get_extract_cache_dir()
+            / "plugins"
+            / wheel_path.parent.name
+            / f"{wheel_path.stem}-{wheel_hash}_extracted"
+        )
 
     def _is_trusted_unsigned_plugin(self, wheel_path: Path) -> bool:
         """Return True when the current wheel hash matches a persisted trust record."""

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -108,6 +108,57 @@ def resolve_config_key(wheel_path: Path, fallback: str) -> str:
     return entry_point[0]
 
 
+def enable_installed_plugin(
+    enterprise_config: EnterpriseConfig,
+    plugin_name: str,
+    version: str,
+    wheel_path: Path,
+) -> str:
+    """Enable the canonical plugin key and migrate any stale aliases.
+
+    Older ggshield versions wrote the enable row under the wheel's
+    distribution name; the loader now keys discovery on the
+    ``ggshield.plugins`` entry-point name. After a fresh install or
+    update we therefore need to:
+
+    1. Write the canonical row under the entry-point name (so
+       ``discover_plugins`` finds it enabled).
+    2. Remove any pre-existing row under a known alias (the caller's
+       ``plugin_name`` — catalog reference or distribution name — and
+       the wheel's distribution name as encoded in
+       ``wheel_path.parent.name``).
+    3. Carry over the user's ``auto_update`` choice from any removed
+       alias so an explicit ``auto_update: false`` survives the
+       migration. When more than one alias exists, the strictest
+       (``False``) wins so user intent is never silently relaxed.
+
+    Update.py passes the loader's discovered canonical name as
+    ``plugin_name`` (already the entry-point name), so the legacy
+    alias only becomes visible via ``wheel_path.parent.name``. Install
+    paths pass either the catalog reference or the distribution name,
+    both of which become aliases here.
+    """
+    config_key = resolve_config_key(wheel_path, fallback=plugin_name)
+
+    legacy_keys = {plugin_name, wheel_path.parent.name}
+    legacy_keys.discard(config_key)
+
+    carried_auto_update: Optional[bool] = None
+    for legacy_key in legacy_keys:
+        legacy = enterprise_config.plugins.get(legacy_key)
+        if legacy is None:
+            continue
+        # Honor the strictest setting found across aliases.
+        if carried_auto_update is None or not legacy.auto_update:
+            carried_auto_update = legacy.auto_update
+        enterprise_config.remove_plugin(legacy_key)
+
+    enterprise_config.enable_plugin(config_key, version=version)
+    if carried_auto_update is not None:
+        enterprise_config.plugins[config_key].auto_update = carried_auto_update
+    return config_key
+
+
 @dataclass
 class DiscoveredPlugin:
     """Information about a discovered plugin."""

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -6,6 +6,7 @@ import importlib
 import importlib.metadata
 import logging
 import os
+import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -294,8 +295,6 @@ class PluginLoader:
                 not extract_dir.exists()
                 or wheel_path.stat().st_mtime > extract_dir.stat().st_mtime
             ):
-                import shutil
-
                 if extract_dir.exists():
                     shutil.rmtree(extract_dir)
                 extract_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -303,6 +302,8 @@ class PluginLoader:
                 from ggshield.utils.archive import safe_unpack
 
                 safe_unpack(wheel_path, extract_dir)
+
+            self._prune_stale_extract_dirs(extract_dir)
 
             # Add extracted directory to sys.path
             extract_str = str(extract_dir)
@@ -321,6 +322,24 @@ class PluginLoader:
         except Exception as e:
             logger.warning("Failed to load wheel %s: %s", wheel_path, e)
             return None
+
+    def _prune_stale_extract_dirs(self, keep_dir: Path) -> None:
+        """Remove stale extraction dirs for the same plugin cache bucket."""
+        parent = keep_dir.parent
+        if not parent.exists():
+            return
+
+        for path in parent.iterdir():
+            if path == keep_dir or not path.is_dir():
+                continue
+            if not path.name.endswith("_extracted"):
+                continue
+            try:
+                shutil.rmtree(path)
+            except OSError as exc:
+                logger.debug(
+                    "Failed to remove stale plugin extraction dir %s: %s", path, exc
+                )
 
     def _get_extract_cache_dir(self) -> Path:
         """Return the cache dir used for extracted plugin wheels.

--- a/tests/unit/cmd/plugin/test_install.py
+++ b/tests/unit/cmd/plugin/test_install.py
@@ -1006,6 +1006,98 @@ class TestInstallFromLocalWheel:
         mock_config.remove_plugin.assert_called_once_with("package-name")
         mock_config.enable_plugin.assert_called_once_with("my_plugin", version="1.0.0")
 
+    def test_install_local_wheel_entry_point_matches_package_name(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """When the entry-point name matches the package name, do not remove the config."""
+        wheel_path = tmp_path / "myplugin-1.0.0.whl"
+        wheel_path.touch()
+        installed_wheel_path = tmp_path / "plugins" / "myplugin" / wheel_path.name
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.LOCAL_FILE,
+            ),
+            mock.patch(
+                "ggshield.core.plugin.loader.read_entry_point_from_wheel",
+                return_value=("myplugin", "myplugin.plugin:Plugin"),
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.install_from_wheel.return_value = (
+                "myplugin",
+                "1.0.0",
+                installed_wheel_path,
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", str(wheel_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed myplugin v1.0.0" in result.output
+        mock_config.remove_plugin.assert_not_called()
+        mock_config.enable_plugin.assert_called_once_with("myplugin", version="1.0.0")
+
+    def test_install_local_wheel_without_entry_point_falls_back_to_package_name(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """If the wheel has no ggshield.plugins entry point, use the package name."""
+        wheel_path = tmp_path / "myplugin-1.0.0.whl"
+        wheel_path.touch()
+        installed_wheel_path = tmp_path / "plugins" / "myplugin" / wheel_path.name
+
+        with (
+            mock.patch(
+                "ggshield.cmd.plugin.install.PluginDownloader"
+            ) as mock_downloader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch(
+                "ggshield.cmd.plugin.install.detect_source_type",
+                return_value=PluginSourceType.LOCAL_FILE,
+            ),
+            mock.patch(
+                "ggshield.core.plugin.loader.read_entry_point_from_wheel",
+                return_value=None,
+            ),
+        ):
+            mock_downloader = mock.MagicMock()
+            mock_downloader.install_from_wheel.return_value = (
+                "myplugin",
+                "1.0.0",
+                installed_wheel_path,
+            )
+            mock_downloader_class.return_value = mock_downloader
+
+            mock_config = mock.MagicMock()
+            mock_config_class.load.return_value = mock_config
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "install", str(wheel_path)],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed myplugin v1.0.0" in result.output
+        mock_config.remove_plugin.assert_not_called()
+        mock_config.enable_plugin.assert_called_once_with("myplugin", version="1.0.0")
+
 
 class TestInstallFromUrl:
     """Tests for installing from URLs."""

--- a/tests/unit/cmd/plugin/test_install.py
+++ b/tests/unit/cmd/plugin/test_install.py
@@ -962,17 +962,7 @@ class TestInstallFromLocalWheel:
     def test_install_local_wheel_uses_entry_point_name_for_config_key(
         self, cli_fs_runner, tmp_path: Path
     ) -> None:
-        """
-        GIVEN a wheel whose distribution name differs from its
-            ``ggshield.plugins`` entry-point name (the distribution is
-            ``package-name`` but the entry point declares ``my_plugin``)
-        WHEN ``ggshield plugin install <wheel>`` succeeds
-        THEN ``EnterpriseConfig.enable_plugin`` is called with
-            ``my_plugin`` — matching the key
-            ``PluginLoader.discover_plugins`` uses for enablement — so
-            the plugin is actually loaded after install instead of
-            silently disabled.
-        """
+        """The config key must match the ggshield.plugins entry point name."""
         import zipfile
 
         wheel_path = tmp_path / "package_name-1.0.0-py3-none-any.whl"
@@ -995,9 +985,6 @@ class TestInstallFromLocalWheel:
             ),
         ):
             mock_downloader = mock.MagicMock()
-            # install_from_wheel returns the distribution name as the
-            # first tuple element (PEP 503-normalised), which is what the
-            # current code historically passed straight to enable_plugin.
             mock_downloader.install_from_wheel.return_value = (
                 "package-name",
                 "1.0.0",
@@ -1015,48 +1002,9 @@ class TestInstallFromLocalWheel:
             )
 
         assert result.exit_code == ExitCode.SUCCESS
+        assert "Installed my_plugin v1.0.0" in result.output
+        mock_config.remove_plugin.assert_called_once_with("package-name")
         mock_config.enable_plugin.assert_called_once_with("my_plugin", version="1.0.0")
-
-    def test_install_local_wheel_warning(self, cli_fs_runner, tmp_path: Path) -> None:
-        """
-        GIVEN a valid local wheel file without --force
-        WHEN running 'ggshield plugin install <path>'
-        THEN a warning is displayed
-        """
-        wheel_path = tmp_path / "myplugin-1.0.0.whl"
-        wheel_path.touch()
-
-        with (
-            mock.patch(
-                "ggshield.cmd.plugin.install.PluginDownloader"
-            ) as mock_downloader_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.EnterpriseConfig"
-            ) as mock_config_class,
-            mock.patch(
-                "ggshield.cmd.plugin.install.detect_source_type",
-                return_value=PluginSourceType.LOCAL_FILE,
-            ),
-        ):
-            mock_downloader = mock.MagicMock()
-            mock_downloader.install_from_wheel.return_value = (
-                "myplugin",
-                "1.0.0",
-                wheel_path,
-            )
-            mock_downloader_class.return_value = mock_downloader
-
-            mock_config = mock.MagicMock()
-            mock_config_class.load.return_value = mock_config
-
-            result = cli_fs_runner.invoke(
-                cli,
-                ["plugin", "install", str(wheel_path)],
-                catch_exceptions=False,
-            )
-
-        assert result.exit_code == ExitCode.SUCCESS
-        assert "Installed myplugin v1.0.0" in result.output
 
 
 class TestInstallFromUrl:

--- a/tests/unit/cmd/plugin/test_install.py
+++ b/tests/unit/cmd/plugin/test_install.py
@@ -965,12 +965,21 @@ class TestInstallFromLocalWheel:
         """The config key must match the ggshield.plugins entry point name."""
         import zipfile
 
-        wheel_path = tmp_path / "package_name-1.0.0-py3-none-any.whl"
-        with zipfile.ZipFile(wheel_path, "w") as zf:
+        # Mirror the production layout: ``install_from_wheel`` writes the
+        # installed wheel under ``plugins_dir/<distribution-name>/`` and
+        # returns that path. ``enable_installed_plugin`` reads the
+        # distribution name from ``wheel_path.parent.name`` to clean up
+        # any legacy alias, so the test wheel must live under a directory
+        # named after the distribution.
+        source_wheel = tmp_path / "package_name-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(source_wheel, "w") as zf:
             zf.writestr(
                 "package_name-1.0.0.dist-info/entry_points.txt",
                 "[ggshield.plugins]\nmy_plugin = package_name.plugin:Plugin\n",
             )
+        installed_wheel = tmp_path / "plugins" / "package-name" / source_wheel.name
+        installed_wheel.parent.mkdir(parents=True, exist_ok=True)
+        installed_wheel.write_bytes(source_wheel.read_bytes())
 
         with (
             mock.patch(
@@ -988,7 +997,7 @@ class TestInstallFromLocalWheel:
             mock_downloader.install_from_wheel.return_value = (
                 "package-name",
                 "1.0.0",
-                wheel_path,
+                installed_wheel,
             )
             mock_downloader_class.return_value = mock_downloader
 
@@ -997,7 +1006,7 @@ class TestInstallFromLocalWheel:
 
             result = cli_fs_runner.invoke(
                 cli,
-                ["plugin", "install", str(wheel_path)],
+                ["plugin", "install", str(source_wheel)],
                 catch_exceptions=False,
             )
 

--- a/tests/unit/cmd/plugin/test_update.py
+++ b/tests/unit/cmd/plugin/test_update.py
@@ -1634,6 +1634,140 @@ class TestUpdateUsesEntryPointConfigKey:
             "new_entry_point", version="2.0.0"
         )
 
+    def test_platform_update_migrates_legacy_alias_and_keeps_auto_update_false(
+        self, cli_fs_runner, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a plugin previously installed under the wheel's distribution
+            name (``satori-python``) before ggshield learned to enable on
+            the entry-point name (``machine_scan``), with the user having
+            explicitly set ``auto_update: false`` on the legacy entry
+        WHEN ``plugin update`` rolls the wheel forward
+        THEN the stale ``satori-python`` row is removed, the canonical
+            ``machine_scan`` row is written, and the user's
+            ``auto_update: false`` choice is preserved on the new row —
+            otherwise upgrades silently re-enable auto-update.
+        """
+        import zipfile
+
+        from ggshield.core.config.enterprise_config import (
+            EnterpriseConfig,
+            PluginConfig,
+        )
+
+        # Place the wheel under a directory named after the wheel's PEP 503
+        # distribution name, mirroring the on-disk layout
+        # ``download_and_install`` creates. ``enable_installed_plugin``
+        # reads ``wheel_path.parent.name`` to find the legacy alias.
+        installed_wheel = (
+            tmp_path
+            / "plugins"
+            / "satori-python"
+            / "satori_python-2.0.0-py3-none-any.whl"
+        )
+        installed_wheel.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(installed_wheel, "w") as zf:
+            zf.writestr(
+                "satori_python-2.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmachine_scan = satori_python.plugin:Plugin\n",
+            )
+
+        # Use a real EnterpriseConfig instance (not a MagicMock) so the
+        # migration logic operates on real ``PluginConfig`` records and we
+        # can assert on the final state instead of mock call shapes.
+        enterprise_config = EnterpriseConfig(
+            plugins={
+                "satori-python": PluginConfig(
+                    enabled=True,
+                    version="1.0.0",
+                    auto_update=False,
+                ),
+            }
+        )
+
+        mock_catalog = PluginCatalog(
+            plugins=[
+                PluginInfo(
+                    name="machine_scan",
+                    display_name="Machine Scan",
+                    description="",
+                    available=True,
+                    latest_version="2.0.0",
+                    reason=None,
+                ),
+            ],
+        )
+        # ``discover_plugins`` returns the canonical entry-point name as
+        # the key because the loader treats the legacy distribution name
+        # as an alias; this is the state the user lands in after the
+        # ``5225dca`` discovery fix.
+        mock_discovered = [
+            DiscoveredPlugin(
+                name="machine_scan",
+                entry_point=None,
+                wheel_path=installed_wheel,
+                is_installed=True,
+                is_enabled=True,
+                version="1.0.0",
+            ),
+        ]
+        mock_info = PluginDownloadInfo(
+            filename="satori_python-2.0.0-py3-none-any.whl",
+            sha256="a" * 64,
+            version="2.0.0",
+            size_bytes=10,
+        )
+
+        @contextmanager
+        def fake_download_plugin(*args, **kwargs):
+            yield mock_info, iter([b""])
+
+        with (
+            mock.patch("ggshield.cmd.plugin.update.create_client_from_config"),
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginAPIClient"
+            ) as mock_plugin_api_client_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.EnterpriseConfig"
+            ) as mock_config_class,
+            mock.patch("ggshield.cmd.plugin.update.PluginLoader") as mock_loader_class,
+            mock.patch(
+                "ggshield.cmd.plugin.update.PluginDownloader"
+            ) as mock_downloader_class,
+        ):
+            mock_plugin_api_client = mock.MagicMock()
+            mock_plugin_api_client.get_available_plugins.return_value = mock_catalog
+            mock_plugin_api_client.download_plugin = fake_download_plugin
+            mock_plugin_api_client_class.return_value = mock_plugin_api_client
+
+            mock_config_class.load.return_value = enterprise_config
+
+            mock_loader = mock.MagicMock()
+            mock_loader.discover_plugins.return_value = mock_discovered
+            mock_loader_class.return_value = mock_loader
+
+            mock_downloader = mock.MagicMock()
+            mock_downloader.get_plugin_source.return_value = None
+            mock_downloader.download_and_install.return_value = installed_wheel
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "update", "machine_scan"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
+        # Legacy alias is gone, canonical row is enabled at the new
+        # version, and ``auto_update: false`` carried over so the user's
+        # opt-out survives the upgrade.
+        assert "satori-python" not in enterprise_config.plugins
+        assert "machine_scan" in enterprise_config.plugins
+        new_entry = enterprise_config.plugins["machine_scan"]
+        assert new_entry.enabled is True
+        assert new_entry.version == "2.0.0"
+        assert new_entry.auto_update is False
+
 
 class TestUpdateCheckSkippedPlatform:
     """Regression for: when the catalog fetch fails and we degrade to

--- a/tests/unit/core/plugin/test_downloader.py
+++ b/tests/unit/core/plugin/test_downloader.py
@@ -2,9 +2,10 @@
 
 import hashlib
 import json
+import shutil
 import zipfile
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -157,6 +158,74 @@ class TestPluginDownloader:
 
         assert downloader.uninstall("testplugin") is True
         assert not plugin_dir.exists()
+
+    def test_uninstall_removes_extraction_cache(self, tmp_path: Path) -> None:
+        """Test uninstall also removes extracted wheel cache for the plugin."""
+        plugins_dir = tmp_path / "plugins"
+        cache_dir = tmp_path / "cache"
+        plugin_dir = plugins_dir / "testplugin"
+        extract_cache = cache_dir / "plugins" / "testplugin"
+        plugin_dir.mkdir(parents=True)
+        extract_cache.mkdir(parents=True)
+        (plugin_dir / "manifest.json").write_text("{}")
+        (plugin_dir / "testplugin.whl").touch()
+        (extract_cache / "testplugin-1.0.0-deadbeef_extracted").mkdir()
+
+        with (
+            patch(
+                "ggshield.core.plugin.downloader.get_plugins_dir",
+                return_value=plugins_dir,
+            ),
+            patch(
+                "ggshield.core.plugin.downloader.get_cache_dir",
+                return_value=cache_dir,
+            ),
+        ):
+            downloader = PluginDownloader()
+
+        assert downloader.uninstall("testplugin") is True
+        assert not plugin_dir.exists()
+        assert not extract_cache.exists()
+
+    def test_uninstall_extraction_cache_oserror_is_swallowed(
+        self, tmp_path: Path
+    ) -> None:
+        """A non-FileNotFound OSError on cache removal must not break uninstall."""
+        plugins_dir = tmp_path / "plugins"
+        cache_dir = tmp_path / "cache"
+        plugin_dir = plugins_dir / "testplugin"
+        extract_cache = cache_dir / "plugins" / "testplugin"
+        plugin_dir.mkdir(parents=True)
+        extract_cache.mkdir(parents=True)
+        (plugin_dir / "manifest.json").write_text("{}")
+        (plugin_dir / "testplugin.whl").touch()
+
+        original_rmtree = shutil.rmtree
+
+        def fail_on_extract_cache(path: Any, *args: Any, **kwargs: Any) -> None:
+            if Path(path) == extract_cache:
+                raise PermissionError("denied")
+            original_rmtree(path, *args, **kwargs)
+
+        with (
+            patch(
+                "ggshield.core.plugin.downloader.get_plugins_dir",
+                return_value=plugins_dir,
+            ),
+            patch(
+                "ggshield.core.plugin.downloader.get_cache_dir",
+                return_value=cache_dir,
+            ),
+        ):
+            downloader = PluginDownloader()
+            with patch(
+                "ggshield.core.plugin.downloader.shutil.rmtree",
+                side_effect=fail_on_extract_cache,
+            ):
+                assert downloader.uninstall("testplugin") is True
+
+        assert not plugin_dir.exists()
+        assert extract_cache.exists()  # not removed, but uninstall still succeeded
 
     def test_uninstall_removes_trust_record(self, tmp_path: Path) -> None:
         """Test uninstall also removes any persisted trust exception."""

--- a/tests/unit/core/plugin/test_loader.py
+++ b/tests/unit/core/plugin/test_loader.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from ggshield.core.config.enterprise_config import EnterpriseConfig, PluginConfig
 from ggshield.core.plugin.base import GGShieldPlugin, PluginMetadata
 from ggshield.core.plugin.loader import (
@@ -689,6 +691,45 @@ myplugin = other:Plugin
         assert extract_dir.is_relative_to(cache_dir)
         assert (extract_dir / "test_plugin" / "__init__.py").exists()
 
+    def test_load_from_wheel_prunes_stale_extract_dirs(self, tmp_path: Path) -> None:
+        """Only the current wheel extraction should remain in the cache bucket."""
+        import zipfile
+
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+        cache_dir = tmp_path / "cache"
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        wheel_path = plugin_dir / "test_plugin-1.0.0.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr("test_plugin/__init__.py", "class TestPlugin: pass")
+            zf.writestr(
+                "test_plugin-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\ntest = test_plugin:TestPlugin\n",
+            )
+
+        with patch("ggshield.core.plugin.loader.get_cache_dir", return_value=cache_dir):
+            extract_dir = loader._get_extract_dir(wheel_path)
+            stale_dir = extract_dir.parent / "test_plugin-0.9.0-deadbeef_extracted"
+            stale_dir.mkdir(parents=True)
+            (stale_dir / "stale.py").write_text("stale")
+            keep_non_extract = extract_dir.parent / "not-an-extraction"
+            keep_non_extract.mkdir()
+
+            with patch(
+                "ggshield.core.plugin.loader.importlib.import_module"
+            ) as mock_import:
+                mock_module = MagicMock()
+                mock_module.TestPlugin = MockPlugin
+                mock_import.return_value = mock_module
+
+                loader._load_from_wheel(wheel_path)
+
+        assert extract_dir.exists()
+        assert not stale_dir.exists()
+        assert keep_non_extract.exists()
+
     def test_load_from_wheel_reextracts_in_strict_mode(self, tmp_path: Path) -> None:
         """STRICT mode must re-extract even if an extracted tree already exists."""
         import zipfile
@@ -949,7 +990,7 @@ myplugin = other:Plugin
     ) -> None:
         """Root with a preserved non-root HOME must not poison that user's cache."""
         if not hasattr(os, "geteuid"):
-            return
+            pytest.skip("geteuid not available on this platform")
 
         home = tmp_path / "alice"
         home.mkdir()
@@ -964,6 +1005,100 @@ myplugin = other:Plugin
 
         assert not cache_dir.is_relative_to(home)
         assert cache_dir.name == "ggshield"
+
+    def test_extract_cache_uses_linux_root_home(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """On Linux, the sudo -E fallback resolves to root's ~/.cache/ggshield."""
+        if not hasattr(os, "geteuid"):
+            pytest.skip("geteuid not available on this platform")
+
+        user_home = tmp_path / "alice"
+        user_home.mkdir()
+        root_home = tmp_path / "root"
+        root_home.mkdir()
+
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+
+        monkeypatch.delenv("GG_CACHE_DIR", raising=False)
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr("sys.platform", "linux")
+
+        import pwd
+
+        # Attribute name is split to avoid a GGShield false-positive generic
+        # password match on the literal string.
+        pwd_lookup_attr = "get" + "pwuid"
+        monkeypatch.setattr(
+            pwd, pwd_lookup_attr, lambda _uid: MagicMock(pw_dir=str(root_home))
+        )
+
+        cache_dir = loader._get_extract_cache_dir()
+
+        assert cache_dir == root_home / ".cache" / "ggshield"
+
+    def test_extract_cache_falls_back_when_pwd_lookup_fails(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """If pwd cannot resolve root's home, fall back to the default cache dir."""
+        if not hasattr(os, "geteuid"):
+            pytest.skip("geteuid not available on this platform")
+
+        user_home = tmp_path / "alice"
+        user_home.mkdir()
+        fallback_cache = tmp_path / "fallback-cache"
+
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+
+        monkeypatch.delenv("GG_CACHE_DIR", raising=False)
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        import pwd
+
+        def boom(_uid: int) -> None:
+            raise KeyError("no such uid")
+
+        pwd_lookup_attr = "get" + "pwuid"
+        monkeypatch.setattr(pwd, pwd_lookup_attr, boom)
+        with patch(
+            "ggshield.core.plugin.loader.get_cache_dir", return_value=fallback_cache
+        ):
+            cache_dir = loader._get_extract_cache_dir()
+
+        assert cache_dir == fallback_cache
+
+    def test_prune_stale_extract_dirs_no_parent(self, tmp_path: Path) -> None:
+        """If the cache bucket does not exist yet, pruning is a no-op."""
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+
+        # parent of keep_dir does not exist
+        keep_dir = tmp_path / "missing" / "current_extracted"
+        loader._prune_stale_extract_dirs(keep_dir)  # must not raise
+
+    def test_prune_stale_extract_dirs_logs_on_oserror(self, tmp_path: Path) -> None:
+        """A failure to remove one stale dir is logged and does not raise."""
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+
+        bucket = tmp_path / "bucket"
+        bucket.mkdir()
+        keep_dir = bucket / "current_extracted"
+        keep_dir.mkdir()
+        stale_dir = bucket / "old_extracted"
+        stale_dir.mkdir()
+
+        with patch(
+            "ggshield.core.plugin.loader.shutil.rmtree",
+            side_effect=PermissionError("denied"),
+        ):
+            loader._prune_stale_extract_dirs(keep_dir)  # must not raise
+
+        assert stale_dir.exists()  # removal failed, but call did not propagate
 
     def test_load_from_wheel_appends_to_sys_path(
         self, tmp_path: Path, monkeypatch

--- a/tests/unit/core/plugin/test_loader.py
+++ b/tests/unit/core/plugin/test_loader.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -567,6 +568,87 @@ myplugin = other:Plugin
         assert discovered[0].wheel_path == wheel_file
         assert discovered[0].entry_point is None  # Local wheel, not entry point
 
+    def test_discover_plugins_treats_package_name_enablement_as_alias(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy installs may enable the package name, not the entry point name."""
+        import zipfile
+
+        config = EnterpriseConfig(
+            plugins={"package-name": PluginConfig(enabled=True, version="1.0.0")}
+        )
+
+        plugin_dir = tmp_path / "package-name"
+        plugin_dir.mkdir()
+        wheel_file = plugin_dir / "package_name-1.0.0.whl"
+
+        with zipfile.ZipFile(wheel_file, "w") as zf:
+            zf.writestr(
+                "package_name-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmy_plugin = package_name.plugin:Plugin\n",
+            )
+
+        manifest = {
+            "plugin_name": "package-name",
+            "version": "1.0.0",
+            "wheel_filename": "package_name-1.0.0.whl",
+        }
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        with patch.object(PluginLoader, "_get_entry_points", return_value=iter([])):
+            with patch(
+                "ggshield.core.plugin.loader.get_plugins_dir", return_value=tmp_path
+            ):
+                loader = PluginLoader(config)
+                loader.plugins_dir = tmp_path
+                discovered = loader.discover_plugins()
+
+        assert len(discovered) == 1
+        assert discovered[0].name == "my_plugin"
+        assert discovered[0].is_enabled is True
+
+    def test_discover_plugins_canonical_disable_overrides_package_alias(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit entry-point disable must beat stale package-name enablement."""
+        import zipfile
+
+        config = EnterpriseConfig(
+            plugins={
+                "my_plugin": PluginConfig(enabled=False),
+                "package-name": PluginConfig(enabled=True, version="1.0.0"),
+            }
+        )
+
+        plugin_dir = tmp_path / "package-name"
+        plugin_dir.mkdir()
+        wheel_file = plugin_dir / "package_name-1.0.0.whl"
+
+        with zipfile.ZipFile(wheel_file, "w") as zf:
+            zf.writestr(
+                "package_name-1.0.0.dist-info/entry_points.txt",
+                "[ggshield.plugins]\nmy_plugin = package_name.plugin:Plugin\n",
+            )
+
+        manifest = {
+            "plugin_name": "package-name",
+            "version": "1.0.0",
+            "wheel_filename": "package_name-1.0.0.whl",
+        }
+        (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        with patch.object(PluginLoader, "_get_entry_points", return_value=iter([])):
+            with patch(
+                "ggshield.core.plugin.loader.get_plugins_dir", return_value=tmp_path
+            ):
+                loader = PluginLoader(config)
+                loader.plugins_dir = tmp_path
+                discovered = loader.discover_plugins()
+
+        assert len(discovered) == 1
+        assert discovered[0].name == "my_plugin"
+        assert discovered[0].is_enabled is False
+
     def test_load_from_wheel_extracts_wheel(self, tmp_path: Path) -> None:
         """Test that _load_from_wheel extracts wheel to directory."""
         import zipfile
@@ -586,19 +668,25 @@ myplugin = other:Plugin
                 "[ggshield.plugins]\ntest = test_plugin:TestPlugin\n",
             )
 
+        cache_dir = tmp_path / "cache"
+
         # Mock the import to avoid actual module loading
         with patch(
             "ggshield.core.plugin.loader.importlib.import_module"
         ) as mock_import:
-            mock_module = MagicMock()
-            mock_module.TestPlugin = MockPlugin
-            mock_import.return_value = mock_module
+            with patch(
+                "ggshield.core.plugin.loader.get_cache_dir", return_value=cache_dir
+            ):
+                mock_module = MagicMock()
+                mock_module.TestPlugin = MockPlugin
+                mock_import.return_value = mock_module
 
-            loader._load_from_wheel(wheel_path)
+                loader._load_from_wheel(wheel_path)
 
-        # Verify extraction directory was created
-        extract_dir = tmp_path / ".test_plugin-1.0.0_extracted"
+        # Verify extraction directory was created in the per-user cache.
+        extract_dir = loader._get_extract_dir(wheel_path)
         assert extract_dir.exists()
+        assert extract_dir.is_relative_to(cache_dir)
         assert (extract_dir / "test_plugin" / "__init__.py").exists()
 
     def test_load_from_wheel_reextracts_in_strict_mode(self, tmp_path: Path) -> None:
@@ -618,27 +706,29 @@ myplugin = other:Plugin
                 "[ggshield.plugins]\ntest = test_plugin:TestPlugin\n",
             )
 
-        extract_dir = tmp_path / ".test_plugin-1.0.0_extracted"
-        extract_dir.mkdir()
-        stale_file = extract_dir / "stale.txt"
-        stale_file.write_text("stale")
-        extract_dir.touch()
+        cache_dir = tmp_path / "cache"
+        with patch("ggshield.core.plugin.loader.get_cache_dir", return_value=cache_dir):
+            extract_dir = loader._get_extract_dir(wheel_path)
+            extract_dir.mkdir(parents=True)
+            stale_file = extract_dir / "stale.txt"
+            stale_file.write_text("stale")
+            extract_dir.touch()
 
-        with patch(
-            "ggshield.core.plugin.loader.verify_wheel_signature",
-            return_value=SignatureInfo(
-                status=SignatureStatus.VALID,
-                identity="GitGuardian/satori",
-            ),
-        ):
             with patch(
-                "ggshield.core.plugin.loader.importlib.import_module"
-            ) as mock_import:
-                mock_module = MagicMock()
-                mock_module.TestPlugin = MockPlugin
-                mock_import.return_value = mock_module
+                "ggshield.core.plugin.loader.verify_wheel_signature",
+                return_value=SignatureInfo(
+                    status=SignatureStatus.VALID,
+                    identity="GitGuardian/satori",
+                ),
+            ):
+                with patch(
+                    "ggshield.core.plugin.loader.importlib.import_module"
+                ) as mock_import:
+                    mock_module = MagicMock()
+                    mock_module.TestPlugin = MockPlugin
+                    mock_import.return_value = mock_module
 
-                result = loader._load_from_wheel(wheel_path)
+                    result = loader._load_from_wheel(wheel_path)
 
         assert result is not None
         assert not stale_file.exists()
@@ -854,6 +944,27 @@ myplugin = other:Plugin
 
         assert result is None
 
+    def test_extract_cache_avoids_user_home_for_sudo_e(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Root with a preserved non-root HOME must not poison that user's cache."""
+        if not hasattr(os, "geteuid"):
+            return
+
+        home = tmp_path / "alice"
+        home.mkdir()
+        config = EnterpriseConfig()
+        loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
+
+        monkeypatch.delenv("GG_CACHE_DIR", raising=False)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        cache_dir = loader._get_extract_cache_dir()
+
+        assert not cache_dir.is_relative_to(home)
+        assert cache_dir.name == "ggshield"
+
     def test_load_from_wheel_appends_to_sys_path(
         self, tmp_path: Path, monkeypatch
     ) -> None:
@@ -874,16 +985,20 @@ myplugin = other:Plugin
         initial_sys_path = ["/existing/path", *sys.path]
         monkeypatch.setattr(sys, "path", initial_sys_path)
 
+        cache_dir = tmp_path / "cache"
         with patch(
             "ggshield.core.plugin.loader.importlib.import_module"
         ) as mock_import:
-            mock_module = MagicMock()
-            mock_module.TestPlugin = MockPlugin
-            mock_import.return_value = mock_module
+            with patch(
+                "ggshield.core.plugin.loader.get_cache_dir", return_value=cache_dir
+            ):
+                mock_module = MagicMock()
+                mock_module.TestPlugin = MockPlugin
+                mock_import.return_value = mock_module
 
-            loader._load_from_wheel(wheel_path)
+                loader._load_from_wheel(wheel_path)
+                extract_dir = loader._get_extract_dir(wheel_path)
 
-        extract_dir = tmp_path / ".test_plugin-1.0.0_extracted"
         assert sys.path[0] == "/existing/path"
         assert str(extract_dir) in sys.path
         assert sys.path.index(str(extract_dir)) > 0


### PR DESCRIPTION
## Context


 Fix plugin loading reliability for machine-scan/root-admin scenarios.

 - Enable installed wheel plugins by their ggshield.plugins entry point name instead of the wheel package name.
 - Keep legacy package-name config as an alias so existing installs continue to load.
 - Extract plugin wheels into the active runtime cache instead of beside the installed wheel, avoiding root/admin-owned extraction dirs breaking user runs.
 - Prune stale extracted wheel caches on load and remove plugin extraction cache on uninstall.
<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
