### PR TITLE
fix(auth): use OS port selection for local OAuth server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-<a id='changelog-1.52.0'></a>
-
-## 1.52.0 — 2026-05-27
-
-### Fixed
-
-- OAuth local server now uses OS-assigned port (port 0) instead of the hardcoded range 29170-29998, eliminating port conflicts when running multiple ggshield instances or other tools. ([#948](https://github.com/GitGuardian/ggshield/pull/948))
-
 <a id='changelog-1.51.0'></a>
 
 ## 1.51.0 — 2026-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+<a id='changelog-1.52.0'></a>
+
+## 1.52.0 — 2026-05-27
+
+### Fixed
+
+- OAuth local server now uses OS-assigned port (port 0) instead of the hardcoded range 29170-29998, eliminating port conflicts when running multiple ggshield instances or other tools. ([#948](https://github.com/GitGuardian/ggshield/pull/948))
+
 <a id='changelog-1.51.0'></a>
 
 ## 1.51.0 — 2026-05-26

--- a/changelog.d/20260528_195952_henri.hubert_fix_port_selection.md
+++ b/changelog.d/20260528_195952_henri.hubert_fix_port_selection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- OAuth local server now uses OS-assigned port (port 0) instead of the hardcoded range 29170-29998, eliminating port conflicts when running multiple ggshield instances or other tools.

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -35,12 +35,6 @@ SCAN_SCOPE = "scan"
 # redirecting to localhost; the user pastes the code back into the terminal.
 OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
-# potential port range to be used to run local server
-# to handle authorization code callback
-# this is the largest band of not commonly occupied ports
-# https://stackoverflow.com/questions/10476987/best-tcp-port-number-range-for-internal-applications
-USABLE_PORT_RANGE = (29170, 29998)
-
 logger = logging.getLogger(__name__)
 
 # Number of leading characters of an authorization code we keep visible when
@@ -92,7 +86,7 @@ class OAuthClient:
         self._access_token: Optional[str] = None
         # If the PAT expiration date has been enforced to respect the workspace policy
         self._expire_at_downsized: bool = False
-        self._port = USABLE_PORT_RANGE[0]
+        self._port = 0
         self.server: Optional[HTTPServer] = None
 
         # When True, run the browser-less (out-of-band) flow: the CLI prints
@@ -262,18 +256,13 @@ class OAuthClient:
         webbrowser.open_new_tab(request_uri)
 
     def _prepare_server(self) -> None:
-        for port in range(*USABLE_PORT_RANGE):
-            try:
-                self.server = HTTPServer(
-                    # only consider requests from localhost on the predetermined port
-                    ("127.0.0.1", port),
-                    functools.partial(RequestHandler, self),
-                )
-                self._port = port
-                break
-            except OSError:
-                continue
-        else:
+        try:
+            self.server = HTTPServer(
+                ("127.0.0.1", 0),
+                functools.partial(RequestHandler, self),
+            )
+            self._port = self.server.server_port
+        except OSError:
             raise UnexpectedError("Could not find unoccupied port.")
 
     def _wait_for_callback(self) -> None:

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -541,7 +541,6 @@ class TestAuthLoginWeb:
 
     @pytest.mark.parametrize("token_name", [None, "some token name"])
     @pytest.mark.parametrize("lifetime", [None, 0, 1, 365])
-    @pytest.mark.parametrize("used_port_count", [0, 1, 10])
     @pytest.mark.parametrize("existing_expired_token", [False, True])
     @pytest.mark.parametrize("existing_unrelated_token", [False, True])
     @pytest.mark.parametrize("downsized_token", [False, True, None])
@@ -550,7 +549,6 @@ class TestAuthLoginWeb:
         downsized_token,
         existing_unrelated_token,
         existing_expired_token,
-        used_port_count,
         lifetime,
         token_name,
         cli_fs_runner,
@@ -560,7 +558,6 @@ class TestAuthLoginWeb:
             monkeypatch,
             token_name=token_name,
             lifetime=lifetime,
-            used_port_count=used_port_count,
             downsized_token=downsized_token,
         )
 
@@ -578,7 +575,7 @@ class TestAuthLoginWeb:
         assert exit_code == ExitCode.SUCCESS, output
 
         self._webbrowser_open_mock.assert_called_once()
-        self._assert_open_url(expected_port=29170 + used_port_count)
+        self._assert_open_url()
 
         self._request_mock.assert_all_requests_happened()
 
@@ -627,7 +624,6 @@ class TestAuthLoginWeb:
         token_name=None,
         lifetime=None,
         instance_url=None,
-        used_port_count=0,
         login_result: LoginResult = LoginResult.SUCCESS,
         sso_url=None,
         downsized_token: Optional[bool] = False,
@@ -679,12 +675,13 @@ class TestAuthLoginWeb:
             self._get_oauth_client_class(callback_url),
         )
 
-        # avoid starting a server on port 1234
+        # mock the HTTPServer to return a server with a known server_port
+        mock_server = Mock()
+        mock_server.server_port = 29170
         if login_result == LoginResult.NOT_ENOUGH_PORTS:
-            used_port_count = 1000
-        mock_server_class = Mock(
-            side_effect=self._get_oserror_side_effect(used_port_count)
-        )
+            mock_server_class = Mock(side_effect=OSError("No ports available"))
+        else:
+            mock_server_class = Mock(return_value=mock_server)
         monkeypatch.setattr(
             "ggshield.verticals.auth.oauth.HTTPServer", mock_server_class
         )
@@ -784,18 +781,6 @@ class TestAuthLoginWeb:
             )
 
     @staticmethod
-    def _get_oserror_side_effect(failure_count=1):
-        """
-        return a side effect to pass to a mock object
-        the n first call will raise an exception
-        the call n + 1 will be silent
-        """
-        return (
-            OSError("This port is already in use.") if i < failure_count else None
-            for i in range(failure_count + 1)
-        )
-
-    @staticmethod
     def _assert_last_print(output: str, expected_str: str):
         """
         assert that the last log output is the same as the one passed in param
@@ -807,6 +792,7 @@ class TestAuthLoginWeb:
         *,
         host: Optional[str] = None,
         expected_port: int = 29170,
+        used_port_count: int = 0,
         scope_set: Optional[Set[str]] = None,
     ):
         """
@@ -833,7 +819,7 @@ class TestAuthLoginWeb:
         redirect_uri = url_params["redirect_uri"][0]
 
         assert redirect_uri.startswith(
-            f"http://localhost:{expected_port}"
+            f"http://localhost:{expected_port + used_port_count}"
         ), redirect_uri
 
         # We pass `WebApplicationClient.prepare_request_uri()` a list of


### PR DESCRIPTION
Fixes #913

## Problem

The `OAuthClient._prepare_server()` method iterates through a hardcoded port range (29170–29998) trying to bind a local HTTP server. When running multiple ggshield instances, or when other tools occupy ports in that range, the login flow fails with "Could not find unoccupied port."

## Solution

Pass port `0` to `HTTPServer` so the operating system selects an available port automatically, then read the assigned port from `server.server_port`.

### Changes

**`ggshield/verticals/auth/oauth.py`:**
- Removed the `USABLE_PORT_RANGE` constant and the try-loop in `_prepare_server()`
- `HTTPServer` now binds to `("127.0.0.1", 0)` — the OS assigns an ephemeral port
- The assigned port is read from `self.server.server_port` immediately after creation
- Error handling preserved: if the OS cannot assign a port (extremely rare system-wide exhaustion), the original `UnexpectedError` is still raised

**`tests/unit/cmd/auth/test_login.py`:**
- Removed the `used_port_count` parameter and `_get_oserror_side_effect` helper since port contention simulation is no longer relevant
- The mock `HTTPServer` now returns a server object with a fixed `server_port` rather than using a side-effect chain
- The `NOT_ENOUGH_PORTS` test case still works by making the mock raise `OSError` directly
- Simplified `_assert_open_url` port assertions

## Testing

- All 147 existing auth login tests pass
- The fix is purely internal (no API changes), so existing test coverage fully validates behavior