### PR TITLE
ci: build Linux ARM (aarch64) packages

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -56,8 +56,18 @@ jobs:
           - os: ubuntu-22.04
             # When building on Linux we use a container to build using an old enough version
             container: rockylinux/rockylinux:8
+            arch: x86_64
+            nfpm_arch: x86_64
             sha256sum:
               python: e8d7ed8c6f8c6f85cd083d5051cafd8c6c01d09eca340d1da74d0c00ff1cb897
+              nfpm: 9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
+          - os: ubuntu-24.04-arm
+            container: rockylinux/rockylinux:8
+            arch: aarch64
+            nfpm_arch: arm64
+            sha256sum:
+              python: 5dcd0486c403d07e27a1f2c256810122ac5d153f921433d77116df5c7d09b4c9
+              nfpm: ccfc3a154dec318100c6b6e28deddef0a1ffddf5e258364d74b647a129c72a0e
           - os: windows-2022
           - os: macos-15-intel
             arch: x86_64
@@ -88,7 +98,7 @@ jobs:
           echo PYTHON_CMD=python >> $GITHUB_ENV
 
       - name: Install Linux specific dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           # Install latest security updates
           yum update -y
@@ -102,7 +112,7 @@ jobs:
           PYTHON_VERSION=3.10.16
           PYTHON_BUILD=20250317
           scripts/download \
-            https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz \
+            https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${{ matrix.arch }}-unknown-linux-gnu-install_only_stripped.tar.gz \
             python.tar.gz \
             ${{ matrix.sha256sum.python }}
 
@@ -114,12 +124,11 @@ jobs:
 
           # Install NFPM
           NFPM_VERSION=2.36.1
-          NFPM_CHECKSUM=9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
 
           scripts/download \
-            https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz \
+            https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_${{ matrix.nfpm_arch }}.tar.gz \
             nfpm.tar.gz \
-            $NFPM_CHECKSUM
+            ${{ matrix.sha256sum.nfpm }}
 
           tar xf nfpm.tar.gz nfpm
           cp nfpm /usr/local/bin
@@ -284,11 +293,16 @@ jobs:
   # libraries it needs to run
   linux_package_smoke_tests:
     needs: build_os_packages
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     container: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
+        # Each runner architecture tests the packages built by the matching
+        # build_os_packages matrix entry
+        runner:
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
         image:
           - debian:stable
           - ubuntu:latest
@@ -314,7 +328,7 @@ jobs:
       - name: Download OS packages
         uses: actions/download-artifact@v4
         with:
-          pattern: os-packages-ubuntu-22.04
+          pattern: os-packages-${{ matrix.runner }}
           path: packages
           merge-multiple: true
 

--- a/changelog.d/20260612_benjamin.rigaud_linux_arm_builds.md
+++ b/changelog.d/20260612_benjamin.rigaud_linux_arm_builds.md
@@ -1,0 +1,4 @@
+### Added
+
+- Standalone Linux artifacts are now also built for ARM (aarch64): tar.gz
+  archive, .deb and .rpm packages.

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -80,11 +80,14 @@ init_system_vars() {
     arch=$(uname -m)
 
     case "$arch" in
-    arm64)
+    arm64|aarch64)
         HUMAN_ARCH=ARM-based
+        # Debian-style architecture name, used by nfpm
+        NFPM_ARCH=arm64
         ;;
     x86_64)
         HUMAN_ARCH=Intel-based
+        NFPM_ARCH=amd64
         ;;
     *)
         die "Unsupported architecture '$arch'"
@@ -363,6 +366,7 @@ create_linux_packages() {
 
         PYINSTALLER_OUTPUT_DIR=$PYINSTALLER_OUTPUT_DIR \
         VERSION=$VERSION \
+        NFPM_ARCH=$NFPM_ARCH \
             nfpm package \
                 --packager $format \
                 --config "$SCRIPT_DIR/nfpm.yaml" \

--- a/scripts/build-os-packages/nfpm.yaml
+++ b/scripts/build-os-packages/nfpm.yaml
@@ -9,7 +9,7 @@ description: |-
   ggshield runs in your local environment or in a CI environment to help you
   detect leaked secrets, as well as other potential security vulnerabilities.
 
-arch: amd64
+arch: ${NFPM_ARCH}
 platform: linux
 version: ${VERSION}
 version_schema: semver


### PR DESCRIPTION
## Context

Linux release artifacts are only built for x86_64; ARM machines (AWS Graviton, Ampere, ARM laptops) cannot install the standalone binary and must fall back to pip installs.

Closes END-531 (Linear).

## What this does

- Adds an arm64 entry to the `build_os_packages` matrix: GitHub's free `ubuntu-24.04-arm` runner with the same `rockylinux/rockylinux:8` container as the x86_64 build, so both share the same glibc baseline.
- Parameterizes the python-build-standalone and nfpm downloads by arch, with pinned sha256 checksums verified against the upstream `SHA256SUMS` / `checksums.txt` files.
- Derives the nfpm `arch` from `uname -m` instead of hardcoding `amd64`. New artifacts: `ggshield-X.Y.Z-aarch64-unknown-linux-gnu.tar.gz`, `ggshield_X.Y.Z-1_arm64.deb`, `ggshield-X.Y.Z-1.aarch64.rpm`.
- Runs `linux_package_smoke_tests` on both architectures (same distro image list).

No changes needed in `tag.yml`: the release upload, attestation, and Cloudsmith push steps all use wildcards that match the new artifact names (`scripts/push-to-cloudsmith` globs `packages/*.{rpm,deb}`).

## Validation

- `nfpm package` run locally against the modified `nfpm.yaml` with `NFPM_ARCH=arm64`/`amd64`: produces `ggshield_1.99.0-1_arm64.deb` (`Architecture: arm64` in metadata) and `ggshield-1.99.0-1.aarch64.rpm`; x86_64 names unchanged.
- aarch64 checksums verified against upstream checksum files.
- The CI run on this PR builds the arm64 packages end-to-end (PyInstaller on aarch64 is the part that cannot be validated locally).
- The libcrypt.so.1 bundling workaround (#1036) uses `/usr/lib64/libcrypt.so.1.1.0`, which is the same path on aarch64 rocky8 — covered by the rocky 8.8/9 smoke tests on the arm runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)