### PR TITLE
Jeremycotineau/hon 1419 harden honeytoken plant aws file handling comments read only

### DIFF
--- a/changelog.d/20260602_155124_jeremy.cotineau_ggshield_plant_honeytoken.md
+++ b/changelog.d/20260602_155124_jeremy.cotineau_ggshield_plant_honeytoken.md
@@ -1,4 +1,4 @@
 ### Added
 
 - `ggshield honeytoken plant` reconciles this machine's honeytokens with
-  GitGuardian and writes or removes the decoy AWS credential profiles on disk.
+  GitGuardian and writes or removes the decoy AWS credential profiles on disk. Existing comments and file permissions are preserved.

--- a/ggshield/cmd/honeytoken/plant.py
+++ b/ggshield/cmd/honeytoken/plant.py
@@ -220,9 +220,9 @@ def _reconcile_for_user(
                     err=True,
                 )
             elif result is RemoveOutcome.REMOVED and path.exists():
-                # The removal rewrote the file (other profiles remain). As root that
-                # temp-file+os.replace leaves it root-owned 0600, locking the target
-                # user out of their own ~/.aws — re-assert their ownership/perms.
+                # The removal rewrote the file (other profiles remain). As root the
+                # temp-file swap leaves it root-owned, locking the target user out of
+                # their own ~/.aws — re-assert their ownership (the mode is preserved).
                 apply_perms_and_owner(path, target, running_as_root)
             _confirm(client, item, ConfirmStatus.REMOVED, target)
             removed += 1

