### PR TITLE
feat(ai): skip already-shipped agent activity via a local cursor

### DIFF
--- a/changelog.d/20260529_000000_paul.beslin.ext_raw_history.md
+++ b/changelog.d/20260529_000000_paul.beslin.ext_raw_history.md
@@ -1,0 +1,4 @@
+### Changed
+
+- `ggshield ai discover --history` now also ships raw transcript/database records
+  from supported AI agents to GitGuardian.

--- a/changelog.d/20260602_000000_achille.mascia_agent_activity.md
+++ b/changelog.d/20260602_000000_achille.mascia_agent_activity.md
@@ -1,0 +1,6 @@
+### Changed
+
+- `ggshield ai discover --history` now collects raw AI-agent activity records
+  from Claude Code, Codex, Cursor, Copilot CLI and VSCode (Copilot Chat) and
+  ships them verbatim to GitGuardian, which scans the content and strips
+  secrets server-side before storing it.

--- a/changelog.d/20260602_120000_achille.mascia_agent_activity_offset.md
+++ b/changelog.d/20260602_120000_achille.mascia_agent_activity_offset.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `ggshield ai discover --history` now keeps a local cursor so each run only
+  ships AI-agent transcript records added since the previous run, instead of
+  re-uploading every record every time. The cursor is best-effort (delete the
+  cache file to force a full re-scan) and only applies to append-only
+  transcripts; database-backed sources are still read in full.

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -4,7 +4,7 @@ for tools, resources, and prompts.
 """
 
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import click
 from pygitguardian.models import AIDiscovery
@@ -15,6 +15,10 @@ from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
 from ggshield.core.errors import APIKeyCheckError, UnknownInstanceError
 from ggshield.core.text_utils import STYLE, format_text, pluralize
+from ggshield.verticals.ai.agent_activity import (
+    AgentActivityReport,
+    collect_agent_activity,
+)
 from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.discovery import (
     discover_ai_configuration,
@@ -72,11 +76,13 @@ def discover_cmd(
         return
 
     backfill_report = BackfillReport()
+    activity_report: Optional[AgentActivityReport] = None
     try:
         config = submit_ai_discovery(client, config)
         save_discovery_cache(config)
         if scan_history:
             backfill_report = backfill_mcp_history(client, config)
+            activity_report = collect_agent_activity(client)
     except Exception as exc:
         if "missing the following scope:" in str(exc):
             scope = str(exc).split("missing the following scope:")[1].strip()
@@ -86,7 +92,7 @@ def discover_cmd(
         ui.display_warning(f"Could not upload AI discovery to GitGuardian: {reason}")
 
     # Summarize after sending to GIM, so we can benefit from its fixes.
-    summary = _summarize_discovery(config, backfill_report)
+    summary = _summarize_discovery(config, backfill_report, activity_report)
 
     if use_json:
         click.echo(json.dumps(summary, indent=2))
@@ -94,7 +100,11 @@ def discover_cmd(
         print_summary(summary)
 
 
-def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[str, Any]:
+def _summarize_discovery(
+    config: AIDiscovery,
+    report: BackfillReport,
+    activity_report: Optional[AgentActivityReport] = None,
+) -> Dict[str, Any]:
     """Summarize what we want to show of the discovery."""
     agent_names = set()
     servers = []
@@ -120,7 +130,7 @@ def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[st
             }
         )
     servers = sorted(servers, key=lambda x: x["name"])
-    return {
+    summary: Dict[str, Any] = {
         "agents": [AGENTS[name].display_name for name in agent_names],
         "servers": servers,
         "history": {
@@ -130,6 +140,14 @@ def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[st
             "skipped": report.skipped,
         },
     }
+    if activity_report is not None:
+        summary["agent_activity"] = {
+            "parsed": activity_report.parsed,
+            "ingested": activity_report.ingested,
+            "duplicates": activity_report.duplicates,
+            "failed_batches": activity_report.failed_batches,
+        }
+    return summary
 
 
 def print_summary(summary: Dict[str, Any]) -> None:
@@ -187,3 +205,19 @@ def print_summary(summary: Dict[str, Any]) -> None:
             f"({history['duplicates']:,} already known, "
             f"{history.get('skipped', 0):,} skipped)"
         )
+
+    agent_activity = summary.get("agent_activity")
+    # Only surface the agent-activity block when there is something to report;
+    # otherwise every `--history` run prints an all-zeros section.
+    if agent_activity is not None and (
+        agent_activity["parsed"] or agent_activity.get("failed_batches", 0)
+    ):
+        click.echo(f"{format_text('Collecting agent activity…', STYLE['key'])}")
+        click.echo(f"  • Parsed {agent_activity['parsed']:,} activity events")
+        click.echo(
+            f"  • Recorded {agent_activity['ingested']:,} activity events "
+            f"({agent_activity['duplicates']:,} already known)"
+        )
+        if agent_activity.get("failed_batches", 0) > 0:
+            label = format_text("Failed batches:", STYLE["detector_line_start"])
+            click.echo(f"  • {label} {agent_activity['failed_batches']:,}")

--- a/ggshield/verticals/ai/agent_activity/__init__.py
+++ b/ggshield/verticals/ai/agent_activity/__init__.py
@@ -1,0 +1,35 @@
+"""AI-agent activity collection: read transcript files and SQLite databases and
+ship each record **raw** (verbatim) to the GitGuardian API, which scans the
+content and strips secrets server-side before storing it."""
+
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+from ggshield.verticals.ai.agent_activity.orchestrator import (
+    BATCH_SIZE,
+    AgentActivityBatchResult,
+    AgentActivityReport,
+    collect_agent_activity,
+    send_agent_activity_batch,
+)
+from ggshield.verticals.ai.agent_activity.readers import iter_jsonl, iter_sqlite_rows
+from ggshield.verticals.ai.agent_activity.sources import (
+    ActivitySource,
+    JSONActivitySource,
+    JSONLActivitySource,
+    SQLiteActivitySource,
+)
+
+
+__all__ = [
+    "BATCH_SIZE",
+    "ActivitySource",
+    "JSONActivitySource",
+    "JSONLActivitySource",
+    "AgentActivityBatchResult",
+    "AgentActivityEvent",
+    "AgentActivityReport",
+    "SQLiteActivitySource",
+    "collect_agent_activity",
+    "iter_jsonl",
+    "iter_sqlite_rows",
+    "send_agent_activity_batch",
+]

--- a/ggshield/verticals/ai/agent_activity/cursors.py
+++ b/ggshield/verticals/ai/agent_activity/cursors.py
@@ -1,0 +1,96 @@
+"""Best-effort local cursors so we only ship NEW agent-activity records.
+
+``ggshield ai discover --history`` re-reads every agent transcript on each run.
+Re-uploading records we already sent (which the server then re-scans and
+deduplicates) is wasteful, so we persist a per-source high-water mark: the index
+of the last record we successfully shipped. On the next run, append-only sources
+skip records at or below that mark.
+
+This is purely an optimisation. The store is **fail-open**: if it is missing or
+unreadable we simply re-send everything (the server deduplicates on its own
+``event_hash``, so a lost cursor costs one redundant batch, never correctness).
+Delete the file to force a full re-scan.
+
+Cursors are scoped to the ``(instance, API key)`` pair, so pointing ggshield at
+a different account or instance starts from a clean slate. The raw key is never
+written: the scope is a hash of it.
+"""
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from pygitguardian import GGClient
+
+from ggshield.core.dirs import get_cache_dir
+
+
+logger = logging.getLogger(__name__)
+
+CURSOR_FILE_NAME = "agent_activity_cursors.json"
+
+# Index meaning "nothing committed yet"; every real record index is >= 0.
+NOTHING = -1
+
+
+def scope_for(client: GGClient) -> str:
+    """Return an opaque key binding cursors to one ``(instance, credential)``.
+
+    Hashes ``base_uri`` + ``api_key`` so switching either resets the cursor,
+    without ever storing the raw key on disk.
+    """
+    digest = hashlib.sha256(f"{client.base_uri}\n{client.api_key}".encode())
+    return digest.hexdigest()[:16]
+
+
+class CursorStore:
+    """JSON map ``scope -> agent -> source_kind -> source_path -> last index``."""
+
+    def __init__(self, path: Path, data: Dict[str, Any]) -> None:
+        self.path = path
+        self._data = data
+
+    @classmethod
+    def load(cls) -> "CursorStore":
+        """Load the cursor file, falling back to an empty store on any error."""
+        path = get_cache_dir() / CURSOR_FILE_NAME
+        data: Dict[str, Any] = {}
+        try:
+            if path.is_file():
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = loaded
+        except (OSError, ValueError) as exc:
+            logger.warning("agent_activity: ignoring unreadable cursor file: %s", exc)
+        return cls(path, data)
+
+    def get(self, scope: str, agent: str, kind: str, source_path: str) -> int:
+        """Return the last committed index for a source, or ``NOTHING``."""
+        try:
+            return int(self._data[scope][agent][kind][source_path])
+        except (KeyError, TypeError, ValueError):
+            return NOTHING
+
+    def advance(
+        self, scope: str, agent: str, kind: str, source_path: str, index: int
+    ) -> None:
+        """Move a source's mark forward to ``index`` (never backwards)."""
+        node = (
+            self._data.setdefault(scope, {}).setdefault(agent, {}).setdefault(kind, {})
+        )
+        node[source_path] = max(int(node.get(source_path, NOTHING)), int(index))
+
+    def save(self) -> None:
+        """Atomically write the store; best-effort (never raises)."""
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_name(self.path.name + ".tmp")
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._data, f)
+            os.replace(tmp, self.path)
+        except OSError as exc:
+            logger.warning("agent_activity: failed to save cursor file: %s", exc)

--- a/ggshield/verticals/ai/agent_activity/models.py
+++ b/ggshield/verticals/ai/agent_activity/models.py
@@ -1,0 +1,34 @@
+"""Wire shape for raw history events sent to the GitGuardian API."""
+
+from dataclasses import asdict, dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class AgentActivityEvent:
+    """One raw record from an agent's transcript or database.
+
+    Fields:
+    - ``agent_name``: short agent identifier matching ``Agent.name`` (e.g. ``"claude-code"``).
+    - ``source_kind``: agent-scoped identifier for the file/table the record came from
+      (e.g. ``"session_transcript"``, ``"composer_bubble"``).
+    - ``source_path``: on-disk path relative to the agent's config dir, with variable
+      parts (session UUIDs, workspace hashes) preserved.
+    - ``record_offset``: stable string identifier of the record within its source file.
+      Line index serialised as a string (``"0"``, ``"1"``, …) for JSONL and JSON files.
+      For SQLite, the value(s) of the declared ``key_columns`` — single column: the
+      column value; multiple columns: a JSON-encoded list. Subclasses may override
+      :meth:`ActivitySource.record_offset` for non-trivial cases.
+    - ``content``: the record serialised as a string. JSONL and JSON files: the raw
+      line or file text verbatim. SQLite rows: the row dict serialised with
+      ``json.dumps`` (default) or a custom per-source filter.
+    """
+
+    agent_name: str
+    source_kind: str
+    source_path: str
+    record_offset: str
+    content: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)

