### PR TITLE
fix(macos): sign ggshield launcher with allow-jit entitlement

### DIFF
--- a/changelog.d/20260617_091316_clement.tourriere_macos_allow_jit_entitlement.md
+++ b/changelog.d/20260617_091316_clement.tourriere_macos_allow_jit_entitlement.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- macOS: `ggshield machine scan` is no longer several times slower than on other platforms. The signed launcher now carries the `com.apple.security.cs.allow-jit` entitlement, so the scanner's PCRE2 JIT works under the hardened runtime instead of silently falling back to the interpreter.

--- a/scripts/build-os-packages/macos-entitlements.plist
+++ b/scripts/build-os-packages/macos-entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      The machine-scan plugin (satori) matches with PCRE2, whose JIT is ~6-7x
+      faster than its interpreter on regex-heavy files. JIT needs executable
+      (MAP_JIT) memory, which the hardened runtime denies unless the process's
+      MAIN executable carries this entitlement. Without it PCRE2 silently falls
+      back to the interpreter and `ggshield machine scan` is dramatically
+      slower. Attached to the `ggshield` launcher in macos_sign_file().
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/build-os-packages/macos-functions.bash
+++ b/scripts/build-os-packages/macos-functions.bash
@@ -24,12 +24,32 @@ macos_sign_file() {
     local file
     file="$1"
     info "- Signing $file"
-    rcodesign sign \
-        --p12-file "$MACOS_P12_FILE" \
-        --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
-        --code-signature-flags runtime \
-        --for-notarization \
-        "$file"
+
+    # The hardened runtime ("runtime" code-signature flag) denies JIT
+    # (executable MAP_JIT memory) unless the process's MAIN executable carries
+    # the allow-jit entitlement. The machine-scan plugin (satori) matches with
+    # PCRE2, whose JIT is ~6-7x faster than its interpreter on regex-heavy
+    # files; without the entitlement PCRE2 silently falls back to the
+    # interpreter and `ggshield machine scan` is dramatically slower. JIT
+    # permission is a process-level attribute taken from the main executable, so
+    # the entitlement goes on the `ggshield` launcher only — the bundled
+    # .so/.dylib libraries inherit the process permission and don't need it.
+    if [ "$(basename "$file")" = "ggshield" ] ; then
+        rcodesign sign \
+            --p12-file "$MACOS_P12_FILE" \
+            --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
+            --code-signature-flags runtime \
+            --entitlements-xml-path "$SCRIPT_DIR/macos-entitlements.plist" \
+            --for-notarization \
+            "$file"
+    else
+        rcodesign sign \
+            --p12-file "$MACOS_P12_FILE" \
+            --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
+            --code-signature-flags runtime \
+            --for-notarization \
+            "$file"
+    fi
 }
 
 macos_list_files_to_sign() {


### PR DESCRIPTION
## What

Sign the macOS `ggshield` launcher with the `com.apple.security.cs.allow-jit` entitlement.

## Why

The launcher is signed with the hardened runtime but no entitlements, so the kernel denies JIT (`MAP_JIT`) memory. The machine-scan plugin matches with PCRE2, whose JIT is several times faster than its interpreter on regex-heavy content; without the entitlement `pcre2_jit_compile` fails and PCRE2 silently falls back to the interpreter, making `ggshield machine scan` ~6–7× slower on macOS.

JIT permission is a property of the process's main executable, so the entitlement is attached to the `ggshield` launcher only (the bundled libraries inherit the process permission). Library validation is intentionally left intact — first-party plugins are same-team signed and continue to load.

Closes #1292.

## Changes

- Add `scripts/build-os-packages/macos-entitlements.plist` (just `allow-jit`).
- `macos_sign_file`: pass `--entitlements-xml-path …/macos-entitlements.plist` when signing the `ggshield` launcher.

## Test plan

Reproduced and verified by signing a binary three ways and scanning the same files (only the signature changed):

| signature | CPU (user) | throughput |
|---|---|---|
| adhoc (no hardened runtime) | 73 s | 24 MB/s |
| hardened, no `allow-jit` | 528 s | 2 MB/s |
| hardened + `allow-jit` | 73–76 s | 18–22 MB/s |

On a signed release artifact, confirm `codesign -d --entitlements - …/ggshield` shows `com.apple.security.cs.allow-jit`, and that `ggshield machine scan` runs at full speed.
