### PR TITLE
fix(honeytoken): serialize concurrent plant runs with an advisory lock

### DIFF
--- a/ggshield/verticals/honeytoken/aws_profile.py
+++ b/ggshield/verticals/honeytoken/aws_profile.py
@@ -163,11 +163,19 @@ def _decide_write(
 
 def open_aws_dir_fd(aws_dir: Path, *, create: bool) -> int:
     """Open ``.aws`` ``O_NOFOLLOW|O_DIRECTORY``, returning an fd that pins the real inode
-    (swap-immune). Symlink/non-dir → ``PlacementError``. ``create`` makes a missing dir
-    0700; else ``FileNotFoundError`` propagates (callers treat absent as a no-op)."""
+    (swap-immune) and holds an exclusive advisory lock for the read-modify-write window.
+    Symlink/non-dir → ``PlacementError``. ``create`` makes a missing dir 0700; else
+    ``FileNotFoundError`` propagates (callers treat absent as a no-op)."""
+    import fcntl
+
+    # flock(LOCK_EX) on the fd serializes concurrent `plant` invocations for the whole
+    # read-modify-write window; released when the caller closes the fd (or the process
+    # dies — no stale lock).
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     try:
-        return os.open(aws_dir, flags)
+        fd = os.open(aws_dir, flags)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return fd
     except FileNotFoundError:
         if not create:
             raise
@@ -182,7 +190,9 @@ def open_aws_dir_fd(aws_dir: Path, *, create: bool) -> int:
     except FileExistsError:
         pass
     try:
-        return os.open(aws_dir, flags)
+        fd = os.open(aws_dir, flags)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return fd
     except OSError as exc:
         raise PlacementError(
             f"refusing to use {aws_dir}: not a real directory (symlink?): {exc}"

--- a/tests/unit/verticals/honeytoken/test_aws_profile.py
+++ b/tests/unit/verticals/honeytoken/test_aws_profile.py
@@ -94,6 +94,16 @@ def test_write_creates_when_absent(tmp_path):
     }
 
 
+@pytest.mark.skipif(not FD_HARDENED, reason="needs dir fds / O_NOFOLLOW (POSIX)")
+def test_write_creates_aws_dir_when_missing(tmp_path):
+    """Planting into a home with no ``~/.aws`` creates it (private) and writes the profile."""
+    path = tmp_path / "home" / ".aws" / "credentials"  # .aws does not exist yet
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    assert _section(path, "gg")["aws_access_key_id"] == "K1"
+    assert path.parent.is_dir()
+    assert (path.parent.stat().st_mode & 0o077) == 0  # no group/other access
+
+
 def test_write_is_idempotent_for_same_key(tmp_path):
     path = tmp_path / "credentials"
     write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
@@ -528,3 +538,70 @@ def test_write_cleans_up_temp_on_failure(tmp_path, monkeypatch):
     leftover = [p.name for p in path.parent.iterdir() if p.name.startswith(".plant.")]
     assert leftover == []
     assert path.read_text() == original
+
+
+# --- concurrency: advisory lock over the read-modify-write window ------------------
+
+
+@pytest.mark.skipif(not FD_HARDENED, reason="POSIX advisory lock")
+def test_open_aws_dir_fd_holds_exclusive_lock(tmp_path):
+    """The dir fd carries an exclusive advisory lock, so a second acquirer is blocked."""
+    import fcntl
+
+    from ggshield.verticals.honeytoken.aws_profile import open_aws_dir_fd
+
+    aws = tmp_path / ".aws"
+    aws.mkdir()
+    dir_fd = open_aws_dir_fd(aws, create=False)
+    try:
+        probe = os.open(aws, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            os.close(probe)
+    finally:
+        os.close(dir_fd)  # releases the lock
+
+
+@pytest.mark.skipif(not FD_HARDENED, reason="POSIX advisory lock")
+def test_concurrent_plants_do_not_lose_a_profile(tmp_path, monkeypatch):
+    """Two plant invocations racing on the same file must not lose an update: the lock
+    serializes their read-modify-write so both profiles survive (a missing lock would
+    let the second rename clobber the first)."""
+    import threading
+    import time
+
+    from ggshield.verticals.honeytoken import aws_profile
+
+    path = tmp_path / ".aws" / "credentials"
+    path.parent.mkdir(parents=True)
+
+    # Widen the RMW window so an unlocked race would reliably drop one update.
+    real_write = aws_profile._atomic_write_via_fd
+
+    def slow_write(*args, **kwargs):
+        time.sleep(0.3)
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(aws_profile, "_atomic_write_via_fd", slow_write)
+
+    start = threading.Barrier(2)
+    errors = []
+
+    def plant(name):
+        try:
+            start.wait()
+            write_aws_profile(path, name, _creds(name, name + "-secret"), force=False)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=plant, args=(n,)) for n in ("gg1", "gg2")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert _section(path, "gg1")["aws_access_key_id"] == "gg1"
+    assert _section(path, "gg2")["aws_access_key_id"] == "gg2"


### PR DESCRIPTION
Hold an exclusive flock on the .aws dir fd for the whole read-modify-write window (write and remove) so two concurrent plant runs can't lose each other's update. Released on fd close or process death — no stale lock. POSIX only.

Refs HON-1407

## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
