### PR TITLE
chore(ci): validate chocolatey package metadata at build time

### DIFF
--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -52,6 +52,13 @@ windows_build_chocolatey_package() {
     # vendored trust root, so drop them.
     rm -rf choco-package/tools/_internal/sigstore/_store/https%3A*
 
+    # Surface CCR metadata errors the push server masks as a 409 (chocolatey/home#399).
+    # Isolated + non-fatal: validate to a temp dir, then uninstall before the real pack.
+    info "Validating chocolatey package metadata (chocolatey/home#399)"
+    choco install chocolatey-community-validation.extension -y || true
+    choco pack choco-package/* --version "$VERSION" --outdir "$(mktemp -d)" || true
+    choco uninstall chocolatey-community-validation.extension -y || true
+
     choco pack choco-package/* --version $VERSION --outdir $PACKAGES_DIR
 
     info "Chocolatey package created in $PACKAGES_DIR/ggshield.$VERSION.nupkg"


### PR DESCRIPTION
## What

In the windows package build (`windows_build_chocolatey_package`), install [`chocolatey-community-validation.extension`](https://github.com/chocolatey-community/chocolatey-community-validation) and run a throwaway `choco pack` so the build surfaces any CCR package-metadata violations.

## Why

ggshield has failed to publish to Chocolatey since 1.50.1: `push.chocolatey.org` returns only an opaque `409 Conflict` (even with `--debug --verbose`), and the versions never enter moderation. In [chocolatey/home#399](https://github.com/chocolatey/home/issues/399), a Chocolatey maintainer (pauby) suggested the Community Validation Extension, which runs CCR's validator rules locally at `choco pack` time and reports the real metadata error.

This wires that into CI (which builds the choco package on every push), so the validation output lands in the `Build packages (windows-2022)` log — no release or production push needed. It also permanently guards future releases against the same class of error.

## Safety

It's **isolated and non-fatal**:
- validation `choco pack` writes to a throwaway `$(mktemp -d)` and is `|| true`,
- the extension is **uninstalled before the real pack**, so the artifact build is unchanged and the step can't fail the build.

Once we read the surfaced error and fix the nuspec, a follow-up can promote this to a hard gate. Refs chocolatey/home#399.