--- a/ggshield/verticals/ai/agent_activity/orchestrator.py
+++ b/ggshield/verticals/ai/agent_activity/orchestrator.py
@@ -1,0 +1,96 @@
+"""Orchestrate agent-activity collection across agents and ship batches to the API."""
+
+import logging
+from dataclasses import dataclass
+from typing import List
+
+import requests
+from pygitguardian import GGClient
+from pygitguardian.models import Detail
+
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+# Flush a batch once it reaches BATCH_SIZE events OR this many bytes of content,
+# whichever comes first, so a few large records can't produce a huge request.
+MAX_BATCH_BYTES = 5 * 1024 * 1024
+
+
+@dataclass
+class AgentActivityBatchResult:
+    ingested: int
+    duplicates: int
+    success: bool
+
+
+@dataclass
+class AgentActivityReport:
+    parsed: int = 0
+    ingested: int = 0
+    duplicates: int = 0
+    failed_batches: int = 0
+
+
+def send_agent_activity_batch(
+    client: GGClient, events: List[AgentActivityEvent]
+) -> AgentActivityBatchResult:
+    """Serialise ``events`` and submit them as one batch."""
+    if not events:
+        return AgentActivityBatchResult(ingested=0, duplicates=0, success=True)
+    payload = [e.to_dict() for e in events]
+    response = client.send_agent_activity(payload)
+    if isinstance(response, Detail):
+        logger.warning("agent_activity: API returned an error: %s", response.detail)
+        return AgentActivityBatchResult(ingested=0, duplicates=0, success=False)
+    return AgentActivityBatchResult(
+        ingested=response.ingested,
+        duplicates=response.duplicates,
+        success=True,
+    )
+
+
+def collect_agent_activity(client: GGClient) -> AgentActivityReport:
+    """Walk every supported agent's raw sources and ship records in BATCH_SIZE-event batches."""
+    # Imported lazily: agent modules register agent-activity sources that subclass
+    # ``ActivitySource``, so importing ``AGENTS`` at module load would create a
+    # cycle (agents -> agent_activity -> orchestrator -> agents).
+    from ggshield.verticals.ai.agents import AGENTS
+
+    report = AgentActivityReport()
+    buffer: List[AgentActivityEvent] = []
+    buffer_bytes = 0
+
+    def flush() -> None:
+        nonlocal buffer_bytes
+        if not buffer:
+            return
+        # Records are shipped raw: GitGuardian scans and strips secrets
+        # server-side before storing them, so the client stays "dumb".
+        try:
+            result = send_agent_activity_batch(client, list(buffer))
+        except requests.exceptions.RequestException as exc:
+            logger.warning(
+                "agent_activity: batch of %d events failed: %s", len(buffer), exc
+            )
+            report.failed_batches += 1
+        else:
+            report.ingested += result.ingested
+            report.duplicates += result.duplicates
+            if not result.success:
+                report.failed_batches += 1
+        buffer.clear()
+        buffer_bytes = 0
+
+    for agent in AGENTS.values():
+        for event in agent.iter_agent_activity_events():
+            buffer.append(event)
+            buffer_bytes += len(event.content.encode("utf-8"))
+            report.parsed += 1
+            if len(buffer) >= BATCH_SIZE or buffer_bytes >= MAX_BATCH_BYTES:
+                flush()
+    flush()
+    return report

--- a/ggshield/verticals/ai/agent_activity/orchestrator.py
+++ b/ggshield/verticals/ai/agent_activity/orchestrator.py
@@ -2,13 +2,19 @@
 
 import logging
 from dataclasses import dataclass
-from typing import List
+from functools import partial
+from typing import Dict, List, Set, Tuple
 
 import requests
 from pygitguardian import GGClient
 from pygitguardian.models import Detail
 
+from ggshield.verticals.ai.agent_activity.cursors import NOTHING, CursorStore, scope_for
 from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+
+
+# A resumable source, identified by (agent_name, source_kind, source_path).
+SourceKey = Tuple[str, str, str]
 
 
 logger = logging.getLogger(__name__)
@@ -53,21 +59,66 @@ def send_agent_activity_batch(
     )
 
 
+def _resume_lookup(
+    store: CursorStore, scope: str, agent_name: str, kind: str, source_path: str
+) -> int:
+    """Adapter matching ``ResumeLookup`` once bound to a store/scope/agent."""
+    return store.get(scope, agent_name, kind, source_path)
+
+
+def _batch_high_water(
+    events: List[AgentActivityEvent], resumable_kinds: Set[Tuple[str, str]]
+) -> Dict[SourceKey, int]:
+    """Highest record index per resumable source present in ``events``."""
+    out: Dict[SourceKey, int] = {}
+    for event in events:
+        if (event.agent_name, event.source_kind) not in resumable_kinds:
+            continue
+        try:
+            index = int(event.record_offset)
+        except (TypeError, ValueError):
+            continue
+        key: SourceKey = (event.agent_name, event.source_kind, event.source_path)
+        if index > out.get(key, NOTHING):
+            out[key] = index
+    return out
+
+
 def collect_agent_activity(client: GGClient) -> AgentActivityReport:
-    """Walk every supported agent's raw sources and ship records in BATCH_SIZE-event batches."""
+    """Walk every supported agent's raw sources and ship records in BATCH_SIZE-event batches.
+
+    Records already shipped on a previous run are skipped using a local cursor
+    (see :mod:`ggshield.verticals.ai.agent_activity.cursors`). A source's cursor
+    only advances over the contiguous prefix that was successfully ingested: a
+    failed batch freezes its sources so the next run resends from the gap rather
+    than skipping past it.
+    """
     # Imported lazily: agent modules register agent-activity sources that subclass
     # ``ActivitySource``, so importing ``AGENTS`` at module load would create a
     # cycle (agents -> agent_activity -> orchestrator -> agents).
     from ggshield.verticals.ai.agents import AGENTS
 
+    store = CursorStore.load()
+    scope = scope_for(client)
+    resumable_kinds: Set[Tuple[str, str]] = {
+        (agent.name, source.kind)
+        for agent in AGENTS.values()
+        for source in agent.agent_activity_sources
+        if source.supports_resume
+    }
+
     report = AgentActivityReport()
     buffer: List[AgentActivityEvent] = []
     buffer_bytes = 0
+    committed: Dict[SourceKey, int] = {}
+    frozen: Set[SourceKey] = set()
 
     def flush() -> None:
         nonlocal buffer_bytes
         if not buffer:
             return
+        batch_keys = _batch_high_water(buffer, resumable_kinds)
+        succeeded = False
         # Records are shipped raw: GitGuardian scans and strips secrets
         # server-side before storing them, so the client stays "dumb".
         try:
@@ -80,17 +131,33 @@ def collect_agent_activity(client: GGClient) -> AgentActivityReport:
         else:
             report.ingested += result.ingested
             report.duplicates += result.duplicates
-            if not result.success:
+            if result.success:
+                succeeded = True
+            else:
                 report.failed_batches += 1
+        if succeeded:
+            for key, index in batch_keys.items():
+                if key not in frozen:
+                    committed[key] = max(committed.get(key, NOTHING), index)
+        else:
+            # Never advance a source past a gap left by a failed batch.
+            frozen.update(batch_keys)
         buffer.clear()
         buffer_bytes = 0
 
     for agent in AGENTS.values():
-        for event in agent.iter_agent_activity_events():
+        resume_for = partial(_resume_lookup, store, scope, agent.name)
+        for event in agent.iter_agent_activity_events(resume_for=resume_for):
             buffer.append(event)
             buffer_bytes += len(event.content.encode("utf-8"))
             report.parsed += 1
             if len(buffer) >= BATCH_SIZE or buffer_bytes >= MAX_BATCH_BYTES:
                 flush()
     flush()
+
+    if committed:
+        for (agent_name, kind, source_path), index in committed.items():
+            store.advance(scope, agent_name, kind, source_path, index)
+        store.save()
+
     return report

--- a/ggshield/verticals/ai/agent_activity/readers.py
+++ b/ggshield/verticals/ai/agent_activity/readers.py
@@ -1,0 +1,60 @@
+"""Generic readers for raw history sources (JSONL files, SQLite tables)."""
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterator, Sequence, Union
+
+
+logger = logging.getLogger(__name__)
+
+
+def iter_jsonl(path: Path) -> Iterator[str]:
+    """Yield each non-blank line of a JSONL file as a raw string.
+
+    Returns an empty iterator on I/O failure.
+    """
+    if not path.is_file():
+        return
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fp:
+            for line in fp:
+                line = line.rstrip("\n").rstrip("\r")
+                if not line.strip():
+                    continue
+                yield line
+    except OSError:
+        return
+
+
+def iter_sqlite_rows(
+    db_path: Path,
+    query: str,
+    params: Sequence[Union[str, int, float, bytes, None]] = (),
+) -> Iterator[Dict[str, object]]:
+    """Yield each row of ``query`` as a ``{column: value}`` dict.
+
+    Missing DB/error → empty iterator.
+    """
+    if not db_path.is_file():
+        return
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        logger.warning("iter_sqlite_rows: cannot open %s: %s", db_path, exc)
+        return
+    try:
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.execute(query, params)
+        except sqlite3.Error as exc:
+            logger.warning("iter_sqlite_rows: query failed on %s: %s", db_path, exc)
+            return
+        try:
+            for row in cursor:
+                yield {key: row[key] for key in row.keys()}
+        except sqlite3.Error as exc:
+            logger.warning("iter_sqlite_rows: read failed on %s: %s", db_path, exc)
+            return
+    finally:
+        conn.close()

