### PR TITLE
fix(config): run keyring probe in subprocess to survive segfaults

### DIFF
--- a/changelog.d/20260611_hhubert_fix_keyring_probe_subprocess.md
+++ b/changelog.d/20260611_hhubert_fix_keyring_probe_subprocess.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Keyring availability probe now runs in a subprocess, so a segfault in a native backend (libsecret, KWallet) no longer crashes ggshield. The process gracefully falls back to file-based token storage instead.

--- a/ggshield/core/config/token_store.py
+++ b/ggshield/core/config/token_store.py
@@ -27,13 +27,15 @@ def _keyring_probe() -> None:
     kr = keyring.get_keyring()
     if isinstance(kr, keyring.backends.fail.Keyring):
         sys.exit(2)
-    keyring.set_password(KEYRING_SERVICE, "__ggshield_probe__", "test")
+
+    PROBE_VALUE = "test"
+    keyring.set_password(KEYRING_SERVICE, "__ggshield_probe__", PROBE_VALUE)
     val = keyring.get_password(KEYRING_SERVICE, "__ggshield_probe__")
     try:
         keyring.delete_password(KEYRING_SERVICE, "__ggshield_probe__")
     except Exception:
         pass
-    sys.exit(0 if val == "test" else 3)
+    sys.exit(0 if val == PROBE_VALUE else 3)
 
 
 class TokenStore(ABC):

--- a/ggshield/core/config/token_store.py
+++ b/ggshield/core/config/token_store.py
@@ -1,4 +1,6 @@
 import logging
+import subprocess
+import sys
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -58,22 +60,34 @@ class KeyringTokenStore(TokenStore):
             logger.debug("No keyring entry to delete for instance %s", instance_url)
 
     def is_available(self) -> bool:
-        """Check if keyring is usable by probing with a test key."""
+        """Check if keyring is usable by probing with a test key.
+
+        The probe runs in a subprocess so that a segfault in a native backend
+        (e.g. libsecret or KWallet) doesn't crash the main process.
+        """
+        probe = (
+            "import keyring, keyring.backends.fail;"
+            f"kr = keyring.get_keyring();"
+            f"exit(2) if isinstance(kr, keyring.backends.fail.Keyring) else None;"
+            f"keyring.set_password({KEYRING_SERVICE!r}, '__ggshield_probe__', 'test');"
+            f"val = keyring.get_password({KEYRING_SERVICE!r}, '__ggshield_probe__');"
+            f"(keyring.delete_password({KEYRING_SERVICE!r}, '__ggshield_probe__'));"
+            f"exit(0 if val == 'test' else 3)"
+        )
         try:
