### PR TITLE
Detect MCP servers' display_name

### DIFF
--- a/changelog.d/20260526_113917_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260526_113917_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Added
+
+- Improved MCP server name detection for more human-readable names.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal
+from typing import Any, Dict, Iterator, Literal
 
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -177,15 +177,11 @@ class Claude(Agent):
         - claudeAiMcpEverConnected in ~/.claude.json (historical list)
         - ~/.claude/mcp-needs-auth-cache.json (currently-authorized list)
         """
-        names: List[str] = []
-        seen: set = set()
+        names: set[str] = set()
 
         def _add(name: str) -> None:
             name = name.removeprefix("claude.ai ")
-            if name in seen:
-                return
-            seen.add(name)
-            names.append(name)
+            names.add(name)
 
         claude_json = self._load_file(get_user_home_dir() / ".claude.json")
         if claude_json:
@@ -205,6 +201,7 @@ class Claude(Agent):
                 transport=Transport.HTTP,
                 project=None,
                 url="claude.ai",
+                display_name=name,
             )
 
     def discover_project_directories(self) -> Iterator[Path]:

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -78,9 +78,7 @@ class Codex(Agent):
         # Standard project-level MCP servers
         yield from super()._get_project_mcp_configurations(directory)
         # Detect local plugin
-        yield from self._get_codex_plugin_mcp_configurations(
-            directory / ".codex-plugin", Scope.PROJECT
-        )
+        yield from self._get_codex_plugin_mcp_configurations(directory, Scope.PROJECT)
 
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         # Standard user-level MCP servers
@@ -93,12 +91,20 @@ class Codex(Agent):
     def _get_codex_plugin_mcp_configurations(
         self, plugin_dir: Path, scope: Scope
     ) -> Iterator[MCPConfiguration]:
-        if not plugin_dir.is_dir():
+        # Try to read the package.json
+        if package := self._load_file(plugin_dir / ".codex-plugin" / "package.json"):
+            display_name = package.get("interface", {}).get("displayName")
+            mcp_location = package.get("mcpServers", ".mcp.json")
+        else:
+            display_name = None
+            mcp_location = ".mcp.json"
+
+        # Try to read the mcp.json file
+        if not (data := self._load_file(plugin_dir / mcp_location)):
             return
-        if not (data := self._load_file(plugin_dir / ".mcp.json")):
-            return
+
         yield from self._parse_servers_block(
-            data, scope, None if scope == Scope.USER else plugin_dir
+            data, scope, None if scope == Scope.USER else plugin_dir, display_name
         )
 
     def parse_mcp_activity(

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -8,7 +8,7 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
-from ..models import Agent, EventType, HookPayload, HookResult
+from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
 
 
 class VSCode(Agent):
@@ -69,6 +69,28 @@ class VSCode(Agent):
                 path = Path(data["folder"].removeprefix("file://"))
                 if path.is_dir():
                     yield path.resolve()
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        confs = list(super()._get_user_mcp_configurations())
+        # We can find display names in the extensions MCP configurations,
+        # update the configurations accordingly
+        display_names = self._get_extensions_names()
+        for config in confs:
+            if config.name in display_names:
+                config.display_name = display_names[config.name]
+        return iter(confs)
+
+    def _get_extensions_names(self) -> Dict[str, str]:
+        """Get the display names of the MCP servers installed from the VS Code MCP gallery."""
+        names: Dict[str, str] = {}
+        for file in self.config_folder.glob("mcp/*/manifest.json"):
+            if not (data := self._load_file(file)):
+                continue
+            name = data.get("name", "")
+            display_name = data.get("displayName")
+            if display_name:
+                names[name] = display_name
+        return names
 
     def parse_mcp_activity(
         self, payload: HookPayload, ai_config: AIDiscovery

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -2,11 +2,11 @@ import json
 from typing import Dict, Optional, Tuple
 
 from marshmallow.exceptions import ValidationError
-from pygitguardian.models import AIDiscovery
+from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer
 
 from ggshield.core.dirs import get_cache_dir
 
-from .models import MCPConfiguration, MCPServer, Scope
+from .models import Scope
 
 
 AI_DISCOVERY_CACHE_FILENAME = "ai_discovery.json"

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -8,12 +8,13 @@ from time import perf_counter
 from typing import Dict, List, Optional
 
 from pygitguardian import GGClient
-from pygitguardian.models import AIDiscovery, Detail, MCPConfiguration, MCPServer
+from pygitguardian.models import AIDiscovery, Detail, MCPServer
 
 from ggshield.core.errors import UnexpectedError
 
 from .agents import AGENTS
 from .cache import has_changed_from, load_discovery_cache, save_discovery_cache
+from .models import MCPConfiguration
 from .user import get_user_info
 
 
@@ -103,6 +104,18 @@ def _merge_mcp_configurations(
         servers[configuration.name].append(configuration)
 
     return [
-        MCPServer(name=name, configurations=configurations)
+        MCPServer(
+            name=name,
+            configurations=configurations,  # type: ignore (we can safely assume covariance)
+            display_name=_get_display_name(configurations),
+        )
         for name, configurations in servers.items()
     ]
+
+
+def _get_display_name(configurations: List[MCPConfiguration]) -> Optional[str]:
+    """Get the first non-empty display name from a list of configurations"""
+    for configuration in configurations:
+        if configuration.display_name:
+            return configuration.display_name
+    return None

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -7,15 +7,19 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
 import tomli
-from pygitguardian.models import (
-    AIDiscovery,
-    MCPActivityRequest,
-    MCPConfiguration,
-    MCPServer,
-)
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
+from pygitguardian.models import MCPConfiguration as BaseMCPConfiguration
+from pygitguardian.models import MCPServer
 
 from ggshield.core.scan import File, Scannable, StringScannable
 from ggshield.utils.files import is_path_binary
+
+
+@dataclass
+class MCPConfiguration(BaseMCPConfiguration):
+    """MCP configuration that can store a human-readable name for its server."""
+
+    display_name: Optional[str] = None
 
 
 # Small re-exports arount Py-gitguardian models to make our life easier.
@@ -233,6 +237,7 @@ class Agent(ABC):
         data: Dict[str, Dict[str, Any]],
         scope: Scope,
         project: Optional[Path],
+        display_name: Optional[str] = None,
     ) -> Iterator[MCPConfiguration]:
         """Utility function to parse a "mcpServer" block and return the MCP server entries.
 