--- a/ggshield/verticals/ai/agent_activity/sources.py
+++ b/ggshield/verticals/ai/agent_activity/sources.py
@@ -25,7 +25,17 @@ usually only supply ``discover`` (+ optional ``record_offset`` override).
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import ClassVar, Dict, Iterable, Iterator, Optional, Sequence, Tuple, Union
+from typing import (
+    Callable,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
@@ -33,6 +43,11 @@ from ggshield.verticals.ai.agent_activity.readers import iter_jsonl, iter_sqlite
 
 
 RawRecord = Union[str, Dict[str, object]]
+
+# Given (source_kind, source_path), return the index of the last record already
+# shipped for that source (or a negative value if none) — see
+# :mod:`ggshield.verticals.ai.agent_activity.cursors`.
+ResumeLookup = Callable[[str, str], int]
 
 # Cap a single record's content as a cheap defensive bound on payload size.
 MAX_CONTENT_BYTES = 256 * 1024
@@ -60,6 +75,12 @@ class ActivitySource(ABC):
     """
 
     kind: ClassVar[str] = ""
+
+    # Whether this source's records can be resumed by positional index across
+    # runs. Only true for append-only sources (a record's index never changes
+    # once written). Mutable sources (e.g. an edited-in-place DB row) leave this
+    # False so they are always re-read in full.
+    supports_resume: ClassVar[bool] = False
 
     @abstractmethod
     def discover(self) -> Iterable[Path]:
@@ -119,12 +140,25 @@ class ActivitySource(ABC):
         return str(index)
 
     def iter_events(
-        self, agent_name: str, path_root: Optional[Path] = None
+        self,
+        agent_name: str,
+        path_root: Optional[Path] = None,
+        resume_for: Optional[ResumeLookup] = None,
     ) -> Iterator[AgentActivityEvent]:
-        """Run the full discover → read → serialize pipeline for this source."""
+        """Run the full discover → read → serialize pipeline for this source.
+
+        When ``resume_for`` is given and this source ``supports_resume``, records
+        whose index is at or below the per-source high-water mark it returns are
+        skipped — they were shipped on a previous run.
+        """
         for path in self.discover():
             source_path = self.source_path_for(path, path_root)
+            resume_after = -1
+            if resume_for is not None and self.supports_resume:
+                resume_after = resume_for(self.kind, source_path)
             for index, record in enumerate(self.read(path)):
+                if index <= resume_after:
+                    continue
                 content = _cap_content(self.serialize(record))
                 yield AgentActivityEvent(
                     agent_name=agent_name,
@@ -136,7 +170,13 @@ class ActivitySource(ABC):
 
 
 class JSONLActivitySource(ActivitySource):
-    """Source backed by a JSONL file. Ships one raw line per record."""
+    """Source backed by a JSONL file. Ships one raw line per record.
+
+    JSONL transcripts are append-only (lines are never rewritten), so records
+    can be resumed by index across runs.
+    """
+
+    supports_resume = True
 
     def read(self, path: Path) -> Iterator[str]:
         yield from iter_jsonl(path)

--- a/ggshield/verticals/ai/agent_activity/sources.py
+++ b/ggshield/verticals/ai/agent_activity/sources.py
@@ -1,0 +1,217 @@
+"""Activity source abstraction.
+
+An ``ActivitySource`` is one logical source of raw records belonging to an agent
+(e.g. "the JSONL session transcripts under ~/.claude/projects/*/*.jsonl").
+
+The pipeline is three stages:
+1. ``discover()``  — locate the files to read.
+2. ``read(path)``  — yield raw records from one file.
+3. ``serialize(record)`` — turn one record into the string shipped as the
+   event ``content``. The client is deliberately "dumb": it ships the agent's
+   **raw** record verbatim (a JSONL line, or a serialised DB row) so the shape
+   never depends on the ggshield version. GitGuardian scans the content and
+   strips secrets server-side before storing it.
+
+Each file's :meth:`source_path_for` returns the relative-to-root portion of
+its path. Each record's :meth:`record_offset` returns its position within the
+file (line index by default).
+
+Subclasses fill in the parts they care about. The three concrete bases
+(``JSONLActivitySource``, ``JSONActivitySource``, ``SQLiteActivitySource``) plug
+``read`` and a verbatim ``serialize`` in for the common cases; per-agent sources
+usually only supply ``discover`` (+ optional ``record_offset`` override).
+"""
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import ClassVar, Dict, Iterable, Iterator, Optional, Sequence, Tuple, Union
+
+from ggshield.core.dirs import get_user_home_dir
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+from ggshield.verticals.ai.agent_activity.readers import iter_jsonl, iter_sqlite_rows
+
+
+RawRecord = Union[str, Dict[str, object]]
+
+# Cap a single record's content as a cheap defensive bound on payload size.
+MAX_CONTENT_BYTES = 256 * 1024
+CONTENT_TRUNCATED_MARKER = "…[ggshield: truncated]"
+
+
+def _cap_content(content: str) -> str:
+    """Truncate ``content`` to ``MAX_CONTENT_BYTES`` (UTF-8), marking the cut."""
+    encoded = content.encode("utf-8")
+    if len(encoded) <= MAX_CONTENT_BYTES:
+        return content
+    return (
+        encoded[:MAX_CONTENT_BYTES].decode("utf-8", errors="ignore")
+        + CONTENT_TRUNCATED_MARKER
+    )
+
+
+class ActivitySource(ABC):
+    """Base class for a single agent-activity source.
+
+    Subclasses MUST set ``kind`` (the wire identifier) and implement
+    ``discover``. The format bases below also implement ``serialize`` (verbatim);
+    ``source_path_for`` and ``record_offset`` have sensible defaults and only
+    need overriding for sources that demand custom behaviour.
+    """
+
+    kind: ClassVar[str] = ""
+
+    @abstractmethod
+    def discover(self) -> Iterable[Path]:
+        """Yield file paths to read."""
+
+    @abstractmethod
+    def read(self, path: Path) -> Iterator[RawRecord]:
+        """Yield raw records from a single file."""
+
+    def serialize(self, record: RawRecord) -> str:
+        """Serialise one record to the string shipped as the event ``content``.
+
+        The format bases ship the record verbatim (the agent's raw line / row) —
+        the client stays "dumb" so the shape never depends on the ggshield
+        version. GitGuardian scans and strips secrets server-side before storing
+        it. A source whose record type none of the format bases handle must
+        implement this.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement serialize().")
+
+    def source_path_for(self, path: Path, path_root: Optional[Path]) -> str:
+        """Return the variable-suffix portion of ``path`` as a string.
+
+        Default: the path relative to ``path_root`` (typically the agent's
+        ``config_folder``). Sources whose files live outside the agent's config
+        dir should override this method to strip a different prefix.
+
+        As a safety net, paths that fall outside ``path_root`` are still made
+        home-relative (``~/…``) so we never ship the user's absolute home
+        directory, which embeds their username.
+
+        Always returns forward-slash (POSIX) separators so the shipped path is
+        consistent regardless of the client OS.
+        """
+        if path_root is not None:
+            try:
+                return path.relative_to(path_root).as_posix()
+            except ValueError:
+                pass
+        try:
+            return "~/" + path.relative_to(get_user_home_dir()).as_posix()
+        except (ValueError, RuntimeError):
+            return path.as_posix()
+
+    def record_offset(self, record: RawRecord, index: int) -> str:
+        """Identifier for ``record`` within its file.
+
+        Receives the **raw record** from ``read()`` (before serialising), so
+        SQLite subclasses can inspect dict columns even after ``serialize``
+        stringifies the row.
+
+        Default: the positional ``index`` serialised as a string (``"0"``, ``"1"``, …).
+        Note that ``index`` counts the records ``read()`` actually yields (e.g.
+        non-blank JSONL lines), not physical line numbers. Override when the
+        record carries a natural unique ID.
+        """
+        return str(index)
+
+    def iter_events(
+        self, agent_name: str, path_root: Optional[Path] = None
+    ) -> Iterator[AgentActivityEvent]:
+        """Run the full discover → read → serialize pipeline for this source."""
+        for path in self.discover():
+            source_path = self.source_path_for(path, path_root)
+            for index, record in enumerate(self.read(path)):
+                content = _cap_content(self.serialize(record))
+                yield AgentActivityEvent(
+                    agent_name=agent_name,
+                    source_kind=self.kind,
+                    source_path=source_path,
+                    record_offset=self.record_offset(record, index),
+                    content=content,
+                )
+
+
+class JSONLActivitySource(ActivitySource):
+    """Source backed by a JSONL file. Ships one raw line per record."""
+
+    def read(self, path: Path) -> Iterator[str]:
+        yield from iter_jsonl(path)
+
+    def serialize(self, record: RawRecord) -> str:
+        assert isinstance(record, str)
+        return record
+
+
+class JSONActivitySource(ActivitySource):
+    """Source backed by a JSON file. Ships the raw file content as one record."""
+
+    def read(self, path: Path) -> Iterator[str]:
+        if not path.is_file():
+            return
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return
+        if text:
+            yield text
+
+    def serialize(self, record: RawRecord) -> str:
+        assert isinstance(record, str)
+        return record
+
+
+class SQLiteActivitySource(ActivitySource):
+    """Source backed by a SQLite database.
+
+    Ships each row verbatim as a JSON object (``{column: value, …}``); secrets
+    inside it are scanned and stripped server-side by GitGuardian.
+
+    Subclasses MUST implement:
+    - ``query`` — the SELECT to run per database (abstract property).
+    - ``key_columns`` — the column(s) that uniquely identify a row (or override
+      :meth:`record_offset` directly).
+
+    Optional class variable:
+    - ``params`` — bound parameters for ``query`` (default: no parameters).
+
+    Why ``key_columns`` is required: there is no universal stable key across
+    the supported databases — each table uses its own identifier (``id`` UUID,
+    ``key`` string, or a composite pair of UUID columns). Some tables (e.g.
+    Cursor's ``cursorDiskKV``) also insert rows of different types in
+    interleaved order, so positional index is not reliable even within a
+    single file.
+
+    Subclasses that need something fancier can override :meth:`record_offset`
+    directly, bypassing ``key_columns``.
+    """
+
+    query: ClassVar[str] = ""
+
+    params: ClassVar[Sequence[Union[str, int, float, bytes, None]]] = ()
+    key_columns: ClassVar[Tuple[str, ...]] = ()
+
+    def read(self, path: Path) -> Iterator[Dict[str, object]]:
+        yield from iter_sqlite_rows(path, self.query, self.params)
+
+    def serialize(self, record: RawRecord) -> str:
+        return json.dumps(record)
+
+    def record_offset(self, record: RawRecord, index: int) -> str:
+        """Build a stable string key from ``key_columns``.
+
+        Single key column → that column's value as a string.
+        Multiple key columns → a JSON-encoded list of their values, in order.
+        """
+        if not self.key_columns:
+            raise NotImplementedError(
+                f"{type(self).__name__} must set 'key_columns' (the column(s) "
+                "uniquely identifying a row), or override record_offset() directly."
+            )
+        assert isinstance(record, dict)
+        if len(self.key_columns) == 1:
+            return str(record[self.key_columns[0]])
+        return json.dumps([str(record[c]) for c in self.key_columns])

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -9,6 +9,7 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
+from ..agent_activity.sources import JSONLActivitySource
 from ..models import (
     Agent,
     EventType,
@@ -20,8 +21,26 @@ from ..models import (
 )
 
 
+class ClaudeActivitySource(JSONLActivitySource):
+    """Every Claude Code session transcript line, shipped raw.
+
+    Claude appends one JSON object per line to ``~/.claude/projects/*/*.jsonl``
+    (prompts, tool calls, tool results, assistant messages). The line is shipped
+    verbatim; GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "session_transcript"
+
+    def discover(self) -> Iterator[Path]:
+        return iter(
+            sorted((get_user_home_dir() / ".claude").glob("projects/*/*.jsonl"))
+        )
+
+
 class Claude(Agent):
     """Behavior specific to Claude Code."""
+
+    agent_activity_sources = [ClaudeActivitySource()]
 
     @property
     def name(self) -> str:

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -8,12 +8,33 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
+from ..agent_activity.sources import JSONLActivitySource
 from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration, Scope
 from .claude_code import _mangle_server_name
 
 
+class CodexActivitySource(JSONLActivitySource):
+    """Every Codex session rollout line, shipped raw.
+
+    Codex writes one ``response_item`` / metadata object per line to
+    ``~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl``. The line is shipped
+    verbatim; GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "session_rollout"
+
+    def discover(self) -> Iterator[Path]:
+        return iter(
+            sorted(
+                (get_user_home_dir() / ".codex").glob("sessions/*/*/*/rollout-*.jsonl")
+            )
+        )
+
+
 class Codex(Agent):
     """Behavior specific to OpenAI Codex."""
+
+    agent_activity_sources = [CodexActivitySource()]
 
     @property
     def name(self) -> str:

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Tuple
 
 from ggshield.core.dirs import get_user_home_dir
+from ggshield.verticals.ai.agent_activity.sources import JSONLActivitySource
 from ggshield.verticals.ai.models import (
     AIDiscovery,
     EventType,
@@ -22,11 +23,29 @@ from .vscode import VSCode
 logger = logging.getLogger(__name__)
 
 
+class CopilotActivitySource(JSONLActivitySource):
+    """Every Copilot CLI session line, shipped raw.
+
+    Copilot CLI appends one JSON object per line to
+    ``~/.copilot/session-state/<uuid>/events.jsonl``. The line is shipped
+    verbatim; GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "session_events"
+
+    def discover(self) -> Iterator[Path]:
+        root = get_user_home_dir() / ".copilot"
+        return iter(sorted(root.glob("session-state/*/events.jsonl")))
+
+
 class Copilot(VSCode):
     """Behavior specific to Copilot CLI.
 
     Inherits most of its behavior from VSCode.
     """
+
+    # Override VSCode's source: Copilot stores sessions under a different root.
+    agent_activity_sources = [CopilotActivitySource()]
 
     @property
     def name(self) -> str:

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -17,6 +17,7 @@ from pygitguardian.models import (
 
 from ggshield.core.dirs import get_user_home_dir
 
+from ..agent_activity.sources import SQLiteActivitySource
 from ..models import (
     Agent,
     EventType,
@@ -42,8 +43,31 @@ CHAT_DB_RELATIVE_PATH = (
 )
 
 
+class CursorActivitySource(SQLiteActivitySource):
+    """Every Cursor composer bubble, shipped raw.
+
+    Cursor stores chat bubbles (prompts, assistant turns, tool calls) as JSON
+    blobs in the ``cursorDiskKV`` table of its SQLite ``state.vscdb``, keyed
+    ``bubbleId:<composer>:<bubble>``. The database lives outside the agent's
+    config dir, so :meth:`source_path_for` falls back to a home-relative path.
+
+    Each row is shipped verbatim (``{"key": …, "value": <bubble json>}``);
+    GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "composer_bubble"
+    query = "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
+    key_columns = ("key",)
+
+    def discover(self) -> Iterator[Path]:
+        db_path = get_user_home_dir() / CHAT_DB_RELATIVE_PATH
+        return iter([db_path] if db_path.is_file() else [])
+
+
 class Cursor(Agent):
     """Behavior specific to Cursor."""
+
+    agent_activity_sources = [CursorActivitySource()]
 
     @property
     def name(self) -> str:

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -10,14 +10,33 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
 
+from ..agent_activity.sources import JSONLActivitySource
 from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
 
 
 logger = logging.getLogger(__name__)
 
 
+class VSCodeActivitySource(JSONLActivitySource):
+    """Every Copilot Chat (VSCode) session line, shipped raw.
+
+    VSCode/Copilot Chat appends one JSON object per line to
+    ``~/.config/Code/User/workspaceStorage/<hash>/chatSessions/<id>.jsonl``. The
+    line is shipped verbatim; GitGuardian scans and strips secrets server-side
+    before storing it.
+    """
+
+    kind = "chat_session"
+
+    def discover(self) -> Iterator[Path]:
+        root = get_user_home_dir() / ".config" / "Code" / "User"
+        return iter(sorted(root.glob("workspaceStorage/*/chatSessions/*.jsonl")))
+
+
 class VSCode(Agent):
     """Behavior specific to VSCode."""
+
+    agent_activity_sources = [VSCodeActivitySource()]
 
     @property
     def name(self) -> str:

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
+
+
+if TYPE_CHECKING:
+    from ggshield.verticals.ai.agent_activity import ActivitySource, AgentActivityEvent
 
 import tomli
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -336,6 +340,26 @@ class Agent(ABC):
         SQLite databases, etc.
         """
         return iter(())
+
+    agent_activity_sources: ClassVar[List["ActivitySource"]] = []
+    """Subclasses set this to the list of agent-activity sources they expose.
+
+    Each entry is a ``ActivitySource`` instance (see
+    ``ggshield.verticals.ai.agent_activity``). The default implementation of
+    :meth:`iter_agent_activity_events` walks every source.
+    """
+
+    def iter_agent_activity_events(self) -> Iterator["AgentActivityEvent"]:
+        """Yield every ``AgentActivityEvent`` this agent can recover from disk.
+
+        Default implementation: iterate ``self.agent_activity_sources``, passing
+        ``self.config_folder`` as the ``path_root`` so each event's
+        ``source_path`` is recorded relative to the agent's config dir.
+        """
+        for source in self.agent_activity_sources:
+            yield from source.iter_events(
+                agent_name=self.name, path_root=self.config_folder
+            )
 
     def _user_or_default(self, ai_config: Optional[AIDiscovery]) -> UserInfo:
         """Return ``ai_config.user`` or a blank ``UserInfo`` if no config is provided."""

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
 
 if TYPE_CHECKING:
     from ggshield.verticals.ai.agent_activity import ActivitySource, AgentActivityEvent
+    from ggshield.verticals.ai.agent_activity.sources import ResumeLookup
 
 import tomli
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
@@ -349,16 +350,23 @@ class Agent(ABC):
     :meth:`iter_agent_activity_events` walks every source.
     """
 
-    def iter_agent_activity_events(self) -> Iterator["AgentActivityEvent"]:
+    def iter_agent_activity_events(
+        self, resume_for: Optional["ResumeLookup"] = None
+    ) -> Iterator["AgentActivityEvent"]:
         """Yield every ``AgentActivityEvent`` this agent can recover from disk.
 
         Default implementation: iterate ``self.agent_activity_sources``, passing
         ``self.config_folder`` as the ``path_root`` so each event's
         ``source_path`` is recorded relative to the agent's config dir.
+
+        ``resume_for`` is forwarded to each source so already-shipped records can
+        be skipped (see :mod:`ggshield.verticals.ai.agent_activity.cursors`).
         """
         for source in self.agent_activity_sources:
             yield from source.iter_events(
-                agent_name=self.name, path_root=self.config_folder
+                agent_name=self.name,
+                path_root=self.config_folder,
+                resume_for=resume_for,
             )
 
     def _user_or_default(self, ai_config: Optional[AIDiscovery]) -> UserInfo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "marshmallow-dataclass~=8.5.8",
     "oauthlib~=3.2.1",
     "packaging>=22.0",
-    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@d3152b7bf33077fd17a8ea692d658dd428c73ac3",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@d0dbef612cdda82dd9e8f2fc1c7b435b3ebf1817",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",

--- a/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
+++ b/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
@@ -1,0 +1,129 @@
+"""Each agent's registered source discovers its on-disk transcript and ships the
+record **raw** (verbatim). GitGuardian scans and strips secrets server-side, so
+secrets are still present client-side here. Uses GG_USER_HOME_DIR to redirect
+every ``get_user_home_dir()`` call at once."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("GG_USER_HOME_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_claude_agent_ships_raw_transcript_lines(fake_home: Path) -> None:
+    from ggshield.verticals.ai.agents.claude_code import Claude
+
+    proj = fake_home / ".claude" / "projects" / "-repo"
+    proj.mkdir(parents=True)
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "name": "Bash"}]},
+        }
+    )
+    (proj / "s.jsonl").write_text(line + "\n")
+
+    [event] = list(Claude().iter_agent_activity_events())
+
+    assert event.agent_name == "claude-code"
+    assert event.source_kind == "session_transcript"
+    assert event.source_path == "projects/-repo/s.jsonl"
+    # Shipped verbatim — server-side scanning happens later, not in the source.
+    assert event.content == line
+
+
+def test_codex_agent_ships_raw_rollout_lines(fake_home: Path) -> None:
+    from ggshield.verticals.ai.agents.codex import Codex
+
+    sessions = fake_home / ".codex" / "sessions" / "2026" / "06" / "01"
+    sessions.mkdir(parents=True)
+    line = json.dumps({"type": "response_item", "payload": {"type": "function_call"}})
+    (sessions / "rollout-x.jsonl").write_text(line + "\n")
+
+    [event] = list(Codex().iter_agent_activity_events())
+
+    assert event.agent_name == "codex"
+    assert event.content == line
+
+
+def test_cursor_agent_ships_raw_bubble_rows(fake_home: Path) -> None:
+    from ggshield.verticals.ai.agents.cursor import Cursor
+
+    db_path = (
+        fake_home / ".config" / "Cursor" / "User" / "globalStorage" / "state.vscdb"
+    )
+    db_path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE cursorDiskKV (key TEXT, value TEXT)")
+    bubble_value = json.dumps({"type": 2, "bubbleId": "b1", "text": "hi"})
+    conn.execute(
+        "INSERT INTO cursorDiskKV VALUES (?, ?)", ("bubbleId:c1:b1", bubble_value)
+    )
+    # A non-bubble row must be filtered out by the source query.
+    conn.execute("INSERT INTO cursorDiskKV VALUES (?, ?)", ("composerData:c1", "{}"))
+    conn.commit()
+    conn.close()
+
+    [event] = list(Cursor().iter_agent_activity_events())
+
+    assert event.agent_name == "cursor"
+    assert event.record_offset == "bubbleId:c1:b1"
+    # Whole row shipped verbatim as {"key": ..., "value": <bubble json>}.
+    row = json.loads(event.content)
+    assert row["key"] == "bubbleId:c1:b1"
+    assert json.loads(row["value"])["bubbleId"] == "b1"
+
+
+def test_copilot_agent_ships_raw_event_lines(fake_home: Path) -> None:
+    from ggshield.verticals.ai.agents.copilot import Copilot
+
+    session = fake_home / ".copilot" / "session-state" / "uuid-1"
+    session.mkdir(parents=True)
+    line = json.dumps({"type": "tool.execution_start", "data": {"mcpToolName": "x"}})
+    (session / "events.jsonl").write_text(line + "\n")
+
+    [event] = list(Copilot().iter_agent_activity_events())
+
+    assert event.agent_name == "copilot"
+    assert event.source_kind == "session_events"
+    assert event.source_path == "session-state/uuid-1/events.jsonl"
+    assert event.content == line
+
+
+def test_vscode_agent_ships_raw_chat_session_lines(fake_home: Path) -> None:
+    from ggshield.verticals.ai.agents.vscode import VSCode
+
+    sessions = (
+        fake_home
+        / ".config"
+        / "Code"
+        / "User"
+        / "workspaceStorage"
+        / "hash"
+        / "chatSessions"
+    )
+    sessions.mkdir(parents=True)
+    line = json.dumps({"kind": 2, "v": [{"role": "user", "text": "hi"}]})
+    (sessions / "s1.jsonl").write_text(line + "\n")
+
+    [event] = list(VSCode().iter_agent_activity_events())
+
+    assert event.agent_name == "vscode"
+    assert event.source_kind == "chat_session"
+    assert event.source_path == "workspaceStorage/hash/chatSessions/s1.jsonl"
+    assert event.content == line
+
+
+def test_copilot_does_not_inherit_vscode_source(fake_home: Path) -> None:
+    """Copilot stores sessions under ~/.copilot, not VSCode's workspaceStorage,
+    so it must override (not inherit) VSCode's activity source."""
+    from ggshield.verticals.ai.agents.copilot import Copilot, CopilotActivitySource
+
+    [source] = Copilot().agent_activity_sources
+    assert isinstance(source, CopilotActivitySource)

--- a/tests/unit/verticals/ai/agent_activity/test_cursors.py
+++ b/tests/unit/verticals/ai/agent_activity/test_cursors.py
@@ -1,0 +1,70 @@
+"""The cursor store is a best-effort JSON file in the (autouse-isolated) cache
+dir, scoped per credential. See cursors.py."""
+
+from types import SimpleNamespace
+
+from ggshield.verticals.ai.agent_activity.cursors import (
+    NOTHING,
+    CursorStore,
+    scope_for,
+)
+
+
+def _client(base_uri="https://api.gg.com", api_key="tok-abc"):
+    return SimpleNamespace(base_uri=base_uri, api_key=api_key)
+
+
+def test_scope_is_stable_and_credential_specific():
+    base = scope_for(_client())
+    assert base == scope_for(_client())  # deterministic
+    assert base != scope_for(_client(api_key="other"))  # key changes it
+    assert base != scope_for(_client(base_uri="https://eu.gg.com"))  # instance too
+    assert "tok-abc" not in base  # raw key never embedded
+
+
+def test_get_missing_returns_nothing():
+    store = CursorStore.load()
+    assert store.get("s", "claude-code", "session_transcript", "p.jsonl") == NOTHING
+
+
+def test_advance_and_get_roundtrip():
+    store = CursorStore.load()
+    store.advance("s", "claude-code", "session_transcript", "p.jsonl", 7)
+    assert store.get("s", "claude-code", "session_transcript", "p.jsonl") == 7
+
+
+def test_advance_never_goes_backwards():
+    store = CursorStore.load()
+    store.advance("s", "a", "k", "p", 10)
+    store.advance("s", "a", "k", "p", 4)  # lower index is ignored
+    assert store.get("s", "a", "k", "p") == 10
+
+
+def test_save_then_reload_persists():
+    store = CursorStore.load()
+    store.advance("s", "a", "k", "p", 3)
+    store.save()
+    assert CursorStore.load().get("s", "a", "k", "p") == 3
+
+
+def test_scopes_are_isolated():
+    store = CursorStore.load()
+    store.advance("scope-1", "a", "k", "p", 5)
+    assert store.get("scope-2", "a", "k", "p") == NOTHING
+
+
+def test_corrupt_file_is_fail_open():
+    store = CursorStore.load()
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("{ this is not json", encoding="utf-8")
+    # Loading garbage yields an empty store instead of raising.
+    assert CursorStore.load().get("s", "a", "k", "p") == NOTHING
+
+
+def test_save_is_fail_open_on_oserror():
+    store = CursorStore.load()
+    store.advance("s", "a", "k", "p", 1)
+    # Make the cache dir path an existing file so the atomic write cannot create
+    # it; save() must swallow the OSError rather than propagate it.
+    store.path.parent.write_text("not a directory", encoding="utf-8")
+    store.save()  # does not raise

--- a/tests/unit/verticals/ai/agent_activity/test_models.py
+++ b/tests/unit/verticals/ai/agent_activity/test_models.py
@@ -1,0 +1,25 @@
+import json
+
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+
+
+def test_agent_activity_event_to_dict_is_json_serializable() -> None:
+    raw_content = json.dumps(
+        {"key": "bubbleId:0b1f32eb:abc123", "value": '{"role":"user"}'}
+    )
+    e = AgentActivityEvent(
+        agent_name="cursor",
+        source_kind="composer_bubble",
+        source_path="globalStorage/state.vscdb",
+        record_offset="bubbleId:0b1f32eb:abc123",
+        content=raw_content,
+    )
+    payload = e.to_dict()
+    assert payload == {
+        "agent_name": "cursor",
+        "source_kind": "composer_bubble",
+        "source_path": "globalStorage/state.vscdb",
+        "record_offset": "bubbleId:0b1f32eb:abc123",
+        "content": raw_content,
+    }
+    assert json.loads(json.dumps(payload)) == payload

--- a/tests/unit/verticals/ai/agent_activity/test_orchestrator.py
+++ b/tests/unit/verticals/ai/agent_activity/test_orchestrator.py
@@ -1,8 +1,14 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import requests
 from pygitguardian.models import Detail
 
+from ggshield.verticals.ai.agent_activity.cursors import (
+    NOTHING,
+    CursorStore,
+    scope_for,
+)
 from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
 from ggshield.verticals.ai.agent_activity.orchestrator import (
     BATCH_SIZE,
@@ -88,6 +94,9 @@ def test_collect_agent_activity_counts_detail_response_as_failed_batch() -> None
 def _make_agent(name: str, events: list[AgentActivityEvent]) -> MagicMock:
     a = MagicMock()
     a.name = name
+    # No resumable sources by default: these tests focus on batching/counts, not
+    # cursor behaviour (covered in test_cursors.py and the resume tests below).
+    a.agent_activity_sources = []
     a.iter_agent_activity_events.return_value = iter(events)
     return a
 
@@ -189,3 +198,190 @@ def test_collect_agent_activity_counts_network_error_as_failed_batch() -> None:
     assert report.parsed == 1
     assert report.ingested == 0
     assert report.failed_batches == 1
+
+
+# --- cursor / resume behaviour -------------------------------------------------
+
+
+def _resumable_agent(
+    name: str, kind: str, events: list[AgentActivityEvent]
+) -> MagicMock:
+    a = MagicMock()
+    a.name = name
+    a.agent_activity_sources = [SimpleNamespace(kind=kind, supports_resume=True)]
+    a.iter_agent_activity_events.return_value = iter(events)
+    return a
+
+
+def _rec(
+    agent_name: str, kind: str, source_path: str, index: int
+) -> AgentActivityEvent:
+    return AgentActivityEvent(
+        agent_name=agent_name,
+        source_kind=kind,
+        source_path=source_path,
+        record_offset=str(index),
+        content="{}",
+    )
+
+
+def test_cursor_advances_on_successful_ingest() -> None:
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=3, duplicates=0
+    )
+    events = [_rec("claude-code", "session_transcript", "p.jsonl", i) for i in range(3)]
+    agent = _resumable_agent("claude-code", "session_transcript", events)
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        collect_agent_activity(client)
+
+    scope = scope_for(client)
+    store = CursorStore.load()
+    assert store.get(scope, "claude-code", "session_transcript", "p.jsonl") == 2
+
+
+def test_cursor_not_advanced_when_batch_fails() -> None:
+    client = MagicMock()
+    client.send_agent_activity.return_value = Detail("boom", status_code=500)
+    events = [_rec("claude-code", "session_transcript", "p.jsonl", i) for i in range(2)]
+    agent = _resumable_agent("claude-code", "session_transcript", events)
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        report = collect_agent_activity(client)
+
+    assert report.failed_batches == 1
+    scope = scope_for(client)
+    store = CursorStore.load()
+    assert store.get(scope, "claude-code", "session_transcript", "p.jsonl") == NOTHING
+
+
+def test_cursor_freeze_does_not_skip_gap_after_failure(monkeypatch) -> None:
+    """With one record per batch: index 0 succeeds, 1 fails, 2 succeeds. The
+    cursor must stay at 0 — never jump past the failed record."""
+    monkeypatch.setattr(
+        "ggshield.verticals.ai.agent_activity.orchestrator.BATCH_SIZE", 1
+    )
+    client = MagicMock()
+    client.send_agent_activity.side_effect = [
+        MagicMock(success=True, ingested=1, duplicates=0),
+        Detail("boom", status_code=500),
+        MagicMock(success=True, ingested=1, duplicates=0),
+    ]
+    events = [_rec("claude-code", "session_transcript", "p.jsonl", i) for i in range(3)]
+    agent = _resumable_agent("claude-code", "session_transcript", events)
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        collect_agent_activity(client)
+
+    scope = scope_for(client)
+    store = CursorStore.load()
+    assert store.get(scope, "claude-code", "session_transcript", "p.jsonl") == 0
+
+
+def test_non_resumable_source_is_not_tracked() -> None:
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=1, duplicates=0
+    )
+    agent = MagicMock()
+    agent.name = "cursor"
+    agent.agent_activity_sources = [
+        SimpleNamespace(kind="composer_bubble", supports_resume=False)
+    ]
+    agent.iter_agent_activity_events.return_value = iter(
+        [_rec("cursor", "composer_bubble", "state.vscdb", 0)]
+    )
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        collect_agent_activity(client)
+
+    scope = scope_for(client)
+    store = CursorStore.load()
+    assert store.get(scope, "cursor", "composer_bubble", "state.vscdb") == NOTHING
+
+
+def test_collect_passes_committed_cursor_as_resume_lookup() -> None:
+    """A pre-seeded cursor is handed to the agent as the resume lookup."""
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=0, duplicates=0
+    )
+    scope = scope_for(client)
+    seed = CursorStore.load()
+    seed.advance(scope, "claude-code", "session_transcript", "p.jsonl", 5)
+    seed.save()
+
+    captured = {}
+
+    def _iter(resume_for=None):
+        captured["mark"] = resume_for("session_transcript", "p.jsonl")
+        return iter([])
+
+    agent = MagicMock()
+    agent.name = "claude-code"
+    agent.agent_activity_sources = [
+        SimpleNamespace(kind="session_transcript", supports_resume=True)
+    ]
+    agent.iter_agent_activity_events.side_effect = _iter
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        collect_agent_activity(client)
+
+    assert captured["mark"] == 5
+
+
+def test_cursor_skips_record_with_non_integer_offset() -> None:
+    """A resumable record whose offset is not an int is excluded from the mark."""
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=1, duplicates=0
+    )
+    bad = AgentActivityEvent(
+        agent_name="claude-code",
+        source_kind="session_transcript",
+        source_path="p.jsonl",
+        record_offset="not-an-int",
+        content="{}",
+    )
+    agent = _resumable_agent("claude-code", "session_transcript", [bad])
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        collect_agent_activity(client)
+
+    scope = scope_for(client)
+    store = CursorStore.load()
+    assert store.get(scope, "claude-code", "session_transcript", "p.jsonl") == NOTHING
+
+
+def test_resume_end_to_end_skips_already_shipped_records(tmp_path) -> None:
+    """Full chain (real Claude source + real cursor): the second run, after one
+    new line is appended, ships only that new line."""
+    from ggshield.verticals.ai.agents.claude_code import Claude
+
+    # GG_USER_HOME_DIR / GG_CACHE_DIR are redirected to tmp_path by an autouse
+    # fixture, so the real source discovers this transcript and the cursor file
+    # lives in the isolated cache dir.
+    proj = tmp_path / "home" / ".claude" / "projects" / "-repo"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text('{"i": 0}\n{"i": 1}\n')
+
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=2, duplicates=0
+    )
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"claude": Claude()}):
+        first = collect_agent_activity(client)
+        assert first.parsed == 2
+
+        (proj / "s.jsonl").write_text('{"i": 0}\n{"i": 1}\n{"i": 2}\n')
+        client.send_agent_activity.reset_mock()
+        client.send_agent_activity.return_value = MagicMock(
+            success=True, ingested=1, duplicates=0
+        )
+        second = collect_agent_activity(client)
+
+    assert second.parsed == 1  # only the newly-appended line
+    payload = client.send_agent_activity.call_args.args[0]
+    assert [r["record_offset"] for r in payload] == ["2"]

