### PR TITLE
feat(scripts): add ggshield install/uninstall scripts

### DIFF
--- a/changelog.d/20260615_143744_benjaminrigaud_install_scripts.md
+++ b/changelog.d/20260615_143744_benjaminrigaud_install_scripts.md
@@ -1,0 +1,3 @@
+### Added
+
+- Install and uninstall scripts under `scripts/install/`: a one-line `curl | bash` (Linux/macOS) and `irm | iex` (Windows) installer that detects the platform, picks the best install method, authenticates, and optionally installs plugins, plus a matching uninstaller that cleanly removes ggshield and its data.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -1,0 +1,149 @@
+# ggshield install scripts
+
+One-line scripts to install ggshield on your machine (for developers and
+non-developers), authenticate, optionally install plugins (`--plugin
+<name>`), and cleanly uninstall it later.
+
+## Install
+
+Linux / macOS:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1 | iex
+```
+
+Prefer inspecting before running:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL -o install.sh \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh
+less install.sh
+bash install.sh
+```
+
+The script detects the OS and architecture (including Rosetta 2 and musl) and
+picks the best installation method available:
+
+| Platform                                  | Method                                                               |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| macOS with Homebrew                       | `brew install ggshield`                                              |
+| macOS without Homebrew                    | standalone tarball in `~/.local/bin` (no sudo)                       |
+| Linux with apt/dnf/yum/zypper + sudo      | GitGuardian Cloudsmith deb/rpm repository                            |
+| Linux without sudo (x86_64 / arm64 glibc) | standalone tarball in `~/.local/bin`                                 |
+| Linux musl                                | `pipx`                                                               |
+| Windows elevated                          | standalone `.msi`                                                    |
+| Windows non-elevated                      | standalone `.zip` in `%LOCALAPPDATA%\Programs\ggshield`              |
+| Windows, last resort                      | Chocolatey (`-Method choco` to force) — the channel can lag upstream |
+
+Standalone downloads are checksum-verified against the digest GitHub publishes
+for each asset, and — when `gh` is available — against the release's [build
+provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
+
+The Linux repository method is different: it runs GitGuardian's Cloudsmith
+`setup.deb.sh` / `setup.rpm.sh` over HTTPS **as root** to configure the apt/rpm
+repository. That bootstrap script is not independently checksum-verified (this
+is the standard Cloudsmith install flow) — inspect it first if that trust
+boundary matters to you, or use `--method tarball`.
+
+arm64 Linux builds are recent: on older releases that lack them, the script
+uses `pipx` instead.
+
+### Options
+
+```text
+-y, --yes           never prompt, accept defaults (for CI)
+    --instance URL  GitGuardian instance to authenticate against
+    --version X.Y.Z ggshield version to install (default: latest)
+    --method M      auto|brew|repo|tarball|pipx (default: auto)
+    --install-only  install ggshield, skip auth and plugins
+    --plugin NAME   install this ggshield plugin (repeatable)
+```
+
+Pass options through the pipe with `bash -s --`:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
+  bash -s -- --instance https://dashboard.gitguardian.mycorp.local --plugin <plugin_name>
+```
+
+`install.ps1` takes the equivalent options (`-Yes`, `-Instance URL`, `-Version X.Y.Z`,
+`-Method auto|choco|msi|zip`, `-InstallOnly`, `-Plugin name[,name]`):
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1))) `
+  -Instance https://dashboard.gitguardian.mycorp.local -Plugin <plugin_name> -Yes
+```
+
+### Instance
+
+ggshield authenticates against the US workspace
+(`https://dashboard.gitguardian.com`) by default. Use `--instance`
+(`-Instance` on Windows) to target another one — for the EU workspace:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
+  bash -s -- --instance https://dashboard.eu1.gitguardian.com
+```
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1))) `
+  -Instance https://dashboard.eu1.gitguardian.com
+```
+
+A self-hosted instance works the same way, e.g.
+`--instance https://dashboard.gitguardian.example.com`.
+
+### Environment variables
+
+| Variable              | Effect                                                                                   |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `GGSHIELD_VERSION`    | same as `--version`                                                                      |
+| `GITGUARDIAN_API_KEY` | authenticate with this API key instead of the browser login; works with `--instance`     |
+| `GGSHIELD_BIN_DIR`    | symlink directory for tarball installs (default `~/.local/bin`)                          |
+| `GGSHIELD_OPT_DIR`    | extraction directory for tarball installs (default `~/.local/share/ggshield-standalone`) |
+
+## Uninstall
+
+Linux / macOS:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.ps1 | iex
+```
+
+Every removal is confirmed individually by default; pass `-y` / `-Yes` to
+accept everything (required for non-interactive runs).
+
+It removes the installed plugins, logs out, deletes ggshield's configuration,
+cache and data, and removes every ggshield installation it detects — whether
+put there by this script or another way (system package, Homebrew, pipx, uv,
+pip, mise, the macOS package, Chocolatey, MSI or a standalone build). It can
+also clear the uv download cache, the pre-commit cache and any scheduled
+scans.
+
+### Not handled
+
+Installations the scripts neither perform nor remove — clean these manually:
+
+| Channel                                                   | Cleanup                                          |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| aqua                                                      | remove from `aqua.yaml`, `aqua gc`               |
+| Nix / home-manager / NixOS                                | `nix profile remove`, or edit your configuration |
+| Docker / Podman images                                    | `docker rmi gitguardian/ggshield`                |
+| CI-scoped installs (GitHub Action, GitLab template, etc.) | per-job, nothing persists on this machine        |
+| From-source checkouts (`pip install -e .`)                | remove the venv/checkout                         |

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,225 @@
+# ggshield installer for Windows.
+#
+# Installs ggshield using the best method available on this machine,
+# authenticates, and optionally installs plugins (-Plugin NAME).
+#
+#   irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1 | iex
+#
+# With options:
+#   & ([scriptblock]::Create((irm <url>))) -Instance https://dashboard.example.com -Yes
+#
+# See scripts/install/README.md. Cleanup: uninstall.ps1.
+#
+# Compatible with Windows PowerShell 5.1 (no pwsh required).
+
+[CmdletBinding()]
+param(
+    [switch]$Yes,
+    [string]$Instance = $env:GGSHIELD_INSTANCE,
+    [string]$Version = $env:GGSHIELD_VERSION,
+    [ValidateSet('auto', 'choco', 'msi', 'zip')]
+    [string]$Method = 'auto',
+    [switch]$InstallOnly,
+    [string[]]$Plugin = @()
+)
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$GithubRepo = 'GitGuardian/ggshield'
+$ZipDir = Join-Path $env:LOCALAPPDATA 'Programs\ggshield'
+$StateDir = Join-Path $env:LOCALAPPDATA 'ggshield-install'
+
+function Say($msg) { Write-Host "==> $msg" -ForegroundColor Blue }
+function Warn($msg) { Write-Host "warning: $msg" -ForegroundColor Yellow }
+function Die($msg) { throw "error: $msg" }
+
+function Confirm-Step($prompt) {
+    if ($Yes) { return $true }
+    $reply = Read-Host "$prompt [Y/n]"
+    return $reply -notmatch '^[nN]'
+}
+
+# Run a native command, discarding output. With $ErrorActionPreference=Stop,
+# redirecting native stderr would otherwise throw (PowerShell 5.1 gotcha).
+function Invoke-Native {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & $args[0] @($args | Select-Object -Skip 1) 2>&1 | Out-Null }
+    finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+function Update-SessionPath {
+    $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+    [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + $env:Path
+}
+
+function Test-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Resolve-Version {
+    if ($script:Version) {
+        $script:Version = $script:Version.TrimStart('v')
+        return
+    }
+    Say 'Resolving latest ggshield version'
+    $release = Invoke-RestMethod "https://api.github.com/repos/$GithubRepo/releases/latest"
+    $script:Version = $release.tag_name.TrimStart('v')
+}
+
+# GitHub computes a sha256 digest for every release asset
+function Get-AssetDigest($assetName) {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$GithubRepo/releases/tags/v$script:Version"
+    $asset = $release.assets | Where-Object { $_.name -eq $assetName }
+    if ($asset -and $asset.digest) { return $asset.digest -replace '^sha256:', '' }
+    return $null
+}
+
+function Test-Download($file, $assetName) {
+    $expected = Get-AssetDigest $assetName
+    if (-not $expected) {
+        Warn 'could not retrieve the expected sha256 digest from the GitHub API'
+        if (-not (Confirm-Step 'Continue without checksum verification?')) { Die 'aborted' }
+    }
+    else {
+        Say 'Verifying sha256 checksum'
+        $actual = (Get-FileHash -Algorithm SHA256 -Path $file).Hash
+        if ($actual -ne $expected) { Die "checksum mismatch for $assetName" }
+    }
+
+    # opportunistic build provenance check; older gh has no `attestation`
+    if ((Get-Command gh -ErrorAction SilentlyContinue) -and
+        (Invoke-Native gh attestation --help) -eq 0 -and
+        (Invoke-Native gh auth status) -eq 0) {
+        Say 'Verifying build provenance attestation'
+        if ((Invoke-Native gh attestation verify $file --repo $GithubRepo) -ne 0) {
+            Die "artifact attestation verification failed for $assetName"
+        }
+    }
+}
+
+function Get-ReleaseAsset($assetName) {
+    $tmp = Join-Path ([IO.Path]::GetTempPath()) $assetName
+    Say "Downloading $assetName"
+    Invoke-WebRequest -UseBasicParsing `
+        -Uri "https://github.com/$GithubRepo/releases/download/v$script:Version/$assetName" `
+        -OutFile $tmp
+    Test-Download $tmp $assetName
+    return $tmp
+}
+
+function Install-WithChoco {
+    Say 'Installing ggshield with Chocolatey'
+    $chocoArgs = @('install', 'ggshield', '-y')
+    if ($script:Version) { $chocoArgs += "--version=$script:Version" }
+    & choco @chocoArgs
+    if ($LASTEXITCODE -ne 0) { Die 'choco install failed' }
+}
+
+function Install-WithMsi {
+    if (-not (Test-Admin)) { Die '-Method msi requires an elevated (administrator) PowerShell' }
+    Resolve-Version
+    $msi = Get-ReleaseAsset "ggshield-$script:Version-x86_64-pc-windows-msvc.msi"
+    Say 'Installing the MSI'
+    $proc = Start-Process msiexec -ArgumentList '/i', "`"$msi`"", '/qn', '/norestart' -Wait -PassThru
+    if ($proc.ExitCode -ne 0) { Die "msiexec failed with exit code $($proc.ExitCode)" }
+    Remove-Item $msi -ErrorAction SilentlyContinue
+}
+
+function Install-WithZip {
+    Resolve-Version
+    $zip = Get-ReleaseAsset "ggshield-$script:Version-x86_64-pc-windows-msvc.zip"
+    Say "Installing to $ZipDir"
+    if (Test-Path $ZipDir) { Remove-Item $ZipDir -Recurse -Force }
+    Expand-Archive -Path $zip -DestinationPath $ZipDir -Force
+    Remove-Item $zip -ErrorAction SilentlyContinue
+
+    $exe = Get-ChildItem $ZipDir -Recurse -Filter ggshield.exe | Select-Object -First 1
+    if (-not $exe) { Die "no ggshield.exe found in $ZipDir" }
+    $binDir = $exe.DirectoryName
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (($userPath -split ';') -notcontains $binDir) {
+        Say "Adding $binDir to your user PATH"
+        [Environment]::SetEnvironmentVariable('Path', "$binDir;$userPath", 'User')
+    }
+    $env:Path = "$binDir;$env:Path"
+}
+
+function Write-State {
+    New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+    @{ method = $script:Method; version = $script:Version; zipDir = $ZipDir } |
+        ConvertTo-Json | Set-Content (Join-Path $StateDir 'state.json')
+}
+
+function Invoke-PostInstall {
+    Update-SessionPath
+    $gg = Get-Command ggshield -ErrorAction SilentlyContinue
+    if (-not $gg) { Die 'ggshield not found on PATH after install (open a new terminal and retry)' }
+    Say "Installed: $(& ggshield --version)"
+
+    if ($InstallOnly) {
+        Say 'Done (-InstallOnly). Next: ggshield auth login'
+        return
+    }
+
+    $loginArgs = @('auth', 'login')
+    if ($Instance) { $loginArgs += @('--instance', $Instance) }
+    if ($env:GITGUARDIAN_API_KEY) {
+        # token login (key read from stdin) persists the key for later
+        # shells and validates it against the selected instance
+        Say 'Authenticating with the API key from GITGUARDIAN_API_KEY'
+        $loginArgs += @('--method', 'token')
+        $env:GITGUARDIAN_API_KEY | & ggshield @loginArgs
+        if ($LASTEXITCODE -ne 0) { Die 'authentication failed' }
+    }
+    elseif ($Yes) {
+        # -Yes means never prompt; an interactive browser login would hang CI
+        Warn 'non-interactive run (-Yes) without GITGUARDIAN_API_KEY: skipping auth and plugins'
+        return
+    }
+    else {
+        Say 'Authenticating'
+        & ggshield @loginArgs
+        if ($LASTEXITCODE -ne 0) { Die 'authentication failed' }
+    }
+
+    if (-not $Plugin) {
+        Say 'Done. To list available plugins: ggshield plugin status'
+        return
+    }
+
+    foreach ($p in $Plugin) {
+        Say "Installing the $p plugin"
+        & ggshield plugin install $p
+        if ($LASTEXITCODE -ne 0) { Die "installation of plugin '$p' failed" }
+    }
+}
+
+if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
+    Die "unsupported architecture: $env:PROCESSOR_ARCHITECTURE (only x86_64 builds are published)"
+}
+
+# Routing: msi (elevated) > zip (per-user) > choco last. The Chocolatey
+# channel can lag upstream, so it is only a final fallback; use
+# -Method choco to pick it explicitly.
+if ($Method -eq 'auto') {
+    if (Test-Admin) { $Method = 'msi' }
+    elseif ($env:LOCALAPPDATA) { $Method = 'zip' }
+    elseif (Get-Command choco -ErrorAction SilentlyContinue) { $Method = 'choco' }
+    else { $Method = 'zip' }
+}
+Say "Windows/x86_64 - install method: $Method"
+
+switch ($Method) {
+    'choco' { Install-WithChoco }
+    'msi' { Install-WithMsi }
+    'zip' { Install-WithZip }
+}
+
+Write-State
+Invoke-PostInstall

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+#
+# ggshield installer.
+#
+# Installs ggshield using the best method available on this machine,
+# authenticates, and optionally installs plugins (--plugin NAME).
+#
+#   curl --proto '=https' --tlsv1.2 -sSfL \
+#     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
+#
+# See scripts/install/README.md for options. Cleanup: uninstall.sh.
+
+set -euo pipefail
+
+GITHUB_REPO="GitGuardian/ggshield"
+CLOUDSMITH_BASE="https://dl.cloudsmith.io/public/gitguardian/ggshield"
+
+BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+# NOT ~/.local/share/ggshield: that is ggshield's own data dir (plugins…)
+OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
+STATE_FILE="$STATE_DIR/state"
+
+ASSUME_YES=0
+INSTALL_ONLY=0
+METHOD_AUTO=0
+PLUGINS=()
+INSTANCE=""
+VERSION="${GGSHIELD_VERSION:-}"
+METHOD="auto"
+
+usage() {
+    cat <<EOF
+Usage: install.sh [OPTIONS]
+
+Install ggshield and authenticate. With --plugin, also install the named
+plugin(s).
+
+Options:
+  -y, --yes           never prompt, accept defaults (for CI)
+      --instance URL  GitGuardian instance to authenticate against
+      --version X.Y.Z ggshield version to install (default: latest;
+                      also via GGSHIELD_VERSION env var)
+      --method M      auto|brew|repo|tarball|pipx (default: auto)
+      --install-only  install ggshield, skip auth and plugins
+      --plugin NAME   install this ggshield plugin (repeatable)
+  -h, --help          show this help
+
+Environment:
+  GITGUARDIAN_API_KEY  authenticate with this API key instead of the browser
+                       flow (token login, combine with --instance)
+  GGSHIELD_BIN_DIR     symlink dir for tarball installs (default ~/.local/bin)
+EOF
+}
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# The script is usually piped into bash, so stdin is not a TTY: reconnect
+# prompts to /dev/tty (rustup pattern).
+confirm() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    local reply
+    if [ -t 0 ]; then
+        read -r -p "$1 [Y/n] " reply
+    elif [ -e /dev/tty ]; then
+        read -r -p "$1 [Y/n] " reply </dev/tty
+    else
+        die "cannot prompt for '$1' (no TTY). Re-run with -y"
+    fi
+    case "$reply" in
+    n* | N*) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+
+fetch() {
+    curl --proto '=https' --tlsv1.2 -sSfL --retry 3 "$@"
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+detect_platform() {
+    case "$(uname -s)" in
+    Linux) OS=linux ;;
+    Darwin) OS=darwin ;;
+    MINGW* | MSYS* | CYGWIN*)
+        die "Windows is not supported by this script. Use install.ps1 instead: \
+irm https://raw.githubusercontent.com/$GITHUB_REPO/main/scripts/install/install.ps1 | iex"
+        ;;
+    *) die "unsupported OS: $(uname -s)" ;;
+    esac
+
+    case "$(uname -m)" in
+    x86_64 | amd64) ARCH=x86_64 ;;
+    arm64 | aarch64) ARCH=arm64 ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+    esac
+
+    LIBC=gnu
+    if [ "$OS" = darwin ]; then
+        LIBC="" # macOS has no libc variant; keep it out of the platform banner
+        # uname -m lies under Rosetta 2; sysctl does not (rustup pattern)
+        if [ "$ARCH" = x86_64 ] &&
+            [ "$(sysctl -n hw.optional.arm64 2>/dev/null || true)" = 1 ]; then
+            ARCH=arm64
+        fi
+        TARGET="$ARCH-apple-darwin"
+    else
+        # base Alpine has no ldd (musl-utils), so check the loader file too
+        if [ -e "/lib/ld-musl-$(uname -m).so.1" ] ||
+            ldd --version 2>&1 | grep -qi musl; then
+            LIBC=musl
+        fi
+        # ggshield's Linux target triple uses the kernel arch name (aarch64);
+        # macOS keeps arm64. Normalize only for the Linux triple.
+        local linux_arch="$ARCH"
+        [ "$ARCH" = arm64 ] && linux_arch=aarch64
+        TARGET="$linux_arch-unknown-linux-gnu"
+    fi
+}
+
+have_root() {
+    [ "$(id -u)" = 0 ] && return 0
+    command -v sudo >/dev/null 2>&1 || return 1
+    # sudo present != sudo usable. Require passwordless escalation, or a TTY for
+    # sudo to prompt on, so auto-select does not pick `repo` and then die on a
+    # non-sudoer or a non-interactive (-y) run. In -y mode only passwordless
+    # sudo qualifies — never trigger an interactive password prompt.
+    sudo -n true 2>/dev/null && return 0
+    [ "$ASSUME_YES" = 1 ] && return 1
+    [ -t 0 ] || [ -e /dev/tty ]
+}
+
+run_as_root() {
+    if [ "$(id -u)" = 0 ]; then
+        "$@"
+    else
+        sudo -E "$@"
+    fi
+}
+
+linux_pkg_manager() {
+    local mgr
+    for mgr in apt-get dnf yum microdnf zypper; do
+        if command -v "$mgr" >/dev/null 2>&1; then
+            echo "$mgr"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Standalone tarballs exist for both macOS archs and x86_64/arm64 glibc Linux.
+# No musl build. arm64 Linux builds are recent, so older releases lack them —
+# install_tarball checks the asset actually exists before downloading.
+tarball_available() {
+    [ "$OS" = darwin ] && return 0
+    [ "$LIBC" = gnu ] && { [ "$ARCH" = x86_64 ] || [ "$ARCH" = arm64 ]; }
+}
+
+select_method() {
+    if [ "$METHOD" != auto ]; then
+        return 0
+    fi
+    METHOD_AUTO=1
+    if [ "$OS" = darwin ]; then
+        if command -v brew >/dev/null 2>&1; then
+            METHOD=brew
+        else
+            METHOD=tarball
+        fi
+        return 0
+    fi
+    if linux_pkg_manager >/dev/null && have_root; then
+        METHOD=repo
+    elif tarball_available; then
+        METHOD=tarball
+    elif command -v pipx >/dev/null 2>&1; then
+        METHOD=pipx
+    else
+        die "no standalone build for $ARCH/$LIBC Linux and neither a \
+supported package manager with sudo nor pipx is available. \
+Install pipx, then re-run, or see https://docs.gitguardian.com/ggshield-docs/getting-started"
+    fi
+}
+
+resolve_version() {
+    if [ -n "$VERSION" ]; then
+        VERSION="${VERSION#v}"
+        return 0
+    fi
+    say "Resolving latest ggshield version"
+    VERSION=$(fetch "https://api.github.com/repos/$GITHUB_REPO/releases/latest" |
+        grep -o '"tag_name": *"v[^"]*"' | head -1 | grep -o '[0-9][^"]*') || true
+    [ -n "$VERSION" ] || die "could not resolve the latest version from the GitHub API"
+}
+
+# GitHub computes a sha256 digest for every release asset; pair each "name"
+# with the "digest" that follows it in the release JSON.
+asset_digest() {
+    local asset="$1"
+    fetch "https://api.github.com/repos/$GITHUB_REPO/releases/tags/v$VERSION" |
+        grep -o '"name": *"[^"]*"\|"digest": *"sha256:[0-9a-f]*"' |
+        grep -A1 -F "\"$asset\"" | grep -o 'sha256:[0-9a-f]*' | head -1 || true
+}
+
+# HTTP status of an asset's download URL (HEAD, following redirects). Used to
+# tell "asset absent" (404) from "couldn't reach GitHub" (504/000/…) so we
+# only fall back when the build is genuinely missing, not on a transient error.
+# Deliberately not the `fetch` wrapper: no -f, so 4xx still yields the code.
+asset_http_status() {
+    curl --proto '=https' --tlsv1.2 -sIL -o /dev/null -w '%{http_code}' \
+        --max-time 20 --retry 2 \
+        "https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$1" \
+        2>/dev/null || echo 000
+}
+
+verify_download() {
+    local file="$1" asset="$2" digest sum_tool
+    digest=$(asset_digest "$asset")
+    if [ -z "$digest" ]; then
+        # Fail closed when we cannot prompt: never silently install unverified.
+        if [ "$ASSUME_YES" = 1 ]; then
+            die "could not retrieve the expected sha256 digest; refusing to install unverified in non-interactive mode (-y)"
+        fi
+        warn "could not retrieve the expected sha256 digest from the GitHub API"
+        confirm "Continue without checksum verification?" || die "aborted"
+    else
+        if command -v sha256sum >/dev/null 2>&1; then
+            sum_tool="sha256sum"
+        elif command -v shasum >/dev/null 2>&1; then
+            sum_tool="shasum -a 256"
+        else
+            die "cannot verify $asset: no sha256 tool found (need sha256sum or shasum)"
+        fi
+        say "Verifying sha256 checksum"
+        echo "${digest#sha256:}  $file" | $sum_tool -c - >/dev/null ||
+            die "checksum mismatch for $asset"
+    fi
+
+    # older gh releases have no `attestation` subcommand
+    if command -v gh >/dev/null 2>&1 &&
+        gh attestation --help >/dev/null 2>&1 &&
+        gh auth status >/dev/null 2>&1; then
+        say "Verifying build provenance attestation"
+        gh attestation verify "$file" --repo "$GITHUB_REPO" >/dev/null ||
+            die "artifact attestation verification failed for $asset"
+    fi
+}
+
+install_tarball() {
+    tarball_available || die "no standalone build for $ARCH/$LIBC $OS. \
+Try --method pipx or --method repo"
+    need tar
+    resolve_version
+
+    local asset dir tmp bin
+    asset="ggshield-$VERSION-$TARGET.tar.gz"
+    case "$(asset_http_status "$asset")" in
+    200) ;;
+    404)
+        if [ "$METHOD_AUTO" = 1 ] && command -v pipx >/dev/null 2>&1; then
+            warn "release v$VERSION has no $asset (arm64 Linux ships from a later release); using pipx"
+            METHOD=pipx
+            install_pipx
+            return 0
+        fi
+        die "release v$VERSION has no standalone asset $asset; try --method pipx or --method repo"
+        ;;
+    *)
+        # network/API hiccup: don't spuriously fall back; let the download try
+        warn "could not confirm $asset availability; attempting the download anyway"
+        ;;
+    esac
+    dir="$OPT_DIR/ggshield-$VERSION-$TARGET"
+    tmp=$(mktemp -d)
+    # shellcheck disable=SC2064 # expand now: $tmp is local, gone at exit time
+    trap "rm -rf '$tmp'" EXIT
+
+    say "Downloading $asset"
+    # Download to a file first: never pipe the network into tar
+    fetch -o "$tmp/$asset" \
+        "https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$asset"
+    verify_download "$tmp/$asset" "$asset"
+
+    say "Installing to $dir"
+    rm -rf "$dir"
+    mkdir -p "$OPT_DIR"
+    tar -xzf "$tmp/$asset" -C "$OPT_DIR"
+    [ -d "$dir" ] || die "unexpected archive layout: $dir not found after extraction"
+
+    bin=$(find "$dir" -type f -name ggshield | head -1)
+    if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+        die "no ggshield executable found in $dir"
+    fi
+    mkdir -p "$BIN_DIR"
+    if [ -L "$BIN_DIR/ggshield" ]; then
+        case "$(readlink "$BIN_DIR/ggshield")" in
+        "$OPT_DIR"/*) ;;
+        *) warn "replacing existing ggshield at $BIN_DIR/ggshield (was: $(readlink "$BIN_DIR/ggshield"))" ;;
+        esac
+    fi
+    ln -sf "$bin" "$BIN_DIR/ggshield"
+
+    case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+        warn "$BIN_DIR is not in your PATH. Add this to your shell profile:"
+        warn "  export PATH=\"$BIN_DIR:\$PATH\""
+        ;;
+    esac
+    GGSHIELD="$BIN_DIR/ggshield"
+}
+
+install_repo() {
+    local mgr setup pkg
+    mgr=$(linux_pkg_manager) || die "no supported package manager found"
+    have_root || die "--method repo requires root or sudo"
+    local tmp
+    tmp=$(mktemp -d)
+    # shellcheck disable=SC2064 # expand now: $tmp is local, gone at exit time
+    trap "rm -rf '$tmp'" EXIT
+
+    if [ "$mgr" = apt-get ]; then
+        setup="setup.deb.sh"
+        pkg="ggshield${VERSION:+=$VERSION*}"
+    else
+        setup="setup.rpm.sh"
+        pkg="ggshield${VERSION:+-$VERSION}"
+    fi
+
+    say "Configuring the GitGuardian Cloudsmith repository ($setup)"
+    fetch -o "$tmp/$setup" "$CLOUDSMITH_BASE/$setup"
+    run_as_root bash "$tmp/$setup"
+
+    say "Installing ggshield with $mgr"
+    if [ "$mgr" = zypper ]; then
+        run_as_root zypper install -y "$pkg"
+    else
+        run_as_root "$mgr" install -y "$pkg"
+    fi
+    GGSHIELD="/usr/bin/ggshield"
+}
+
+install_brew() {
+    [ -z "$VERSION" ] || warn "--version is ignored with brew (installs latest)"
+    if brew list ggshield >/dev/null 2>&1; then
+        say "Upgrading ggshield with Homebrew"
+        brew upgrade ggshield || true
+    else
+        say "Installing ggshield with Homebrew"
+        brew install ggshield
+    fi
+    GGSHIELD="ggshield"
+}
+
+install_pipx() {
+    need pipx
+    say "Installing ggshield with pipx"
+    pipx install ${VERSION:+--force} "ggshield${VERSION:+==$VERSION}"
+    GGSHIELD="ggshield"
+}
+
+write_state() {
+    mkdir -p "$STATE_DIR"
+    cat >"$STATE_FILE" <<EOF
+method=$METHOD
+version=${VERSION:-latest}
+opt_dir=$OPT_DIR
+bin_link=$BIN_DIR/ggshield
+EOF
+}
+
+run_gg() {
+    # Children may prompt; give them the TTY back when we are piped
+    if [ ! -t 0 ] && [ -e /dev/tty ]; then
+        "$GGSHIELD" "$@" </dev/tty
+    else
+        "$GGSHIELD" "$@"
+    fi
+}
+
+post_install() {
+    hash -r 2>/dev/null || true
+    # actually run it: an executable can still fail (e.g. wrong libc)
+    local version_out
+    if ! version_out=$("$GGSHIELD" --version 2>&1); then
+        die "ggshield was installed but cannot run: $version_out"
+    fi
+    say "Installed: $version_out"
+
+    # a leftover from a previous install may shadow the fresh one on PATH
+    local resolved
+    resolved=$(command -v ggshield 2>/dev/null || true)
+    case "$GGSHIELD" in
+    */*)
+        if [ -n "$resolved" ] && [ "$resolved" != "$GGSHIELD" ]; then
+            warn "another ggshield at $resolved shadows the one just installed ($GGSHIELD)"
+            warn "remove it or fix your PATH order"
+        fi
+        ;;
+    esac
+
+    if [ "$INSTALL_ONLY" = 1 ]; then
+        say "Done (--install-only). Next: ggshield auth login"
+        return 0
+    fi
+
+    if [ -n "${GITGUARDIAN_API_KEY:-}" ]; then
+        # token login persists the key for later shells and validates it
+        # against the selected instance. Reads the token from stdin: do not
+        # use run_gg here, it would rebind stdin to /dev/tty.
+        say "Authenticating with the API key from GITGUARDIAN_API_KEY"
+        printf '%s\n' "$GITGUARDIAN_API_KEY" |
+            "$GGSHIELD" auth login --method token ${INSTANCE:+--instance "$INSTANCE"}
+    elif [ "$ASSUME_YES" = 1 ]; then
+        # -y means never prompt; an interactive browser login would hang CI
+        warn "non-interactive run (-y) without GITGUARDIAN_API_KEY: skipping auth and plugins"
+        return 0
+    else
+        say "Authenticating"
+        run_gg auth login ${INSTANCE:+--instance "$INSTANCE"}
+    fi
+
+    if [ ${#PLUGINS[@]} -eq 0 ]; then
+        say "Done. To list available plugins: ggshield plugin status"
+        return 0
+    fi
+
+    local plugin
+    for plugin in "${PLUGINS[@]}"; do
+        say "Installing the $plugin plugin"
+        run_gg plugin install "$plugin"
+    done
+}
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -y | --yes) ASSUME_YES=1 ;;
+        --instance)
+            shift
+            INSTANCE="${1:?--instance requires a URL}"
+            ;;
+        --version)
+            shift
+            VERSION="${1:?--version requires a value}"
+            ;;
+        --method)
+            shift
+            METHOD="${1:?--method requires a value}"
+            ;;
+        --install-only) INSTALL_ONLY=1 ;;
+        --plugin)
+            shift
+            PLUGINS+=("${1:?--plugin requires a name}")
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *) die "unknown option: $1 (see --help)" ;;
+        esac
+        shift
+    done
+
+    case "$METHOD" in
+    auto | brew | repo | tarball | pipx) ;;
+    *) die "invalid --method: $METHOD" ;;
+    esac
+
+    need curl
+    need uname
+    detect_platform
+    select_method
+    say "Platform: $OS/$ARCH${LIBC:+ ($LIBC)} — install method: $METHOD"
+
+    case "$METHOD" in
+    brew) install_brew ;;
+    repo) install_repo ;;
+    tarball) install_tarball ;;
+    pipx) install_pipx ;;
+    esac
+
+    write_state
+    post_install
+}
+
+main "$@"

