### PR TITLE
chore(ci): capture choco push --debug --verbose output

### DIFF
--- a/scripts/chocolatey/push
+++ b/scripts/chocolatey/push
@@ -14,8 +14,9 @@ fi
 choco_nupkg=$1
 
 # push to chocolatey
+# --debug --verbose: the server returns only an opaque 409, so capture full client output for diagnosis. GitHub Actions masks the API key.
 set +e
-output=$(choco push "$choco_nupkg" --source https://push.chocolatey.org/ --api-key "$CHOCOLATEY_API_KEY" 2>&1)
+output=$(choco push "$choco_nupkg" --source https://push.chocolatey.org/ --api-key "$CHOCOLATEY_API_KEY" --debug --verbose 2>&1)
 status=$?
 set -e
 
@@ -24,7 +25,7 @@ echo "$output"
 
 # `choco push` returns 409 when the version already exists in Chocolatey's system,
 # including "pending"/"rejected" moderation states that are hidden from the public
-# feed — re-pushing the same version then always fails. See END-315.
+# feed — re-pushing the same version then always fails.
 if grep -qiE '409|conflict|already exists' <<<"$output"; then
     nupkg_name=$(basename "$choco_nupkg")
     version=${nupkg_name#ggshield.}


### PR DESCRIPTION
## What

Adds `--debug --verbose` to the `choco push` invocation in `scripts/chocolatey/push`.

## Why

Every ggshield release since 1.50.1 fails to publish to Chocolatey: `push.chocolatey.org` returns only an **opaque HTTP 409** with no detail, and the affected versions never appear in moderation (no queue entry, no email, 404 even for the owner). This is a known behaviour where the server masks the real error as a generic `Conflict` (see [chocolatey/home#105](https://github.com/chocolatey/home/issues/105), [#78](https://github.com/chocolatey/home/issues/78)).

Running the push with `--debug --verbose` makes future failed pushes capture the full client-side output, which we can attach when asking Chocolatey site admins to read their server-side logs.

Note: GitHub Actions masks `CHOCOLATEY_API_KEY` in logs, so the key stays redacted (`***`) even under verbose output.

Refs END-315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)