--- a/tests/unit/verticals/ai/agent_activity/test_orchestrator.py
+++ b/tests/unit/verticals/ai/agent_activity/test_orchestrator.py
@@ -1,0 +1,191 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+from pygitguardian.models import Detail
+
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+from ggshield.verticals.ai.agent_activity.orchestrator import (
+    BATCH_SIZE,
+    MAX_BATCH_BYTES,
+    collect_agent_activity,
+    send_agent_activity_batch,
+)
+
+
+def test_send_agent_activity_batch_serialises_and_calls_client() -> None:
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=2, duplicates=0
+    )
+    events = [
+        AgentActivityEvent(
+            agent_name="claude-code",
+            source_kind="session_transcript",
+            source_path="projects/-p/bc7b2260.jsonl",
+            record_offset="0",
+            content='{"x": 1}',
+        ),
+        AgentActivityEvent(
+            agent_name="cursor",
+            source_kind="composer_bubble",
+            source_path="globalStorage/state.vscdb",
+            record_offset="bubbleId:abc:xyz",
+            content='{"key": "bubbleId:abc:xyz", "value": "{"y": 2}"}',
+        ),
+    ]
+    result = send_agent_activity_batch(client, events)
+    client.send_agent_activity.assert_called_once_with(
+        [
+            {
+                "agent_name": "claude-code",
+                "source_kind": "session_transcript",
+                "source_path": "projects/-p/bc7b2260.jsonl",
+                "record_offset": "0",
+                "content": '{"x": 1}',
+            },
+            {
+                "agent_name": "cursor",
+                "source_kind": "composer_bubble",
+                "source_path": "globalStorage/state.vscdb",
+                "record_offset": "bubbleId:abc:xyz",
+                "content": '{"key": "bubbleId:abc:xyz", "value": "{"y": 2}"}',
+            },
+        ]
+    )
+    assert result.ingested == 2
+
+
+def test_send_agent_activity_batch_empty_list_short_circuits() -> None:
+    client = MagicMock()
+    result = send_agent_activity_batch(client, [])
+    client.send_agent_activity.assert_not_called()
+    assert result.ingested == 0
+
+
+def test_send_agent_activity_batch_treats_detail_as_failure() -> None:
+    """An API error (Detail) is reported as a failed batch, not an ingest."""
+    client = MagicMock()
+    client.send_agent_activity.return_value = Detail("boom", status_code=500)
+    result = send_agent_activity_batch(client, [_event("a", 1)])
+    assert result.success is False
+    assert result.ingested == 0
+    assert result.duplicates == 0
+
+
+def test_collect_agent_activity_counts_detail_response_as_failed_batch() -> None:
+    client = MagicMock()
+    client.send_agent_activity.return_value = Detail("boom", status_code=500)
+    with patch(
+        "ggshield.verticals.ai.agents.AGENTS",
+        {"a": _make_agent("a", [_event("a", 1)])},
+    ):
+        report = collect_agent_activity(client)
+    assert report.parsed == 1
+    assert report.ingested == 0
+    assert report.failed_batches == 1
+
+
+def _make_agent(name: str, events: list[AgentActivityEvent]) -> MagicMock:
+    a = MagicMock()
+    a.name = name
+    a.iter_agent_activity_events.return_value = iter(events)
+    return a
+
+
+def _event(agent_name: str, i: int) -> AgentActivityEvent:
+    return AgentActivityEvent(
+        agent_name=agent_name,
+        source_kind="k",
+        source_path="f.jsonl",
+        record_offset=str(i),
+        content=f'{{"i": {i}}}',
+    )
+
+
+def test_collect_agent_activity_batches_in_chunks_of_batch_size() -> None:
+    """An agent yielding more than BATCH_SIZE events triggers multiple sends."""
+    events = [_event("a", i) for i in range(BATCH_SIZE + 3)]
+    agent = _make_agent("a", events)
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=BATCH_SIZE, duplicates=0
+    )
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": agent}):
+        report = collect_agent_activity(client)
+
+    assert client.send_agent_activity.call_count == 2
+    assert report.parsed == BATCH_SIZE + 3
+
+
+def test_collect_agent_activity_aggregates_per_agent_counts() -> None:
+    events_a = [_event("a", 1)]
+    events_b = [_event("b", 2)]
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(
+        success=True, ingested=2, duplicates=0
+    )
+
+    with patch(
+        "ggshield.verticals.ai.agents.AGENTS",
+        {
+            "a": _make_agent("a", events_a),
+            "b": _make_agent("b", events_b),
+        },
+    ):
+        report = collect_agent_activity(client)
+
+    assert report.parsed == 2
+    assert report.ingested == 2
+
+
+def test_collect_agent_activity_handles_empty_agents() -> None:
+    client = MagicMock()
+    with patch(
+        "ggshield.verticals.ai.agents.AGENTS",
+        {
+            "a": _make_agent("a", []),
+        },
+    ):
+        report = collect_agent_activity(client)
+    client.send_agent_activity.assert_not_called()
+    assert report.parsed == 0
+
+
+def test_collect_agent_activity_flushes_on_byte_threshold() -> None:
+    """Large records flush on the byte budget before reaching BATCH_SIZE count."""
+    big = "x" * (MAX_BATCH_BYTES + 1)  # each event alone exceeds the budget
+    events = [
+        AgentActivityEvent(
+            agent_name="a",
+            source_kind="k",
+            source_path="f",
+            record_offset=str(i),
+            content=big,
+        )
+        for i in range(3)
+    ]
+    client = MagicMock()
+    client.send_agent_activity.return_value = MagicMock(ingested=1, duplicates=0)
+
+    with patch("ggshield.verticals.ai.agents.AGENTS", {"a": _make_agent("a", events)}):
+        report = collect_agent_activity(client)
+
+    # 3 oversized events => 3 separate sends, none waiting for the 500 count.
+    assert client.send_agent_activity.call_count == 3
+    assert report.parsed == 3
+
+
+def test_collect_agent_activity_counts_network_error_as_failed_batch() -> None:
+    """A network error while sending a batch is counted as a failed batch."""
+    client = MagicMock()
+    client.send_agent_activity.side_effect = requests.exceptions.ConnectionError("down")
+    with patch(
+        "ggshield.verticals.ai.agents.AGENTS",
+        {"a": _make_agent("a", [_event("a", 1)])},
+    ):
+        report = collect_agent_activity(client)
+
+    assert report.parsed == 1
+    assert report.ingested == 0
+    assert report.failed_batches == 1

