### PR TITLE
docs(honeytoken): make plant help summary a clean one-liner

### DIFF
--- a/ggshield/cmd/honeytoken/plant.py
+++ b/ggshield/cmd/honeytoken/plant.py
@@ -106,10 +106,12 @@ def plant_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Reconcile this machine's honeytokens against GitGuardian and apply the desired
-    on-disk state: write/refresh the decoy AWS credentials profile for `write` entries,
-    remove it for `delete` (revoked) entries — preserving any other profiles. ggshield
-    never revokes a honeytoken; it only reports placement status.
+    Reconcile and plant this machine's honeytokens against GitGuardian.
+
+    Apply the desired on-disk state: write/refresh the decoy AWS credentials
+    profile for `write` entries, remove it for `delete` (revoked) entries —
+    preserving any other profiles. ggshield never revokes a honeytoken; it only
+    reports placement status.
 
     Authorize with the `honeytokens:write` scope.
     """


### PR DESCRIPTION
## What

Tighten the `ggshield honeytoken plant` docstring so its first line is a self-contained one-line summary.

## Why

The public reference docs are generated from the CLI `--help`: the **first docstring line** becomes the command's short help and the "## Description" lead. `plant`'s first line wrapped mid-sentence (`…apply the desired`), so the generated page split the sentence across the usage code block:

> Reconcile this machine's honeytokens against GitGuardian and apply the desired
> ```
> ggshield honeytoken plant [OPTIONS]
> ```
> on-disk state: …

Now the first line is a clean summary and the on-disk-state detail moves to the body, so both `--help` and the generated [reference page](https://gitlab.gitguardian.ovh/gg-code/public-docs/-/merge_requests/2024) read correctly. No behavior change.

Ref: END-375

🤖 Generated with [Claude Code](https://claude.com/claude-code)