### PR TITLE
fix(plugin): verify wheels against the bundled sigstore trust root

### DIFF
--- a/changelog.d/20260615_101500_ctourriere_plugin_offline_signature_verification.md
+++ b/changelog.d/20260615_101500_ctourriere_plugin_offline_signature_verification.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- `ggshield plugin install` no longer fails with "failed to refresh TUF metadata" on
+  locked-down or proxied networks (most often seen on Windows). Plugin signatures are
+  now always verified against the sigstore trust root bundled with ggshield's
+  dependencies rather than refreshing TUF metadata over the network. Plugin identity is
+  still fully enforced; only trust-root freshness now tracks the pinned sigstore version.
+
+### Changed
+
+- `ggshield plugin list` shows a verified plugin simply as `signed` instead of
+  `signed (<signing-repository>)`. The signing identity is still recorded in the plugin
+  manifest for auditing.

--- a/ggshield/core/plugin/downloader.py
+++ b/ggshield/core/plugin/downloader.py
@@ -111,18 +111,16 @@ def get_signature_label(
         return None
 
     status = sig_info.get("status", "unknown")
-    identity = sig_info.get("identity")
 
+    # The signing identity is recorded in the manifest for audit but never
+    # shown: the product model is binary (signed / not), so the label is a
+    # single clean word with no signing-repository parenthetical.
     if status == SignatureStatus.VALID.value:
-        if identity:
-            return f"signed ({identity})"
         return "signed"
 
     if trusted_unsigned:
         return "unsigned (trusted)"
 
-    if identity:
-        return f"{status} ({identity})"
     return status
 
 

--- a/ggshield/core/plugin/signature.py
+++ b/ggshield/core/plugin/signature.py
@@ -5,22 +5,31 @@ Provides keyless signature verification for plugin wheels using sigstore
 bundles. Signatures are identity-based: ggshield trusts a configured set
 of GitHub Actions workflow identities (OIDC).
 
-Verification modes:
+Verification always runs against the trust root bundled inside our pinned
+sigstore dependency (see ``_bundled_verifier``). ggshield never refreshes TUF
+metadata over the network, because that refresh fails on locked-down / proxied
+networks ("failed to refresh TUF metadata"). The bundled root is enough to
+verify GitGuardian's own plugin signatures; the trade-off is that trust-root
+freshness tracks the pinned sigstore version, so keep that dependency current.
+
+Verification modes (these decide how a result is handled, not how it is computed):
 - STRICT: block unsigned or invalid plugins
-- WARN: log a warning but allow loading. Verification still runs against the
-  embedded / cached sigstore trust root (offline=True) so the TUF metadata
-  refresh, which can fail in restricted networks, is skipped.
+- WARN: log a warning but allow loading (the ``--allow-unsigned`` override)
 - DISABLED: skip verification entirely
 """
 
 import enum
+import functools
 import logging
 from dataclasses import dataclass
+from importlib.resources import as_file, files
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import quote
 
+from sigstore._internal.tuf import DEFAULT_TUF_URL
 from sigstore.errors import VerificationError
-from sigstore.models import Bundle
+from sigstore.models import Bundle, TrustedRoot
 from sigstore.verify import Verifier
 from sigstore.verify.policy import AllOf, GitHubWorkflowRepository, OIDCIssuer
 
@@ -96,6 +105,31 @@ def get_bundle_path(wheel_path: Path) -> Optional[Path]:
     return None
 
 
+@functools.lru_cache(maxsize=1)
+def _bundled_verifier() -> Verifier:
+    """Build a Verifier pinned to the trust root bundled in our sigstore release.
+
+    We deliberately do NOT use ``Verifier.production(offline=True)``: in offline
+    mode sigstore reads its shared on-disk TUF target cache and only seeds the
+    embedded root when that cache is *absent* (sigstore ``_internal/tuf.py``
+    ``TrustUpdater``), so a stale root left by earlier sigstore use on the
+    machine would be used instead. We always verify against the root shipped in
+    the pinned sigstore distribution: deterministic, and it never touches the
+    network (the network refresh is what fails on locked-down / proxied networks
+    with "failed to refresh TUF metadata").
+
+    Resolves the same embedded resource sigstore's own ``read_embedded`` reads
+    (``sigstore._store/<quoted-tuf-url>/trusted_root.json``); the dedicated unit
+    test fails loudly if a sigstore upgrade relocates it.
+    """
+    embedded = (
+        files("sigstore._store") / quote(DEFAULT_TUF_URL, safe="") / "trusted_root.json"
+    )
+    with as_file(embedded) as trusted_root_path:
+        trusted_root = TrustedRoot.from_file(str(trusted_root_path))
+    return Verifier(trusted_root=trusted_root)
+
+
 def verify_wheel_signature(
     wheel_path: Path,
     mode: SignatureVerificationMode,
@@ -133,13 +167,9 @@ def verify_wheel_signature(
         logger.warning("%s", msg)
         return SignatureInfo(status=SignatureStatus.MISSING, message=msg)
 
-    # Verify bundle. In WARN mode (--allow-unsigned) we use the embedded /
-    # cached sigstore trust root via offline=True so that the TUF metadata
-    # refresh -- which can fail in restricted networks -- is skipped.
     bundle = Bundle.from_json(bundle_path.read_bytes())
     wheel_bytes = wheel_path.read_bytes()
-    offline = mode == SignatureVerificationMode.WARN
-    verifier = Verifier.production(offline=offline)
+    verifier = _bundled_verifier()
 
     for trusted in trusted_identities:
         policy = AllOf(

--- a/ggshield/core/plugin/signature.py
+++ b/ggshield/core/plugin/signature.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from typing import List, Optional
 from urllib.parse import quote
 
-from sigstore._internal.tuf import DEFAULT_TUF_URL
 from sigstore.errors import VerificationError
 from sigstore.models import Bundle, TrustedRoot
 from sigstore.verify import Verifier
@@ -105,6 +104,12 @@ def get_bundle_path(wheel_path: Path) -> Optional[Path]:
     return None
 
 
+# Hardcode sigstore's production TUF URL rather than importing the private
+# sigstore._internal.tuf.DEFAULT_TUF_URL, so a refactor of that module can't
+# break our import. The value is stable and rarely (if ever) changes.
+_SIGSTORE_PROD_TUF_URL = "https://tuf-repo-cdn.sigstore.dev"
+
+
 @functools.lru_cache(maxsize=1)
 def _bundled_verifier() -> Verifier:
     """Build a Verifier pinned to the trust root bundled in our sigstore release.
@@ -122,8 +127,14 @@ def _bundled_verifier() -> Verifier:
     (``sigstore._store/<quoted-tuf-url>/trusted_root.json``); the dedicated unit
     test fails loudly if a sigstore upgrade relocates it.
     """
+    # sigstore exposes no public API to load its embedded trust root without the
+    # on-disk TUF cache, so read the bundled root straight from its package data
+    # -- the same sigstore._store resource sigstore's own read_embedded uses.
+    # TestBundledVerifier fails loudly if a sigstore upgrade relocates it.
     embedded = (
-        files("sigstore._store") / quote(DEFAULT_TUF_URL, safe="") / "trusted_root.json"
+        files("sigstore._store")
+        / quote(_SIGSTORE_PROD_TUF_URL, safe="")
+        / "trusted_root.json"
     )
     with as_file(embedded) as trusted_root_path:
         trusted_root = TrustedRoot.from_file(str(trusted_root_path))

--- a/tests/unit/cmd/plugin/test_list.py
+++ b/tests/unit/cmd/plugin/test_list.py
@@ -117,7 +117,7 @@ class TestPluginList:
             cli_fs_runner,
             plugins,
             source_for_name={"machine_scan": PluginSource(type=source_type)},
-            signature_label="signed (GitGuardian/satori)",
+            signature_label="signed",
         )
 
         assert result.exit_code == ExitCode.SUCCESS
@@ -125,7 +125,7 @@ class TestPluginList:
         assert expected_label in result.output
         # The legacy label must not leak through for any recognised source type.
         assert ", local," not in result.output
-        assert "signature: signed (GitGuardian/satori)" in result.output
+        assert "signature: signed" in result.output
 
     def test_list_legacy_wheel_without_manifest_falls_back_to_on_disk(
         self, cli_fs_runner

--- a/tests/unit/core/plugin/test_downloader.py
+++ b/tests/unit/core/plugin/test_downloader.py
@@ -1714,14 +1714,16 @@ class TestGetSignatureLabel:
         manifest: dict = {"signature": {}}
         assert get_signature_label(manifest) is None
 
-    def test_returns_signed_with_identity(self) -> None:
+    def test_returns_plain_signed_and_drops_identity(self) -> None:
+        # The signing identity is kept in the manifest for audit but never
+        # shown: the label is binary ("signed") and identical on every OS.
         manifest: dict = {
             "signature": {
                 "status": "valid",
                 "identity": "GitGuardian/satori",
             }
         }
-        assert get_signature_label(manifest) == "signed (GitGuardian/satori)"
+        assert get_signature_label(manifest) == "signed"
 
     def test_returns_status_without_identity(self) -> None:
         manifest: dict = {"signature": {"status": "missing"}}
@@ -1734,8 +1736,9 @@ class TestGetSignatureLabel:
         )
 
     def test_returns_unknown_when_no_status(self) -> None:
+        # Identity is never appended to the label, even for non-signed states.
         manifest: dict = {"signature": {"identity": "org/repo"}}
-        assert get_signature_label(manifest) == "unknown (org/repo)"
+        assert get_signature_label(manifest) == "unknown"
 
 
 class TestDownloadUrlBundle:

--- a/tests/unit/core/plugin/test_signature.py
+++ b/tests/unit/core/plugin/test_signature.py
@@ -317,7 +317,7 @@ class TestBundledVerifier:
     def test_resolves_embedded_root_and_skips_production(self) -> None:
         # Exercises the real embedded-root resolution
         # (files / as_file / TrustedRoot.from_file): fails loudly if a sigstore
-        # upgrade relocates the embedded _store or the DEFAULT_TUF_URL constant.
+        # upgrade relocates the embedded _store or changes the production TUF URL.
         # Verifier itself is mocked so no real verifier/network is built; we
         # only assert it is constructed from a trusted_root, never via the
         # cache/network-backed production() path.

--- a/tests/unit/core/plugin/test_signature.py
+++ b/tests/unit/core/plugin/test_signature.py
@@ -92,72 +92,57 @@ class TestMissingBundle:
         assert result.status == SignatureStatus.MISSING
 
 
-class TestSignatureVerificationModeWarn:
-    """WARN mode verifies offline so the sigstore TUF refresh is skipped."""
+class TestVerifierIsPinnedToBundledRoot:
+    """Both modes must verify against the trust root bundled in the pinned
+    sigstore release, never the cache/network-backed ``Verifier.production``
+    path (which fails on locked-down networks: "failed to refresh TUF
+    metadata")."""
 
-    def test_warn_mode_uses_offline_verifier(self, tmp_path: Path) -> None:
+    def _assert_uses_bundled_verifier(
+        self, tmp_path: Path, mode: SignatureVerificationMode
+    ) -> None:
         wheel = tmp_path / "plugin-1.0.0.whl"
         wheel.write_bytes(b"fake wheel content")
         bundle = tmp_path / "plugin-1.0.0.whl.sigstore"
         bundle.write_bytes(b'{"fake": "bundle"}')
 
+        mock_verifier = MagicMock()
+        mock_verifier.verify_artifact.return_value = None
         mock_verifier_cls = MagicMock()
         mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
-        mock_verifier_cls.production.return_value.verify_artifact.return_value = None
         mock_bundle_cls.from_json.return_value = MagicMock()
 
         with (
+            patch(
+                "ggshield.core.plugin.signature._bundled_verifier",
+                return_value=mock_verifier,
+            ) as mock_bundled,
             patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
             patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
-            patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
-            patch("ggshield.core.plugin.signature.OIDCIssuer", mock_oidc_issuer_cls),
+            patch("ggshield.core.plugin.signature.AllOf", MagicMock()),
+            patch("ggshield.core.plugin.signature.OIDCIssuer", MagicMock()),
             patch(
                 "ggshield.core.plugin.signature.GitHubWorkflowRepository",
-                mock_gh_repo_cls,
+                MagicMock(),
             ),
         ):
-            verify_wheel_signature(wheel, SignatureVerificationMode.WARN)
+            verify_wheel_signature(wheel, mode)
 
-        # The TUF refresh runs inside Verifier.production() unless offline=True
-        # is passed; --allow-unsigned must opt into offline verification.
-        mock_verifier_cls.production.assert_called_once_with(offline=True)
+        # The pinned, bundled verifier does the work...
+        mock_bundled.assert_called_once_with()
+        mock_verifier.verify_artifact.assert_called_once()
+        # ...and the cache/network-backed production() path is never taken.
+        mock_verifier_cls.production.assert_not_called()
 
-    def test_strict_mode_uses_online_verifier(self, tmp_path: Path) -> None:
-        wheel = tmp_path / "plugin-1.0.0.whl"
-        wheel.write_bytes(b"fake wheel content")
-        bundle = tmp_path / "plugin-1.0.0.whl.sigstore"
-        bundle.write_bytes(b'{"fake": "bundle"}')
+    def test_strict_mode_uses_bundled_verifier(self, tmp_path: Path) -> None:
+        self._assert_uses_bundled_verifier(tmp_path, SignatureVerificationMode.STRICT)
 
-        mock_verifier_cls = MagicMock()
-        mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
-        mock_verifier_cls.production.return_value.verify_artifact.return_value = None
-        mock_bundle_cls.from_json.return_value = MagicMock()
-
-        with (
-            patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
-            patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
-            patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
-            patch("ggshield.core.plugin.signature.OIDCIssuer", mock_oidc_issuer_cls),
-            patch(
-                "ggshield.core.plugin.signature.GitHubWorkflowRepository",
-                mock_gh_repo_cls,
-            ),
-        ):
-            verify_wheel_signature(wheel, SignatureVerificationMode.STRICT)
-
-        mock_verifier_cls.production.assert_called_once_with(offline=False)
+    def test_warn_mode_uses_bundled_verifier(self, tmp_path: Path) -> None:
+        self._assert_uses_bundled_verifier(tmp_path, SignatureVerificationMode.WARN)
 
 
 class TestBundleVerification:
-    """Tests for bundle verification with mocked sigstore."""
+    """Tests for bundle verification with a mocked (bundled) verifier."""
 
     def _setup_wheel_and_bundle(self, tmp_path: Path) -> Path:
         """Create a fake wheel and bundle file."""
@@ -170,16 +155,20 @@ class TestBundleVerification:
     @staticmethod
     @contextmanager
     def _sigstore_modules(
-        mock_verifier_cls: MagicMock,
+        mock_verifier: MagicMock,
         mock_bundle_cls: MagicMock,
         mock_all_of_cls: MagicMock,
         mock_oidc_issuer_cls: MagicMock,
         mock_gh_repo_cls: MagicMock,
     ) -> Iterator[None]:
-        """Patch the top-level sigstore imports in the signature module."""
+        """Patch the sigstore seams: the bundled/pinned verifier plus the
+        bundle and policy helpers used by the signature module."""
         with (
             patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
-            patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
+            patch(
+                "ggshield.core.plugin.signature._bundled_verifier",
+                return_value=mock_verifier,
+            ),
             patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
             patch(
                 "ggshield.core.plugin.signature.OIDCIssuer",
@@ -196,18 +185,10 @@ class TestBundleVerification:
         """Test successful signature verification."""
         wheel = self._setup_wheel_and_bundle(tmp_path)
 
-        mock_verifier_cls = MagicMock()
-        mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
         mock_verifier = MagicMock()
-        mock_verifier_cls.production.return_value = mock_verifier
         mock_verifier.verify_artifact.return_value = None  # Success
-
-        mock_bundle = MagicMock()
-        mock_bundle_cls.from_json.return_value = mock_bundle
+        mock_bundle_cls = MagicMock()
+        mock_bundle_cls.from_json.return_value = MagicMock()
 
         trusted = [
             TrustedIdentity(
@@ -217,11 +198,11 @@ class TestBundleVerification:
         ]
 
         with self._sigstore_modules(
-            mock_verifier_cls,
+            mock_verifier,
             mock_bundle_cls,
-            mock_all_of_cls,
-            mock_oidc_issuer_cls,
-            mock_gh_repo_cls,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         ):
             result = verify_wheel_signature(
                 wheel, SignatureVerificationMode.STRICT, trusted
@@ -234,20 +215,12 @@ class TestBundleVerification:
         """Test that invalid signature raises in STRICT mode."""
         wheel = self._setup_wheel_and_bundle(tmp_path)
 
-        mock_verifier_cls = MagicMock()
-        mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
         mock_verifier = MagicMock()
-        mock_verifier_cls.production.return_value = mock_verifier
         mock_verifier.verify_artifact.side_effect = SigstoreVerificationError(
             "Verification failed"
         )
-
-        mock_bundle = MagicMock()
-        mock_bundle_cls.from_json.return_value = mock_bundle
+        mock_bundle_cls = MagicMock()
+        mock_bundle_cls.from_json.return_value = MagicMock()
 
         trusted = [
             TrustedIdentity(
@@ -257,11 +230,11 @@ class TestBundleVerification:
         ]
 
         with self._sigstore_modules(
-            mock_verifier_cls,
+            mock_verifier,
             mock_bundle_cls,
-            mock_all_of_cls,
-            mock_oidc_issuer_cls,
-            mock_gh_repo_cls,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         ):
             with pytest.raises(SignatureVerificationError) as exc_info:
                 verify_wheel_signature(wheel, SignatureVerificationMode.STRICT, trusted)
@@ -272,20 +245,12 @@ class TestBundleVerification:
         """Test that invalid signature returns INVALID in WARN mode."""
         wheel = self._setup_wheel_and_bundle(tmp_path)
 
-        mock_verifier_cls = MagicMock()
-        mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
         mock_verifier = MagicMock()
-        mock_verifier_cls.production.return_value = mock_verifier
         mock_verifier.verify_artifact.side_effect = SigstoreVerificationError(
             "Verification failed"
         )
-
-        mock_bundle = MagicMock()
-        mock_bundle_cls.from_json.return_value = mock_bundle
+        mock_bundle_cls = MagicMock()
+        mock_bundle_cls.from_json.return_value = MagicMock()
 
         trusted = [
             TrustedIdentity(
@@ -295,11 +260,11 @@ class TestBundleVerification:
         ]
 
         with self._sigstore_modules(
-            mock_verifier_cls,
+            mock_verifier,
             mock_bundle_cls,
-            mock_all_of_cls,
-            mock_oidc_issuer_cls,
-            mock_gh_repo_cls,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         ):
             result = verify_wheel_signature(
                 wheel, SignatureVerificationMode.WARN, trusted
@@ -311,22 +276,14 @@ class TestBundleVerification:
         """Test that multiple trusted identities are tried in order."""
         wheel = self._setup_wheel_and_bundle(tmp_path)
 
-        mock_verifier_cls = MagicMock()
-        mock_bundle_cls = MagicMock()
-        mock_all_of_cls = MagicMock()
-        mock_oidc_issuer_cls = MagicMock()
-        mock_gh_repo_cls = MagicMock()
-
         mock_verifier = MagicMock()
-        mock_verifier_cls.production.return_value = mock_verifier
         # First identity fails, second succeeds
         mock_verifier.verify_artifact.side_effect = [
             SigstoreVerificationError("Wrong identity"),
             None,  # Success
         ]
-
-        mock_bundle = MagicMock()
-        mock_bundle_cls.from_json.return_value = mock_bundle
+        mock_bundle_cls = MagicMock()
+        mock_bundle_cls.from_json.return_value = MagicMock()
 
         trusted = [
             TrustedIdentity(
@@ -340,11 +297,11 @@ class TestBundleVerification:
         ]
 
         with self._sigstore_modules(
-            mock_verifier_cls,
+            mock_verifier,
             mock_bundle_cls,
-            mock_all_of_cls,
-            mock_oidc_issuer_cls,
-            mock_gh_repo_cls,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         ):
             result = verify_wheel_signature(
                 wheel, SignatureVerificationMode.STRICT, trusted
@@ -352,3 +309,30 @@ class TestBundleVerification:
 
         assert result.status == SignatureStatus.VALID
         assert result.identity == trusted[1].repository
+
+
+class TestBundledVerifier:
+    """Guards the private-sigstore wiring that pins the bundled trust root."""
+
+    def test_resolves_embedded_root_and_skips_production(self) -> None:
+        # Exercises the real embedded-root resolution
+        # (files / as_file / TrustedRoot.from_file): fails loudly if a sigstore
+        # upgrade relocates the embedded _store or the DEFAULT_TUF_URL constant.
+        # Verifier itself is mocked so no real verifier/network is built; we
+        # only assert it is constructed from a trusted_root, never via the
+        # cache/network-backed production() path.
+        from ggshield.core.plugin.signature import _bundled_verifier
+
+        _bundled_verifier.cache_clear()
+        sentinel = MagicMock()
+        try:
+            with patch("ggshield.core.plugin.signature.Verifier") as mock_verifier_cls:
+                mock_verifier_cls.return_value = sentinel
+                result = _bundled_verifier()
+        finally:
+            _bundled_verifier.cache_clear()
+
+        assert result is sentinel
+        mock_verifier_cls.assert_called_once()
+        assert "trusted_root" in mock_verifier_cls.call_args.kwargs
+        mock_verifier_cls.production.assert_not_called()


### PR DESCRIPTION
## What

`ggshield plugin install` failed on locked-down / proxied networks (commonly Windows) with `failed to refresh TUF metadata`, forcing users onto `--allow-unsigned` — which disables signature verification entirely.

## Why

Strict-mode verification built `Verifier.production(offline=False)`, which makes sigstore refresh its TUF trust root over the network from `tuf-repo-cdn.sigstore.dev`. Behind a corporate proxy/firewall that refresh raises `TUFError("Failed to refresh TUF metadata")` and aborts the install. macOS/Linux dev machines have open egress, so they never saw it.

## Fix

- Pin verification to the trust root **bundled in the installed sigstore release** (`_bundled_verifier`): resolve the same embedded resource sigstore's own `read_embedded` uses and build `Verifier(trusted_root=...)` directly. No network, deterministic, and not subject to sigstore's mutable shared TUF cache (which `offline=True` would otherwise reuse even when stale). Plugin identity (`GitGuardian/satori`) is still fully enforced — verification still fails closed on an untrusted signature.
- `ggshield plugin list` now shows a plain `signed` label. The signing repository is kept in the manifest for audit but no longer displayed, so the label is identical on every OS.

## Trade-off

Trust-root freshness now tracks the pinned `sigstore` dependency (no live TUF refresh). Acceptable for verifying GitGuardian's own first-party plugin signatures; keep `sigstore` current via renovate.

## Tests

- Reworked the signature / downloader / list unit tests; added a guard test (`TestBundledVerifier`) that exercises the real embedded-root resolution so a sigstore upgrade relocating `_store` / `DEFAULT_TUF_URL` fails loudly.
- 456 plugin unit tests pass; black / flake8 / isort clean.

## Companion change (separate repo)

The satori plugin's `_hide_signature_identity()` manifest self-rewrite — previously used to hide the signing repo, and flagged in PENTEST.md as a supply-chain smell — is now redundant (ggshield owns the label) and removed in a matching satori_gl change.