--- a/tests/unit/verticals/ai/agent_activity/test_readers.py
+++ b/tests/unit/verticals/ai/agent_activity/test_readers.py
@@ -1,0 +1,74 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ggshield.verticals.ai.agent_activity.readers import iter_jsonl, iter_sqlite_rows
+
+
+def test_iter_jsonl_yields_each_line_as_raw_string(tmp_path: Path) -> None:
+    f = tmp_path / "log.jsonl"
+    f.write_text('{"a": 1}\n{"b": 2}\n')
+    assert list(iter_jsonl(f)) == ['{"a": 1}', '{"b": 2}']
+
+
+def test_iter_jsonl_preserves_content_verbatim_even_if_unparseable(
+    tmp_path: Path,
+) -> None:
+    """No JSON parsing — every non-empty line is yielded as-is."""
+    f = tmp_path / "log.jsonl"
+    f.write_text('{"a": 1}\nnot-json\n  {"b": 2}  \n')
+    assert list(iter_jsonl(f)) == ['{"a": 1}', "not-json", '  {"b": 2}  ']
+
+
+def test_iter_jsonl_drops_blank_lines(tmp_path: Path) -> None:
+    f = tmp_path / "log.jsonl"
+    f.write_text('{"a": 1}\n\n   \n{"b": 2}\n')
+    assert list(iter_jsonl(f)) == ['{"a": 1}', '{"b": 2}']
+
+
+def test_iter_jsonl_missing_file_yields_nothing(tmp_path: Path) -> None:
+    assert list(iter_jsonl(tmp_path / "absent.jsonl")) == []
+
+
+@pytest.fixture
+def kv_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "data.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE kv (key TEXT, value TEXT)")
+    conn.executemany(
+        "INSERT INTO kv (key, value) VALUES (?, ?)",
+        [("a", "1"), ("b", "2"), ("c", "3")],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_iter_sqlite_rows_yields_dicts(kv_db: Path) -> None:
+    rows = list(iter_sqlite_rows(kv_db, "SELECT key, value FROM kv ORDER BY key"))
+    assert rows == [
+        {"key": "a", "value": "1"},
+        {"key": "b", "value": "2"},
+        {"key": "c", "value": "3"},
+    ]
+
+
+def test_iter_sqlite_rows_passes_parameters(kv_db: Path) -> None:
+    rows = list(iter_sqlite_rows(kv_db, "SELECT value FROM kv WHERE key = ?", ("b",)))
+    assert rows == [{"value": "2"}]
+
+
+def test_iter_sqlite_rows_missing_db_yields_nothing(tmp_path: Path) -> None:
+    assert list(iter_sqlite_rows(tmp_path / "absent.db", "SELECT 1")) == []
+
+
+def test_iter_sqlite_rows_opens_read_only(kv_db: Path) -> None:
+    """Writes via the opened connection must not succeed."""
+    rows = list(
+        iter_sqlite_rows(kv_db, "INSERT INTO kv (key, value) VALUES ('x', 'y')")
+    )
+    assert rows == []
+    conn = sqlite3.connect(kv_db)
+    assert conn.execute("SELECT count(*) FROM kv WHERE key='x'").fetchone() == (0,)
+    conn.close()

--- a/tests/unit/verticals/ai/agent_activity/test_sources.py
+++ b/tests/unit/verticals/ai/agent_activity/test_sources.py
@@ -88,6 +88,62 @@ def test_jsonl_source_ships_line_verbatim_by_default(tmp_path: Path) -> None:
     assert event.content == '{"a": 1, "cmd": "ls -la"}'
 
 
+def test_jsonl_supports_resume_but_json_does_not():
+    # Only append-only sources can be resumed by index.
+    assert JSONLActivitySource.supports_resume is True
+    assert JSONActivitySource.supports_resume is False
+    assert SQLiteActivitySource.supports_resume is False
+
+
+def test_iter_events_resumes_after_high_water(tmp_path: Path) -> None:
+    """resume_for skips records at or below the per-source mark (append-only)."""
+    f = tmp_path / "s.jsonl"
+    f.write_text("".join(f'{{"i": {i}}}\n' for i in range(4)))
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return [f]
+
+    # Already shipped up to index 1 -> only indices 2 and 3 are yielded.
+    events = list(
+        S().iter_events(
+            agent_name="t", path_root=tmp_path, resume_for=lambda kind, sp: 1
+        )
+    )
+    assert [e.record_offset for e in events] == ["2", "3"]
+
+
+def test_iter_events_ignores_resume_for_non_resumable_source(tmp_path: Path) -> None:
+    """A source that does not support resume re-reads everything regardless."""
+    db = tmp_path / "x.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE kv (key TEXT, value TEXT)")
+    conn.executemany("INSERT INTO kv VALUES (?, ?)", [("k1", "v1"), ("k2", "v2")])
+    conn.commit()
+    conn.close()
+
+    class S(SQLiteActivitySource):
+        kind = "demo_kv"
+        query = "SELECT key, value FROM kv ORDER BY key"
+        key_columns = ("key",)
+
+        def discover(self) -> Iterable[Path]:
+            return [db]
+
+        def serialize(self, record: object) -> str:  # type: ignore[override]
+            return json.dumps(record)
+
+    # Even with a high mark, every row is still yielded.
+    events = list(
+        S().iter_events(
+            agent_name="t", path_root=tmp_path, resume_for=lambda kind, sp: 99
+        )
+    )
+    assert [e.record_offset for e in events] == ["k1", "k2"]
+
+
 def test_source_path_for_redacts_home_when_outside_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/verticals/ai/agent_activity/test_sources.py
