### PR TITLE
fix(secret): censor ignored secrets appearing in context lines

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -24,6 +24,10 @@ secret:
       name: Test secret mentioned in commit 6282ceb9035c1bfcceec5f6372f69063cdd588f7
     - match: e90eaa00d17c03309b660e1879c70b815509422c2d4cf0980b2e1221dffa0381
       name: Test secret mentioned in commit 6282ceb9035c1bfcceec5f6372f69063cdd588f7
+    - match: 796c064d6cfd48964052633c64979c19bf232e9fe7da667b75f1a0485d62fb8d
+      name: Fake secret in test_ignored_secret_context_leak.py
+    - match: 5af590dc986688e893c7cb22638a4175d8e3b3268a9499c4fb007d5f43cf3b8b
+      name: Fake secret in test_ignored_secret_context_leak.py
 
   ignored_paths:
     - '**/README.md'

--- a/changelog.d/20260612_henri.hubert_ignored_secret_context_leak.md
+++ b/changelog.d/20260612_henri.hubert_ignored_secret_context_leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ignored secrets (for example secrets on context or deleted lines of a patch) no longer appear in plaintext when they show up in the context lines of another displayed secret.

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -144,6 +144,11 @@ class Result:
     url: str
     secrets: List[Secret]
     ignored_secrets_count_by_kind: Counter[IgnoreKind]
+    # Matches of ignored secrets which are not in `secrets`. Kept so that
+    # `censor()` can censor their lines too: `Line` objects are shared, so an
+    # uncensored ignored secret would leak in the context lines of the
+    # displayed secrets.
+    filtered_out_matches: List[ExtendedMatch] = field(default_factory=list)
 
     @property
     def is_on_patch(self) -> bool:
@@ -153,6 +158,8 @@ class Result:
         for secret in self.secrets:
             for extended_match in secret.matches:
                 cast(ExtendedMatch, extended_match).censor()
+        for extended_match in self.filtered_out_matches:
+            extended_match.censor()
 
     @property
     def has_secrets(self) -> bool:
@@ -168,6 +175,7 @@ class Result:
         """
 
         to_keep: List[Tuple[PolicyBreak, Optional[IgnoreReason]]] = []
+        filtered_out: List[PolicyBreak] = []
         ignored_secrets_count_by_kind = Counter()
         for policy_break in scan_result.policy_breaks:
             ignore_reason = compute_ignore_reason(policy_break, secret_config)
@@ -176,6 +184,7 @@ class Result:
                     to_keep.append((policy_break, ignore_reason))
                 else:
                     ignored_secrets_count_by_kind[ignore_reason.kind] += 1
+                    filtered_out.append(policy_break)
             else:
                 to_keep.append((policy_break, None))
 
@@ -214,6 +223,11 @@ class Result:
         ]
 
         result.secrets = secrets
+        result.filtered_out_matches = [
+            ExtendedMatch.from_match(match, lines, result.is_on_patch)
+            for policy_break in filtered_out
+            for match in policy_break.matches
+        ]
         return result
 
 

--- a/tests/unit/verticals/secret/output/test_ignored_secret_context_leak.py
+++ b/tests/unit/verticals/secret/output/test_ignored_secret_context_leak.py
@@ -1,0 +1,141 @@
+"""
+Regression test: ignored (NOT_INTRODUCED) secrets must not leak in plaintext
+through context lines of adjacent displayed secrets.
+
+Bug: when two secrets are adjacent in a patch and the first is on a context
+line (DiffKind.CONTEXT → filtered as NOT_INTRODUCED), Result.censor() never
+touches its Line object.  That same Line object appears in the displayed
+secret's lines_before_secret / lines_after_secret, so it is printed in
+plaintext despite show_secrets=False.
+"""
+
+import click
+from pygitguardian.models import ScanResult
+
+from ggshield.core.config.user_config import SecretConfig
+from ggshield.core.scan import StringScannable
+from ggshield.utils.git_shell import Filemode
+from ggshield.verticals.secret import Result, Results, SecretScanCollection
+from ggshield.verticals.secret.output import SecretTextOutputHandler
+
+
+# ---------------------------------------------------------------------------
+# Patch content
+# Context line holds an existing secret; the addition line holds a new one.
+# The two are adjacent so the context secret lands in lines_before_secret of
+# the displayed addition secret.
+# ---------------------------------------------------------------------------
+_PATCH = '@@ -1,2 +1,3 @@\n SMTP_PASSWORD = "existing_secret_abc123"\n+SMTP_PASSWORD2 = "new_secret_def456"\n'
+
+_EXISTING_SECRET = "existing_secret_abc123"
+_NEW_SECRET = "new_secret_def456"
+
+_EXISTING_START = _PATCH.index(_EXISTING_SECRET)
+_EXISTING_END = _EXISTING_START + len(_EXISTING_SECRET) - 1
+_NEW_START = _PATCH.index(_NEW_SECRET)
+_NEW_END = _NEW_START + len(_NEW_SECRET) - 1
+
+# ScanResult with:
+#   - policy break 1: diff_kind=context  → will be filtered as NOT_INTRODUCED
+#   - policy break 2: diff_kind=addition → displayed in output
+_SCAN_RESULT = ScanResult.SCHEMA.load(
+    {
+        "policies": ["Secrets detection"],
+        "policy_breaks": [
+            {
+                "type": "Generic Password",
+                "detector_name": "generic_password",
+                "detector_group_name": "generic_password",
+                "documentation_url": None,
+                "policy": "Secrets detection",
+                "validity": "no_checker",
+                "known_secret": False,
+                "incident_url": None,
+                "is_excluded": False,
+                "is_vaulted": False,
+                "diff_kind": "context",
+                "matches": [
+                    {
+                        "match": _EXISTING_SECRET,
+                        "index_start": _EXISTING_START,
+                        "index_end": _EXISTING_END,
+                        "type": "password",
+                    }
+                ],
+            },
+            {
+                "type": "Generic Password",
+                "detector_name": "generic_password",
+                "detector_group_name": "generic_password",
+                "documentation_url": None,
+                "policy": "Secrets detection",
+                "validity": "no_checker",
+                "known_secret": False,
+                "incident_url": None,
+                "is_excluded": False,
+                "is_vaulted": False,
+                "diff_kind": "addition",
+                "matches": [
+                    {
+                        "match": _NEW_SECRET,
+                        "index_start": _NEW_START,
+                        "index_end": _NEW_END,
+                        "type": "password",
+                    }
+                ],
+            },
+        ],
+        "policy_break_count": 2,
+    }
+)
+
+
+def _run_output(show_secrets: bool) -> str:
+    result = Result.from_scan_result(
+        StringScannable(
+            content=_PATCH,
+            url="emailService.js",
+            filemode=Filemode.MODIFY,
+        ),
+        scan_result=_SCAN_RESULT,
+        secret_config=SecretConfig(),
+    )
+    handler = SecretTextOutputHandler(
+        secret_config=SecretConfig(show_secrets=show_secrets),
+        verbose=True,
+    )
+    raw = handler._process_scan_impl(
+        SecretScanCollection(
+            id="scan",
+            type="commit",
+            results=Results(results=[result]),
+        )
+    )
+    return click.unstyle(raw)
+
+
+def test_ignored_context_secret_not_leaked_in_adjacent_secret_context():
+    """
+    GIVEN a patch where a context-line secret (NOT_INTRODUCED) is immediately
+      above an addition-line secret
+    WHEN the text output handler renders the result with show_secrets=False
+    THEN the ignored secret's plaintext value must not appear anywhere in the
+      output (not even as a context line for the displayed addition secret)
+    """
+    output = _run_output(show_secrets=False)
+
+    assert (
+        _EXISTING_SECRET not in output
+    ), f"Ignored secret '{_EXISTING_SECRET}' leaked in plaintext output:\n{output}"
+    assert (
+        _NEW_SECRET not in output
+    ), f"Displayed secret '{_NEW_SECRET}' not censored in output:\n{output}"
+
+
+def test_show_secrets_reveals_both():
+    """
+    Sanity check: with show_secrets=True both values appear.
+    (The addition secret is shown; the context secret may appear in context.)
+    """
+    output = _run_output(show_secrets=True)
+    assert _NEW_SECRET in output

--- a/tests/unit/verticals/secret/output/test_ignored_secret_context_leak.py
+++ b/tests/unit/verticals/secret/output/test_ignored_secret_context_leak.py
@@ -1,12 +1,6 @@
 """
