### PR TITLE
fix(plugin): handle permission errors when uninstalling

### DIFF
--- a/changelog.d/20260611_143425_ctourriere_plugin_uninstall_permissions.md
+++ b/changelog.d/20260611_143425_ctourriere_plugin_uninstall_permissions.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield plugin uninstall` no longer crashes with a raw `PermissionError` when plugin files cannot be removed. Read-only entries are now fixed automatically, and files owned by another user (e.g. residue from a legacy `sudo` install) produce a clear remediation message instead of a traceback.

--- a/ggshield/cmd/plugin/manage.py
+++ b/ggshield/cmd/plugin/manage.py
@@ -10,7 +10,7 @@ from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core import ui
 from ggshield.core.config.enterprise_config import EnterpriseConfig
 from ggshield.core.errors import ExitCode
-from ggshield.core.plugin.downloader import PluginDownloader
+from ggshield.core.plugin.downloader import PluginDownloader, UninstallPermissionError
 
 
 @click.command()
@@ -114,7 +114,27 @@ def uninstall_cmd(
             )
 
         # Uninstall
-        if downloader.uninstall(plugin_name):
+        try:
+            removed = downloader.uninstall(plugin_name)
+        except UninstallPermissionError as exc:
+            if exc.owner_uid is not None:
+                reason = (
+                    f"'{exc.offending_path}' is owned by another user "
+                    f"(uid {exc.owner_uid}), probably from a sudo install"
+                )
+            else:
+                reason = f"permission denied on '{exc.offending_path}'"
+            ui.display_error(
+                f"Cannot remove plugin files at '{exc.plugin_dir}': {reason}."
+            )
+            ui.display_info(
+                "Re-run with elevated rights "
+                f"(e.g. sudo ggshield plugin uninstall {plugin_name}) "
+                f"or remove the directory manually: sudo rm -rf '{exc.plugin_dir}'"
+            )
+            ctx.exit(ExitCode.UNEXPECTED_ERROR)
+
+        if removed:
             # Remove from config
             enterprise_config = EnterpriseConfig.load()
             enterprise_config.remove_plugin(plugin_name)

--- a/ggshield/core/plugin/downloader.py
+++ b/ggshield/core/plugin/downloader.py
@@ -149,6 +149,67 @@ class InsecureSourceError(DownloadError):
     pass
 
 
+class UninstallPermissionError(Exception):
+    """Plugin files could not be removed because of filesystem permissions."""
+
+    def __init__(
+        self,
+        plugin_dir: Path,
+        offending_path: Path,
+        owner_uid: Optional[int] = None,
+    ):
+        self.plugin_dir = plugin_dir
+        self.offending_path = offending_path
+        self.owner_uid = owner_uid
+        detail = f"cannot remove {offending_path}"
+        if owner_uid is not None:
+            detail += f" (owned by uid {owner_uid})"
+        super().__init__(detail)
+
+
+def _chmod_tree_for_removal(root: Path) -> None:
+    """Best-effort chmod so the current user can delete the tree.
+
+    Directories need u+rwx to list and unlink their entries; files get
+    u+w to clear read-only bits (the usual rmtree blocker on Windows).
+    Entries owned by another user cannot be re-moded — failures are
+    ignored here and surfaced by the caller's retry.
+    """
+    for dirpath, _dirnames, filenames in os.walk(root):
+        try:
+            os.chmod(dirpath, 0o700)
+        except OSError:
+            pass
+        for filename in filenames:
+            try:
+                os.chmod(os.path.join(dirpath, filename), 0o600)
+            except OSError:
+                pass
+
+
+def _find_foreign_owned_path(root: Path) -> Optional[Tuple[Path, int]]:
+    """Return the first path under root owned by another user, with its uid.
+
+    Returns None when everything belongs to the current user or on
+    platforms without POSIX ownership (Windows).
+    """
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return None
+    euid = geteuid()
+    candidates = [root]
+    for dirpath, dirnames, filenames in os.walk(root):
+        candidates.extend(Path(dirpath) / name for name in (*dirnames, *filenames))
+    for path in candidates:
+        try:
+            uid = path.lstat().st_uid
+        except OSError:
+            continue
+        if uid != euid:
+            return path, uid
+    return None
+
+
 class GitHubArtifactError(DownloadError):
     """Error downloading GitHub artifact."""
 
@@ -702,7 +763,13 @@ class PluginDownloader:
         return plugin_name, version, dest_wheel_path
 
     def uninstall(self, plugin_name: str) -> bool:
-        """Uninstall a plugin (by package name or entry point name)."""
+        """Uninstall a plugin (by package name or entry point name).
+
+        Raises UninstallPermissionError when the plugin files cannot be
+        removed — typically a tree planted by another user, e.g. a
+        root-owned extraction dir left inside the plugin dir by a
+        legacy `sudo ggshield plugin install`.
+        """
         if not self._is_valid_plugin_name(plugin_name):
             logger.warning("Invalid plugin name: %s", plugin_name)
             return False
@@ -711,12 +778,47 @@ class PluginDownloader:
         if plugin_dir is None:
             return False
 
+        self._remove_plugin_tree(plugin_dir)
+        # Revoke only after the files are gone: revoking first would leave
+        # a failed uninstall installed but untrusted.
         self.trust_store.revoke_plugin(plugin_dir.name)
-        shutil.rmtree(plugin_dir)
         self._remove_extract_cache(plugin_dir.name)
 
         logger.info("Uninstalled plugin: %s", plugin_name)
         return True
+
+    def _remove_plugin_tree(self, plugin_dir: Path) -> None:
+        """Remove the plugin directory, fixing permissions if needed.
+
+        A plain rmtree fails on read-only entries and on foreign-owned
+        trees. Retry once after a chmod pass; if it still fails, report
+        the offending path so the command layer can print a remediation
+        instead of a raw traceback.
+        """
+        try:
+            shutil.rmtree(plugin_dir)
+            return
+        except FileNotFoundError:
+            return
+        except OSError:
+            pass
+
+        _chmod_tree_for_removal(plugin_dir)
+        try:
+            shutil.rmtree(plugin_dir)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            foreign = _find_foreign_owned_path(plugin_dir)
+            if foreign is not None:
+                offending_path, owner_uid = foreign
+            else:
+                filename = getattr(exc, "filename", None)
+                offending_path = Path(filename) if filename else plugin_dir
+                owner_uid = None
+            raise UninstallPermissionError(
+                plugin_dir, offending_path, owner_uid
+            ) from exc
 
     def _remove_extract_cache(self, plugin_dir_name: str) -> None:
         """Best-effort removal of extracted wheel cache for an uninstalled plugin."""

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -388,9 +388,31 @@ class PluginLoader:
             try:
                 shutil.rmtree(path)
             except OSError as exc:
-                logger.debug(
-                    "Failed to remove stale plugin extraction dir %s: %s", path, exc
-                )
+                if self._is_foreign_owned(path):
+                    logger.warning(
+                        "Cannot prune stale plugin extraction dir %s: it is "
+                        "owned by another user (sudo install residue?). "
+                        "Remove it manually: sudo rm -rf '%s'",
+                        path,
+                        path,
+                    )
+                else:
+                    logger.debug(
+                        "Failed to remove stale plugin extraction dir %s: %s",
+                        path,
+                        exc,
+                    )
+
+    @staticmethod
+    def _is_foreign_owned(path: Path) -> bool:
+        """True when path belongs to another POSIX user (always False on Windows)."""
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is None:
+            return False
+        try:
+            return path.lstat().st_uid != geteuid()
+        except OSError:
+            return False
 
     def _get_extract_cache_dir(self) -> Path:
         """Return the cache dir used for extracted plugin wheels.

--- a/tests/unit/cmd/plugin/test_manage.py
+++ b/tests/unit/cmd/plugin/test_manage.py
@@ -2,10 +2,12 @@
 Tests for the enterprise plugin management commands (enable/disable/uninstall).
 """
 
+from pathlib import Path
 from unittest import mock
 
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
+from ggshield.core.plugin.downloader import UninstallPermissionError
 
 
 class TestPluginEnable:
@@ -233,6 +235,70 @@ class TestPluginUninstall:
 
         assert result.exit_code == ExitCode.SUCCESS
         assert "Uninstalled plugin: testplugin" in result.output
+
+    def test_uninstall_permission_error_shows_remediation(self, cli_fs_runner):
+        """
+        GIVEN an installed plugin whose files are owned by another user (sudo residue)
+        WHEN running 'ggshield plugin uninstall <plugin> -y'
+        THEN a remediation message is displayed instead of a traceback
+        """
+        plugin_dir = Path("/tmp/plugins/testplugin")
+        error = UninstallPermissionError(
+            plugin_dir=plugin_dir,
+            offending_path=plugin_dir / ".old_extracted" / "RECORD",
+            owner_uid=0,
+        )
+        with mock.patch(
+            "ggshield.cmd.plugin.manage.PluginDownloader"
+        ) as mock_downloader_class:
+            mock_downloader = mock.MagicMock()
+            mock_downloader.is_installed.return_value = True
+            mock_downloader.uninstall.side_effect = error
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "uninstall", "testplugin", "-y"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "owned by another user" in result.output
+        assert "sudo rm -rf" in result.output
+        assert "Traceback" not in result.output
+
+    def test_uninstall_permission_error_without_uid_shows_generic_message(
+        self, cli_fs_runner
+    ):
+        """
+        GIVEN uninstall fails on permissions but no owner uid could be resolved
+        WHEN running 'ggshield plugin uninstall <plugin> -y'
+        THEN a generic permission-denied remediation is shown (no uid mention)
+        """
+        plugin_dir = Path("/tmp/plugins/testplugin")
+        error = UninstallPermissionError(
+            plugin_dir=plugin_dir,
+            offending_path=plugin_dir / "RECORD",
+            owner_uid=None,
+        )
+        with mock.patch(
+            "ggshield.cmd.plugin.manage.PluginDownloader"
+        ) as mock_downloader_class:
+            mock_downloader = mock.MagicMock()
+            mock_downloader.is_installed.return_value = True
+            mock_downloader.uninstall.side_effect = error
+            mock_downloader_class.return_value = mock_downloader
+
+            result = cli_fs_runner.invoke(
+                cli,
+                ["plugin", "uninstall", "testplugin", "-y"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == ExitCode.UNEXPECTED_ERROR
+        assert "permission denied on" in result.output
+        assert "owned by another user" not in result.output
+        assert "Traceback" not in result.output
 
     def test_uninstall_not_installed(self, cli_fs_runner):
         """

--- a/tests/unit/core/plugin/test_downloader.py
+++ b/tests/unit/core/plugin/test_downloader.py
@@ -2,7 +2,9 @@
 
 import hashlib
 import json
+import os
 import shutil
+import sys
 import zipfile
 from pathlib import Path
 from typing import Any, Iterator
@@ -11,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from ggshield.core.plugin import downloader as downloader_module
 from ggshield.core.plugin.client import (
     PluginDownloadInfo,
     PluginSource,
@@ -22,6 +25,9 @@ from ggshield.core.plugin.downloader import (
     GitHubArtifactError,
     InsecureSourceError,
     PluginDownloader,
+    UninstallPermissionError,
+    _chmod_tree_for_removal,
+    _find_foreign_owned_path,
     get_plugins_dir,
     get_signature_label,
 )
@@ -226,6 +232,194 @@ class TestPluginDownloader:
 
         assert not plugin_dir.exists()
         assert extract_cache.exists()  # not removed, but uninstall still succeeded
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission semantics")
+    def test_uninstall_fixes_unwritable_residue(self, tmp_path: Path) -> None:
+        """
+        GIVEN an installed plugin holding a non-writable legacy extraction dir
+        WHEN uninstalling
+        THEN the chmod-retry pass removes the whole tree
+        """
+        plugin_dir = tmp_path / "testplugin"
+        residue = plugin_dir / ".testplugin-1.0.0_extracted" / "testplugin.dist-info"
+        residue.mkdir(parents=True)
+        (residue / "RECORD").touch()
+        (plugin_dir / "manifest.json").write_text("{}")
+        (plugin_dir / "testplugin.whl").touch()
+        residue.chmod(0o555)
+        residue.parent.chmod(0o555)
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        try:
+            assert downloader.uninstall("testplugin") is True
+        finally:
+            # Re-grant write so pytest can clean tmp_path if removal failed
+            for path in (residue.parent, residue):
+                if path.exists():
+                    path.chmod(0o755)
+
+        assert not plugin_dir.exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_uninstall_foreign_owned_tree_raises_remediation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a plugin tree that rmtree cannot delete because another user owns it
+        WHEN uninstalling
+        THEN UninstallPermissionError names the foreign path and the trust
+             record is NOT revoked (the files are still installed)
+        """
+        plugin_dir = tmp_path / "testplugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{}")
+        record = plugin_dir / "RECORD"
+        record.touch()
+
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        real_euid = os.geteuid()
+        with (
+            patch(
+                "ggshield.core.plugin.downloader.shutil.rmtree",
+                side_effect=PermissionError(13, "Permission denied", str(record)),
+            ),
+            patch("os.geteuid", return_value=real_euid + 1),
+            patch.object(downloader.trust_store, "revoke_plugin") as mock_revoke,
+        ):
+            with pytest.raises(UninstallPermissionError) as exc_info:
+                downloader.uninstall("testplugin")
+
+        error = exc_info.value
+        assert error.plugin_dir == plugin_dir
+        assert error.offending_path == plugin_dir
+        assert error.owner_uid == real_euid
+        mock_revoke.assert_not_called()
+        assert plugin_dir.exists()
+
+    def test_remove_plugin_tree_handles_vanished_dir(self, tmp_path: Path) -> None:
+        """A dir that disappears before the first rmtree is a no-op, not an error."""
+        plugin_dir = tmp_path / "testplugin"
+        plugin_dir.mkdir()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        with patch(
+            "ggshield.core.plugin.downloader.shutil.rmtree",
+            side_effect=FileNotFoundError(),
+        ):
+            downloader._remove_plugin_tree(plugin_dir)  # must not raise
+
+    def test_remove_plugin_tree_retry_hits_vanished_dir(self, tmp_path: Path) -> None:
+        """If the tree vanishes during the chmod-retry, that's success, not an error."""
+        plugin_dir = tmp_path / "testplugin"
+        plugin_dir.mkdir()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        rmtree = MagicMock(side_effect=[OSError("busy"), FileNotFoundError()])
+        with patch("ggshield.core.plugin.downloader.shutil.rmtree", rmtree):
+            downloader._remove_plugin_tree(plugin_dir)  # must not raise
+        assert rmtree.call_count == 2
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_remove_plugin_tree_owned_but_unremovable_uses_filename(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A persistently unremovable tree that is NOT foreign-owned still raises,
+        falling back to the OSError's filename and a None owner uid.
+        """
+        plugin_dir = tmp_path / "testplugin"
+        plugin_dir.mkdir()
+        stuck = plugin_dir / "stuck"
+        stuck.touch()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        err = PermissionError(13, "Permission denied", str(stuck))
+        with patch("ggshield.core.plugin.downloader.shutil.rmtree", side_effect=err):
+            with pytest.raises(UninstallPermissionError) as exc_info:
+                downloader._remove_plugin_tree(plugin_dir)
+
+        assert exc_info.value.owner_uid is None
+        assert exc_info.value.offending_path == stuck
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_remove_plugin_tree_unremovable_no_filename_falls_back_to_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """When the OSError carries no filename, the plugin dir is reported."""
+        plugin_dir = tmp_path / "testplugin"
+        plugin_dir.mkdir()
+        with patch(
+            "ggshield.core.plugin.downloader.get_plugins_dir", return_value=tmp_path
+        ):
+            downloader = PluginDownloader()
+
+        with patch(
+            "ggshield.core.plugin.downloader.shutil.rmtree",
+            side_effect=OSError("denied"),
+        ):
+            with pytest.raises(UninstallPermissionError) as exc_info:
+                downloader._remove_plugin_tree(plugin_dir)
+
+        assert exc_info.value.offending_path == plugin_dir
+        assert exc_info.value.owner_uid is None
+
+    def test_chmod_tree_for_removal_swallows_chmod_errors(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """chmod failures on individual entries must not abort the pass."""
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "file").touch()
+
+        def boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("cannot chmod")
+
+        monkeypatch.setattr(downloader_module.os, "chmod", boom)
+        _chmod_tree_for_removal(tmp_path)  # must not raise
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_find_foreign_owned_path_all_owned_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """A tree fully owned by the current user has no foreign entries."""
+        (tmp_path / "file").touch()
+        assert _find_foreign_owned_path(tmp_path) is None
+
+    def test_find_foreign_owned_path_without_geteuid_returns_none(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """On platforms without os.geteuid (Windows), ownership can't be judged."""
+        monkeypatch.setattr(downloader_module.os, "geteuid", None, raising=False)
+        assert _find_foreign_owned_path(tmp_path) is None
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_find_foreign_owned_path_skips_unstatable_entries(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Entries whose lstat raises are skipped rather than crashing the walk."""
+        (tmp_path / "file").touch()
+
+        def boom(self: Path) -> None:
+            raise OSError("gone")
+
+        monkeypatch.setattr(Path, "lstat", boom)
+        assert _find_foreign_owned_path(tmp_path) is None
 
     def test_uninstall_removes_trust_record(self, tmp_path: Path) -> None:
         """Test uninstall also removes any persisted trust exception."""

--- a/tests/unit/core/plugin/test_loader.py
+++ b/tests/unit/core/plugin/test_loader.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -100,6 +101,53 @@ class TestPluginLoader:
         loader = PluginLoader(config)
 
         assert loader._is_enabled("any-plugin") is False
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="requires os.geteuid")
+    def test_is_foreign_owned_false_for_owned_path(self, tmp_path: Path) -> None:
+        """A path owned by the current user is not foreign."""
+        assert PluginLoader._is_foreign_owned(tmp_path) is False
+
+    def test_is_foreign_owned_false_without_geteuid(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """Without os.geteuid (Windows), ownership cannot be judged."""
+        monkeypatch.setattr(os, "geteuid", None, raising=False)
+        assert PluginLoader._is_foreign_owned(tmp_path) is False
+
+    def test_is_foreign_owned_false_on_lstat_error(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """An unstatable path is treated as not-foreign rather than crashing."""
+
+        def boom(self: Path) -> None:
+            raise OSError("gone")
+
+        monkeypatch.setattr(Path, "lstat", boom)
+        assert PluginLoader._is_foreign_owned(tmp_path / "x") is False
+
+    def test_prune_stale_warns_on_foreign_owned_residue(
+        self, tmp_path: Path, caplog: "pytest.LogCaptureFixture"
+    ) -> None:
+        """A foreign-owned stale extraction dir is surfaced as a warning."""
+        config = EnterpriseConfig()
+        loader = PluginLoader(config)
+
+        keep_dir = tmp_path / "keep_extracted"
+        keep_dir.mkdir()
+        (tmp_path / "old_extracted").mkdir()
+
+        with (
+            patch(
+                "ggshield.core.plugin.loader.shutil.rmtree",
+                side_effect=OSError("denied"),
+            ),
+            patch.object(PluginLoader, "_is_foreign_owned", return_value=True),
+            caplog.at_level(logging.WARNING),
+        ):
+            loader._prune_stale_extract_dirs(keep_dir)
+
+        assert "owned by another user" in caplog.text
+        assert "sudo rm -rf" in caplog.text
 
     def test_is_enabled_explicit_enabled(self) -> None:
         """Test checking explicitly enabled plugin."""


### PR DESCRIPTION
## Problem

`ggshield plugin uninstall <name>` crashes with a raw, unhandled traceback when the plugin's files can't be removed:

```
PermissionError: [Errno 13] Permission denied: 'RECORD'
[82629] Failed to execute script '__main__' due to unhandled exception!
```

`PluginDownloader.uninstall` did a bare `shutil.rmtree(plugin_dir)` with no permission handling. Two real-world conditions trigger it:

- **Read-only entries** in the tree (the usual Windows `rmtree` blocker).
- **Foreign-owned files** — most commonly a stale, root-owned wheel-extraction dir left *inside* the plugin dir by a legacy `sudo ggshield plugin install` (older layout that extracted wheels under the plugin dir). The current user can't unlink files such as `RECORD` inside a root-owned dir.

Secondary bug: `trust_store.revoke_plugin` ran *before* `rmtree`, so a failed uninstall left the plugin installed but trust-revoked.

Note: the v1.51.0 root-install hardening (`ctourriere/fix_root_plugin_installation`) fixed install/load/update and redirected root extraction caches, but never touched the uninstall path — this closes that gap.

## Fix

- `uninstall` now removes the tree via a new `_remove_plugin_tree`: try `rmtree`; on failure, run a chmod pass (dirs `u+rwx`, files `u+w`) and retry once.
- If removal still fails, raise `UninstallPermissionError` carrying the plugin dir, the offending path, and (on POSIX) the owner uid.
- `uninstall_cmd` catches it and prints a clear remediation (re-run with sudo, or `sudo rm -rf '<dir>'`) and exits `UNEXPECTED_ERROR` — no traceback.
- Revoke the trust record **only after** the files are gone.
- `PluginLoader._prune_stale_extract_dirs` now logs a `warning` (was `debug`) with remediation when stale extraction residue is foreign-owned, so it's visible rather than silently swallowed.

## Tests

- `test_uninstall_fixes_unwritable_residue` — chmod-retry removes an otherwise-unremovable read-only `*_extracted/dist-info/RECORD` tree.
- `test_uninstall_foreign_owned_tree_raises_remediation_error` — foreign-owned tree raises `UninstallPermissionError` with the path/uid, and trust is **not** revoked.
- `test_uninstall_permission_error_shows_remediation` — CLI prints the remediation and exits cleanly (no traceback).

442 plugin tests pass; black/flake8/isort/pyright/import-linter all green.

## Manual verification

Reproduced the exact `PermissionError: [Errno 13] ... 'RECORD'` on an unwritable `RECORD`, confirmed the fixed CLI removes the same tree cleanly, and ran a read-only check against a real root-owned `.<dist>-<ver>_extracted` residue — the fix correctly detects uid 0 and renders the remediation naming that directory.