+++ b/tests/unit/verticals/ai/agent_activity/test_sources.py
@@ -1,0 +1,260 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from ggshield.verticals.ai.agent_activity.models import AgentActivityEvent
+from ggshield.verticals.ai.agent_activity.sources import (
+    CONTENT_TRUNCATED_MARKER,
+    MAX_CONTENT_BYTES,
+    JSONActivitySource,
+    JSONLActivitySource,
+    SQLiteActivitySource,
+)
+
+
+def test_jsonl_source_yields_raw_lines_with_offsets_and_relative_path(
+    tmp_path: Path,
+) -> None:
+    a = tmp_path / "a.jsonl"
+    a.write_text('{"i": 1}\n{"i": 2}\n')
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return [a]
+
+        def serialize(self, record: str) -> str:  # type: ignore[override]
+            return record
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert events == [
+        AgentActivityEvent(
+            agent_name="t",
+            source_kind="demo",
+            source_path="a.jsonl",
+            record_offset="0",
+            content='{"i": 1}',
+        ),
+        AgentActivityEvent(
+            agent_name="t",
+            source_kind="demo",
+            source_path="a.jsonl",
+            record_offset="1",
+            content='{"i": 2}',
+        ),
+    ]
+
+
+def test_jsonl_source_serialize_strips_pii_fields(tmp_path: Path) -> None:
+    f = tmp_path / "x.jsonl"
+    f.write_text(
+        '{"msg": "hello", "pii": "secret"}\n{"msg": "world", "pii": "other"}\n'
+    )
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return [f]
+
+        def serialize(self, record: str) -> str:  # type: ignore[override]
+            data = json.loads(record)
+            data.pop("pii", None)
+            return json.dumps(data)
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert [(e.record_offset, e.content) for e in events] == [
+        ("0", '{"msg": "hello"}'),
+        ("1", '{"msg": "world"}'),
+    ]
+
+
+def test_jsonl_source_ships_line_verbatim_by_default(tmp_path: Path) -> None:
+    """The JSONL base ships each raw line unchanged (the client stays 'dumb')."""
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1, "cmd": "ls -la"}\n')
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return [f]
+
+    [event] = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert event.content == '{"a": 1, "cmd": "ls -la"}'
+
+
+def test_source_path_for_redacts_home_when_outside_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Files outside path_root are made home-relative so $HOME never leaks."""
+    fake_home = tmp_path / "home" / "alice"
+    fake_home.mkdir(parents=True)
+    monkeypatch.setenv("GG_USER_HOME_DIR", str(fake_home))
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return []
+
+    outside = fake_home / ".codex" / "sessions" / "rollout.jsonl"
+    assert (
+        S().source_path_for(outside, tmp_path / "unrelated")
+        == "~/.codex/sessions/rollout.jsonl"
+    )
+
+
+def test_iter_events_caps_oversized_content(tmp_path: Path) -> None:
+    """A record larger than MAX_CONTENT_BYTES is truncated with a marker."""
+    f = tmp_path / "big.jsonl"
+    f.write_text("x" * (MAX_CONTENT_BYTES + 5000) + "\n")
+
+    class S(JSONLActivitySource):
+        kind = "demo"
+
+        def discover(self) -> Iterable[Path]:
+            return [f]
+
+        def serialize(self, record: str) -> str:  # type: ignore[override]
+            return record
+
+    [event] = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert event.content.endswith(CONTENT_TRUNCATED_MARKER)
+    body = event.content[: -len(CONTENT_TRUNCATED_MARKER)]
+    assert len(body.encode("utf-8")) <= MAX_CONTENT_BYTES
+
+
+def test_json_source_yields_one_record_per_file(tmp_path: Path) -> None:
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text('{"hello": "world"}')
+    b.write_text("[1, 2, 3]")
+
+    class S(JSONActivitySource):
+        kind = "json_file"
+
+        def discover(self) -> Iterable[Path]:
+            return sorted(tmp_path.glob("*.json"))
+
+        def serialize(self, record: str) -> str:  # type: ignore[override]
+            return record
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert events == [
+        AgentActivityEvent(
+            agent_name="t",
+            source_kind="json_file",
+            source_path="a.json",
+            record_offset="0",
+            content='{"hello": "world"}',
+        ),
+        AgentActivityEvent(
+            agent_name="t",
+            source_kind="json_file",
+            source_path="b.json",
+            record_offset="0",
+            content="[1, 2, 3]",
+        ),
+    ]
+
+
+def test_sqlite_source_raises_without_key_columns(tmp_path: Path) -> None:
+    """Forgetting key_columns is a footgun, so the base class refuses to fall back."""
+    db = tmp_path / "x.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE t (k TEXT, v INTEGER)")
+    conn.execute("INSERT INTO t VALUES ('a', 1)")
+    conn.commit()
+    conn.close()
+
+    class S(SQLiteActivitySource):
+        kind = "demo_rows"
+        query = "SELECT k, v FROM t"
+
+        def discover(self) -> Iterable[Path]:
+            return [db]
+
+        def serialize(self, record: object) -> str:  # type: ignore[override]
+            return json.dumps(record)
+
+    with pytest.raises(NotImplementedError, match="key_columns"):
+        list(S().iter_events(agent_name="t", path_root=tmp_path))
+
+
+def test_sqlite_source_uses_key_columns_for_offset(tmp_path: Path) -> None:
+    """Single key column → record_offset is that column's value."""
+    db = tmp_path / "x.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE kv (key TEXT, value TEXT)")
+    conn.executemany("INSERT INTO kv VALUES (?, ?)", [("k1", "v1"), ("k2", "v2")])
+    conn.commit()
+    conn.close()
+
+    class S(SQLiteActivitySource):
+        kind = "demo_kv"
+        query = "SELECT key, value FROM kv ORDER BY key"
+        key_columns = ("key",)
+
+        def discover(self) -> Iterable[Path]:
+            return [db]
+
+        def serialize(self, record: object) -> str:  # type: ignore[override]
+            return json.dumps(record)
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert [e.record_offset for e in events] == ["k1", "k2"]
+
+
+def test_sqlite_source_composite_key_columns(tmp_path: Path) -> None:
+    """Multiple key columns → record_offset is a tuple of their values, in order."""
+    db = tmp_path / "x.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE t (a TEXT, b TEXT, v INTEGER)")
+    conn.executemany("INSERT INTO t VALUES (?, ?, ?)", [("x", "1", 10), ("x", "2", 20)])
+    conn.commit()
+    conn.close()
+
+    class S(SQLiteActivitySource):
+        kind = "demo_composite"
+        query = "SELECT a, b, v FROM t ORDER BY a, b"
+        key_columns = ("a", "b")
+
+        def discover(self) -> Iterable[Path]:
+            return [db]
+
+        def serialize(self, record: object) -> str:  # type: ignore[override]
+            return json.dumps(record)
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert [e.record_offset for e in events] == ['["x", "1"]', '["x", "2"]']
+
+
+def test_sqlite_source_record_offset_override_still_wins(tmp_path: Path) -> None:
+    """Subclasses may still override record_offset() for non-trivial cases."""
+    db = tmp_path / "x.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE kv (key TEXT, value TEXT)")
+    conn.execute("INSERT INTO kv VALUES ('k1', 'v1')")
+    conn.commit()
+    conn.close()
+
+    class S(SQLiteActivitySource):
+        kind = "demo_custom"
+        query = "SELECT key, value FROM kv"
+
+        def discover(self) -> Iterable[Path]:
+            return [db]
+
+        def record_offset(self, record: dict, index: int) -> str:  # type: ignore[override]
+            return f"custom:{record['key']}"
+
+        def serialize(self, record: object) -> str:  # type: ignore[override]
+            return json.dumps(record)
+
+    events = list(S().iter_events(agent_name="t", path_root=tmp_path))
+    assert [e.record_offset for e in events] == ["custom:k1"]

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -9,6 +9,7 @@ from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserI
 from ggshield.__main__ import cli
 from ggshield.cmd.ai.discover import print_summary
 from ggshield.core.errors import APIKeyCheckError
