### PR TITLE
fix(ci): surface Chocolatey 409 conflicts and fix packageSourceUrl

### DIFF
--- a/scripts/chocolatey/ggshield.nuspec
+++ b/scripts/chocolatey/ggshield.nuspec
@@ -11,7 +11,7 @@
     <licenseUrl>https://raw.githubusercontent.com/GitGuardian/ggshield/refs/heads/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/GitGuardian/ggshield</projectSourceUrl>
-    <packageSourceUrl>https://github.com/GitGuardian/ggshield/tree/main/scripts/push-to-chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/GitGuardian/ggshield/tree/main/scripts/chocolatey</packageSourceUrl>
     <docsUrl>https://docs.gitguardian.com/ggshield-docs/getting-started</docsUrl>
     <tags>ggshield</tags>
     <summary>ggshield is a CLI application that helps you detect secrets.</summary>

--- a/scripts/chocolatey/push
+++ b/scripts/chocolatey/push
@@ -14,4 +14,35 @@ fi
 choco_nupkg=$1
 
 # push to chocolatey
-choco push $choco_nupkg --source https://push.chocolatey.org/ --api-key $CHOCOLATEY_API_KEY
+set +e
+output=$(choco push "$choco_nupkg" --source https://push.chocolatey.org/ --api-key "$CHOCOLATEY_API_KEY" 2>&1)
+status=$?
+set -e
+
+echo "$output"
+[ "$status" -eq 0 ] && exit 0
+
+# `choco push` returns 409 when the version already exists in Chocolatey's system,
+# including "pending"/"rejected" moderation states that are hidden from the public
+# feed — re-pushing the same version then always fails. See END-315.
+if grep -qiE '409|conflict|already exists' <<<"$output"; then
+    nupkg_name=$(basename "$choco_nupkg")
+    version=${nupkg_name#ggshield.}
+    version=${version%.nupkg}
+    cat >&2 <<EOF
+
+ERROR: Chocolatey rejected the push of ${nupkg_name} with HTTP 409 (Conflict).
+Version ${version} already exists in Chocolatey's system — it was most likely
+submitted earlier and is now pending or rejected in moderation. Such versions are
+hidden from the public feed, so the channel looks stuck on the last approved one.
+
+Re-pushing the same version will always 409; this release was NOT published.
+Action: review the ggshield package in the maintainer view at
+https://community.chocolatey.org (it lists pending/rejected versions). If
+${version} is rejected, the version number is burned — publish a fresh version.
+EOF
+    exit 1
+fi
+
+echo "Chocolatey push of ${choco_nupkg} failed (exit ${status}). See output above." >&2
+exit "$status"


### PR DESCRIPTION
## Context

The Chocolatey channel has been stuck on **1.50.1** since 2026-04-29. Investigation under END-315 found the `push_to_chocolatey` job has failed on **every** release since — 1.50.2, 1.50.3, 1.50.4 and 1.51.0 — each with the same **HTTP 409 (Conflict)**: the version already exists in Chocolatey's moderation system. Because the failure looked like a generic red X and re-pushing always 409s, it went unnoticed for ~6 weeks.

Refs END-315.

## What has been done

- **`scripts/chocolatey/push`**: detect a 409 from `choco push` and exit with an explicit, actionable message ("version already in moderation → publish a fresh version") instead of a generic failure. Non-409 errors keep their original exit code; the missing-API-key guard is unchanged.
- **`scripts/chocolatey/ggshield.nuspec`**: fix `packageSourceUrl` — it pointed at `scripts/push-to-chocolatey`, but that directory was renamed to `scripts/chocolatey` (in v1.40.0), so the URL 404'd. The Chocolatey moderation reviewer explicitly verifies this URL.

> This makes the failure **loud and actionable** but does not by itself republish a stuck version — the 1.50.2–1.51.0 submissions need a moderation-side resolution (handled separately).

## Validation

- `bash -n scripts/chocolatey/push` passes.
- Behavioral checks with a mocked `choco`:
  - 409 output → exits 1 with the moderation message, naming the version.
  - success → exits 0.
  - non-409 error (e.g. 403) → generic failure surfaced, **not** the 409 message.
  - missing `CHOCOLATEY_API_KEY` → guarded.
- The new `packageSourceUrl` resolves **HTTP 200**.

## PR check list

- [x] Changes covered by the mocked-`choco` behavioral checks above (no unit-test harness exists for the release shell scripts)
- [x] `skip-changelog` label added — release-pipeline change, no end-user impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)