--- a/ggshield/verticals/honeytoken/aws_profile.py
+++ b/ggshield/verticals/honeytoken/aws_profile.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 import configparser
 import enum
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Optional, Tuple
+
+from configupdater import ConfigUpdater
 
 from ggshield.verticals.honeytoken.endpoint_deployments import (
     DeploymentMethod,
@@ -87,31 +90,62 @@ def resolve_placement(
     raise PlacementError("unsupported deployment method — client may be out of date")
 
 
-def _load(path: Path) -> configparser.ConfigParser:
-    # interpolation=None: AWS secret keys can contain ``%``, which the default
-    # interpolation would choke on.
-    parser = configparser.ConfigParser(interpolation=None)
+def _load(path: Path) -> ConfigUpdater:
+    # configupdater edits in place and keeps comments (configparser wouldn't).
+    parser = ConfigUpdater()
     if path.exists():
         try:
-            parser.read(path, encoding="utf-8")
+            text = path.read_text(encoding="utf-8")
+            # Else configupdater glues our new section onto the last line.
+            if text and not text.endswith("\n"):
+                text += "\n"
+            parser.read_string(text)
         except (configparser.Error, UnicodeDecodeError) as exc:
-            # A malformed/garbage file is an expected condition, not a crash: surface it
-            # as a PlacementError so the caller reports a clean per-deployment failure
-            # and leaves the file untouched.
+            # configupdater parse errors subclass configparser.Error.
             raise PlacementError(
                 f"could not parse {path}: not a valid AWS credentials/INI file ({exc})"
             )
     return parser
 
 
-def _atomic_write(path: Path, parser: configparser.ConfigParser) -> None:
+def _get_value(parser: ConfigUpdater, section: str, key: str) -> Optional[str]:
+    sec = parser[section]
+    if sec.has_option(key):
+        return sec[key].value
+    return None
+
+
+def _reject_symlinked_target(path: Path) -> None:
+    """Refuse a symlinked ``.aws`` dir or credentials file: as root in the fan-out,
+    following it would redirect the write/chmod/chown outside the user's home."""
+    parent = path.parent
+    if parent.is_symlink():
+        raise PlacementError(
+            f"refusing to use {parent}: '.aws' is a symlink "
+            "(possible redirect outside the home directory)"
+        )
+    if path.is_symlink():
+        raise PlacementError(
+            f"refusing to write through symlinked credentials file {path}"
+        )
+
+
+def _atomic_write(path: Path, parser: ConfigUpdater) -> None:
+    _reject_symlinked_target(path)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # Preserve the file's existing mode (new file → 0600).
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        mode = 0o600
     fd, tmp = tempfile.mkstemp(prefix=".plant.", suffix=".tmp", dir=str(path.parent))
     try:
-        os.chmod(tmp, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             parser.write(handle)
+        # Swap first (temp stays at mkstemp's 0600 while holding the secret), then
+        # restore the final mode — chmod'ing the temp pre-swap would briefly widen it.
         os.replace(tmp, path)
+        os.chmod(path, mode)
     except BaseException:
         try:
             os.unlink(tmp)
@@ -131,10 +165,11 @@ def write_aws_profile(
       (rotation is handled upstream by processing ``delete`` before ``write``, so this
       only trips on a genuine collision the operator should review)
     """
+    _reject_symlinked_target(path)
     parser = _load(path)
     if parser.has_section(section):
-        existing_id = parser.get(section, _ACCESS_KEY, fallback=None)
-        existing_secret = parser.get(section, _SECRET_KEY, fallback=None)
+        existing_id = _get_value(parser, section, _ACCESS_KEY)
+        existing_secret = _get_value(parser, section, _SECRET_KEY)
         if existing_id == creds.access_token_id and existing_secret == creds.secret_key:
             return WriteOutcome.ALREADY_CURRENT
         if not force:
@@ -142,8 +177,8 @@ def write_aws_profile(
     else:
         parser.add_section(section)
 
-    parser.set(section, _ACCESS_KEY, creds.access_token_id)
-    parser.set(section, _SECRET_KEY, creds.secret_key)
+    parser[section][_ACCESS_KEY] = creds.access_token_id
+    parser[section][_SECRET_KEY] = creds.secret_key
     _atomic_write(path, parser)
     return WriteOutcome.WROTE
 
@@ -151,14 +186,16 @@ def write_aws_profile(
 def remove_aws_profile(
     path: Path, section: str, expected_access_key_id: Optional[str]
 ) -> RemoveOutcome:
-    """Remove the named honeytoken profile, leaving other profiles intact. If ours was
-    the only one, remove the file rather than leave an empty stub.
+    """Remove the named honeytoken profile, leaving other profiles intact. Remove the
+    file only when nothing at all is left (no other profile **and** no comments) rather
+    than leave an empty stub.
 
     When ``expected_access_key_id`` is set, the profile is removed **only if** its
     ``aws_access_key_id`` matches — a profile holding a different key is foreign and is
     left untouched (``FOREIGN_KEPT``). ``None`` removes by name unconditionally (legacy /
     when the server omitted the token).
     """
+    _reject_symlinked_target(path)
     if not path.exists():
         return RemoveOutcome.ALREADY_ABSENT
     parser = _load(path)
@@ -166,15 +203,16 @@ def remove_aws_profile(
         return RemoveOutcome.ALREADY_ABSENT
 
     if expected_access_key_id is not None:
-        on_disk = parser.get(section, _ACCESS_KEY, fallback=None)
+        on_disk = _get_value(parser, section, _ACCESS_KEY)
         if on_disk != expected_access_key_id:
             return RemoveOutcome.FOREIGN_KEPT
 
     parser.remove_section(section)
-    if parser.sections():
+    # Empty `sections()` can still mean a comments-only file (ConfigUpdater keeps them),
+    # so test the rendered content — unlink only when nothing at all is left.
+    if str(parser).strip():
         _atomic_write(path, parser)
     else:
-        # Last section gone — drop the now-empty file rather than leave a stub behind.
         try:
             path.unlink()
         except OSError:

--- a/ggshield/verticals/honeytoken/aws_profile.py
+++ b/ggshield/verticals/honeytoken/aws_profile.py
@@ -8,6 +8,11 @@ methods land under ``~/.aws/``. The two methods differ only in the INI section n
 - ``aws_credentials`` → ``[profile_name]`` in the shared **credentials** file.
 - ``aws_config_profile`` → ``[profile profile_name]`` in the **config** file (AWS
   mandates the ``profile `` prefix there).
+
+Privileged handling runs in the root fan-out: on POSIX we anchor every op to a ``.aws`` fd
+opened ``O_NOFOLLOW`` (``dir_fd``/``fchmod``/no-follow), so the fd pins the real inode and a
+symlink swapped in after a check (TOCTOU) has no effect. Windows lacks dir fds and uses a
+path-based check (no root fan-out there).
 """
 
 from __future__ import annotations
@@ -36,6 +41,15 @@ SUPPORTED_METHODS = (
 
 _ACCESS_KEY = "aws_access_key_id"
 _SECRET_KEY = "aws_secret_access_key"
+
+# No-follow, fd-anchored file ops available (POSIX). os.rename (not os.replace) carries
+# dir_fd on Linux+macOS and replaces atomically on POSIX.
+FD_HARDENED = (
+    hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.rename in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+)
 
 
 class WriteOutcome(enum.Enum):
@@ -90,20 +104,22 @@ def resolve_placement(
     raise PlacementError("unsupported deployment method — client may be out of date")
 
 
-def _load(path: Path) -> ConfigUpdater:
+# --- INI parsing + our-profile decision (shared by both I/O backends) -------------
+
+
+def _parse_text(text: Optional[str], where: Path) -> ConfigUpdater:
     # configupdater edits in place and keeps comments (configparser wouldn't).
     parser = ConfigUpdater()
-    if path.exists():
+    if text:
+        # Else configupdater glues our new section onto the last line.
+        if not text.endswith("\n"):
+            text += "\n"
         try:
-            text = path.read_text(encoding="utf-8")
-            # Else configupdater glues our new section onto the last line.
-            if text and not text.endswith("\n"):
-                text += "\n"
             parser.read_string(text)
         except (configparser.Error, UnicodeDecodeError) as exc:
             # configupdater parse errors subclass configparser.Error.
             raise PlacementError(
-                f"could not parse {path}: not a valid AWS credentials/INI file ({exc})"
+                f"could not parse {where}: not a valid AWS credentials/INI file ({exc})"
             )
     return parser
 
@@ -115,25 +131,138 @@ def _get_value(parser: ConfigUpdater, section: str, key: str) -> Optional[str]:
     return None
 
 
-def _reject_symlinked_target(path: Path) -> None:
-    """Refuse a symlinked ``.aws`` dir or credentials file: as root in the fan-out,
-    following it would redirect the write/chmod/chown outside the user's home."""
-    parent = path.parent
-    if parent.is_symlink():
+def _decide_write(
+    parser: ConfigUpdater,
+    section: str,
+    creds: HoneytokenCreds,
+    force: bool,
+    path: Path,
+) -> WriteOutcome:
+    """Mutate ``parser`` to hold our profile and return the outcome.
+
+    - profile absent → write
+    - profile present with the same access key **and** secret → no-op (``ALREADY_CURRENT``)
+    - profile present but access key id **and/or** secret differ → refuse unless ``force``
+    """
+    if parser.has_section(section):
+        existing_id = _get_value(parser, section, _ACCESS_KEY)
+        existing_secret = _get_value(parser, section, _SECRET_KEY)
+        if existing_id == creds.access_token_id and existing_secret == creds.secret_key:
+            return WriteOutcome.ALREADY_CURRENT
+        if not force:
+            raise ForceRefusal(section, path)
+    else:
+        parser.add_section(section)
+    parser[section][_ACCESS_KEY] = creds.access_token_id
+    parser[section][_SECRET_KEY] = creds.secret_key
+    return WriteOutcome.WROTE
+
+
+# --- no-follow, fd-anchored backend (POSIX) ---------------------------------------
+
+
+def open_aws_dir_fd(aws_dir: Path, *, create: bool) -> int:
+    """Open ``.aws`` ``O_NOFOLLOW|O_DIRECTORY``, returning an fd that pins the real inode
+    (swap-immune). Symlink/non-dir → ``PlacementError``. ``create`` makes a missing dir
+    0700; else ``FileNotFoundError`` propagates (callers treat absent as a no-op)."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        return os.open(aws_dir, flags)
+    except FileNotFoundError:
+        if not create:
+            raise
+    except OSError as exc:
         raise PlacementError(
-            f"refusing to use {parent}: '.aws' is a symlink "
-            "(possible redirect outside the home directory)"
+            f"refusing to use {aws_dir}: not a real directory (symlink?): {exc}"
         )
-    if path.is_symlink():
+    # Create the home chain, then `.aws` itself 0700 (the no-follow re-open is the gate).
+    os.makedirs(aws_dir.parent, mode=0o700, exist_ok=True)
+    try:
+        os.mkdir(aws_dir, 0o700)
+    except FileExistsError:
+        pass
+    try:
+        return os.open(aws_dir, flags)
+    except OSError as exc:
         raise PlacementError(
-            f"refusing to write through symlinked credentials file {path}"
+            f"refusing to use {aws_dir}: not a real directory (symlink?): {exc}"
         )
 
 
-def _atomic_write(path: Path, parser: ConfigUpdater) -> None:
-    _reject_symlinked_target(path)
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+def _read_via_fd(dir_fd: int, name: str) -> Optional[str]:
+    """Read ``name`` under the pinned dir, no-follow. ``None`` if absent."""
+    try:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:  # ELOOP → the file itself is a symlink
+        raise PlacementError(
+            f"refusing to read through symlinked credentials file {name}: {exc}"
+        )
+    with os.fdopen(fd, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _atomic_write_via_fd(dir_fd: int, name: str, parser: ConfigUpdater) -> None:
     # Preserve the file's existing mode (new file → 0600).
+    try:
+        mode = stat.S_IMODE(os.stat(name, dir_fd=dir_fd, follow_symlinks=False).st_mode)
+    except FileNotFoundError:
+        mode = 0o600
+    fd = -1
+    tmp = None
+    for _ in range(8):
+        candidate = f".plant.{os.urandom(8).hex()}.tmp"
+        try:
+            fd = os.open(
+                candidate,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            tmp = candidate
+            break
+        except FileExistsError:
+            continue
+    if tmp is None:
+        raise PlacementError(f"could not create a temp file in {name}'s directory")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            parser.write(handle)
+        # Atomic POSIX replace, anchored to the pinned dir on both ends.
+        os.rename(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    except BaseException:
+        try:
+            os.unlink(tmp, dir_fd=dir_fd)
+        except OSError:
+            pass
+        raise
+    # Restore the preserved mode via an fd on the final file (no path re-resolution).
+    ffd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    try:
+        os.fchmod(ffd, mode)
+    finally:
+        os.close(ffd)
+
+
+# --- path-based fallback (no dir fds / O_NOFOLLOW, e.g. Windows) -------------------
+
+
+def _reject_symlinked_target(path: Path) -> None:
+    """Best-effort pre-check for the path-based (non-POSIX) backend."""
+    if path.parent.is_symlink():
+        raise PlacementError(f"refusing to use {path.parent}: '.aws' is a symlink")
+    if path.is_symlink():
+        raise PlacementError(f"refusing to write through symlinked file {path}")
+
+
+def _load_path(path: Path) -> ConfigUpdater:
+    text = path.read_text(encoding="utf-8") if path.exists() else None
+    return _parse_text(text, path)
+
+
+def _atomic_write_path(path: Path, parser: ConfigUpdater) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:
         mode = stat.S_IMODE(path.stat().st_mode)
     except FileNotFoundError:
@@ -142,8 +271,7 @@ def _atomic_write(path: Path, parser: ConfigUpdater) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             parser.write(handle)
-        # Swap first (temp stays at mkstemp's 0600 while holding the secret), then
-        # restore the final mode — chmod'ing the temp pre-swap would briefly widen it.
+        # Swap first (temp keeps mkstemp's 0600 while holding the secret), then chmod.
         os.replace(tmp, path)
         os.chmod(path, mode)
     except BaseException:
@@ -154,33 +282,46 @@ def _atomic_write(path: Path, parser: ConfigUpdater) -> None:
         raise
 
 
+# --- public API -------------------------------------------------------------------
+
+
+def require_safe_backend() -> None:
+    """Fail closed on POSIX without dir fds: the only alternative is TOCTOU-prone path
+    ops, and POSIX is where the root fan-out makes that exploitable. Windows is exempt.
+    """
+    if os.name == "posix" and not FD_HARDENED:
+        raise PlacementError(
+            "this platform lacks the directory file-descriptor support "
+            "(O_NOFOLLOW/dir_fd) required to place honeytokens safely — refusing"
+        )
+
+
 def write_aws_profile(
     path: Path, section: str, creds: HoneytokenCreds, force: bool
 ) -> WriteOutcome:
     """Write/overwrite the (server-named) honeytoken profile, preserving other profiles.
 
-    - profile absent → write
-    - profile present with the same access key **and** secret → no-op (``ALREADY_CURRENT``)
-    - profile present but access key id **and/or** secret differ → refuse unless ``force``
-      (rotation is handled upstream by processing ``delete`` before ``write``, so this
-      only trips on a genuine collision the operator should review)
+    Rotation is handled upstream by processing ``delete`` before ``write``, so a
+    credentials mismatch only trips on a genuine collision the operator should review.
     """
-    _reject_symlinked_target(path)
-    parser = _load(path)
-    if parser.has_section(section):
-        existing_id = _get_value(parser, section, _ACCESS_KEY)
-        existing_secret = _get_value(parser, section, _SECRET_KEY)
-        if existing_id == creds.access_token_id and existing_secret == creds.secret_key:
-            return WriteOutcome.ALREADY_CURRENT
-        if not force:
-            raise ForceRefusal(section, path)
-    else:
-        parser.add_section(section)
+    require_safe_backend()
+    if FD_HARDENED:
+        dir_fd = open_aws_dir_fd(path.parent, create=True)
+        try:
+            parser = _parse_text(_read_via_fd(dir_fd, path.name), path)
+            outcome = _decide_write(parser, section, creds, force, path)
+            if outcome is WriteOutcome.WROTE:
+                _atomic_write_via_fd(dir_fd, path.name, parser)
+            return outcome
+        finally:
+            os.close(dir_fd)
 
-    parser[section][_ACCESS_KEY] = creds.access_token_id
-    parser[section][_SECRET_KEY] = creds.secret_key
-    _atomic_write(path, parser)
-    return WriteOutcome.WROTE
+    _reject_symlinked_target(path)
+    parser = _load_path(path)
+    outcome = _decide_write(parser, section, creds, force, path)
+    if outcome is WriteOutcome.WROTE:
+        _atomic_write_path(path, parser)
+    return outcome
 
 
 def remove_aws_profile(
@@ -192,29 +333,59 @@ def remove_aws_profile(
 
     When ``expected_access_key_id`` is set, the profile is removed **only if** its
     ``aws_access_key_id`` matches — a profile holding a different key is foreign and is
-    left untouched (``FOREIGN_KEPT``). ``None`` removes by name unconditionally (legacy /
-    when the server omitted the token).
+    left untouched (``FOREIGN_KEPT``). ``None`` removes by name unconditionally.
     """
+    require_safe_backend()
+    if FD_HARDENED:
+        try:
+            dir_fd = open_aws_dir_fd(path.parent, create=False)
+        except FileNotFoundError:
+            return RemoveOutcome.ALREADY_ABSENT
+        try:
+            text = _read_via_fd(dir_fd, path.name)
+            if text is None:
+                return RemoveOutcome.ALREADY_ABSENT
+            parser = _parse_text(text, path)
+            outcome = _decide_remove(parser, section, expected_access_key_id)
+            if outcome is not RemoveOutcome.REMOVED:
+                return outcome
+            if str(parser).strip():
+                _atomic_write_via_fd(dir_fd, path.name, parser)
+            else:
+                try:
+                    os.unlink(path.name, dir_fd=dir_fd)
+                except OSError:
+                    pass
+            return RemoveOutcome.REMOVED
+        finally:
+            os.close(dir_fd)
+
     _reject_symlinked_target(path)
     if not path.exists():
         return RemoveOutcome.ALREADY_ABSENT
-    parser = _load(path)
-    if not parser.has_section(section):
-        return RemoveOutcome.ALREADY_ABSENT
-
-    if expected_access_key_id is not None:
-        on_disk = _get_value(parser, section, _ACCESS_KEY)
-        if on_disk != expected_access_key_id:
-            return RemoveOutcome.FOREIGN_KEPT
-
-    parser.remove_section(section)
-    # Empty `sections()` can still mean a comments-only file (ConfigUpdater keeps them),
-    # so test the rendered content — unlink only when nothing at all is left.
+    parser = _load_path(path)
+    outcome = _decide_remove(parser, section, expected_access_key_id)
+    if outcome is not RemoveOutcome.REMOVED:
+        return outcome
     if str(parser).strip():
-        _atomic_write(path, parser)
+        _atomic_write_path(path, parser)
     else:
         try:
             path.unlink()
         except OSError:
             pass
+    return RemoveOutcome.REMOVED
+
+
+def _decide_remove(
+    parser: ConfigUpdater, section: str, expected_access_key_id: Optional[str]
+) -> RemoveOutcome:
+    """Drop our section if present and (optionally) key-matched; return the outcome.
+    ``REMOVED`` means the caller must persist (or unlink) the mutated parser."""
+    if not parser.has_section(section):
+        return RemoveOutcome.ALREADY_ABSENT
+    if expected_access_key_id is not None:
+        if _get_value(parser, section, _ACCESS_KEY) != expected_access_key_id:
+            return RemoveOutcome.FOREIGN_KEPT
+    parser.remove_section(section)
     return RemoveOutcome.REMOVED

--- a/ggshield/verticals/honeytoken/targets.py
+++ b/ggshield/verticals/honeytoken/targets.py
@@ -87,15 +87,15 @@ def resolve_targets(user: Optional[str], user_dir: Optional[Path]) -> List[Targe
 
 
 def apply_perms_and_owner(path: Path, target: Target, running_as_root: bool) -> None:
-    """Tighten perms (file 0600, dir 0700) and, as root, chown the file + its ``.aws``
-    dir to the target user so they own their decoy. No-op off Unix."""
+    """Keep the ``.aws`` dir private (0700) and, as root, chown the file + dir to the
+    target user. The file mode is left to ``_atomic_write``. No-op off Unix."""
     if os.name != "posix":
         return
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
     parent = path.parent
+    # Don't chmod/chown through a symlink: as root that could redirect onto e.g. /etc
+    # (write/remove already reject symlinks; this closes the chown leg + the TOCTOU).
+    if parent.is_symlink() or path.is_symlink():
+        return
     try:
         os.chmod(parent, 0o700)
     except OSError:

--- a/ggshield/verticals/honeytoken/targets.py
+++ b/ggshield/verticals/honeytoken/targets.py
@@ -22,6 +22,11 @@ from typing import Dict, List, Optional
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.core.machine_id import _get_hostname, _get_machine_id, _get_username
+from ggshield.verticals.honeytoken.aws_profile import (
+    PlacementError,
+    open_aws_dir_fd,
+    require_safe_backend,
+)
 
 
 # Home roots that look like real human-user spaces (kept even if the shell is nologin,
@@ -87,28 +92,36 @@ def resolve_targets(user: Optional[str], user_dir: Optional[Path]) -> List[Targe
 
 
 def apply_perms_and_owner(path: Path, target: Target, running_as_root: bool) -> None:
-    """Keep the ``.aws`` dir private (0700) and, as root, chown the file + dir to the
-    target user. The file mode is left to ``_atomic_write``. No-op off Unix."""
+    """Keep ``.aws`` private (0700) and, as root, chown the file + dir to the target user
+    (mode left to the write path). No-op off Unix. Anchored to an ``O_NOFOLLOW`` dir fd
+    (``fchmod``/``fchown``/``dir_fd``) so a symlinked ``.aws`` can't redirect the
+    privileged chmod/chown elsewhere."""
     if os.name != "posix":
         return
+    require_safe_backend()  # POSIX without dir fds → refuse (no unsafe path fallback)
     parent = path.parent
-    # Don't chmod/chown through a symlink: as root that could redirect onto e.g. /etc
-    # (write/remove already reject symlinks; this closes the chown leg + the TOCTOU).
-    if parent.is_symlink() or path.is_symlink():
-        return
-    try:
-        os.chmod(parent, 0o700)
-    except OSError:
-        pass
 
-    if running_as_root and target.uid is not None:
-        gid = _gid_for_uid(target.uid)
-        gid = gid if gid is not None else target.uid
+    try:
+        dir_fd = open_aws_dir_fd(parent, create=False)
+    except (FileNotFoundError, PlacementError):
+        return  # nothing planted there, or .aws is a symlink — leave it alone
+    try:
         try:
-            os.chown(path, target.uid, gid)
-            os.chown(parent, target.uid, gid)
+            os.fchmod(dir_fd, 0o700)
         except OSError:
             pass
+        if running_as_root and target.uid is not None:
+            gid = _gid_for_uid(target.uid)
+            gid = gid if gid is not None else target.uid
+            try:
+                os.fchown(dir_fd, target.uid, gid)
+                os.chown(
+                    path.name, target.uid, gid, dir_fd=dir_fd, follow_symlinks=False
+                )
+            except OSError:
+                pass
+    finally:
+        os.close(dir_fd)
 
 
 def _passwd_for_name(name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "platformdirs~=4.2",
     "charset-normalizer~=3.1.0",
     "click~=8.1.0",
+    "configupdater>=3.2,<4",
     "cryptography~=43.0.1",
     "marshmallow>=3.18,<3.27",
     "marshmallow-dataclass~=8.5.8",

--- a/tests/unit/verticals/honeytoken/test_aws_profile.py
+++ b/tests/unit/verticals/honeytoken/test_aws_profile.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from ggshield.verticals.honeytoken.aws_profile import (
+    FD_HARDENED,
     ForceRefusal,
     PlacementError,
     RemoveOutcome,
@@ -284,6 +285,21 @@ def test_remove_preserves_comments_on_other_profiles(tmp_path):
     assert "# work account, see https://wiki.internal/aws" in content
 
 
+def test_remove_keeps_file_when_only_comments_remain(tmp_path):
+    """If removing our profile leaves no other section but the user still has comments,
+    keep the file (with the comments) rather than deleting it as an empty stub."""
+    path = tmp_path / "credentials"
+    path.write_text(
+        "# keep me\n[gg]\naws_access_key_id = K1\naws_secret_access_key = S1\n"
+    )
+
+    assert remove_aws_profile(path, "gg", None) is RemoveOutcome.REMOVED
+    assert path.exists()
+    content = path.read_text()
+    assert "# keep me" in content
+    assert "[gg]" not in content
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode bits")
 def test_write_preserves_existing_file_mode(tmp_path):
     """A normal write to an existing file keeps the user's permission bits (here 0640)
@@ -387,10 +403,10 @@ def test_write_rejects_symlinked_credentials_file(tmp_path):
     assert "gg" not in target.read_text()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode bits")
+@pytest.mark.skipif(not FD_HARDENED, reason="needs dir fds / O_NOFOLLOW (POSIX)")
 def test_write_keeps_temp_private_until_swap(tmp_path, monkeypatch):
     """Even when the existing file is permissive (0644), the temp stays 0600 until the
-    `os.replace` swap — the secret never sits in a group/world-readable temp."""
+    rename swap — the secret never sits in a group/world-readable temp."""
     from ggshield.verticals.honeytoken import aws_profile
 
     path = tmp_path / "credentials"
@@ -400,14 +416,115 @@ def test_write_keeps_temp_private_until_swap(tmp_path, monkeypatch):
     os.chmod(path, 0o644)
 
     modes_at_swap = []
-    real_replace = os.replace
+    real_rename = os.rename
 
-    def _spy_replace(src, dst):
-        modes_at_swap.append(stat.S_IMODE(os.stat(src).st_mode))
-        return real_replace(src, dst)
+    def _spy_rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
+        modes_at_swap.append(
+            stat.S_IMODE(os.stat(src, dir_fd=src_dir_fd, follow_symlinks=False).st_mode)
+        )
+        return real_rename(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
-    monkeypatch.setattr(aws_profile.os, "replace", _spy_replace)
+    monkeypatch.setattr(aws_profile.os, "rename", _spy_rename)
     write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
 
     assert modes_at_swap == [0o600]  # temp private at swap time
     assert (path.stat().st_mode & 0o777) == 0o644  # final mode preserved
+
+
+@pytest.mark.skipif(not FD_HARDENED, reason="needs dir fds / O_NOFOLLOW (POSIX)")
+def test_write_is_immune_to_aws_dir_swap_after_open(tmp_path, monkeypatch):
+    """TOCTOU: swap `.aws` for a symlink to an attacker dir right after the dir fd is
+    opened. The write must follow the fd to the original real dir, never the attacker's.
+    """
+    from ggshield.verticals.honeytoken import aws_profile
+
+    home = tmp_path / "home"
+    real_aws = home / ".aws"
+    real_aws.mkdir(parents=True)
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    path = real_aws / "credentials"
+
+    real_open = os.open
+    state = {"swapped": False}
+
+    def _swap_then_open(p, *args, **kwargs):
+        fd = real_open(p, *args, **kwargs)
+        if not state["swapped"] and os.path.basename(str(p)) == ".aws":
+            state["swapped"] = True
+            real_aws.rename(tmp_path / ".aws.real")
+            os.symlink(attacker, real_aws, target_is_directory=True)
+        return fd
+
+    monkeypatch.setattr(aws_profile.os, "open", _swap_then_open)
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    # Landed in the original (moved-aside) real dir via the fd — never the attacker's.
+    assert (tmp_path / ".aws.real" / "credentials").exists()
+    assert list(attacker.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only fail-closed guard")
+def test_write_fails_closed_on_posix_without_fd_support(tmp_path, monkeypatch):
+    """On POSIX we refuse rather than fall back to TOCTOU-prone path operations when the
+    no-follow / dir-fd backend isn't available."""
+    from ggshield.verticals.honeytoken import aws_profile
+
+    monkeypatch.setattr(aws_profile, "FD_HARDENED", False)
+    with pytest.raises(PlacementError):
+        write_aws_profile(
+            tmp_path / "credentials", "gg", _creds("K1", "S1"), force=False
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only fail-closed guard")
+def test_remove_fails_closed_on_posix_without_fd_support(tmp_path, monkeypatch):
+    from ggshield.verticals.honeytoken import aws_profile
+
+    path = tmp_path / "credentials"
+    path.write_text("[gg]\naws_access_key_id = K1\naws_secret_access_key = S1\n")
+    monkeypatch.setattr(aws_profile, "FD_HARDENED", False)
+    with pytest.raises(PlacementError):
+        remove_aws_profile(path, "gg", None)
+
+
+@pytest.mark.skipif(not FD_HARDENED, reason="needs dir fds / O_NOFOLLOW (POSIX)")
+def test_remove_when_aws_dir_absent(tmp_path):
+    """remove on a home whose ``.aws`` doesn't exist yet → nothing to do."""
+    path = tmp_path / "home" / ".aws" / "credentials"  # .aws never created
+    assert remove_aws_profile(path, "gg", None) is RemoveOutcome.ALREADY_ABSENT
+
+
+def test_write_refuses_section_missing_a_key_without_force(tmp_path):
+    """An existing profile that carries our access key but is missing the secret is a
+    mismatch (not ALREADY_CURRENT) → refuse without --force."""
+    path = tmp_path / ".aws" / "credentials"
+    path.parent.mkdir(parents=True)
+    path.write_text("[gg]\naws_access_key_id = K1\n")  # no secret line
+
+    with pytest.raises(ForceRefusal):
+        write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+
+@pytest.mark.skipif(not FD_HARDENED, reason="needs dir fds / O_NOFOLLOW (POSIX)")
+def test_write_cleans_up_temp_on_failure(tmp_path, monkeypatch):
+    """If serializing the parser fails mid-write, the temp file is unlinked (no leak in
+    ``.aws``) and the original file is left intact."""
+    from configupdater import ConfigUpdater
+
+    path = tmp_path / ".aws" / "credentials"
+    path.parent.mkdir(parents=True)
+    original = "[default]\naws_access_key_id = USER\naws_secret_access_key = MINE\n"
+    path.write_text(original)
+
+    def boom(self, *args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(ConfigUpdater, "write", boom)
+
+    with pytest.raises(RuntimeError):
+        write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    leftover = [p.name for p in path.parent.iterdir() if p.name.startswith(".plant.")]
+    assert leftover == []
+    assert path.read_text() == original

--- a/tests/unit/verticals/honeytoken/test_aws_profile.py
+++ b/tests/unit/verticals/honeytoken/test_aws_profile.py
@@ -1,4 +1,6 @@
 import configparser
+import os
+import stat
 import sys
 from pathlib import Path
 
@@ -205,3 +207,207 @@ def test_remove_keeps_foreign_key(tmp_path):
     assert remove_aws_profile(path, "gg", "K1") is RemoveOutcome.FOREIGN_KEPT
     # Section left untouched.
     assert _section(path, "gg")["aws_access_key_id"] == "OTHER"
+
+
+# --- comment / formatting preservation --------------------------------------------
+#
+# Planting only touches our own profile; comments, blank lines and other profiles
+# stay intact.
+
+
+_FILE_WITH_COMMENTS = """\
+# Personal AWS credentials -- DO NOT COMMIT
+[default]
+aws_access_key_id = USER
+aws_secret_access_key = MINE
+
+# work account, see https://wiki.internal/aws
+[work]
+aws_access_key_id = WK
+aws_secret_access_key = WS
+"""
+
+
+def test_write_preserves_existing_comments(tmp_path):
+    path = tmp_path / "credentials"
+    path.write_text(_FILE_WITH_COMMENTS)
+
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    content = path.read_text()
+    assert "# Personal AWS credentials -- DO NOT COMMIT" in content
+    assert "# work account, see https://wiki.internal/aws" in content
+    # And our profile must of course be present.
+    assert _section(path, "gg")["aws_access_key_id"] == "K1"
+
+
+def test_write_leaves_other_sections_byte_for_byte(tmp_path):
+    """Planting our profile must not reformat or reorder the rest of the file: the
+    original content should remain a prefix of the result, with only our section
+    appended."""
+    path = tmp_path / "credentials"
+    path.write_text(_FILE_WITH_COMMENTS)
+
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    content = path.read_text()
+    assert content.startswith(_FILE_WITH_COMMENTS)
+
+
+def test_write_appends_cleanly_to_file_without_trailing_newline(tmp_path):
+    """A source file with no final newline must still get our profile as a real,
+    separate section -- not glued onto the last line (``...= MINE[gg]``), which would
+    silently drop our profile (or raise on a duplicate option)."""
+    path = tmp_path / "credentials"
+    path.write_bytes(
+        b"# kept\n[default]\naws_access_key_id = USER\naws_secret_access_key = MINE"
+    )  # note: no trailing newline
+
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    assert _section(path, "gg")["aws_access_key_id"] == "K1"
+    assert _section(path, "default")["aws_access_key_id"] == "USER"
+    content = path.read_text()
+    assert "# kept" in content
+    assert content.endswith("\n")
+
+
+def test_remove_preserves_comments_on_other_profiles(tmp_path):
+    path = tmp_path / "credentials"
+    path.write_text(_FILE_WITH_COMMENTS)
+    # Plant then remove our profile; the user's commented profiles must survive intact.
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    remove_aws_profile(path, "gg", "K1")
+
+    content = path.read_text()
+    assert "# Personal AWS credentials -- DO NOT COMMIT" in content
+    assert "# work account, see https://wiki.internal/aws" in content
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode bits")
+def test_write_preserves_existing_file_mode(tmp_path):
+    """A normal write to an existing file keeps the user's permission bits (here 0640)
+    rather than forcing 0600 -- same 'don't disturb the user's file' spirit as comments.
+    """
+    path = tmp_path / "credentials"
+    path.write_text(
+        "[default]\naws_access_key_id = USER\naws_secret_access_key = MINE\n"
+    )
+    os.chmod(path, 0o640)
+
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    assert (path.stat().st_mode & 0o777) == 0o640
+    assert _section(path, "gg")["aws_access_key_id"] == "K1"
+
+
+def test_write_does_not_mix_newlines_on_crlf_file(tmp_path):
+    """A CRLF (Windows-authored) file must not come back with mixed line endings: the
+    result must use a single consistent convention. (We don't assert which one -- the
+    text-mode write resolves to the platform's newline -- only that it isn't mixed.)"""
+    path = tmp_path / "credentials"
+    path.write_bytes(
+        b"# windows-authored creds\r\n"
+        b"[default]\r\n"
+        b"aws_access_key_id = USER\r\n"
+        b"aws_secret_access_key = MINE\r\n"
+    )
+
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    raw = path.read_bytes()
+    # No lone LF that isn't part of a CRLF (would signal a CRLF/LF mix).
+    assert b"\r\n" not in raw or raw.replace(b"\r\n", b"").count(b"\n") == 0
+    assert b"# windows-authored creds" in raw
+
+
+def test_remove_keeps_comments_only_remainder(tmp_path):
+    """A {comments + only our section} file must survive removal with comments intact:
+    `sections()` is empty after removing ours, but the document isn't — so don't unlink.
+    """
+    path = tmp_path / "credentials"
+    path.write_text("# keep me -- personal note\n")
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    assert remove_aws_profile(path, "gg", "K1") is RemoveOutcome.REMOVED
+    assert path.exists()
+    content = path.read_text()
+    assert "# keep me -- personal note" in content
+    assert "[gg]" not in content
+
+
+# --- symlink hardening (root fan-out privilege-escalation guard) ------------------
+#
+# As root in the fleet fan-out, following a symlinked `.aws` (or credentials file)
+# would let a user redirect the write/chmod/chown outside their home. We reject.
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_write_rejects_symlinked_aws_dir(tmp_path):
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".aws").symlink_to(real, target_is_directory=True)
+    path = home / ".aws" / "credentials"
+
+    with pytest.raises(PlacementError):
+        write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    # Nothing was written through the link.
+    assert list(real.iterdir()) == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_remove_rejects_symlinked_aws_dir(tmp_path):
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".aws").symlink_to(real, target_is_directory=True)
+    path = home / ".aws" / "credentials"
+
+    with pytest.raises(PlacementError):
+        remove_aws_profile(path, "gg", None)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_write_rejects_symlinked_credentials_file(tmp_path):
+    target = tmp_path / "target-creds"
+    target.write_text(
+        "[default]\naws_access_key_id = USER\naws_secret_access_key = MINE\n"
+    )
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir(mode=0o700)
+    path = aws_dir / "credentials"
+    path.symlink_to(target)
+
+    with pytest.raises(PlacementError):
+        write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    # The link target was not modified through the symlink.
+    assert "gg" not in target.read_text()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode bits")
+def test_write_keeps_temp_private_until_swap(tmp_path, monkeypatch):
+    """Even when the existing file is permissive (0644), the temp stays 0600 until the
+    `os.replace` swap — the secret never sits in a group/world-readable temp."""
+    from ggshield.verticals.honeytoken import aws_profile
+
+    path = tmp_path / "credentials"
+    path.write_text(
+        "[default]\naws_access_key_id = USER\naws_secret_access_key = MINE\n"
+    )
+    os.chmod(path, 0o644)
+
+    modes_at_swap = []
+    real_replace = os.replace
+
+    def _spy_replace(src, dst):
+        modes_at_swap.append(stat.S_IMODE(os.stat(src).st_mode))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(aws_profile.os, "replace", _spy_replace)
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+
+    assert modes_at_swap == [0o600]  # temp private at swap time
+    assert (path.stat().st_mode & 0o777) == 0o644  # final mode preserved

--- a/tests/unit/verticals/honeytoken/test_targets.py
+++ b/tests/unit/verticals/honeytoken/test_targets.py
@@ -150,14 +150,17 @@ def test_enumerate_dedups_same_home(monkeypatch, tmp_path):
     assert len(targets) == 1  # same realpath → deduped
 
 
-def test_apply_perms_non_root_sets_mode(tmp_path):
+def test_apply_perms_non_root_keeps_dir_private_and_leaves_file_mode(tmp_path):
     path = tmp_path / ".aws" / "credentials"
     path.parent.mkdir()
     path.write_text("x")
+    os.chmod(path, 0o640)
     apply_perms_and_owner(
         path, Target("alice", tmp_path, uid=None), running_as_root=False
     )
-    assert (path.stat().st_mode & 0o777) == 0o600
+    # The file mode is _atomic_write's responsibility (it preserves the user's bits);
+    # apply_perms_and_owner only keeps the .aws dir private and must leave the file alone.
+    assert (path.stat().st_mode & 0o777) == 0o640
     assert (path.parent.stat().st_mode & 0o777) == 0o700
 
 
@@ -171,6 +174,28 @@ def test_apply_perms_root_chowns(monkeypatch, tmp_path):
     apply_perms_and_owner(path, Target("bob", tmp_path, uid=1001), running_as_root=True)
     assert (str(path), 1001, 2002) in chowns
     assert (str(path.parent), 1001, 2002) in chowns
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_apply_perms_skips_symlinked_aws_dir(monkeypatch, tmp_path):
+    """A symlinked `.aws` must not be chmod'd/chown'd through: as root that would let a
+    user redirect `chmod 0700`/`chown` onto an arbitrary directory."""
+    real = tmp_path / "elsewhere"
+    real.mkdir(mode=0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".aws").symlink_to(real, target_is_directory=True)
+    path = home / ".aws" / "credentials"
+    path.write_text("x")  # lands in `real` via the link
+
+    chowns = []
+    monkeypatch.setattr(os, "chown", lambda p, u, g: chowns.append(str(p)))
+    monkeypatch.setattr("pwd.getpwuid", lambda uid: SimpleNamespace(pw_gid=2002))
+
+    apply_perms_and_owner(path, Target("bob", home, uid=1001), running_as_root=True)
+
+    assert chowns == []  # nothing chowned through the link
+    assert (real.stat().st_mode & 0o777) == 0o755  # target dir left untouched
 
 
 def test_gid_for_uid_unknown_returns_none(monkeypatch):

--- a/tests/unit/verticals/honeytoken/test_targets.py
+++ b/tests/unit/verticals/honeytoken/test_targets.py
@@ -168,12 +168,17 @@ def test_apply_perms_root_chowns(monkeypatch, tmp_path):
     path = tmp_path / ".aws" / "credentials"
     path.parent.mkdir()
     path.write_text("x")
+    fchowns = []
     chowns = []
-    monkeypatch.setattr(os, "chown", lambda p, u, g: chowns.append((str(p), u, g)))
+    monkeypatch.setattr(os, "fchown", lambda fd, u, g: fchowns.append((u, g)))
+    monkeypatch.setattr(
+        os, "chown", lambda p, u, g, **kw: chowns.append((str(p), u, g))
+    )
     monkeypatch.setattr("pwd.getpwuid", lambda uid: SimpleNamespace(pw_gid=2002))
     apply_perms_and_owner(path, Target("bob", tmp_path, uid=1001), running_as_root=True)
-    assert (str(path), 1001, 2002) in chowns
-    assert (str(path.parent), 1001, 2002) in chowns
+    # Dir owned via its fd; file via dir_fd + no-follow (relative name).
+    assert (1001, 2002) in fchowns
+    assert (path.name, 1001, 2002) in chowns
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
@@ -196,6 +201,56 @@ def test_apply_perms_skips_symlinked_aws_dir(monkeypatch, tmp_path):
 
     assert chowns == []  # nothing chowned through the link
     assert (real.stat().st_mode & 0o777) == 0o755  # target dir left untouched
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_apply_perms_is_immune_to_aws_dir_swap_after_open(monkeypatch, tmp_path):
+    """TOCTOU: swap `.aws` for a symlink to an attacker dir right after the dir fd is
+    opened. The fchmod must hit the pinned (real) dir, never the attacker's."""
+    from ggshield.verticals.honeytoken import aws_profile
+
+    home = tmp_path / "home"
+    real_aws = home / ".aws"
+    real_aws.mkdir(parents=True)
+    os.chmod(real_aws, 0o755)
+    attacker = tmp_path / "attacker"
+    attacker.mkdir(mode=0o755)
+    path = real_aws / "credentials"
+    path.write_text("x")
+
+    real_open = os.open
+    state = {"swapped": False}
+
+    def _swap_then_open(p, *args, **kwargs):
+        fd = real_open(p, *args, **kwargs)
+        if not state["swapped"] and os.path.basename(str(p)) == ".aws":
+            state["swapped"] = True
+            real_aws.rename(tmp_path / ".aws.real")
+            os.symlink(attacker, real_aws, target_is_directory=True)
+        return fd
+
+    monkeypatch.setattr(aws_profile.os, "open", _swap_then_open)
+    apply_perms_and_owner(path, Target("alice", home, uid=None), running_as_root=False)
+
+    # fchmod(dir_fd, 0700) hit the pinned (moved-aside) real dir, not the attacker's.
+    assert (tmp_path / ".aws.real").stat().st_mode & 0o777 == 0o700
+    assert (attacker.stat().st_mode & 0o777) == 0o755  # untouched
+
+
+def test_apply_perms_fails_closed_without_fd_support(tmp_path, monkeypatch):
+    """POSIX without the no-follow/dir-fd backend → refuse rather than chmod/chown via
+    path (which would be TOCTOU-prone)."""
+    from ggshield.verticals.honeytoken import aws_profile
+    from ggshield.verticals.honeytoken.aws_profile import PlacementError
+
+    path = tmp_path / ".aws" / "credentials"
+    path.parent.mkdir()
+    path.write_text("x")
+    monkeypatch.setattr(aws_profile, "FD_HARDENED", False)
+    with pytest.raises(PlacementError):
+        apply_perms_and_owner(
+            path, Target("a", tmp_path, uid=None), running_as_root=False
+        )
 
 
 def test_gid_for_uid_unknown_returns_none(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -362,6 +362,15 @@ wheels = [
 ]
 
 [[package]]
+name = "configupdater"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/603bd8a65e040b23d25b5843836297b0f4e430f509d8ed2ef8f072fb4127/ConfigUpdater-3.2.tar.gz", hash = "sha256:9fdac53831c1b062929bf398b649b87ca30e7f1a735f3fbf482072804106306b", size = 140603, upload-time = "2023-11-27T17:16:45.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f0/b59cb7613d9d0f866b6ff247c5953ad78363c27ff5d684a2a98899ab8220/ConfigUpdater-3.2-py2.py3-none-any.whl", hash = "sha256:0f65a041627d7693840b4dd743581db4c441c97195298a29d075f91b79539df2", size = 34688, upload-time = "2023-11-27T17:16:43.53Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.10.7"
 source = { registry = "https://pypi.org/simple" }
@@ -853,6 +862,7 @@ source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "click" },
+    { name = "configupdater" },
     { name = "cryptography" },
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "filelock", version = "3.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -926,6 +936,7 @@ tests = [
 requires-dist = [
     { name = "charset-normalizer", specifier = "~=3.1.0" },
     { name = "click", specifier = "~=8.1.0" },
+    { name = "configupdater", specifier = ">=3.2,<4" },
     { name = "cryptography", specifier = "~=43.0.1" },
     { name = "filelock", specifier = ">=3.19.1" },
     { name = "keyring", specifier = ">=24.0.0,<26" },


### PR DESCRIPTION
## Context

Ggshield honeytoken plant was not preserving file comments nor file permissions

## What has been done

Moved to the `configupdater` Library to benefit from INI file handling safety

## Validation

### E2E results — `ggshield honeytoken plant` (local instance)

| # | Scenario | Before | After | Result |
|---|----------|--------|-------|--------|
| A | Commented file, mode 0600 | comments + `[default]`/`[work]` | comments intact, `[prod-backup]` added, mode 0600 | ✅ comments preserved |
| B | Custom mode 0640 | `-rw-r-----` | `-rw-r-----` (`[prod-backup]` added) | ✅ mode preserved (no 0600 reset) |
| C | Read-only 0444 | `-r--r--r--` | modified with no error, `[prod-backup]` added, mode 0444 kept | ✅ trust-the-system (os.replace writes) |
| D | No trailing newline | `[default]` at EOF | `[prod-backup]` is a real section, file ends with `\n` | ✅ trailing-newline guard |
| E | Idempotence | — | run 1 = `2 written`; run 2 = `0 written, 2 skipped` | ✅ no-op on rerun |
| F | Collision (`[prod-backup]` holds other creds) | foreign key present | no `--force` → refused, key kept; `--force` → overwrites, comment kept | ✅ `ForceRefusal` intact |

Tests added (7)
Commit 1 — comments / configupdater

**test_write_preserves_existing_comments**, **test_write_leaves_other_sections_byte_for_byte** → A
**test_write_appends_cleanly_to_file_without_trailing_newline** → D
**test_write_does_not_mix_newlines_on_crlf_file** (CRLF), **test_remove_preserves_comments_on_other_profiles**
Commit 2 — permissions

**test_write_preserves_existing_file_mode** → B, C
**test_apply_perms_non_root_keeps_dir_private_and_leaves_file_mode** (rewritten: dir 0700, no file chmod)
E & F use pre-existing tests (**test_write_is_idempotent_for_same_key**, **test_write_refuses_*_without_force**).

## PR check list

- [X] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
