### PR TITLE
fix: don't crash when truststore setup fails (#1265)

### DIFF
--- a/changelog.d/20260616_000000_henri.hubert_fix_truststore_crash.md
+++ b/changelog.d/20260616_000000_henri.hubert_fix_truststore_crash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- ggshield no longer crashes on startup when the optional `truststore` setup fails (for example on recent macOS versions where the OS version cannot be parsed). It now falls back to the bundled `certifi` certificates instead.

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -269,9 +269,17 @@ def setup_truststore():
         # truststore requires Python 3.10
         return
 
-    import truststore
+    # truststore is only an optimization to use the system trust store instead
+    # of the certificates bundled by certifi. If anything goes wrong while
+    # importing or injecting it (for example truststore failing to parse the
+    # macOS version, see #1265), fall back to certifi rather than crashing the
+    # whole CLI.
+    try:
+        import truststore
 
-    truststore.inject_into_ssl()
+        truststore.inject_into_ssl()
+    except Exception as exc:
+        logger.debug("Could not set up truststore, falling back to certifi: %s", exc)
 
 
 def main(args: Optional[List[str]] = None) -> Any:

--- a/tests/unit/test_main_truststore.py
+++ b/tests/unit/test_main_truststore.py
@@ -1,5 +1,6 @@
 """Tests for truststore setup in __main__.py."""
 
+import builtins
 import sys
 from unittest import mock
 
@@ -9,14 +10,41 @@ import pytest
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="truststore requires Python 3.10+"
 )
-def test_setup_truststore_swallows_errors(monkeypatch) -> None:
-    """A failure while injecting truststore must not crash the CLI (see #1265)."""
+def test_setup_truststore_swallows_import_errors(monkeypatch) -> None:
+    """A failure while *importing* truststore must not crash the CLI (see #1265).
+
+    The reported bug crashes inside ``import truststore`` itself (truststore's
+    ``_macos`` submodule fails to parse the macOS version), before
+    ``inject_into_ssl`` is ever reached, so this is the case we must guard.
+    """
+    import ggshield.__main__ as main_module
+
+    # Make sure the import statement actually triggers __import__ rather than
+    # returning an already-cached module.
+    monkeypatch.delitem(sys.modules, "truststore", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "truststore":
+            raise ValueError("invalid literal for int() with base 10: ''")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Should not raise.
+    main_module.setup_truststore()
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="truststore requires Python 3.10+"
+)
+def test_setup_truststore_swallows_injection_errors(monkeypatch) -> None:
+    """A failure while injecting truststore must also not crash the CLI."""
     import ggshield.__main__ as main_module
 
     fake_truststore = mock.MagicMock()
-    fake_truststore.inject_into_ssl.side_effect = ValueError(
-        "invalid literal for int() with base 10: ''"
-    )
+    fake_truststore.inject_into_ssl.side_effect = RuntimeError("boom")
     monkeypatch.setitem(sys.modules, "truststore", fake_truststore)
 
     # Should not raise.

--- a/tests/unit/test_main_truststore.py
+++ b/tests/unit/test_main_truststore.py
@@ -1,0 +1,25 @@
+"""Tests for truststore setup in __main__.py."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="truststore requires Python 3.10+"
+)
+def test_setup_truststore_swallows_errors(monkeypatch) -> None:
+    """A failure while injecting truststore must not crash the CLI (see #1265)."""
+    import ggshield.__main__ as main_module
+
+    fake_truststore = mock.MagicMock()
+    fake_truststore.inject_into_ssl.side_effect = ValueError(
+        "invalid literal for int() with base 10: ''"
+    )
+    monkeypatch.setitem(sys.modules, "truststore", fake_truststore)
+
+    # Should not raise.
+    main_module.setup_truststore()
+
+    fake_truststore.inject_into_ssl.assert_called_once()


### PR DESCRIPTION
## Context

Fixes #1265.

ggshield crashes on startup when the optional `truststore` setup fails:

\`\`\`
File ".../ggshield/__main__.py", line 272, in setup_truststore
    import truststore
File ".../truststore/_macos.py", line 22, in <module>
    _mac_version_info = tuple(map(int, _mac_version.split(".")))
ValueError: invalid literal for int() with base 10: ''
\`\`\`

The root cause is a bug **inside `truststore`**: on the reporter's setup (macOS 26.2 / Homebrew Python 3.14), `platform.mac_ver()[0]` returns an empty string, so `int('')` raises `ValueError` at import time. This still exists on truststore `main`, so a version bump wouldn't reliably fix it.

`truststore` is only an *optimization* — it makes ggshield use the system trust store instead of the certificates bundled by `certifi`. There's no reason for a failure there to take down the whole CLI.

## Change

Wrap the `truststore` import and `inject_into_ssl()` call in a `try/except` that logs at debug level and falls back to `certifi`.

## Notes

- This makes ggshield resilient but does not restore actual system-trust-store support on affected machines
- Added a unit test (`tests/unit/test_main_truststore.py`) and a changelog entry.
- We tested the behavior and it seems to come from brew python versions.