### PR TITLE
chore(release): split build/ staging from dist/ output

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -281,13 +281,13 @@ jobs:
         with:
           name: os-packages-${{ matrix.os }}
           path: |
-            packages/ggshield-*.gz
-            packages/ggshield-*.pkg
-            packages/ggshield-*.zip
-            packages/ggshield-*.rpm
-            packages/ggshield_*.deb
-            packages/ggshield.*.nupkg
-            packages/ggshield-*.msi
+            dist/ggshield-*.gz
+            dist/ggshield-*.pkg
+            dist/ggshield-*.zip
+            dist/ggshield-*.rpm
+            dist/ggshield_*.deb
+            dist/ggshield.*.nupkg
+            dist/ggshield-*.msi
 
   # Run some basic tests, the goal is to verify the ggshield binary has all the
   # libraries it needs to run
@@ -329,7 +329,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: os-packages-${{ matrix.runner }}
-          path: packages
+          path: dist
           merge-multiple: true
 
       - name: Setup
@@ -337,18 +337,18 @@ jobs:
         run: |
           case "${{ matrix.image }}" in
             debian:*|ubuntu:*)
-              dpkg -i packages/*.deb
+              dpkg -i dist/*.deb
               ;;
             rockylinux*)
-              rpm -i packages/*.rpm
+              rpm -i dist/*.rpm
               ;;
             opensuse*)
-              rpm -i packages/*.rpm
+              rpm -i dist/*.rpm
               ;;
             clearlinux*)
 
               # Unpack ggshield in /usr/local/ggshield
-              pkg_dir=$PWD/packages
+              pkg_dir=$PWD/dist
               mkdir /usr/local/ggshield
               cd /usr/local/ggshield
               tar --strip-components 1 -xf $pkg_dir/*.tar.gz

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -67,20 +67,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: os-packages-*
-          path: packages
+          path: dist
           merge-multiple: true
 
       - name: Generate artifact attestations
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            packages/ggshield-*.pkg
-            packages/ggshield_*.deb
-            packages/ggshield-*.rpm
-            packages/ggshield-*.zip
-            packages/ggshield.*.nupkg
-            packages/ggshield-*.gz
-            packages/ggshield-*.msi
+            dist/ggshield-*.pkg
+            dist/ggshield_*.deb
+            dist/ggshield-*.rpm
+            dist/ggshield-*.zip
+            dist/ggshield.*.nupkg
+            dist/ggshield-*.gz
+            dist/ggshield-*.msi
 
       - name: Create release
         env:
@@ -94,13 +94,13 @@ jobs:
         run: |
           gh release upload \
             ${{ steps.tags.outputs.tag }} \
-            packages/ggshield-*.pkg \
-            packages/ggshield_*.deb \
-            packages/ggshield-*.rpm \
-            packages/ggshield-*.zip \
-            packages/ggshield.*.nupkg \
-            packages/ggshield-*.gz \
-            packages/ggshield-*.msi
+            dist/ggshield-*.pkg \
+            dist/ggshield_*.deb \
+            dist/ggshield-*.rpm \
+            dist/ggshield-*.zip \
+            dist/ggshield.*.nupkg \
+            dist/ggshield-*.gz \
+            dist/ggshield-*.msi
 
   update_vscode_extension:
     needs: release
@@ -165,7 +165,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: os-packages-*
-          path: packages
+          path: dist
           merge-multiple: true
 
       - name: Install Cloudsmith CLI
@@ -190,12 +190,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: os-packages-windows-*
-          path: packages
+          path: dist
           merge-multiple: true
 
       - name: Push to Chocolatey
         shell: bash
         run: |
-          scripts/chocolatey/push packages/ggshield.*.nupkg
+          scripts/chocolatey/push dist/ggshield.*.nupkg
         env:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
-packages/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/doc/dev/os-packages.md
+++ b/doc/dev/os-packages.md
@@ -15,9 +15,9 @@ Here is a high-level overview of the main steps (square boxes are steps):
 ```mermaid
 flowchart TD
     src[/source code/] --> build --> pyinstaller_dir[/"pyinstaller output
-    (dist/ggshield)"/]
+    (build/ggshield)"/]
     pyinstaller_dir --> copy_files --> archive_dir[/"dir ready to be archived
-    (packages/ggshield-$version-$target)"/]
+    (build/ggshield-$version-$target)"/]
     archive_dir --> test["test (run functional tests on archive dir)"]
     test --> signing{Called with --sign?} -->|yes| sign
     signing -->|no| create_archive

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -7,8 +7,12 @@ ROOT_DIR=$(cd "$SCRIPT_DIR/../.." ; pwd)
 
 DEFAULT_STEPS="req build copy_files test sign create_archive"
 
-PYINSTALLER_OUTPUT_DIR=$ROOT_DIR/dist/ggshield
-PACKAGES_DIR=$ROOT_DIR/packages
+# Intermediate build artifacts (PyInstaller bundle, package staging, scratch)
+# live under build/; only the final shippable packages go to dist/.
+BUILD_DIR=$ROOT_DIR/build
+DIST_DIR=$ROOT_DIR/dist
+
+PYINSTALLER_OUTPUT_DIR=$BUILD_DIR/ggshield
 
 REQUIREMENTS="pyinstaller"
 
@@ -175,7 +179,11 @@ step_req() {
 }
 
 step_build() {
-    rm -rf build/ggshield
+    # PyInstaller's analysis cache (workpath) and the onedir bundle (distpath)
+    # both default to a "ggshield" subdir, so give the workpath its own home to
+    # avoid colliding with the bundle now that both live under build/.
+    local pyinstaller_workpath=$BUILD_DIR/.pyinstaller
+    rm -rf "$pyinstaller_workpath"
     rm -rf "$PYINSTALLER_OUTPUT_DIR"
 
     local extra_args=""
@@ -197,6 +205,7 @@ step_build() {
     )
 
     pyinstaller ggshield/__main__.py --name ggshield --exclude-module pkg_resources --noupx \
+        --workpath "$pyinstaller_workpath" --distpath "$BUILD_DIR" \
         "${collect_args[@]}" $extra_args
 
     if [ "$HUMAN_OS" != Windows ] ; then
@@ -304,10 +313,10 @@ step_copy_files() {
         die "Can't find '$pyinstaller_ggshield', maybe 'build' step did not run?"
     fi
 
-    mkdir -p "$PACKAGES_DIR"
+    mkdir -p "$BUILD_DIR"
     case "$HUMAN_OS" in
     Linux|Windows)
-        local output_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
+        local output_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME"
         info "Copying files to $output_dir"
         rm -rf "$output_dir"
         cp -R "$PYINSTALLER_OUTPUT_DIR" "$output_dir"
@@ -320,8 +329,8 @@ step_copy_files() {
             > "$output_dir/README.md"
         ;;
     macOS)
-        local output_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX"
-        local bin_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME/usr/local/bin"
+        local output_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX"
+        local bin_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME/usr/local/bin"
         info "Copying files to $output_dir"
         rm -rf "$output_dir" "$bin_dir"
         mkdir -p "$(dirname $output_dir)"
@@ -355,13 +364,13 @@ step_sign() {
 step_test() {
     for args in --help --version ; do
         info "test: running $args"
-        "$PACKAGES_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX/ggshield${EXE_EXT}" $args
+        "$BUILD_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX/ggshield${EXE_EXT}" $args
         info "test: running $args: OK"
     done
 }
 
 step_functests() {
-    PATH=$PACKAGES_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX:$PATH pytest -n auto tests/functional
+    PATH=$BUILD_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX:$PATH pytest -n auto tests/functional
 }
 
 create_linux_packages() {
@@ -374,16 +383,17 @@ create_linux_packages() {
             nfpm package \
                 --packager $format \
                 --config "$SCRIPT_DIR/nfpm.yaml" \
-                --target "$PACKAGES_DIR"
+                --target "$DIST_DIR"
     done
 }
 
 step_create_archive() {
     local archive_path
+    mkdir -p "$DIST_DIR"
     case "$HUMAN_OS" in
     Linux)
-        archive_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.tar.gz"
-        pushd "$PACKAGES_DIR"
+        archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.tar.gz"
+        pushd "$BUILD_DIR"
         tar -czf "$archive_path" "$ARCHIVE_DIR_NAME"
         popd
         create_linux_packages
@@ -391,12 +401,12 @@ step_create_archive() {
         ;;
     macOS)
         # Create pkg file
-        pkg_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.pkg"
-        pushd "$PACKAGES_DIR"
+        pkg_path="$DIST_DIR/$ARCHIVE_DIR_NAME.pkg"
+        pushd "$BUILD_DIR"
         pkgbuild \
             --identifier com.gitguardian.ggshield \
             --version "$VERSION" \
-            --root "$PACKAGES_DIR/$ARCHIVE_DIR_NAME" \
+            --root "$BUILD_DIR/$ARCHIVE_DIR_NAME" \
             "$pkg_path"
         popd
 
@@ -405,9 +415,9 @@ step_create_archive() {
         fi
 
         # Create tar.gz
-        archive_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.tar.gz"
+        archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.tar.gz"
 
-        # $PACKAGE_DIR/$ARCHIVE_DIR_NAME currently contains the following file tree:
+        # $BUILD_DIR/$ARCHIVE_DIR_NAME currently contains the following file tree:
         #
         #   $INSTALL_PREFIX
         #     ggshield
@@ -420,10 +430,10 @@ step_create_archive() {
         # containing what is currently in $INSTALL_PREFIX. To set this up, we move
         # $INSTALL_PREFIX to a temporary directory and create the tar.gz from there.
         # (we can't use `tar --transform`: it's not supported on macOS)
-        rm -rf "$PACKAGES_DIR/tmp"
-        mkdir "$PACKAGES_DIR/tmp"
-        pushd "$PACKAGES_DIR/tmp"
-        mv "$PACKAGES_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX" "$ARCHIVE_DIR_NAME"
+        rm -rf "$BUILD_DIR/tmp"
+        mkdir "$BUILD_DIR/tmp"
+        pushd "$BUILD_DIR/tmp"
+        mv "$BUILD_DIR/$ARCHIVE_DIR_NAME/$INSTALL_PREFIX" "$ARCHIVE_DIR_NAME"
         tar -czf "$archive_path" "$ARCHIVE_DIR_NAME"
         popd
 

--- a/scripts/build-os-packages/macos-functions.bash
+++ b/scripts/build-os-packages/macos-functions.bash
@@ -53,7 +53,7 @@ macos_sign_file() {
 }
 
 macos_list_files_to_sign() {
-    local archive_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
+    local archive_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME"
     echo "$archive_dir/$INSTALL_PREFIX/ggshield"
     find "$archive_dir" -name '*.so' -o -name '*.dylib'
 }
@@ -66,5 +66,5 @@ step_notarize() {
     rcodesign notary-submit \
         --api-key-file "$MACOS_API_KEY_FILE" \
         --staple \
-        "$PACKAGES_DIR/$ARCHIVE_DIR_NAME.pkg"
+        "$DIST_DIR/$ARCHIVE_DIR_NAME.pkg"
 }

--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -17,7 +17,7 @@ windows_sign() {
         die "$SM_CLIENT_CERT_FILE does not exist"
     fi
 
-    local archive_dir="$PACKAGES_DIR/$ARCHIVE_DIR_NAME"
+    local archive_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME"
     smctl sign \
         --verbose \
         --exit-non-zero-on-fail \
@@ -27,8 +27,9 @@ windows_sign() {
 }
 
 windows_create_archive() {
-    local archive_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.zip"
-    pushd "$PACKAGES_DIR"
+    local archive_path="$DIST_DIR/$ARCHIVE_DIR_NAME.zip"
+    mkdir -p "$DIST_DIR"
+    pushd "$BUILD_DIR"
     7z a "$archive_path" "$ARCHIVE_DIR_NAME"
     popd
     info "Archive created in $archive_path"
@@ -40,8 +41,8 @@ windows_build_chocolatey_package() {
     mkdir choco-package
     mkdir choco-package/tools
 
-    cp -r "$PACKAGES_DIR/$ARCHIVE_DIR_NAME/_internal" choco-package/tools
-    cp "$PACKAGES_DIR/$ARCHIVE_DIR_NAME/ggshield.exe" choco-package/tools
+    cp -r "$BUILD_DIR/$ARCHIVE_DIR_NAME/_internal" choco-package/tools
+    cp "$BUILD_DIR/$ARCHIVE_DIR_NAME/ggshield.exe" choco-package/tools
     cp "$ROOT_DIR/scripts/chocolatey/ggshield.nuspec" choco-package
     cp "$ROOT_DIR/scripts/chocolatey/VERIFICATION.txt" choco-package/tools
     cp "$ROOT_DIR/LICENSE" choco-package/tools/LICENSE.txt
@@ -59,9 +60,9 @@ windows_build_chocolatey_package() {
     choco pack choco-package/* --version "$VERSION" --outdir "$(mktemp -d)" || true
     choco uninstall chocolatey-community-validation.extension -y || true
 
-    choco pack choco-package/* --version $VERSION --outdir $PACKAGES_DIR
+    choco pack choco-package/* --version $VERSION --outdir $DIST_DIR
 
-    info "Chocolatey package created in $PACKAGES_DIR/ggshield.$VERSION.nupkg"
+    info "Chocolatey package created in $DIST_DIR/ggshield.$VERSION.nupkg"
 
     rm -rf choco-package
 
@@ -69,7 +70,7 @@ windows_build_chocolatey_package() {
 
 # cf https://docs.chocolatey.org/en-us/create/create-packages/#testing-your-package
 test_chocolatey_package() {
-    pushd "$PACKAGES_DIR"
+    pushd "$DIST_DIR"
     choco install ggshield --debug --verbose --source . --noop
     popd
 }
@@ -82,9 +83,9 @@ windows_build_msi_package() {
     wxs_path=$(cygpath -w "$SCRIPT_DIR/ggshield.wxs")
 
     local source_dir
-    source_dir=$(cygpath -w "$PACKAGES_DIR/$ARCHIVE_DIR_NAME")
+    source_dir=$(cygpath -w "$BUILD_DIR/$ARCHIVE_DIR_NAME")
 
-    local msi_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.msi"
+    local msi_path="$DIST_DIR/$ARCHIVE_DIR_NAME.msi"
     local msi_path_win
     msi_path_win=$(cygpath -w "$msi_path")
 
@@ -109,7 +110,7 @@ windows_build_msi_package() {
 }
 
 test_msi_package() {
-    local msi_path="$PACKAGES_DIR/$ARCHIVE_DIR_NAME.msi"
+    local msi_path="$DIST_DIR/$ARCHIVE_DIR_NAME.msi"
     if [ ! -f "$msi_path" ] ; then
         die "MSI package not found: $msi_path"
     fi

--- a/scripts/push-to-cloudsmith
+++ b/scripts/push-to-cloudsmith
@@ -12,7 +12,7 @@ if [ -z "${CLOUDSMITH_API_KEY:-}" ] ; then
     die '$CLOUDSMITH_API_KEY is not set'
 fi
 
-for package in packages/*.{rpm,deb} ; do
+for package in dist/*.{rpm,deb} ; do
     case "$package" in
         *.deb)
             cloudsmith push deb $OWNER_REPO_DISTRO_RELEASE "$package"


### PR DESCRIPTION
The release pipeline wrote OS packages (.deb/.rpm/.pkg/.msi/...) to a top-level packages/ directory that also held intermediate staging. We want that name free for source packages in the monorepo, and we want a clean convention: build/ for intermediates, dist/ for shippable output.

- Final artifacts (the files uploaded to releases/cloudsmith/chocolatey) now go to dist/: nfpm --target, the tar.gz/pkg/zip/msi paths, and the chocolatey --outdir.
- Intermediates go to build/: the PyInstaller bundle (PYINSTALLER_OUTPUT_DIR, via --distpath), its analysis cache (--workpath build/.pyinstaller, so it no longer collides with the bundle's ggshield/ subdir), the per-target staging tree, and the macOS tar restructuring scratch dir.

Release workflows are unchanged: every artifact glob was already dist/ggshield-*.<ext>, which now matches only the final output. build/ is already gitignored.
