### PR TITLE
fix(ai,copilot): block Copilot CLI prompts containing secrets

### DIFF
--- a/changelog.d/20260611_xavier.blanchot_copilot_userpromptsubmitted.md
+++ b/changelog.d/20260611_xavier.blanchot_copilot_userpromptsubmitted.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- AI hook: secrets in prompts submitted to GitHub Copilot CLI are now blocked before they reach the model. The prompt event was not recognized under Copilot CLI's native `userPromptSubmitted` name, and the inherited `{"continue": false}` output is ignored on the prompt event, so prompts containing secrets were let through. ggshield now maps the event and emits `{"decision": "block"}`, which Copilot CLI honors to cancel the prompt.

--- a/ggshield/verticals/ai/agents/copilot.py
+++ b/ggshield/verticals/ai/agents/copilot.py
@@ -1,14 +1,18 @@
+import json
 import logging
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Tuple
 
+import click
+
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.verticals.ai.models import (
     AIDiscovery,
     EventType,
     HookPayload,
+    HookResult,
     MCPActivityRequest,
     MCPConfiguration,
     Scope,
@@ -72,13 +76,14 @@ class Copilot(VSCode):
         optional_fields = {"prompt", "tool_name", "tool_input", "tool_result"}
         return set(hook_payload.keys()) - optional_fields == default_fields
 
-    def has_secret_already_leaked(self, payload: HookPayload) -> bool:
-        # Copilot CLI doesn't allow blocking on UserPromptSubmit.
-        # Special case: if we found a secret because we read a file that was "@" in a prompt,
-        # then we did prevent the leak.
-        if payload.event_type == EventType.USER_PROMPT and payload.tool is None:
-            return True
-        return super().has_secret_already_leaked(payload)
+    def output_result(self, result: HookResult) -> int:
+        # Copilot CLI ignores the inherited `{"continue": false}` on the prompt
+        # event, but it does honor `{"decision": "block"}` to cancel a prompt
+        # before it reaches the model (verified against Copilot CLI 1.0.61).
+        if result.block and result.payload.event_type == EventType.USER_PROMPT:
+            click.echo(json.dumps({"decision": "block", "reason": result.message}))
+            return 0
+        return super().output_result(result)
 
     def post_process_payload(self, payload: HookPayload):
         # Copilot CLI doesn't prefix the MCP tools by any specific string,

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -21,6 +21,7 @@ from .models import Agent, EventType, HookPayload, HookResult, Tool
 
 HOOK_NAME_TO_EVENT_TYPE = {
     "userpromptsubmit": EventType.USER_PROMPT,
+    "userpromptsubmitted": EventType.USER_PROMPT,  # Copilot CLI's native event name
     "beforesubmitprompt": EventType.USER_PROMPT,
     "pretooluse": EventType.PRE_TOOL_USE,
     "posttooluse": EventType.POST_TOOL_USE,

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -738,6 +738,26 @@ class TestAIHookScannerParseInput:
         assert payload.tool is None
         assert isinstance(payload.agent, Copilot)
 
+    def test_copilot_user_prompt_submitted(self):
+        """Test Copilot CLI's own 'userPromptSubmitted' event name parsing.
+
+        Copilot CLI fires the camelCase ``userPromptSubmitted`` event, not the
+        VS Code ``UserPromptSubmit``. If it is not mapped, the prompt content is
+        never scanned and ggshield wrongly returns ``{"continue": true}``.
+        """
+        data = {
+            "timestamp": "2026-02-26T11:28:53.112Z",
+            "hook_event_name": "userPromptSubmitted",
+            "session_id": "69cc6a03-7034-4c49-8cf9-3805c292a15c",
+            "prompt": "hello world",
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.USER_PROMPT
+        assert "hello world" in payload.content
+        assert payload.tool is None
+        assert isinstance(payload.agent, Copilot)
+
     def test_copilot_pre_tool_use_run_in_terminal(self):
         """Test Copilot PreToolUse with bash parsing."""
         data = {
@@ -1110,6 +1130,29 @@ class TestFlavorOutputResult:
         args, _ = mock_echo.call_args
         out = json.loads(args[0])
         assert not out["continue"]
+
+    @patch("ggshield.verticals.ai.agents.copilot.click.echo")
+    def test_copilot_output_result_user_prompt_block(self, mock_echo: MagicMock):
+        """Copilot USER_PROMPT block: {"decision": "block"} to stdout, return 0.
+
+        Copilot CLI cancels a prompt before it reaches the model when the hook
+        emits ``{"decision": "block"}`` (verified against Copilot CLI 1.0.61).
+        The inherited ``{"continue": false}`` is ignored on the prompt event.
+        """
+        result = HookResult(
+            block=True,
+            message="Remove secrets from prompt",
+            nbr_secrets=1,
+            payload=_dummy_payload(EventType.USER_PROMPT),
+        )
+        code = Copilot().output_result(result)
+        assert code == 0
+        mock_echo.assert_called_once()
+        args, kwargs = mock_echo.call_args
+        assert kwargs.get("err", False) is False  # stdout (default)
+        out = json.loads(args[0])
+        assert out["decision"] == "block"
+        assert out["reason"] == "Remove secrets from prompt"
 
     @patch("ggshield.verticals.ai.agents.codex.click.echo")
     def test_codex_output_result_allow(self, mock_echo: MagicMock):


### PR DESCRIPTION
Copilot CLI ignores the inherited `{"continue": false}` output on the prompt event, so secrets typed into a prompt reached the model instead of being blocked. Recognize Copilot's native `userPromptSubmitted` event name so the prompt is scanned, and emit `{"decision": "block"}`, which Copilot CLI honors to cancel the prompt before it reaches the model.

Issue: NHI-1700