--- a/scripts/install/uninstall.ps1
+++ b/scripts/install/uninstall.ps1
@@ -1,0 +1,223 @@
+# Uninstall ggshield and its data on Windows: uninstall the plugins, log out,
+# remove caches/config, then remove ggshield itself using the method recorded
+# by install.ps1 (or detected).
+#
+#   irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.ps1 | iex
+#
+# Compatible with Windows PowerShell 5.1 (no pwsh required).
+
+[CmdletBinding()]
+param(
+    [switch]$Yes
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ZipDir = Join-Path $env:LOCALAPPDATA 'Programs\ggshield'
+$StateDir = Join-Path $env:LOCALAPPDATA 'ggshield-install'
+$StateFile = Join-Path $StateDir 'state.json'
+
+function Say($msg) { Write-Host "==> $msg" -ForegroundColor Blue }
+function Warn($msg) { Write-Host "warning: $msg" -ForegroundColor Yellow }
+function Die($msg) { throw "error: $msg" }
+
+function Confirm-Step($prompt) {
+    if ($Yes) { return $true }
+    $reply = Read-Host "$prompt [Y/n]"
+    return $reply -notmatch '^[nN]'
+}
+
+function Get-MsiProduct {
+    $keys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    Get-ItemProperty $keys -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like 'ggshield*' } |
+        Select-Object -First 1
+}
+
+# A machine may carry several installs: detect and remove them all
+function Get-InstallMethods {
+    $methods = @()
+    if (Test-Path $StateFile) {
+        try { $methods += (Get-Content $StateFile -Raw | ConvertFrom-Json).method }
+        catch { Warn "could not read $StateFile" }
+    }
+    $chocoLib = if ($env:ChocolateyInstall) { $env:ChocolateyInstall } else { 'C:\ProgramData\chocolatey' }
+    if ((Get-Command choco -ErrorAction SilentlyContinue) -and
+        (Test-Path (Join-Path $chocoLib 'lib\ggshield'))) { $methods += 'choco' }
+    if (Get-MsiProduct) { $methods += 'msi' }
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $eap = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $uvTools = & uv tool list 2>&1
+        $ErrorActionPreference = $eap
+        if ($LASTEXITCODE -eq 0 -and ($uvTools | Select-String '^ggshield ')) { $methods += 'uv' }
+    }
+    if (Get-Command pipx -ErrorAction SilentlyContinue) {
+        $eap = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $pipxList = & pipx list 2>&1
+        $ErrorActionPreference = $eap
+        if ($LASTEXITCODE -eq 0 -and ($pipxList | Select-String 'ggshield')) { $methods += 'pipx' }
+    }
+    if ((Get-Command python -ErrorAction SilentlyContinue) -and
+        ((Invoke-Native python -m pip show ggshield) -eq 0)) { $methods += 'pip' }
+    if (Test-Path $ZipDir) { $methods += 'zip' }
+    $methods = @($methods | Select-Object -Unique)
+    if (-not $methods) { $methods = @('none') }
+    return $methods
+}
+
+# Run a native command, discarding output. With $ErrorActionPreference=Stop,
+# redirecting native stderr would otherwise throw (PowerShell 5.1 gotcha).
+function Invoke-Native {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & $args[0] @($args | Select-Object -Skip 1) 2>&1 | Out-Null }
+    finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+function Invoke-GgshieldCleanup {
+    if (-not (Get-Command ggshield -ErrorAction SilentlyContinue)) { return }
+    # there is no `plugin uninstall --all`: enumerate and remove one by one
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $plugins = & ggshield plugin list 2>&1 |
+        ForEach-Object { if ("$_" -match '^\s{2}([^:\s]+):') { $Matches[1] } }
+    $ErrorActionPreference = $eap
+    foreach ($p in $plugins) {
+        if (-not (Confirm-Step "Uninstall the $p plugin?")) { continue }
+        if ((Invoke-Native ggshield plugin uninstall --yes $p) -ne 0) {
+            Warn "could not uninstall the $p plugin"
+        }
+    }
+    if (Confirm-Step 'Log out from GitGuardian?') {
+        if ((Invoke-Native ggshield auth logout) -ne 0) {
+            Warn 'could not log out (maybe not logged in)'
+        }
+    }
+}
+
+function Remove-Package($method) {
+    switch ($method) {
+        'choco' {
+            Say 'Removing ggshield with Chocolatey'
+            & choco uninstall ggshield -y
+        }
+        'msi' {
+            $product = Get-MsiProduct
+            if (-not $product) { Warn 'ggshield MSI product not found, skipping'; return }
+            Say 'Removing the ggshield MSI'
+            $proc = Start-Process msiexec -ArgumentList '/x', $product.PSChildName, '/qn', '/norestart' -Wait -PassThru
+            if ($proc.ExitCode -ne 0) { Warn "msiexec failed with exit code $($proc.ExitCode)" }
+        }
+        'uv' {
+            Say 'Removing ggshield with uv'
+            & uv tool uninstall ggshield
+        }
+        'pipx' {
+            Say 'Removing ggshield with pipx'
+            & pipx uninstall ggshield
+        }
+        'pip' {
+            Say 'Removing ggshield with pip'
+            if ((Invoke-Native python -m pip uninstall -y ggshield) -ne 0) {
+                Warn 'pip uninstall failed'
+            }
+        }
+        'zip' {
+            Say 'Removing standalone install'
+            if (Test-Path $ZipDir) { Remove-Item $ZipDir -Recurse -Force }
+            $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+            $cleaned = ($userPath -split ';' | Where-Object { $_ -and $_ -notlike "$ZipDir*" }) -join ';'
+            if ($cleaned -ne $userPath) {
+                Say 'Removing ggshield from your user PATH'
+                [Environment]::SetEnvironmentVariable('Path', $cleaned, 'User')
+            }
+        }
+        'none' {
+            Warn 'no ggshield installation detected, removing leftovers only'
+        }
+    }
+}
+
+function Remove-UserData {
+    # platformdirs(appname="ggshield", appauthor="GitGuardian") on Windows
+    $paths = @(
+        (Join-Path $env:USERPROFILE '.gitguardian.yaml'),
+        (Join-Path $env:LOCALAPPDATA 'GitGuardian\ggshield')
+    )
+    $found = $paths | Where-Object { Test-Path $_ }
+    if (-not $found) {
+        Say 'No ggshield config/cache/data found'
+        return
+    }
+    if (-not (Confirm-Step 'Remove ggshield configuration, cache and data (including plugins)?')) { return }
+    foreach ($p in $found) {
+        Say "Removing $p"
+        Remove-Item $p -Recurse -Force
+    }
+}
+
+# best-effort version lookup, only used to enrich the prompts
+function Get-MethodVersion($method) {
+    try {
+        switch ($method) {
+            'msi' { return (Get-MsiProduct).DisplayVersion }
+            'choco' {
+                $chocoLib = if ($env:ChocolateyInstall) { $env:ChocolateyInstall } else { 'C:\ProgramData\chocolatey' }
+                $nuspec = Get-Content (Join-Path $chocoLib 'lib\ggshield\ggshield.nuspec') -Raw -ErrorAction SilentlyContinue
+                if ($nuspec -match '<version>([^<]+)</version>') { return $Matches[1] }
+            }
+            'uv' {
+                $eap = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+                $line = & uv tool list 2>&1 | Select-String '^ggshield v?([\d.]+)'
+                $ErrorActionPreference = $eap
+                if ($line) { return $line.Matches[0].Groups[1].Value }
+            }
+            'pipx' {
+                $eap = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+                $line = & pipx list 2>&1 | Select-String 'package ggshield ([\d.]+)'
+                $ErrorActionPreference = $eap
+                if ($line) { return $line.Matches[0].Groups[1].Value }
+            }
+            'pip' {
+                $eap = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+                $line = & python -m pip show ggshield 2>&1 | Select-String '^Version: (.+)'
+                $ErrorActionPreference = $eap
+                if ($line) { return $line.Matches[0].Groups[1].Value }
+            }
+            'zip' {
+                if (Test-Path $StateFile) {
+                    return (Get-Content $StateFile -Raw | ConvertFrom-Json).version
+                }
+            }
+        }
+    }
+    catch { return $null }
+}
+
+$methods = Get-InstallMethods
+Say "Detected install method(s): $($methods -join ', ')"
+
+Invoke-GgshieldCleanup
+foreach ($m in $methods) {
+    if ($m -ne 'none') {
+        $v = Get-MethodVersion $m
+        $label = if ($v) { "$m $v" } else { $m }
+        if (-not (Confirm-Step "Remove the ggshield installation ($label)?")) { continue }
+    }
+    Remove-Package $m
+}
+Remove-UserData
+if (Test-Path $StateDir) { Remove-Item $StateDir -Recurse -Force }
+
+if (Get-Command ggshield -ErrorAction SilentlyContinue) {
+    Warn "a 'ggshield' command is still on your PATH: $((Get-Command ggshield).Source)"
+}
+else {
+    Say 'ggshield is fully removed'
+}

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+#
+# Uninstall ggshield and its data: uninstall the plugins, log out, remove
+# caches/config, then remove ggshield itself using the method recorded by
+# install.sh (or detected).
+#
+#   curl --proto '=https' --tlsv1.2 -sSfL \
+#     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
+
+set -euo pipefail
+
+BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
+STATE_FILE="$STATE_DIR/state"
+
+ASSUME_YES=0
+
+usage() {
+    cat <<EOF
+Usage: uninstall.sh [OPTIONS]
+
+Remove ggshield and every trace it can find: plugins, authentication,
+caches, configuration, and the package itself.
+
+Options:
+  -y, --yes   never prompt (for CI)
+  -h, --help  show this help
+EOF
+}
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+confirm() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    local reply
+    if [ -t 0 ]; then
+        read -r -p "$1 [Y/n] " reply
+    elif [ -e /dev/tty ]; then
+        read -r -p "$1 [Y/n] " reply </dev/tty
+    else
+        die "cannot prompt for '$1' (no TTY). Re-run with -y"
+    fi
+    case "$reply" in
+    n* | N*) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+
+have_root() {
+    [ "$(id -u)" = 0 ] || command -v sudo >/dev/null 2>&1
+}
+
+run_as_root() {
+    if [ "$(id -u)" = 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+# A machine may carry several installs (e.g. a tarball leftover plus a
+# system package): detect and remove them all, not just the recorded one.
+detect_methods() {
+    if [ -f "$STATE_FILE" ]; then
+        sed -n 's/^method=//p' "$STATE_FILE"
+    fi
+    if command -v brew >/dev/null 2>&1 && brew list ggshield >/dev/null 2>&1; then
+        echo brew
+    fi
+    if command -v dpkg >/dev/null 2>&1 && dpkg -s ggshield >/dev/null 2>&1; then
+        echo repo
+    elif command -v rpm >/dev/null 2>&1 && rpm -q ggshield >/dev/null 2>&1; then
+        echo repo
+    fi
+    if command -v pacman >/dev/null 2>&1 && pacman -Qi ggshield >/dev/null 2>&1; then
+        echo pacman
+    fi
+    if command -v python3 >/dev/null 2>&1 && python3 -m pip show ggshield >/dev/null 2>&1; then
+        echo pip
+    fi
+    if command -v pkgutil >/dev/null 2>&1 &&
+        pkgutil --pkg-info com.gitguardian.ggshield >/dev/null 2>&1; then
+        echo pkg
+    fi
+    if command -v pipx >/dev/null 2>&1 && pipx list 2>/dev/null | grep -q ggshield; then
+        echo pipx
+    fi
+    if command -v uv >/dev/null 2>&1 && uv tool list 2>/dev/null | grep -q '^ggshield '; then
+        echo uv
+    fi
+    # only claim the bin symlink when it points into our own install dir:
+    # uv/pipx also place a ggshield shim in ~/.local/bin
+    if [ -d "$OPT_DIR" ]; then
+        echo tarball
+    elif [ -L "$BIN_DIR/ggshield" ]; then
+        case "$(readlink "$BIN_DIR/ggshield")" in
+        "$OPT_DIR"/*) echo tarball ;;
+        esac
+    fi
+}
+
+# human label: "repo" covers both package formats, say which one it is
+method_label() {
+    if [ "$1" = repo ]; then
+        if command -v dpkg >/dev/null 2>&1 && dpkg -s ggshield >/dev/null 2>&1; then
+            echo "repo, deb"
+        else
+            echo "repo, rpm"
+        fi
+    else
+        echo "$1"
+    fi
+}
+
+# best-effort version lookup, only used to enrich the prompts
+method_version() {
+    case "$1" in
+    repo)
+        dpkg-query -W -f '${Version}' ggshield 2>/dev/null ||
+            rpm -q --qf '%{VERSION}' ggshield 2>/dev/null || true
+        ;;
+    pacman) pacman -Q ggshield 2>/dev/null | awk '{print $2}' ;;
+    brew) brew list --versions ggshield 2>/dev/null | awk '{print $2}' ;;
+    pipx) pipx list 2>/dev/null | sed -n 's/.*package ggshield \([0-9][0-9.]*\).*/\1/p' ;;
+    uv) uv tool list 2>/dev/null | sed -n 's/^ggshield v\{0,1\}\([0-9][0-9.]*\).*/\1/p' ;;
+    pip) python3 -m pip show ggshield 2>/dev/null | sed -n 's/^Version: //p' ;;
+    pkg) pkgutil --pkg-info com.gitguardian.ggshield 2>/dev/null | sed -n 's/^version: //p' ;;
+    tarball)
+        # version is embedded in the install dir name: ggshield-<ver>-<target>
+        find "$OPT_DIR" -maxdepth 1 -name 'ggshield-*' 2>/dev/null | head -1 |
+            sed -n 's/.*ggshield-\([0-9][0-9.]*\)-.*/\1/p'
+        ;;
+    esac
+}
+
+ggshield_cleanup() {
+    command -v ggshield >/dev/null 2>&1 || return 0
+    # there is no `plugin uninstall --all`: enumerate and remove one by one
+    local plugins plugin
+    # `plugin list` prints the listing to stderr (ui.display_info), so merge it
+    plugins=$(ggshield plugin list 2>&1 | sed -n 's/^  \([^:]*\):.*/\1/p') || true
+    for plugin in $plugins; do
+        confirm "Uninstall the $plugin plugin?" || continue
+        ggshield plugin uninstall --yes "$plugin" >/dev/null 2>&1 ||
+            warn "could not uninstall the $plugin plugin"
+    done
+    if confirm "Log out from GitGuardian?"; then
+        ggshield auth logout >/dev/null 2>&1 ||
+            warn "could not log out (maybe not logged in)"
+    fi
+}
+
+remove_package() {
+    local method="$1"
+    case "$method" in
+    brew)
+        say "Removing ggshield with Homebrew"
+        brew uninstall ggshield
+        ;;
+    repo)
+        have_root || die "removing the system package requires root or sudo"
+        say "Removing the ggshield system package"
+        if command -v dpkg >/dev/null 2>&1 && dpkg -s ggshield >/dev/null 2>&1; then
+            run_as_root apt-get remove -y ggshield
+        elif command -v zypper >/dev/null 2>&1 && rpm -q ggshield >/dev/null 2>&1; then
+            run_as_root zypper remove -y ggshield
+        elif command -v dnf >/dev/null 2>&1 && rpm -q ggshield >/dev/null 2>&1; then
+            run_as_root dnf remove -y ggshield
+        elif command -v microdnf >/dev/null 2>&1 && rpm -q ggshield >/dev/null 2>&1; then
+            run_as_root microdnf remove -y ggshield
+        elif command -v yum >/dev/null 2>&1 && rpm -q ggshield >/dev/null 2>&1; then
+            run_as_root yum remove -y ggshield
+        else
+            warn "ggshield system package not found, skipping"
+        fi
+        # Cloudsmith's setup.*.sh also leaves the repo source + signing key
+        # behind; remove the known files (standard Cloudsmith naming) so the
+        # repo is not left configured. Unmatched globs are ignored by rm -f.
+        say "Removing the Cloudsmith repository configuration"
+        run_as_root rm -f \
+            /etc/apt/sources.list.d/gitguardian-ggshield*.list \
+            /usr/share/keyrings/gitguardian-ggshield*.gpg \
+            /etc/apt/keyrings/gitguardian-ggshield*.gpg \
+            /etc/apt/trusted.gpg.d/gitguardian-ggshield*.gpg \
+            /etc/yum.repos.d/gitguardian-ggshield*.repo \
+            /etc/zypp/repos.d/gitguardian-ggshield*.repo 2>/dev/null || true
+        ;;
+    pipx)
+        say "Removing ggshield with pipx"
+        pipx uninstall ggshield
+        ;;
+    uv)
+        say "Removing ggshield with uv"
+        uv tool uninstall ggshield
+        ;;
+    pacman)
+        have_root || die "removing the pacman package requires root or sudo"
+        say "Removing the ggshield pacman package (AUR)"
+        run_as_root pacman -R --noconfirm ggshield
+        ;;
+    pip)
+        say "Removing ggshield with pip"
+        python3 -m pip uninstall -y ggshield ||
+            warn "pip uninstall failed (externally-managed environment?)"
+        ;;
+    pkg)
+        have_root || die "removing the macOS package requires root or sudo"
+        say "Removing the macOS package"
+        run_as_root rm -rf /opt/gitguardian/ggshield-* /usr/local/bin/ggshield
+        run_as_root pkgutil --forget com.gitguardian.ggshield
+        ;;
+    tarball)
+        say "Removing standalone install"
+        rm -f "$BIN_DIR/ggshield"
+        rm -rf "$OPT_DIR"
+        ;;
+    none)
+        warn "no ggshield installation detected, removing leftovers only"
+        ;;
+    esac
+}
+
+remove_user_data() {
+    # platformdirs(appname="ggshield") config/cache/data, the global config
+    # file, and the scan databases (~/.ggshield)
+    local paths=("$HOME/.gitguardian.yaml" "$HOME/.ggshield")
+    if [ "$(uname -s)" = Darwin ]; then
+        paths+=(
+            "$HOME/Library/Application Support/ggshield"
+            "$HOME/Library/Caches/ggshield"
+        )
+    else
+        paths+=(
+            "${XDG_CONFIG_HOME:-$HOME/.config}/ggshield"
+            "${XDG_CACHE_HOME:-$HOME/.cache}/ggshield"
+            "${XDG_DATA_HOME:-$HOME/.local/share}/ggshield"
+        )
+    fi
+
+    local p found=0
+    for p in "${paths[@]}"; do
+        [ -e "$p" ] && found=1
+    done
+    if [ "$found" = 0 ]; then
+        say "No ggshield config/cache/data found"
+        return 0
+    fi
+
+    confirm "Remove ggshield configuration, cache and data (including plugins)?" || return 0
+    for p in "${paths[@]}"; do
+        if [ -e "$p" ]; then
+            say "Removing $p"
+            rm -rf "$p"
+        fi
+    done
+}
+
+# system-wide scheduled scans: systemd units, /etc/ggshield, wrapper scripts
+remove_system_scheduling() {
+    local unit units=""
+    for unit in /etc/systemd/system/ggshield-*.timer /etc/systemd/system/ggshield-*.service; do
+        [ -e "$unit" ] && units="$units $unit"
+    done
+    if [ -z "$units" ] && [ ! -d /etc/ggshield ]; then
+        return 0
+    fi
+    confirm "Remove system-wide ggshield scheduling (systemd units, /etc/ggshield)?" || return 0
+    if ! have_root; then
+        warn "removing system-wide scheduling requires root or sudo, skipping:$units"
+        return 0
+    fi
+    local script
+    for unit in $units; do
+        case "$unit" in
+        *.timer)
+            run_as_root systemctl disable --now "$(basename "$unit")" >/dev/null 2>&1 || true
+            ;;
+        *.service)
+            # remove the wrapper script the unit points at, when it is ours
+            script=$(sed -n 's/^ExecStart=//p' "$unit" | head -1)
+            case "$script" in
+            *ggshield*) run_as_root rm -f "$script" ;;
+            esac
+            ;;
+        esac
+        say "Removing $unit"
+        run_as_root rm -f "$unit"
+    done
+    run_as_root rm -f /etc/systemd/system/timers.target.wants/ggshield-*.timer
+    if [ -d /etc/ggshield ]; then
+        say "Removing /etc/ggshield"
+        run_as_root rm -rf /etc/ggshield
+    fi
+    run_as_root systemctl daemon-reload >/dev/null 2>&1 || true
+}
+
+# leftovers from ephemeral usages: uvx cache, pre-commit hook environments
+remove_ephemeral_leftovers() {
+    # uv's download cache only speeds up future installs; pruning it scans
+    # the whole cache (slow on large caches), so make it opt-in like pre-commit
+    if command -v uv >/dev/null 2>&1 &&
+        confirm "Prune ggshield from the uv download cache (scans the whole cache, may be slow)?"; then
+        say "Pruning the uv cache (this can take a while)…"
+        uv cache clean ggshield >/dev/null 2>&1 || true
+    fi
+    # Scan the install dir, not `mise ls`: ls only reports tools active in the
+    # current dir's config, so it misses ggshield from most cwds. The dir name
+    # sanitizes the backend colon to a dash (pipx:ggshield -> pipx-ggshield),
+    # so derive the spec back for `mise uninstall` (which is cwd-independent).
+    local mise_installs="$HOME/.local/share/mise/installs"
+    if [ -d "$mise_installs" ]; then
+        local tool name spec
+        for tool in "$mise_installs"/*ggshield*; do
+            [ -d "$tool" ] || continue
+            name=$(basename "$tool")
+            spec="${name/-/:}"
+            confirm "Remove the mise tool '$spec' (all versions)?" || continue
+            if command -v mise >/dev/null 2>&1 &&
+                mise uninstall --all "$spec" >/dev/null 2>&1; then
+                say "Removed mise tool $spec"
+            else
+                warn "could not remove mise tool '$spec'; try: mise uninstall --all $spec"
+            fi
+        done
+    fi
+
+    local pc_cache="$HOME/.cache/pre-commit"
+    if [ -d "$pc_cache" ] &&
+        find "$pc_cache" -name ggshield -type f 2>/dev/null | grep -q .; then
+        if confirm "ggshield found in the pre-commit cache. Clean it (removes ALL cached hook envs)?"; then
+            if command -v pre-commit >/dev/null 2>&1; then
+                pre-commit clean >/dev/null
+            else
+                rm -rf "$pc_cache"
+            fi
+        fi
+    fi
+}
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -y | --yes) ASSUME_YES=1 ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *) die "unknown option: $1 (see --help)" ;;
+        esac
+        shift
+    done
+
+    local methods method
+    methods=$(detect_methods | sort -u)
+    if [ -z "$methods" ]; then
+        methods=none
+    fi
+    say "Detected install method(s): $(echo "$methods" | tr '\n' ' ')"
+
+    ggshield_cleanup
+    local version label
+    for method in $methods; do
+        if [ "$method" != none ]; then
+            version=$(method_version "$method" | head -1)
+            label=$(method_label "$method")
+            confirm "Remove the ggshield installation ($label${version:+ $version})?" || continue
+        fi
+        remove_package "$method"
+    done
+    remove_user_data
+    remove_system_scheduling
+    remove_ephemeral_leftovers
+
+    hash -r 2>/dev/null || true
+    # PATH alone is not enough: ~/.local/bin may not be on PATH in this shell
+    local remaining=""
+    if command -v ggshield >/dev/null 2>&1; then
+        remaining=$(command -v ggshield)
+    elif [ -e "$BIN_DIR/ggshield" ] || [ -L "$BIN_DIR/ggshield" ]; then
+        remaining="$BIN_DIR/ggshield"
+    elif [ -d "$OPT_DIR" ]; then
+        remaining="$OPT_DIR"
+    fi
+    if [ -n "$remaining" ]; then
+        # keep the state file: a later run still needs the recorded method
+        warn "ggshield is still present: $remaining"
+    else
+        rm -rf "$STATE_DIR"
+        say "ggshield is fully removed"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## What

One-line install/uninstall scripts for ggshield, aimed at developers and non-developers:

- **Linux / macOS** (`install.sh`): `curl --proto '=https' --tlsv1.2 -sSfL …/install.sh | bash`
- **Windows** (`install.ps1`): `irm …/install.ps1 | iex`

The installer detects OS/arch and picks the best method available:

| Platform | Method |
| --- | --- |
| macOS | Homebrew, else standalone tarball |
| Linux + apt/dnf/yum/zypper + sudo | Cloudsmith deb/rpm repo |
| Linux without sudo (x86_64 / arm64 glibc) | standalone tarball in `~/.local/bin` |
| Linux musl | pipx |
| Windows | MSI (elevated) → zip (per-user) → Chocolatey (last resort) |

## Highlights

- **Authentication** after install: `--instance` targets EU / self-hosted; `GITGUARDIAN_API_KEY` does a non-interactive token login.
- **Plugins are opt-in**: `--plugin <name>` (repeatable).
- **Download integrity**: standalone downloads are checksum-verified against GitHub's per-asset digest, plus build-provenance attestation when `gh` is available.
- **Uninstall** (`uninstall.sh` / `uninstall.ps1`): confirms each step, removes plugins, logs out, deletes config/cache/data, and removes every install method it detects (system package, brew, pipx, uv, pip, mise, macOS pkg, choco, msi, tarball/zip).

## Notes

- Scripts self-reference `raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/…` — those resolve once merged to `main`.
- arm64 Linux standalone builds are recent; on releases that predate them the installer falls back to pipx.

Refs: END-511
