### PR TITLE
docs(honeytoken): clarify "honeytoken plant" command description

### DIFF
--- a/changelog.d/20260616_192013_benjamin.rigaud_plant_command_description.md
+++ b/changelog.d/20260616_192013_benjamin.rigaud_plant_command_description.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Clarified the description of the `ggshield honeytoken plant` command.

--- a/ggshield/cmd/honeytoken/plant.py
+++ b/ggshield/cmd/honeytoken/plant.py
@@ -106,8 +106,9 @@ def plant_cmd(
     **kwargs: Any,
 ) -> int:
     """
-    Reconcile and plant this machine's honeytokens against GitGuardian.
+    Detect endpoint intrusion by planting a honeytoken on this machine.
 
+    Honeytokens deployed are fully synchronized with the GitGuardian platform.
     Apply the desired on-disk state: write/refresh the decoy AWS credentials
     profile for `write` entries, remove it for `delete` (revoked) entries —
     preserving any other profiles. ggshield never revokes a honeytoken; it only


### PR DESCRIPTION
## What

Reword the `ggshield honeytoken plant` command help/description:

> Detect endpoint intrusion by planting a honeytoken on this machine.
>
> Honeytokens deployed are fully synchronized with the GitGuardian platform.

## Why

Review feedback on the public-docs reference MR ([!2024](https://gitlab.gitguardian.ovh/gg-code/public-docs/-/merge_requests/2024), END-375): the previous "Reconcile and plant this machine's honeytokens against GitGuardian." wording was not meaningful to users.

The reference doc (`reference/honeytoken/plant.md`) is auto-generated from this `--help` text, so the wording has to change here to be durable — otherwise the next release-time regeneration would revert a doc-only edit. The matching doc edit lands in the public-docs MR, keeping the two in sync so the next regeneration is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)