### PR TITLE
fix(config): throw error if no version defined

### DIFF
--- a/changelog.d/20260522_165705_6d7a_yaml_v2_error.md
+++ b/changelog.d/20260522_165705_6d7a_yaml_v2_error.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Display an additional warning when the `.gitguardian.yaml` configuration file is missing the `version` field.

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -200,7 +200,14 @@ def _load_config_dict(
 
     dash_keys = replace_dash_in_keys(dct)
 
-    config_version = dct.pop("version", 1)
+    config_version = dct.pop("version", None)
+    if config_version is None:
+        ui.display_warning(
+            f"{config_path} does not delare a `version` value. "
+            "Add `version: 2` to your config to prevent ggshield "
+            "from falling back to the legacy config format."
+        )
+        config_version = 1
     if config_version == 2:
         if dash_keys:
             _warn_about_dash_keys(config_path, dash_keys)

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -98,6 +98,19 @@ class TestUserConfig:
         with pytest.raises(UnexpectedError):
             UserConfig.load(local_config_path)
 
+    def test_load_missing_version(self, local_config_path, capsys):
+        """
+        GIVEN a non-empty config file with no `version` field
+        WHEN we try to load it
+        THEN the user is warned about the consequences of not setting
+        """
+        write_yaml(local_config_path, {"instance": "https://example.com"})
+
+        UserConfig.load(local_config_path)
+
+        captured = capsys.readouterr()
+        assert "version: 2" in captured.err
+
     def test_save_load_roundtrip(self):
         config_path = "config.yaml"
         config = UserConfig()


### PR DESCRIPTION
## Context

Currently, a missing `version` field in the config makes `ggshield` silently interpret the config as a deprecated version 1 config.

## What has been done

`ggshield` displays an explicit warning, notifying the user that omitting `version: 2` will prompt `ggshield` to fall back to v1.

## Validation

- run `uv sync --all-groups`
- run `uv run ggshield secret scan path ./ggshield/__main__.py` to ensure no warning is displayed
- remove `version: 2` from `.gitguardian.yaml``
- rerun `uv run ggshield secret scan path ./ggshield/__main__.py` and ensure that the warning is displayed

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