-Regression test: ignored (NOT_INTRODUCED) secrets must not leak in plaintext
+Regression test: NOT_INTRODUCED secrets must not leak in plaintext
 through context lines of adjacent displayed secrets.
-
-Bug: when two secrets are adjacent in a patch and the first is on a context
-line (DiffKind.CONTEXT → filtered as NOT_INTRODUCED), Result.censor() never
-touches its Line object.  That same Line object appears in the displayed
-secret's lines_before_secret / lines_after_secret, so it is printed in
-plaintext despite show_secrets=False.
 """
 
 import click


### PR DESCRIPTION
## Context

When a patch contains two adjacent secrets and the first one is on a context or deletion line (`DiffKind.CONTEXT` / `DiffKind.DELETION`), it is filtered out as `NOT_INTRODUCED` and `Result.censor()` never censors it. Since `Line` objects are shared by reference across all matches built from the same content, the ignored secret leaks in plaintext through the `lines_before_secret` / `lines_after_secret` context of the adjacent displayed secret, even with `show_secrets=False`.

Fixes [END-523](https://linear.app/gitguardian/issue/END-523/ggshield-ignored-secrets-leak-in-plaintext-as-context-lines-in-prci).

## What has been done

- Added a `filtered_out_matches` field to `Result`: in `from_scan_result()`, policy breaks that are dropped (when `--all-secrets` is off) now also get their matches converted to `ExtendedMatch` objects and kept there.
- `Result.censor()` now censors those matches alongside the displayed ones. `ExtendedMatch.censor()` modifies the shared `Line` objects in place with a length-preserving replacement, so the spans of displayed secrets are unaffected.
- Added a regression test reproducing the leak, plus a changelog entry.

With `--all-secrets`, ignored breaks become regular `Secret`s and were already censored, so behavior there is unchanged. With `--show-secrets`, nothing is censored, as before.

## Validation

- Run `pytest tests/unit/verticals/secret/output/test_ignored_secret_context_leak.py`: it fails on `main` (the context line shows the secret in plaintext) and passes on this branch (the context line renders as `SMTP_PASSWORD = "exi*****************123"`).
- Full unit suite passes (2106 tests).

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.