### PR TITLE
chore(pre-commit): update to ggshield 1.52.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.52.0
+    rev: v1.52.1
     hooks:
       - id: ggshield
         language_version: python3


### PR DESCRIPTION
Bump the self-referencing ggshield pre-commit hook to v1.52.1 (release END-548).

🤖 Generated with [Claude Code](https://claude.com/claude-code)