### PR TITLE
chore(ci): dump chocolatey.log on failed push

### DIFF
--- a/scripts/chocolatey/push
+++ b/scripts/chocolatey/push
@@ -28,7 +28,7 @@ choco_log="${ChocolateyInstall:-C:/ProgramData/chocolatey}/logs/chocolatey.log"
 choco_log="${choco_log//\\//}"
 if [ -f "$choco_log" ]; then
     echo "=== chocolatey.log (tail -200) ==="
-    tail -n 200 "$choco_log"
+    tail -n 200 "$choco_log" || true  # never let a log-read hiccup mask the 409 guidance below
 fi
 
 # `choco push` returns 409 when the version already exists in Chocolatey's system,

--- a/scripts/chocolatey/push
+++ b/scripts/chocolatey/push
@@ -23,6 +23,14 @@ set -e
 echo "$output"
 [ "$status" -eq 0 ] && exit 0
 
+# On failure, dump choco's own log — it can hold the real server error the console masks as a generic 409 (chocolatey/choco#2007).
+choco_log="${ChocolateyInstall:-C:/ProgramData/chocolatey}/logs/chocolatey.log"
+choco_log="${choco_log//\\//}"
+if [ -f "$choco_log" ]; then
+    echo "=== chocolatey.log (tail -200) ==="
+    tail -n 200 "$choco_log"
+fi
+
 # `choco push` returns 409 when the version already exists in Chocolatey's system,
 # including "pending"/"rejected" moderation states that are hidden from the public
 # feed — re-pushing the same version then always fails.


### PR DESCRIPTION
## What

On a failed `choco push`, dump the tail of choco's own log (`$ChocolateyInstall/logs/chocolatey.log`) to the job log.

## Why

`push.chocolatey.org` returns only a generic `409 Conflict` on the console, even with `--debug --verbose` (see [chocolatey/home#105](https://github.com/chocolatey/home/issues/105)). But `choco` writes a more detailed log to `$ChocolateyInstall/logs/chocolatey.log`, which can contain the real server error (per [chocolatey/choco#2007](https://github.com/chocolatey/choco/issues/2007)). That file lives on the ephemeral Windows runner and was never captured, so past failures (1.51.0/1.52.0/1.52.1) gave us nothing beyond the masked 409.

Dumping it on failure means the next push attempt surfaces the fullest client-side diagnostic we can get. Pairs with the `--debug --verbose` added in #1295.

Note: only runs on failure (the `exit 0` short-circuits a successful push), so it adds no noise to normal releases.