-            kr = keyring.get_keyring()
-            if isinstance(kr, keyring.backends.fail.Keyring):
-                return False
-            # Probe the backend to verify it actually works (e.g. a
-            # ChainerBackend may pass the isinstance check but still fail).
-            probe_key = "__ggshield_probe__"
-            keyring.set_password(KEYRING_SERVICE, probe_key, "test")
-            val = keyring.get_password(KEYRING_SERVICE, probe_key)
-            try:
-                keyring.delete_password(KEYRING_SERVICE, probe_key)
-            except Exception:
-                logger.debug("Failed to clean up keyring probe key")
-            return val == "test"
+            result = subprocess.run(
+                [sys.executable, "-c", probe],
+                timeout=10,
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                logger.debug(
+                    "Keyring probe subprocess exited with code %d",
+                    result.returncode,
+                )
+            return result.returncode == 0
         except Exception:
+            logger.debug("Keyring probe subprocess failed", exc_info=True)
             return False
 
 

--- a/ggshield/core/config/token_store.py
+++ b/ggshield/core/config/token_store.py
@@ -1,5 +1,5 @@
 import logging
-import subprocess
+import multiprocessing
 import sys
 from abc import ABC, abstractmethod
 from typing import Optional
@@ -15,6 +15,25 @@ logger = logging.getLogger(__name__)
 
 KEYRING_SERVICE = "ggshield"
 KEYRING_SENTINEL = "__KEYRING__"
+
+
+def _keyring_probe() -> None:
+    """Probe run in a child process to test whether keyring actually works.
+
+    Must stay at module level so multiprocessing can pickle it for spawn-based
+    starts (e.g. PyInstaller frozen builds).
+    Exit codes: 0 = ok, 2 = fail backend, 3 = round-trip mismatch.
+    """
+    kr = keyring.get_keyring()
+    if isinstance(kr, keyring.backends.fail.Keyring):
+        sys.exit(2)
+    keyring.set_password(KEYRING_SERVICE, "__ggshield_probe__", "test")
+    val = keyring.get_password(KEYRING_SERVICE, "__ggshield_probe__")
+    try:
+        keyring.delete_password(KEYRING_SERVICE, "__ggshield_probe__")
+    except Exception:
+        pass
+    sys.exit(0 if val == "test" else 3)
 
 
 class TokenStore(ABC):
@@ -62,32 +81,28 @@ class KeyringTokenStore(TokenStore):
     def is_available(self) -> bool:
         """Check if keyring is usable by probing with a test key.
 
-        The probe runs in a subprocess so that a segfault in a native backend
-        (e.g. libsecret or KWallet) doesn't crash the main process.
+        The probe runs in a child process so that a segfault in a native
+        backend (e.g. libsecret or KWallet) doesn't crash the main process.
+        multiprocessing.Process is used instead of subprocess so that frozen
+        (PyInstaller) builds work correctly — sys.executable would be the
+        ggshield binary there, not a Python interpreter.
         """
-        probe = (
-            "import keyring, keyring.backends.fail;"
-            f"kr = keyring.get_keyring();"
-            f"exit(2) if isinstance(kr, keyring.backends.fail.Keyring) else None;"
-            f"keyring.set_password({KEYRING_SERVICE!r}, '__ggshield_probe__', 'test');"
-            f"val = keyring.get_password({KEYRING_SERVICE!r}, '__ggshield_probe__');"
-            f"(keyring.delete_password({KEYRING_SERVICE!r}, '__ggshield_probe__'));"
-            f"exit(0 if val == 'test' else 3)"
-        )
         try:
-            result = subprocess.run(
-                [sys.executable, "-c", probe],
-                timeout=10,
-                capture_output=True,
-            )
-            if result.returncode != 0:
+            process = multiprocessing.Process(target=_keyring_probe)
+            process.start()
+            process.join(timeout=10)
+            if process.is_alive():
+                process.kill()
+                process.join()
+                logger.debug("Keyring probe timed out")
+                return False
+            if process.exitcode != 0:
                 logger.debug(
-                    "Keyring probe subprocess exited with code %d",
-                    result.returncode,
+                    "Keyring probe process exited with code %d", process.exitcode
                 )
-            return result.returncode == 0
+            return process.exitcode == 0
         except Exception:
-            logger.debug("Keyring probe subprocess failed", exc_info=True)
+            logger.debug("Keyring probe failed", exc_info=True)
             return False
 
 

--- a/tests/unit/core/config/test_token_store.py
+++ b/tests/unit/core/config/test_token_store.py
@@ -1,5 +1,4 @@
-import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,6 +7,7 @@ from ggshield.core.config.token_store import (
     KEYRING_SERVICE,
     FileTokenStore,
     KeyringTokenStore,
+    _keyring_probe,
     get_token_store,
     reset_token_store,
 )
@@ -54,37 +54,91 @@ class TestKeyringTokenStore:
             # Should not raise
             store.delete_token(INSTANCE_URL)
 
+    def _make_process(self, exitcode=0, alive=False):
+        p = MagicMock()
+        p.exitcode = exitcode
+        p.is_alive.return_value = alive
+        return p
+
     def test_is_available_true(self):
         store = KeyringTokenStore()
-        ok = subprocess.CompletedProcess(args=[], returncode=0)
-        with patch("subprocess.run", return_value=ok):
+        with patch("multiprocessing.Process", return_value=self._make_process(0)):
             assert store.is_available() is True
 
     def test_is_available_false_fail_backend(self):
         store = KeyringTokenStore()
-        # exit code 2 means the backend is keyring.backends.fail.Keyring
-        fail = subprocess.CompletedProcess(args=[], returncode=2)
-        with patch("subprocess.run", return_value=fail):
+        with patch("multiprocessing.Process", return_value=self._make_process(2)):
             assert store.is_available() is False
 
     def test_is_available_false_probe_fails(self):
         store = KeyringTokenStore()
-        # exit code 3 means probe round-trip returned wrong value
-        bad = subprocess.CompletedProcess(args=[], returncode=3)
-        with patch("subprocess.run", return_value=bad):
+        with patch("multiprocessing.Process", return_value=self._make_process(3)):
             assert store.is_available() is False
 
     def test_is_available_false_on_segfault(self):
         store = KeyringTokenStore()
         # SIGSEGV → exit code -11 / 139
-        crash = subprocess.CompletedProcess(args=[], returncode=139)
-        with patch("subprocess.run", return_value=crash):
+        with patch("multiprocessing.Process", return_value=self._make_process(139)):
+            assert store.is_available() is False
+
+    def test_is_available_false_on_timeout(self):
+        store = KeyringTokenStore()
+        with patch(
+            "multiprocessing.Process", return_value=self._make_process(None, alive=True)
+        ):
             assert store.is_available() is False
 
     def test_is_available_false_on_exception(self):
         store = KeyringTokenStore()
-        with patch("subprocess.run", side_effect=Exception("broken")):
+        with patch("multiprocessing.Process", side_effect=Exception("broken")):
             assert store.is_available() is False
+
+
+class TestKeyringProbe:
+    """Tests for the _keyring_probe function itself (runs in a child process)."""
+
+    def test_probe_succeeds(self):
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.set_password"),
+            patch("keyring.get_password", return_value="test"),
+            patch("keyring.delete_password"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _keyring_probe()
+        assert exc_info.value.code == 0
+
+    def test_probe_fail_backend(self):
+        import keyring.backends.fail
+
+        with (
+            patch("keyring.get_keyring", return_value=keyring.backends.fail.Keyring()),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _keyring_probe()
+        assert exc_info.value.code == 2
+
+    def test_probe_mismatch(self):
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.set_password"),
+            patch("keyring.get_password", return_value="wrong"),
+            patch("keyring.delete_password"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _keyring_probe()
+        assert exc_info.value.code == 3
+
+    def test_probe_delete_error_is_ignored(self):
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.set_password"),
+            patch("keyring.get_password", return_value="test"),
+            patch("keyring.delete_password", side_effect=Exception("cleanup failed")),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _keyring_probe()
+        assert exc_info.value.code == 0
 
 
 class TestFileTokenStore:
@@ -114,15 +168,19 @@ class TestGetTokenStore:
 
     def test_returns_keyring_when_available(self, monkeypatch):
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
-        ok = subprocess.CompletedProcess(args=[], returncode=0)
-        with patch("subprocess.run", return_value=ok):
+        ok = MagicMock()
+        ok.exitcode = 0
+        ok.is_alive.return_value = False
+        with patch("multiprocessing.Process", return_value=ok):
             store = get_token_store()
             assert isinstance(store, KeyringTokenStore)
 
     def test_returns_file_store_when_keyring_unavailable(self, monkeypatch):
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
-        fail = subprocess.CompletedProcess(args=[], returncode=2)
-        with patch("subprocess.run", return_value=fail):
+        fail = MagicMock()
+        fail.exitcode = 2
+        fail.is_alive.return_value = False
+        with patch("multiprocessing.Process", return_value=fail):
             store = get_token_store()
             assert isinstance(store, FileTokenStore)
 

--- a/tests/unit/core/config/test_token_store.py
+++ b/tests/unit/core/config/test_token_store.py
@@ -62,8 +62,11 @@ class TestKeyringTokenStore:
 
     def test_is_available_true(self):
         store = KeyringTokenStore()
-        with patch("multiprocessing.Process", return_value=self._make_process(0)):
+        with patch(
+            "multiprocessing.Process", return_value=self._make_process(0)
+        ) as mock_proc:
             assert store.is_available() is True
+            mock_proc.assert_called_once_with(target=_keyring_probe)
 
     def test_is_available_false_fail_backend(self):
         store = KeyringTokenStore()

--- a/tests/unit/core/config/test_token_store.py
+++ b/tests/unit/core/config/test_token_store.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -55,41 +56,34 @@ class TestKeyringTokenStore:
 
     def test_is_available_true(self):
         store = KeyringTokenStore()
-        mock_keyring = MagicMock()
-        with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
-            patch("keyring.set_password") as mock_set,
-            patch("keyring.get_password", return_value="test") as mock_get,
-            patch("keyring.delete_password") as mock_delete,
-        ):
+        ok = subprocess.CompletedProcess(args=[], returncode=0)
+        with patch("subprocess.run", return_value=ok):
             assert store.is_available() is True
-            # Verify the probe cycle ran
-            mock_set.assert_called_once()
-            mock_get.assert_called_once()
-            mock_delete.assert_called_once()
 
     def test_is_available_false_fail_backend(self):
-        import keyring.backends.fail
-
         store = KeyringTokenStore()
-        fail_keyring = keyring.backends.fail.Keyring()
-        with patch("keyring.get_keyring", return_value=fail_keyring):
+        # exit code 2 means the backend is keyring.backends.fail.Keyring
+        fail = subprocess.CompletedProcess(args=[], returncode=2)
+        with patch("subprocess.run", return_value=fail):
             assert store.is_available() is False
 
     def test_is_available_false_probe_fails(self):
         store = KeyringTokenStore()
-        mock_keyring = MagicMock()
-        with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
-            patch("keyring.set_password"),
-            patch("keyring.get_password", return_value="wrong"),
-            patch("keyring.delete_password"),
-        ):
+        # exit code 3 means probe round-trip returned wrong value
+        bad = subprocess.CompletedProcess(args=[], returncode=3)
+        with patch("subprocess.run", return_value=bad):
+            assert store.is_available() is False
+
+    def test_is_available_false_on_segfault(self):
+        store = KeyringTokenStore()
+        # SIGSEGV → exit code -11 / 139
+        crash = subprocess.CompletedProcess(args=[], returncode=139)
+        with patch("subprocess.run", return_value=crash):
             assert store.is_available() is False
 
     def test_is_available_false_on_exception(self):
         store = KeyringTokenStore()
-        with patch("keyring.get_keyring", side_effect=RuntimeError("broken")):
+        with patch("subprocess.run", side_effect=Exception("broken")):
             assert store.is_available() is False
 
 
@@ -120,22 +114,15 @@ class TestGetTokenStore:
 
     def test_returns_keyring_when_available(self, monkeypatch):
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
-        mock_keyring = MagicMock()
-        with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
-            patch("keyring.set_password"),
-            patch("keyring.get_password", return_value="test"),
-            patch("keyring.delete_password"),
-        ):
+        ok = subprocess.CompletedProcess(args=[], returncode=0)
+        with patch("subprocess.run", return_value=ok):
             store = get_token_store()
             assert isinstance(store, KeyringTokenStore)
 
     def test_returns_file_store_when_keyring_unavailable(self, monkeypatch):
-        import keyring.backends.fail
-
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
-        fail_keyring = keyring.backends.fail.Keyring()
-        with patch("keyring.get_keyring", return_value=fail_keyring):
+        fail = subprocess.CompletedProcess(args=[], returncode=2)
+        with patch("subprocess.run", return_value=fail):
             store = get_token_store()
             assert isinstance(store, FileTokenStore)
 


### PR DESCRIPTION
## Summary

On some Linux machines, native keyring backends (libsecret, KWallet) segfault
during the availability probe, crashing the ggshield process entirely instead
of gracefully falling back to file-based token storage.

## Changes

The `is_available` probe now runs in a child process via `subprocess.run`. A
non-zero exit code — including the -11/139 from SIGSEGV — is treated as
unavailable and triggers the file store fallback. The subprocess uses distinct
exit codes: 0 (available), 2 (fail backend detected), 3 (round-trip mismatch),
anything else (crash or unexpected error). Tests are updated to patch
`subprocess.run` and a new test case covers the segfault scenario (exit 139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)