### PR TITLE
feat(scripts): add ggshield install/uninstall scripts

### DIFF
--- a/changelog.d/20260615_143744_benjaminrigaud_install_scripts.md
+++ b/changelog.d/20260615_143744_benjaminrigaud_install_scripts.md
@@ -1,0 +1,3 @@
+### Added
+
+- Install and uninstall scripts under `scripts/install/`: a one-line `curl | bash` (Linux/macOS) and `irm | iex` (Windows) installer for the standalone ggshield build that authenticates and optionally installs plugins, plus a matching uninstaller that removes the install it created.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -1,0 +1,154 @@
+# ggshield install scripts
+
+One-line scripts to install the standalone ggshield build on your machine (for
+developers and non-developers), authenticate, optionally install plugins, and
+cleanly uninstall it later. No admin/sudo required.
+
+## Install
+
+Linux / macOS:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1 | iex
+```
+
+The `irm | iex` form runs the script content directly, so it is not subject to
+the execution policy. If you instead download and run the `.ps1` file, Windows
+requires `powershell -ExecutionPolicy Bypass -File .\install.ps1`.
+
+Prefer inspecting before running:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL -o install.sh \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh
+less install.sh
+bash install.sh
+```
+
+The script installs the standalone build (detecting OS/arch, including Rosetta 2) to:
+
+- **Linux / macOS** → `~/.local/share/ggshield-standalone`, symlinked into
+  `~/.local/bin` (no sudo).
+- **Windows** → `%LOCALAPPDATA%\Programs\ggshield`, added to your user PATH (no
+  admin). `-Method msi` installs the system-wide MSI instead (requires admin).
+
+The download is **checksum-verified** against the digest GitHub publishes for
+each asset (the install aborts if it cannot be verified), and — when `gh` is
+available — against the release's [build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
+
+Alpine/musl is not supported (the standalone build is glibc-only) — use the
+Docker image `gitguardian/ggshield` or `pipx install ggshield`.
+
+### Options
+
+```text
+-y, --yes           never prompt (for CI)
+    --instance URL  GitGuardian instance (default: https://dashboard.gitguardian.com)
+    --version X.Y.Z ggshield version to install (default: latest)
+    --install-only  install ggshield only, skip auth and plugins
+    --plugin NAME   install this ggshield plugin (repeatable)
+```
+
+Pass options through the pipe with `bash -s --`:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
+  bash -s -- --plugin <plugin_name>
+```
+
+`install.ps1` takes the equivalent options (`-Yes`, `-Instance URL`,
+`-Version X.Y.Z`, `-Method zip|msi`, `-InstallOnly`, `-Plugin name[,name]`):
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1))) `
+  -Plugin <plugin_name> -Yes
+```
+
+Authentication and plugin installation are **best-effort**: if they fail (wrong
+instance, cancelled login, no network), the script warns and prints the retry
+commands, but the install itself still succeeds.
+
+### Instance
+
+ggshield authenticates against the US workspace
+(`https://dashboard.gitguardian.com`) by default. Use `--instance` (`-Instance`
+on Windows) to target another one — for the EU workspace:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
+  bash -s -- --instance https://dashboard.eu1.gitguardian.com
+```
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1))) `
+  -Instance https://dashboard.eu1.gitguardian.com
+```
+
+A self-hosted instance works the same way, e.g.
+`--instance https://dashboard.gitguardian.example.com`. On a remote/headless
+machine where the browser flow can't complete, add `--method oob` to the
+printed `ggshield auth login` command.
+
+### Environment variables
+
+| Variable               | Effect                                                        |
+| ---------------------- | ------------------------------------------------------------- |
+| `GGSHIELD_VERSION`     | same as `--version`                                           |
+| `GITGUARDIAN_INSTANCE` | instance to authenticate against (same as `--instance`)       |
+| `GITGUARDIAN_API_KEY`  | authenticate with this API key instead of the browser login   |
+| `GGSHIELD_BIN_DIR`     | symlink dir (default `~/.local/bin`)                          |
+| `GGSHIELD_OPT_DIR`     | extraction dir (default `~/.local/share/ggshield-standalone`) |
+
+## Other install methods
+
+These scripts install the standalone build. If you'd rather use a package
+manager (managed upgrades, system integration), install ggshield directly:
+
+| Method                 | Command                                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Homebrew (macOS/Linux) | `brew install ggshield`                                                                                                     |
+| Debian / Ubuntu (apt)  | `curl -1sLf https://dl.cloudsmith.io/public/gitguardian/ggshield/setup.deb.sh \| sudo -E bash && sudo apt install ggshield` |
+| Fedora / RHEL (dnf)    | `curl -1sLf https://dl.cloudsmith.io/public/gitguardian/ggshield/setup.rpm.sh \| sudo -E bash && sudo dnf install ggshield` |
+| pipx                   | `pipx install ggshield`                                                                                                     |
+| Windows (Chocolatey)   | `choco install ggshield`                                                                                                    |
+| Docker                 | `docker run --rm gitguardian/ggshield ggshield --version`                                                                   |
+
+The Cloudsmith `setup.*.sh` bootstrap runs **as root** and is not independently
+checksum-verified (the standard Cloudsmith flow) — inspect it first if that
+trust boundary matters.
+
+## Uninstall
+
+Linux / macOS:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.ps1 | iex
+```
+
+By default this removes **only the install these scripts created** (the
+standalone tree + its PATH entry, or the MSI when installed with `-Method msi`).
+It does not touch ggshield installed another way — remove those with the
+matching tool (`brew uninstall` / `apt remove` / `pipx uninstall` /
+`choco uninstall` / `msiexec /x`).
+
+Removing ggshield's configuration, cache and data is opt-in:
+
+| Linux / macOS | Windows  | Removes                                                           |
+| ------------- | -------- | ----------------------------------------------------------------- |
+| `--purge`     | `-Purge` | config, cache and data (`~/.gitguardian.yaml`, plugins, scan DBs) |

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,287 @@
+# ggshield installer for Windows.
+#
+# Installs the standalone ggshield build per-user (ZIP, no admin), then
+# best-effort authenticates and installs any requested plugins.
+#
+#   irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1 | iex
+#
+# With options:
+#   & ([scriptblock]::Create((irm <url>))) -Instance https://dashboard.example.com -Yes
+#
+# -Method msi installs the system-wide MSI instead (requires admin).
+# Other methods (Chocolatey) are documented in scripts/install/README.md.
+# Cleanup: uninstall.ps1. Compatible with Windows PowerShell 5.1 (no pwsh).
+
+[CmdletBinding()]
+param(
+    [switch]$Yes,
+    [string]$Instance = $env:GITGUARDIAN_INSTANCE,
+    [string]$Version = $env:GGSHIELD_VERSION,
+    [ValidateSet('zip', 'msi')]
+    [string]$Method = 'zip',
+    [switch]$InstallOnly,
+    [string[]]$Plugin = @()
+)
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$GithubRepo = 'GitGuardian/ggshield'
+$DefaultInstance = 'https://dashboard.gitguardian.com'
+$EuInstance = 'https://dashboard.eu1.gitguardian.com'
+$ZipDir = Join-Path $env:LOCALAPPDATA 'Programs\ggshield'
+$StateDir = Join-Path $env:LOCALAPPDATA 'ggshield-install'
+
+function Say($msg) { Write-Host "==> $msg" -ForegroundColor Blue }
+function Warn($msg) { Write-Host "warning: $msg" -ForegroundColor Yellow }
+function Die($msg) { throw "error: $msg" }
+
+# Run a native command, discarding output. With $ErrorActionPreference=Stop,
+# redirecting native stderr would otherwise throw (PowerShell 5.1 gotcha).
+function Invoke-Native {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & $args[0] @($args | Select-Object -Skip 1) 2>&1 | Out-Null }
+    finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+function Update-SessionPath {
+    $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+    [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + $env:Path
+}
+
+function Test-Admin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Resolve-Version {
+    if ($script:Version) {
+        $script:Version = $script:Version.TrimStart('v')
+        return
+    }
+    Say 'Resolving latest ggshield version'
+    $release = Invoke-RestMethod "https://api.github.com/repos/$GithubRepo/releases/latest"
+    $script:Version = $release.tag_name.TrimStart('v')
+}
+
+# GitHub computes a sha256 digest for every release asset
+function Get-AssetDigest($assetName) {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$GithubRepo/releases/tags/v$script:Version"
+    $asset = $release.assets | Where-Object { $_.name -eq $assetName }
+    if ($asset -and $asset.digest) { return $asset.digest -replace '^sha256:', '' }
+    return $null
+}
+
+# Fail closed: a download we cannot verify is never installed.
+function Test-Download($file, $assetName) {
+    $expected = Get-AssetDigest $assetName
+    if (-not $expected) {
+        Die "could not retrieve the expected sha256 digest for $assetName from the GitHub API; refusing to install unverified"
+    }
+    Say 'Verifying sha256 checksum'
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $file).Hash
+    if ($actual -ne $expected) { Die "checksum mismatch for $assetName" }
+
+    # opportunistic build provenance check; older gh has no `attestation`
+    if ((Get-Command gh -ErrorAction SilentlyContinue) -and
+        (Invoke-Native gh attestation --help) -eq 0 -and
+        (Invoke-Native gh auth status) -eq 0) {
+        Say 'Verifying build provenance attestation'
+        if ((Invoke-Native gh attestation verify $file --repo $GithubRepo) -ne 0) {
+            Die "artifact attestation verification failed for $assetName"
+        }
+    }
+}
+
+function Get-ReleaseAsset($assetName) {
+    $tmp = Join-Path ([IO.Path]::GetTempPath()) $assetName
+    Say "Downloading $assetName"
+    Invoke-WebRequest -UseBasicParsing `
+        -Uri "https://github.com/$GithubRepo/releases/download/v$script:Version/$assetName" `
+        -OutFile $tmp
+    Test-Download $tmp $assetName
+    return $tmp
+}
+
+# Path to a system-wide MSI ggshield.exe (from its recorded install location),
+# or $null. A system MSI sits on the Machine PATH, which Windows searches
+# before the user PATH where the zip installs.
+function Get-MsiGgshieldExe {
+    $p = Get-ItemProperty `
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*', `
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' `
+        -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like 'ggshield*' -and $_.InstallLocation } |
+        Select-Object -First 1
+    if ($p) {
+        $exe = Join-Path $p.InstallLocation 'ggshield.exe'
+        if (Test-Path $exe) { return $exe }
+    }
+    return $null
+}
+
+function Install-WithMsi {
+    if (-not (Test-Admin)) { Die '-Method msi requires an elevated (administrator) PowerShell' }
+    Resolve-Version
+    $msi = Get-ReleaseAsset "ggshield-$script:Version-x86_64-pc-windows-msvc.msi"
+    Say 'Installing the MSI'
+    $proc = Start-Process msiexec -ArgumentList '/i', "`"$msi`"", '/qn', '/norestart' -Wait -PassThru
+    if ($proc.ExitCode -ne 0) { Die "msiexec failed with exit code $($proc.ExitCode)" }
+    Remove-Item $msi -ErrorAction SilentlyContinue
+    $exe = Get-MsiGgshieldExe
+    if ($exe) { $script:GgshieldExe = $exe }
+}
+
+function Install-WithZip {
+    Resolve-Version
+    $zip = Get-ReleaseAsset "ggshield-$script:Version-x86_64-pc-windows-msvc.zip"
+    Say "Installing to $ZipDir"
+    if (Test-Path $ZipDir) { Remove-Item $ZipDir -Recurse -Force }
+    Expand-Archive -Path $zip -DestinationPath $ZipDir -Force
+    Remove-Item $zip -ErrorAction SilentlyContinue
+
+    $exe = Get-ChildItem $ZipDir -Recurse -Filter ggshield.exe | Select-Object -First 1
+    if (-not $exe) { Die "no ggshield.exe found in $ZipDir" }
+    $binDir = $exe.DirectoryName
+    # operate on the exact binary we installed, not whatever PATH resolves to
+    # (a system-wide ggshield on the Machine PATH would otherwise shadow this)
+    $script:GgshieldExe = $exe.FullName
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (($userPath -split ';') -notcontains $binDir) {
+        Say "Adding $binDir to your user PATH"
+        [Environment]::SetEnvironmentVariable('Path', "$binDir;$userPath", 'User')
+    }
+    $env:Path = "$binDir;$env:Path"
+}
+
+function Write-State {
+    New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+    @{ method = $script:Method; version = $script:Version; zipDir = $ZipDir } |
+        ConvertTo-Json | Set-Content (Join-Path $StateDir 'state.json')
+}
+
+# Hints for steps that did NOT complete — only shown when something is left to
+# do (auth failed/skipped, a plugin failed, or -InstallOnly).
+function Write-AuthHint {
+    $inst = if ($Instance) { $Instance } else { $DefaultInstance }
+    Write-Host "    ggshield auth login --instance $inst"
+    if (-not $Instance) { Write-Host "    # EU workspace: ggshield auth login --instance $EuInstance" }
+    Write-Host '    # no browser available: add --method oob'
+}
+
+function Write-PluginHint {
+    if ($Plugin) { Write-Host "    ggshield plugin install $($Plugin -join ' ')" }
+}
+
+# Best-effort: a failed login warns but never fails the installer. Sets
+# $script:AuthSucceeded so the caller can skip plugins when auth did not work.
+function Invoke-BestEffortAuth {
+    $script:AuthSucceeded = $false
+    $inst = if ($Instance) { $Instance } else { $DefaultInstance }
+    if (-not $env:GITGUARDIAN_API_KEY -and $Yes) {
+        Warn 'non-interactive run (-Yes) without GITGUARDIAN_API_KEY: skipping auth'
+        return
+    }
+    $loginArgs = @('auth', 'login')
+    if ($Instance) { $loginArgs += @('--instance', $Instance) }
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        if ($env:GITGUARDIAN_API_KEY) {
+            Say "Authenticating with GITGUARDIAN_API_KEY against $inst"
+            $loginArgs += @('--method', 'token')
+            $env:GITGUARDIAN_API_KEY | & $script:GgshieldExe @loginArgs
+        }
+        else {
+            Say "Authenticating against $inst"
+            & $script:GgshieldExe @loginArgs
+        }
+    }
+    finally { $ErrorActionPreference = $eap }
+    if ($LASTEXITCODE -eq 0) { $script:AuthSucceeded = $true }
+    else { Warn "authentication failed (instance: $inst)" }
+}
+
+function Invoke-PostInstall {
+    Update-SessionPath
+    # operate on the binary we just installed; only fall back to PATH if an
+    # install function did not record it
+    if (-not $script:GgshieldExe -or -not (Test-Path $script:GgshieldExe)) {
+        $gg = Get-Command ggshield -ErrorAction SilentlyContinue
+        if (-not $gg) { Die 'ggshield not found on PATH after install (open a new terminal and retry)' }
+        $script:GgshieldExe = $gg.Source
+    }
+    Say "Installed: $(& $script:GgshieldExe --version)"
+
+    # a pre-existing ggshield earlier on PATH (e.g. a system MSI on the Machine
+    # PATH) shadows a per-user zip install — warn so the version isn't confusing
+    $resolved = (Get-Command ggshield -ErrorAction SilentlyContinue).Source
+    if ($resolved -and $resolved -ne $script:GgshieldExe) {
+        Warn "another ggshield on your PATH ($resolved) shadows the one just installed ($script:GgshieldExe)"
+        # a system-wide install (Program Files / ProgramData) sits on the
+        # Machine PATH, which Windows searches before the per-user PATH — a new
+        # terminal won't help and a per-user install can't override it
+        $sysRoots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:ProgramData) | Where-Object { $_ }
+        $isSystem = $false
+        foreach ($r in $sysRoots) {
+            if ($resolved.StartsWith($r, [System.StringComparison]::OrdinalIgnoreCase)) { $isSystem = $true }
+        }
+        if ($isSystem) {
+            Warn 'that is a system-wide install. Re-run as administrator with -Method msi to replace it, or uninstall it first (uninstall.ps1).'
+        }
+        else {
+            Warn 'remove it or fix your PATH order'
+        }
+    }
+
+    if ($InstallOnly) {
+        Say 'ggshield is installed. To finish setup:'
+        Write-AuthHint
+        Write-PluginHint
+        return
+    }
+
+    # Plugins need a working authentication, so only attempt them once auth
+    # succeeds; otherwise skip.
+    $pluginsPending = $false
+    Invoke-BestEffortAuth
+    if ($script:AuthSucceeded) {
+        foreach ($p in $Plugin) {
+            Say "Installing the $p plugin"
+            if ((Invoke-Native $script:GgshieldExe plugin install $p) -ne 0) {
+                Warn "could not install the $p plugin (continuing)"
+                $pluginsPending = $true
+            }
+        }
+    }
+    elseif ($Plugin) {
+        Warn 'skipping plugin install until ggshield is authenticated'
+        $pluginsPending = $true
+    }
+
+    # Only nag about next steps when something actually remains.
+    if ($script:AuthSucceeded -and -not $pluginsPending) {
+        Say 'ggshield is ready.'
+        return
+    }
+    Say 'To finish setup:'
+    if (-not $script:AuthSucceeded) { Write-AuthHint }
+    if ($pluginsPending) { Write-PluginHint }
+}
+
+if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
+    Die "unsupported architecture: $env:PROCESSOR_ARCHITECTURE (only x86_64 builds are published)"
+}
+
+Say "Windows/x86_64 - install method: $Method"
+switch ($Method) {
+    'msi' { Install-WithMsi }
+    'zip' { Install-WithZip }
+}
+
+Write-State
+Invoke-PostInstall

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+#
+# ggshield installer (Linux / macOS).
+#
+# Installs the standalone ggshield build into ~/.local/bin (no sudo), then
+# best-effort authenticates and installs any requested plugins.
+#
+#   curl --proto '=https' --tlsv1.2 -sSfL \
+#     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
+#
+# See scripts/install/README.md for options and other install methods.
+# Cleanup: uninstall.sh.
+
+set -euo pipefail
+
+GITHUB_REPO="GitGuardian/ggshield"
+DEFAULT_INSTANCE="https://dashboard.gitguardian.com"
+EU_INSTANCE="https://dashboard.eu1.gitguardian.com"
+
+BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+# NOT ~/.local/share/ggshield: that is ggshield's own data dir (plugins…)
+OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
+STATE_FILE="$STATE_DIR/state"
+
+ASSUME_YES=0
+INSTALL_ONLY=0
+PLUGINS=()
+# honor GITGUARDIAN_INSTANCE like ggshield does; --instance overrides it
+INSTANCE="${GITGUARDIAN_INSTANCE:-}"
+VERSION="${GGSHIELD_VERSION:-}"
+
+usage() {
+    cat <<EOF
+Usage: install.sh [OPTIONS]
+
+Install the standalone ggshield build, then authenticate and (optionally)
+install plugins. Other install methods (Homebrew, apt/rpm, pipx) are listed
+in scripts/install/README.md.
+
+Options:
+  -y, --yes           never prompt, accept defaults (for CI)
+      --instance URL  GitGuardian instance to authenticate against
+                      (default: $DEFAULT_INSTANCE)
+      --version X.Y.Z ggshield version to install (default: latest;
+                      also via GGSHIELD_VERSION env var)
+      --install-only  install ggshield only, skip auth and plugins
+      --plugin NAME   install this ggshield plugin (repeatable)
+  -h, --help          show this help
+
+Environment:
+  GITGUARDIAN_API_KEY  authenticate with this API key instead of the browser
+                       flow (token login; combine with --instance)
+  GGSHIELD_BIN_DIR     symlink dir (default ~/.local/bin)
+  GGSHIELD_OPT_DIR     extraction dir (default ~/.local/share/ggshield-standalone)
+EOF
+}
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+fetch() {
+    curl --proto '=https' --tlsv1.2 -sSfL --retry 3 "$@"
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# A remote/headless session has no browser for the OAuth redirect; ggshield's
+# --method oob is the way out (reported by users behind SSH / VM port-forwarding).
+is_headless() {
+    [ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && return 0
+    [ "$OS" = linux ] && [ -z "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && return 0
+    return 1
+}
+
+detect_platform() {
+    case "$(uname -s)" in
+    Linux) OS=linux ;;
+    Darwin) OS=darwin ;;
+    MINGW* | MSYS* | CYGWIN*)
+        die "Windows is not supported by this script. Use install.ps1 instead: \
+irm https://raw.githubusercontent.com/$GITHUB_REPO/main/scripts/install/install.ps1 | iex"
+        ;;
+    *) die "unsupported OS: $(uname -s)" ;;
+    esac
+
+    case "$(uname -m)" in
+    x86_64 | amd64) ARCH=x86_64 ;;
+    arm64 | aarch64) ARCH=arm64 ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+    esac
+
+    if [ "$OS" = darwin ]; then
+        LIBC=""
+        # uname -m lies under Rosetta 2; sysctl does not (rustup pattern)
+        if [ "$ARCH" = x86_64 ] &&
+            [ "$(sysctl -n hw.optional.arm64 2>/dev/null || true)" = 1 ]; then
+            ARCH=arm64
+        fi
+        TARGET="$ARCH-apple-darwin"
+    else
+        LIBC=gnu
+        # base Alpine has no ldd (musl-utils), so check the loader file too
+        if [ -e "/lib/ld-musl-$(uname -m).so.1" ] ||
+            ldd --version 2>&1 | grep -qi musl; then
+            LIBC=musl
+        fi
+        # ggshield's Linux target triple uses the kernel arch name (aarch64);
+        # macOS keeps arm64.
+        local linux_arch="$ARCH"
+        [ "$ARCH" = arm64 ] && linux_arch=aarch64
+        TARGET="$linux_arch-unknown-linux-gnu"
+    fi
+
+    # The standalone build is glibc-only; there is no musl tarball.
+    if [ "$LIBC" = musl ]; then
+        die "the standalone build is glibc-only; Alpine/musl is not supported here.
+Use the Docker image (gitguardian/ggshield) or 'pipx install ggshield'.
+See https://docs.gitguardian.com/ggshield-docs/getting-started"
+    fi
+}
+
+resolve_version() {
+    if [ -n "$VERSION" ]; then
+        VERSION="${VERSION#v}"
+        return 0
+    fi
+    say "Resolving latest ggshield version"
+    VERSION=$(fetch "https://api.github.com/repos/$GITHUB_REPO/releases/latest" |
+        grep -o '"tag_name": *"v[^"]*"' | head -1 | grep -o '[0-9][^"]*') || true
+    [ -n "$VERSION" ] || die "could not resolve the latest version from the GitHub API"
+}
+
+# GitHub computes a sha256 digest for every release asset; pair each "name"
+# with the "digest" that follows it in the release JSON.
+asset_digest() {
+    local asset="$1"
+    fetch "https://api.github.com/repos/$GITHUB_REPO/releases/tags/v$VERSION" |
+        grep -o '"name": *"[^"]*"\|"digest": *"sha256:[0-9a-f]*"' |
+        grep -A1 -F "\"$asset\"" | grep -o 'sha256:[0-9a-f]*' | head -1 || true
+}
+
+# HTTP status of an asset's download URL (HEAD, following redirects). Tells
+# "asset absent" (404) from "couldn't reach GitHub" (504/000/…). Deliberately
+# not the `fetch` wrapper: no -f, so 4xx still yields the code.
+asset_http_status() {
+    curl --proto '=https' --tlsv1.2 -sIL -o /dev/null -w '%{http_code}' \
+        --max-time 20 --retry 2 \
+        "https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$1" \
+        2>/dev/null || echo 000
+}
+
+# Fail closed: a download we cannot verify is never installed.
+verify_download() {
+    local file="$1" asset="$2" digest sum_tool
+    digest=$(asset_digest "$asset")
+    [ -n "$digest" ] ||
+        die "could not retrieve the expected sha256 digest for $asset from the GitHub API; refusing to install unverified"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        sum_tool="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        sum_tool="shasum -a 256"
+    else
+        die "cannot verify $asset: no sha256 tool found (need sha256sum or shasum)"
+    fi
+    say "Verifying sha256 checksum"
+    echo "${digest#sha256:}  $file" | $sum_tool -c - >/dev/null ||
+        die "checksum mismatch for $asset"
+
+    # older gh releases have no `attestation` subcommand
+    if command -v gh >/dev/null 2>&1 &&
+        gh attestation --help >/dev/null 2>&1 &&
+        gh auth status >/dev/null 2>&1; then
+        say "Verifying build provenance attestation"
+        gh attestation verify "$file" --repo "$GITHUB_REPO" >/dev/null ||
+            die "artifact attestation verification failed for $asset"
+    fi
+}
+
+install_tarball() {
+    need tar
+    resolve_version
+
+    local asset dir tmp bin
+    asset="ggshield-$VERSION-$TARGET.tar.gz"
+    case "$(asset_http_status "$asset")" in
+    200) ;;
+    404) die "release v$VERSION has no standalone asset $asset.
+arm64 Linux builds ship from v1.52.0 on; pick a newer --version, or see the
+other install methods in scripts/install/README.md" ;;
+    *) warn "could not confirm $asset availability; attempting the download anyway" ;;
+    esac
+
+    dir="$OPT_DIR/ggshield-$VERSION-$TARGET"
+    tmp=$(mktemp -d)
+    # shellcheck disable=SC2064 # expand now: $tmp is local, gone at exit time
+    trap "rm -rf '$tmp'" EXIT
+
+    say "Downloading $asset"
+    # Download to a file first: never pipe the network into tar
+    fetch -o "$tmp/$asset" \
+        "https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$asset"
+    verify_download "$tmp/$asset" "$asset"
+
+    say "Installing to $dir"
+    rm -rf "$dir"
+    mkdir -p "$OPT_DIR"
+    tar -xzf "$tmp/$asset" -C "$OPT_DIR"
+    [ -d "$dir" ] || die "unexpected archive layout: $dir not found after extraction"
+
+    bin=$(find "$dir" -type f -name ggshield | head -1)
+    if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+        die "no ggshield executable found in $dir"
+    fi
+    mkdir -p "$BIN_DIR"
+    if [ -e "$BIN_DIR/ggshield" ] && [ ! -L "$BIN_DIR/ggshield" ]; then
+        die "$BIN_DIR/ggshield exists and is not a symlink (manually installed?); remove it first"
+    fi
+    if [ -L "$BIN_DIR/ggshield" ]; then
+        case "$(readlink "$BIN_DIR/ggshield")" in
+        "$OPT_DIR"/*) ;;
+        *) warn "replacing existing ggshield symlink at $BIN_DIR/ggshield (was: $(readlink "$BIN_DIR/ggshield"))" ;;
+        esac
+    fi
+    ln -sf "$bin" "$BIN_DIR/ggshield"
+
+    case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+        warn "$BIN_DIR is not in your PATH. Add this to your shell profile:"
+        warn "  export PATH=\"$BIN_DIR:\$PATH\""
+        ;;
+    esac
+    GGSHIELD="$BIN_DIR/ggshield"
+}
+
+write_state() {
+    mkdir -p "$STATE_DIR"
+    cat >"$STATE_FILE" <<EOF
+method=tarball
+version=${VERSION:-latest}
+opt_dir=$OPT_DIR
+bin_link=$BIN_DIR/ggshield
+EOF
+}
+
+run_gg() {
+    # Children may prompt; reconnect stdin to the terminal when we are piped.
+    # /dev/tty can exist yet be unopenable (no controlling terminal, e.g. CI or
+    # a container), so test that it actually opens — not just that it exists.
+    if [ ! -t 0 ] && { : </dev/tty; } 2>/dev/null; then
+        "$GGSHIELD" "$@" </dev/tty
+    else
+        "$GGSHIELD" "$@"
+    fi
+}
+
+# Hints for steps that did NOT complete — only shown when something is left to
+# do (auth failed/skipped, a plugin failed, or --install-only).
+emit_auth_hint() {
+    local inst="${INSTANCE:-$DEFAULT_INSTANCE}"
+    printf '    ggshield auth login --instance %s\n' "$inst"
+    [ -z "$INSTANCE" ] &&
+        printf '    # EU workspace: ggshield auth login --instance %s\n' "$EU_INSTANCE"
+    is_headless && printf '    # headless / no browser: add --method oob\n'
+    return 0
+}
+
+emit_plugin_hint() {
+    [ ${#PLUGINS[@]} -gt 0 ] &&
+        printf '    ggshield plugin install %s\n' "${PLUGINS[*]}"
+    return 0
+}
+
+try_auth() {
+    local inst="${INSTANCE:-$DEFAULT_INSTANCE}"
+    if [ -n "${GITGUARDIAN_API_KEY:-}" ]; then
+        say "Authenticating with GITGUARDIAN_API_KEY against $inst"
+        # token login reads the key from stdin; do not use run_gg (it would
+        # rebind stdin to /dev/tty)
+        printf '%s\n' "$GITGUARDIAN_API_KEY" |
+            "$GGSHIELD" auth login --method token ${INSTANCE:+--instance "$INSTANCE"} &&
+            return 0
+        warn "authentication with GITGUARDIAN_API_KEY failed (instance: $inst)"
+        return 1
+    fi
+    if [ "$ASSUME_YES" = 1 ]; then
+        warn "non-interactive run (-y) without GITGUARDIAN_API_KEY: skipping auth"
+        return 1
+    fi
+    say "Authenticating against $inst"
+    is_headless &&
+        warn "headless/remote session detected; if the browser flow fails, retry with --method oob"
+    run_gg auth login ${INSTANCE:+--instance "$INSTANCE"} && return 0
+    warn "authentication failed (instance: $inst)"
+    return 1
+}
+
+post_install() {
+    hash -r 2>/dev/null || true
+    # actually run it: an executable can still fail (e.g. wrong libc)
+    local version_out
+    if ! version_out=$("$GGSHIELD" --version 2>&1); then
+        die "ggshield was installed but cannot run: $version_out"
+    fi
+    say "Installed: $version_out"
+
+    # a leftover from a previous install may shadow the fresh one on PATH
+    local resolved
+    resolved=$(command -v ggshield 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ "$resolved" != "$GGSHIELD" ]; then
+        warn "another ggshield at $resolved shadows the one just installed ($GGSHIELD); fix your PATH order"
+    fi
+
+    if [ "$INSTALL_ONLY" = 1 ]; then
+        say "ggshield is installed. To finish setup:"
+        emit_auth_hint
+        emit_plugin_hint
+        return 0
+    fi
+
+    # Plugins need a working authentication, so only attempt them once auth
+    # succeeds; otherwise skip.
+    local auth_ok=0 plugins_pending=0
+    if try_auth; then
+        auth_ok=1
+        local plugin
+        # macOS ships bash 3.2, where "${arr[@]}" on an empty array trips
+        # `set -u`; the ${arr[@]+…} guard expands to nothing when empty.
+        for plugin in ${PLUGINS[@]+"${PLUGINS[@]}"}; do
+            say "Installing the $plugin plugin"
+            run_gg plugin install "$plugin" ||
+                { warn "could not install the $plugin plugin (continuing)"; plugins_pending=1; }
+        done
+    elif [ ${#PLUGINS[@]} -gt 0 ]; then
+        warn "skipping plugin install until ggshield is authenticated"
+        plugins_pending=1
+    fi
+
+    # Only nag about next steps when something actually remains.
+    if [ "$auth_ok" = 1 ] && [ "$plugins_pending" = 0 ]; then
+        say "ggshield is ready."
+        return 0
+    fi
+    say "To finish setup:"
+    [ "$auth_ok" = 0 ] && emit_auth_hint
+    [ "$plugins_pending" = 1 ] && emit_plugin_hint
+    return 0
+}
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -y | --yes) ASSUME_YES=1 ;;
+        --instance)
+            shift
+            INSTANCE="${1:?--instance requires a URL}"
+            ;;
+        --version)
+            shift
+            VERSION="${1:?--version requires a value}"
+            ;;
+        --install-only) INSTALL_ONLY=1 ;;
+        --plugin)
+            shift
+            PLUGINS+=("${1:?--plugin requires a name}")
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *) die "unknown option: $1 (see --help)" ;;
+        esac
+        shift
+    done
+
+    need curl
+    need uname
+    detect_platform
+    say "Platform: $OS/$ARCH${LIBC:+ ($LIBC)} — installing the standalone build"
+
+    install_tarball
+    write_state
+    post_install
+}
+
+main "$@"

--- a/scripts/install/uninstall.ps1
+++ b/scripts/install/uninstall.ps1
@@ -1,0 +1,113 @@
+# ggshield uninstaller for Windows.
+#
+# By default removes ONLY the install this script created (per-user ZIP, or the
+# MSI when installed with -Method msi). It does not touch ggshield installed
+# another way (Chocolatey, a hand-run MSI, pipx, uv, pip). Pass -Purge to also
+# remove ggshield's config, cache and data.
+#
+#   irm https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.ps1 | iex
+#
+# Compatible with Windows PowerShell 5.1 (no pwsh required).
+
+[CmdletBinding()]
+param(
+    [switch]$Yes,
+    [switch]$Purge
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ZipDir = Join-Path $env:LOCALAPPDATA 'Programs\ggshield'
+$StateDir = Join-Path $env:LOCALAPPDATA 'ggshield-install'
+$StateFile = Join-Path $StateDir 'state.json'
+
+function Say($msg) { Write-Host "==> $msg" -ForegroundColor Blue }
+function Warn($msg) { Write-Host "warning: $msg" -ForegroundColor Yellow }
+function Die($msg) { throw "error: $msg" }
+
+function Confirm-Step($prompt) {
+    if ($Yes) { return $true }
+    $reply = Read-Host "$prompt [y/N]"
+    return $reply -match '^[yY]'
+}
+
+# Run a native command, discarding output. With $ErrorActionPreference=Stop,
+# redirecting native stderr would otherwise throw (PowerShell 5.1 gotcha).
+function Invoke-Native {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & $args[0] @($args | Select-Object -Skip 1) 2>&1 | Out-Null }
+    finally { $ErrorActionPreference = $eap }
+    return $LASTEXITCODE
+}
+
+# Never delete a misconfigured GGSHIELD location (empty, a drive root, the
+# user profile or LocalAppData root).
+function Assert-SafeZipDir {
+    $p = $ZipDir.TrimEnd('\', '/')
+    $unsafe = @($env:USERPROFILE.TrimEnd('\'), $env:LOCALAPPDATA.TrimEnd('\'))
+    if ([string]::IsNullOrWhiteSpace($p) -or $p -match '^[A-Za-z]:\\?$' -or $unsafe -contains $p) {
+        Die "refusing to remove unsafe path '$ZipDir'"
+    }
+}
+
+function Get-MsiProduct {
+    $keys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    Get-ItemProperty $keys -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like 'ggshield*' } |
+        Select-Object -First 1
+}
+
+# Remove only the install this script created, per the recorded method.
+function Remove-Standalone {
+    $method = 'zip'
+    if (Test-Path $StateFile) {
+        try { $method = (Get-Content $StateFile -Raw | ConvertFrom-Json).method } catch {}
+    }
+
+    if ($method -eq 'msi') {
+        $product = Get-MsiProduct
+        if (-not $product) { Warn 'recorded MSI install not found; nothing to remove'; return }
+        if (-not (Confirm-Step "Remove the ggshield MSI ($($product.DisplayVersion))?")) { return }
+        Say 'Removing the ggshield MSI'
+        $proc = Start-Process msiexec -ArgumentList '/x', $product.PSChildName, '/qn', '/norestart' -Wait -PassThru
+        if ($proc.ExitCode -ne 0) { Warn "msiexec failed with exit code $($proc.ExitCode)" }
+    }
+    else {
+        if (-not (Test-Path $ZipDir)) {
+            Warn "no script-managed install found at $ZipDir"
+            Warn 'ggshield installed another way (choco, a hand-run MSI, pipx, uv, pip) is left untouched'
+            return
+        }
+        if (-not (Confirm-Step "Remove the standalone ggshield at $ZipDir?")) { return }
+        Assert-SafeZipDir
+        Say "Removing $ZipDir"
+        Remove-Item $ZipDir -Recurse -Force
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        $cleaned = ($userPath -split ';' | Where-Object { $_ -and $_ -notlike "$ZipDir*" }) -join ';'
+        if ($cleaned -ne $userPath) {
+            Say 'Removing ggshield from your user PATH'
+            [Environment]::SetEnvironmentVariable('Path', $cleaned, 'User')
+        }
+    }
+    if (Test-Path $StateDir) { Remove-Item $StateDir -Recurse -Force }
+}
+
+function Remove-UserData {
+    # platformdirs(appname="ggshield", appauthor="GitGuardian") on Windows
+    $paths = @(
+        (Join-Path $env:USERPROFILE '.gitguardian.yaml'),
+        (Join-Path $env:LOCALAPPDATA 'GitGuardian\ggshield')
+    )
+    $found = $paths | Where-Object { Test-Path $_ }
+    if (-not $found) { Say 'No ggshield config/cache/data found'; return }
+    if (-not (Confirm-Step 'Remove ggshield configuration, cache and data (including plugins)?')) { return }
+    foreach ($p in $found) { Say "Removing $p"; Remove-Item $p -Recurse -Force }
+}
+
+Remove-Standalone
+if ($Purge) { Remove-UserData }
+Say 'Done.'

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# ggshield uninstaller (Linux / macOS).
+#
+# By default removes ONLY the standalone install this script created
+# (the ~/.local/bin symlink and ~/.local/share/ggshield-standalone tree).
+# It does not touch ggshield installed another way (Homebrew, apt/rpm, pipx,
+# uv, pip…). Pass --purge to also remove ggshield's config, cache and data.
+#
+#   curl --proto '=https' --tlsv1.2 -sSfL \
+#     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
+
+set -euo pipefail
+
+BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
+
+ASSUME_YES=0
+PURGE=0
+
+usage() {
+    cat <<EOF
+Usage: uninstall.sh [OPTIONS]
+
+Remove the standalone ggshield installed by install.sh. By default this only
+removes the script-owned install; it leaves configuration, caches and any
+ggshield installed another way untouched.
+
+Options:
+  -y, --yes     never prompt
+      --purge   also remove config, cache and data
+                (~/.gitguardian.yaml, ~/.ggshield, plugins)
+  -h, --help    show this help
+EOF
+}
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+confirm() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    local reply
+    if [ -t 0 ]; then
+        read -r -p "$1 [y/N] " reply
+    elif [ -e /dev/tty ]; then
+        read -r -p "$1 [y/N] " reply </dev/tty
+    else
+        die "cannot prompt for '$1' (no TTY). Re-run with -y"
+    fi
+    case "$reply" in
+    y* | Y*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# Never 'rm -rf' a misconfigured GGSHIELD_OPT_DIR (empty, /, $HOME, the bin dir).
+assert_safe_optdir() {
+    local p="${OPT_DIR%/}"
+    case "$p" in
+    "" | "/" | "$HOME" | "${HOME%/}" | "$BIN_DIR" | "${BIN_DIR%/}")
+        die "refusing to remove unsafe GGSHIELD_OPT_DIR='$OPT_DIR'; point it at a dedicated directory" ;;
+    esac
+}
+
+# Remove the standalone install: the bin symlink (only when it points into our
+# own dir — uv/pipx also drop a ggshield shim in ~/.local/bin) and OPT_DIR.
+remove_standalone() {
+    assert_safe_optdir
+    local owns_symlink=0 found=0
+    if [ -L "$BIN_DIR/ggshield" ]; then
+        case "$(readlink "$BIN_DIR/ggshield")" in
+        "$OPT_DIR"/*) owns_symlink=1; found=1 ;;
+        esac
+    fi
+    [ -d "$OPT_DIR" ] && found=1
+
+    if [ "$found" = 0 ]; then
+        warn "no script-managed standalone install found in $OPT_DIR"
+        warn "ggshield installed another way (brew, apt/rpm, pipx, uv, pip) is left untouched"
+        return 0
+    fi
+
+    confirm "Remove the standalone ggshield ($OPT_DIR and its $BIN_DIR symlink)?" || return 0
+    if [ "$owns_symlink" = 1 ]; then
+        say "Removing $BIN_DIR/ggshield"
+        rm -f "$BIN_DIR/ggshield"
+    fi
+    say "Removing $OPT_DIR"
+    rm -rf "$OPT_DIR"
+    rm -rf "$STATE_DIR"
+}
+
+purge_user_data() {
+    # platformdirs(appname="ggshield") config/cache/data, the global config
+    # file, and the scan databases (~/.ggshield)
+    local paths=("$HOME/.gitguardian.yaml" "$HOME/.ggshield")
+    if [ "$(uname -s)" = Darwin ]; then
+        paths+=("$HOME/Library/Application Support/ggshield" "$HOME/Library/Caches/ggshield")
+    else
+        paths+=(
+            "${XDG_CONFIG_HOME:-$HOME/.config}/ggshield"
+            "${XDG_CACHE_HOME:-$HOME/.cache}/ggshield"
+            "${XDG_DATA_HOME:-$HOME/.local/share}/ggshield"
+        )
+    fi
+    local p found=0
+    for p in "${paths[@]}"; do [ -e "$p" ] && found=1; done
+    if [ "$found" = 0 ]; then
+        say "No ggshield config/cache/data found"
+        return 0
+    fi
+    confirm "Remove ggshield configuration, cache and data (including plugins)?" || return 0
+    for p in "${paths[@]}"; do
+        [ -e "$p" ] && { say "Removing $p"; rm -rf "$p"; }
+    done
+    # The loop's last test ([ -e ] on an absent path) leaves $?=1; under set -e
+    # that would fail the caller's `[ "$PURGE" = 1 ] && purge_user_data`.
+    return 0
+}
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -y | --yes) ASSUME_YES=1 ;;
+        --purge) PURGE=1 ;;
+        -h | --help) usage; exit 0 ;;
+        *) die "unknown option: $1 (see --help)" ;;
+        esac
+        shift
+    done
+
+    remove_standalone
+    [ "$PURGE" = 1 ] && purge_user_data
+
+    hash -r 2>/dev/null || true
+    say "Done."
+}
+
+main "$@"


### PR DESCRIPTION
Supersedes #1279 — the simplified, standalone-only version requested in review.

## What changed vs #1279
One install method per OS, everything else documented rather than auto-selected:

- **Linux / macOS** → standalone tarball → `~/.local/share/ggshield-standalone` + `~/.local/bin` symlink (no sudo). No more brew/apt-rpm/pipx auto-routing.
- **Windows** → per-user **zip** by default; **`-Method msi`** explicit (admin). Chocolatey dropped from the script.
- **Other methods** (brew, Cloudsmith apt/rpm, pipx, choco, Docker) are now documented as manual alternatives.

## Behaviour
- **Best-effort auth & plugins**: installing the verified binary is the only hard-fail step. Auth/plugin failures warn and print retry commands; the instance is shown, with an `--method oob` hint for headless sessions.
- **Fail-closed verification**: a download whose sha256 digest can't be retrieved is never installed (no `-y` or interactive opt-out), plus attestation when `gh` is present.
- **Alpine/musl out of scope** (glibc-only build): clean refusal pointing to the Docker image / pipx.
- **Uninstall removes only the script-owned install by default**; config/cache (`--purge`), pre-commit cache, uv cache and systemd scheduling are opt-in flags. No auto-removal of brew/pipx/uv/pip/system installs.

## QA
Unix verified (Docker + qemu): x86_64 and **arm64** tarball installs on 1.52.0, best-effort auth (bad key → exit 0), musl refusal, default uninstall preserves foreign installs + config, `--purge`. Windows `.ps1` parse-checked; VM round-trip pending. macOS path is identical to Linux's (different target triple) but has no CI.

Refs: END-511
