### PR TITLE
fix(hmsl): build canonical Vault KV paths (strip leading slash)

### DIFF
--- a/changelog.d/20260615_172340_benjamin.rigaud_fix_vault_canonical_kv_path.md
+++ b/changelog.d/20260615_172340_benjamin.rigaud_fix_vault_canonical_kv_path.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield hmsl` Vault integration: list secrets correctly when a KV path has a leading slash, instead of failing against recent HashiCorp Vault versions that reject non-canonical paths.

--- a/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
+++ b/ggshield/verticals/hmsl/secret_manager/hashicorp_vault/api_client.py
@@ -81,6 +81,9 @@ class VaultAPIClient:
     def list_kv_items(self, mount: VaultKvMount, path: str) -> List[str]:
         logger.debug(f"Listing kv items for mount {mount.name} at {path}")
 
+        # Strip leading slash so the endpoint stays canonical: recent Vault versions
+        # reject non-canonical "//" paths with a 400 instead of redirecting them.
+        path = path.lstrip("/")
         api_endpoint = (
             f"{mount.name}/metadata/{path}"
             if mount.version == "2"


### PR DESCRIPTION
## What

Fix `ggshield hmsl` Vault integration failing to list KV secrets when a path has a leading slash (e.g. `/b2b`).

## Why

`VaultAPIClient.list_kv_items` built the API endpoint by interpolating the user-supplied `path` directly:

```python
api_endpoint = (
    f"{mount.name}/metadata/{path}"  # v2
    if mount.version == "2"
    else f"{mount.name}/{path}"      # v1
)
```

A leading slash on `path` produced a non-canonical URL with a double slash: `secret_v1//b2b` (v1) or `secret/metadata//b2b` (v2).

This bug has been **latent since the 2023 HMSL-Vault feature**. It only ever worked because older `hashicorp/vault` images 301-redirected `//b2b` to `/b2b`, and `requests` auto-followed the redirect. **Recent Vault versions no longer redirect** and instead return `400 Bad Request: "vault request paths must be canonical and not relative"`, breaking listing for any leading-slash path.

## How

Strip the leading slash before building `api_endpoint`, so the request is always canonical for both v1 and v2 mounts. This removes the dependency on the old redirect behavior. Root path (`""`) and already-canonical paths are unaffected (`lstrip("/")` is a no-op for them).

## Tests

`tests/unit/verticals/hmsl/secret_manager/hashicorp_vault/test_api_client.py` passes (47 passed), including the 12 leading-slash parametrizations of `test_list_kv_items_v1` / `test_list_kv_items_v2`. The committed cassettes already recorded the canonical `/b2b` 200 interaction, so they match the new canonical request on replay with no cassette changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)