+from ggshield.verticals.ai.agent_activity.orchestrator import AgentActivityReport
 from ggshield.verticals.ai.history import BackfillReport
 from ggshield.verticals.ai.models import Scope, Transport
 
@@ -410,6 +411,92 @@ class TestDiscoverCmd:
             "duplicates": 1,
             "skipped": 1,
         }
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch(
+        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        return_value=BackfillReport(parsed=3, ingested=3, duplicates=0),
+    )
+    @patch(
+        "ggshield.cmd.ai.discover.collect_agent_activity",
+        return_value=AgentActivityReport(
+            parsed=7, ingested=7, duplicates=0, failed_batches=0
+        ),
+    )
+    def test_history_flag_also_collects_agent_activity(
+        self,
+        mock_collect: MagicMock,
+        mock_backfill: MagicMock,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        discovery = _discovery(
+            servers=[
+                _server(
+                    "my-mcp",
+                    display_name="My MCP",
+                    configurations=[_config(agent="cursor", scope=Scope.USER)],
+                )
+            ]
+        )
+        mock_submit.return_value = discovery
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--history"])
+        assert result.exit_code == 0, result.output
+        mock_backfill.assert_called_once()
+        mock_collect.assert_called_once()
+        assert "3" in result.output and "7" in result.output
+
+    @patch(
+        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        return_value=_discovery(),
+    )
+    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
+    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch(
+        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        return_value=BackfillReport(parsed=3, ingested=3, duplicates=0),
+    )
+    @patch(
+        "ggshield.cmd.ai.discover.collect_agent_activity",
+        return_value=AgentActivityReport(
+            parsed=10, ingested=8, duplicates=0, failed_batches=2
+        ),
+    )
+    def test_agent_activity_surfaces_failed_batches(
+        self,
+        mock_collect: MagicMock,
+        mock_backfill: MagicMock,
+        mock_save: MagicMock,
+        mock_submit: MagicMock,
+        mock_client: MagicMock,
+        mock_discover: MagicMock,
+    ):
+        discovery = _discovery(
+            servers=[
+                _server(
+                    "my-mcp",
+                    display_name="My MCP",
+                    configurations=[_config(agent="cursor", scope=Scope.USER)],
+                )
+            ]
+        )
+        mock_submit.return_value = discovery
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ai", "discover", "--history"])
+        assert result.exit_code == 0, result.output
+        assert "Failed batches: 2" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -1,14 +1,15 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional
 from unittest.mock import patch
 
 import pytest
-from pygitguardian.models import MCPConfiguration
+from pygitguardian.models import AIDiscovery, MCPActivityRequest, MCPConfiguration
 
 from ggshield.core.scan import File, StringScannable
 from ggshield.verticals.ai.agents import Cursor
 from ggshield.verticals.ai.models import (
+    Agent,
     EventType,
     HookPayload,
     HookResult,
@@ -266,3 +267,109 @@ class TestDiscoverMcpConfigurations:
         with patch.object(type(agent), "config_folder", new=tmp_path / "empty"):
             result = agent.discover_mcp_configurations([])
         assert result == []
+
+
+class _FakeAgent(Agent):
+    """Minimal Agent stub satisfying every abstract member of the ABC."""
+
+    @property
+    def display_name(self) -> str:
+        return "Fake"
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def config_folder(self) -> Path:
+        return Path("/tmp/fake")
+
+    def output_result(self, result: HookResult) -> int:
+        return 0
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return False
+
+    def settings_path(self, mode: Literal["local", "global"]) -> Path:
+        return Path("/tmp/fake/settings.json")
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".fake" / "mcp.json"
+
+    @property
+    def user_mcp_file(self) -> Path:
+        return Path("/tmp/fake/mcp.json")
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        return iter([])
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        raise NotImplementedError
+
+
+def test_agent_default_agent_activity_sources_is_empty() -> None:
+    assert _FakeAgent().agent_activity_sources == []
+
+
+def test_agent_iter_agent_activity_events_loops_each_source(tmp_path: Path) -> None:
+    """Each source is invoked with the agent's config_folder so source_path is relative to it."""
+    from ggshield.verticals.ai.agent_activity import (
+        AgentActivityEvent,
+        JSONLActivitySource,
+    )
+
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    f1 = cfg / "a.jsonl"
+    f2 = cfg / "b.jsonl"
+    f1.write_text('{"x": 1}\n')
+    f2.write_text('{"x": 2}\n')
+
+    class S1(JSONLActivitySource):
+        @property
+        def kind(self):
+            return "k1"
+
+        def discover(self) -> Iterable[Path]:
+            return [f1]
+
+        def serialize(self, record):
+            return record
+
+    class S2(JSONLActivitySource):
+        @property
+        def kind(self):
+            return "k2"
+
+        def discover(self) -> Iterable[Path]:
+            return [f2]
+
+        def serialize(self, record):
+            return record
+
+    class A(_FakeAgent):
+        agent_activity_sources = [S1(), S2()]
+
+        @property
+        def config_folder(self) -> Path:
+            return cfg
+
+    events = list(A().iter_agent_activity_events())
+    assert events == [
+        AgentActivityEvent(
+            agent_name="fake",
+            source_kind="k1",
+            source_path="a.jsonl",
+            record_offset="0",
+            content='{"x": 1}',
+        ),
+        AgentActivityEvent(
+            agent_name="fake",
+            source_kind="k2",
+            source_path="b.jsonl",
+            record_offset="0",
+            content='{"x": 2}',
+        ),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -935,7 +935,7 @@ requires-dist = [
     { name = "oauthlib", specifier = "~=3.2.1" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d3152b7bf33077fd17a8ea692d658dd428c73ac3" },
+    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d0dbef612cdda82dd9e8f2fc1c7b435b3ebf1817" },
     { name = "pyjwt", specifier = "~=2.6.0" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
@@ -2608,7 +2608,7 @@ wheels = [
 [[package]]
 name = "pygitguardian"
 version = "1.30.0"
-source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d3152b7bf33077fd17a8ea692d658dd428c73ac3#d3152b7bf33077fd17a8ea692d658dd428c73ac3" }
+source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=d0dbef612cdda82dd9e8f2fc1c7b435b3ebf1817#d0dbef612cdda82dd9e8f2fc1c7b435b3ebf1817" }
 dependencies = [
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },


### PR DESCRIPTION
## What

Stacked on #1259. `ggshield ai discover --history` re-read every agent transcript on each run and re-sent every record (which GitGuardian then re-scans and deduplicates server-side). This adds a local **cursor** so append-only transcripts only ship records added since the last run.

## How

- A JSON cursor file in the cache dir (`agent_activity_cursors.json`) holds a per-source line-index high-water mark, keyed `scope → agent → source_kind → source_path`.
- **Scope** = `sha256(base_uri + api_key)[:16]` — switching instance/credential starts clean; the raw key is never stored.
- **Best-effort / fail-open:** a missing, corrupt, or unwritable cursor just causes a full re-scan (the server deduplicates), never incorrect data. Delete the file to force one.
- A source's mark advances only over the **contiguous successfully-ingested prefix**; a failed batch *freezes* its sources so the next run resends the gap rather than skipping past it.
- Only append-only **JSONL** transcripts resume (`supports_resume=True`); database-backed sources (Cursor `state.vscdb`) keep full re-scan, since rows are edited in place.

## Tests

- New `test_cursors.py` (store: roundtrip, scope isolation, never-backwards, fail-open load/save) and resume tests in `test_sources.py` / `test_orchestrator.py` (advance-on-success, freeze-on-failure-gap, non-resumable-not-tracked, plus a real-chain integration test: Claude source + cursor across two runs ships only the appended line).
- `cursors.py` and `orchestrator.py` at 100% line coverage; 409 AI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)