@@ -262,6 +267,7 @@ class Agent(ABC):
                 env=entry.get("env", {}),
                 url=entry.get("url"),
                 headers=entry.get("headers", {}),
+                display_name=display_name,
             )
 
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -786,8 +786,8 @@ class TestClaudeGetClaudeAiMcpConfigurations:
         ):
             configs = list(claude._get_claudeai_mcp_configurations())
 
-        names = [c.name for c in configs]
-        assert names == ["Notion", "Granola", "Slack"]
+        names = {c.name for c in configs}
+        assert names == {"Notion", "Granola", "Slack"}
         for cfg in configs:
             assert cfg.scope == Scope.USER
             assert cfg.transport == Transport.HTTP
@@ -978,9 +978,7 @@ class TestCodexDiscoverProjectDirectories:
         config_folder = tmp_path / ".codex"
         config_folder.mkdir()
         (config_folder / "config.toml").write_text(
-            "[projects]\n"
-            '"/home/user/project-a" = {}\n'
-            '"/home/user/project-b" = {}\n'
+            '[projects]\n"/home/user/project-a" = {}\n"/home/user/project-b" = {}\n'
         )
 
         codex = Codex()
@@ -1027,7 +1025,7 @@ class TestCodexGetProjectMcpConfigurations:
         codex_dir = project / ".codex"
         codex_dir.mkdir()
         (codex_dir / "config.toml").write_text(
-            "[mcpServers.proj-srv]\n" 'command = "node"\n' 'args = ["index.js"]\n'
+            '[mcpServers.proj-srv]\ncommand = "node"\nargs = ["index.js"]\n'
         )
 
         codex = Codex()
@@ -1042,7 +1040,7 @@ class TestCodexGetProjectMcpConfigurations:
         project = tmp_path / "myproject"
         plugin_dir = project / ".codex-plugin"
         plugin_dir.mkdir(parents=True)
-        (plugin_dir / ".mcp.json").write_text(
+        (project / ".mcp.json").write_text(
             json.dumps(
                 {
                     "mcpServers": {
@@ -1058,7 +1056,7 @@ class TestCodexGetProjectMcpConfigurations:
         plugin_configs = [c for c in configs if c.name == "plugin-srv"]
         assert len(plugin_configs) == 1
         assert plugin_configs[0].scope == Scope.PROJECT
-        assert plugin_configs[0].project == str(plugin_dir)
+        assert plugin_configs[0].project == str(project)
         assert plugin_configs[0].transport == Transport.STDIO
         assert plugin_configs[0].command == "npx"
 
@@ -1085,7 +1083,7 @@ class TestCodexGetUserMcpConfigurations:
         config_folder = tmp_path / ".codex"
         config_folder.mkdir()
         (config_folder / "config.toml").write_text(
-            "[mcpServers.global-srv]\n" 'command = "npx"\n' 'args = ["-y", "mcp"]\n'
+            '[mcpServers.global-srv]\ncommand = "npx"\nargs = ["-y", "mcp"]\n'
         )
 
         codex = Codex()


### PR DESCRIPTION
## Context

Most MCP servers installed via extensions/plugins have a proper "human-readable" name. They can be used as display names in our platform to show data in a more user-friendly way.


## What has been done

This PR scans for these names whenever possible, and fill the `display_name` field of MCPServers (trusting the first non-empty value found). As an implementation detail, this meant adding a `display_name` field to the MCPConfiguration class as well, in order to transiently store our findings. This field is only used locally, and won't change the format of what is sent to the platform.
