### PR TITLE
feat: support Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-15-intel, windows-2022]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/changelog.d/20260617_172152_benjamin.rigaud_support_python_313.md
+++ b/changelog.d/20260617_172152_benjamin.rigaud_support_python_313.md
@@ -1,0 +1,3 @@
+### Added
+
+- ggshield now officially supports Python 3.13: it is covered by the CI test matrix, advertised through the trove classifiers, and `pip install ggshield` works on a Python 3.13 interpreter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.9",
     "Operating System :: OS Independent",
     "Topic :: Security",
@@ -150,7 +151,7 @@ tests = [
     "jsonschema",
     "vcrpy>=5.1.0",
     "voluptuous<0.15.0",
-    "pyfakefs>=5.2.0,<5.6.0",
+    "pyfakefs>=5.7.0",
     "factory-boy>=3.3.1",
 ]
 dev = [

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import vcr
 import yaml
 from click.testing import CliRunner, Result
-from pyfakefs.fake_filesystem import FakeFilesystem
+from pyfakefs.fake_filesystem import FakeFilesystem, set_uid
 from pygitguardian import GGClient
 from pygitguardian.models import ScanResult, SecretIncident
 from requests.utils import DEFAULT_CA_BUNDLE_PATH, extract_zipped_paths
@@ -794,6 +794,10 @@ def make_fake_path_inaccessible(fs: FakeFilesystem, path: Union[str, Path]):
     Make `path` inaccessible inside `fs`. This is useful to test IO permission errors.
     """
 
+    # pyfakefs skips permission checks for the root user, and maps a Windows
+    # admin (what GitHub CI runners are) to uid 0 — so without a non-root uid
+    # the chmod below is ignored on Windows and the file stays accessible.
+    set_uid(1)
     # `force_unix_mode` is required for Windows.
     # See <https://pytest-pyfakefs.readthedocs.io/en/latest/usage.html#set-file-as-inaccessible-under-windows>
     fs.chmod(path, 0o0000, force_unix_mode=True)

--- a/tests/unit/core/test_cache.py
+++ b/tests/unit/core/test_cache.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pyfakefs.fake_filesystem import FakeFilesystem, set_uid
 
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
@@ -48,18 +49,26 @@ class TestCache:
                 "last_found_secrets": [{"match": "XXX", "name": ""}]
             }
 
-    def test_read_only_fs(self):
+    def test_read_only_fs(self, fs: FakeFilesystem):
         """
         GIVEN a read-only cache file
         WHEN save is called
         THEN it shouldn't raise an exception
         """
 
+        # pyfakefs skips permission checks for the root user and maps a Windows
+        # admin (CI runners) to uid 0; force a non-root uid so the read-only
+        # mode is enforced. Set it before the file is created so it owns it.
+        set_uid(1)
+
         cache = Cache()
         cache.update_cache(last_found_secrets=[{"match": "XXX"}])
 
-        # Make cache file read-only and verify it really is read-only
-        cache.cache_path.touch(mode=0o400)
+        # Make cache file read-only and verify it really is read-only.
+        # `touch(mode=...)` is not honored on Windows; `chmod` with
+        # `force_unix_mode` is required for the read-only bit to take effect.
+        cache.cache_path.touch()
+        fs.chmod(str(cache.cache_path), 0o400, force_unix_mode=True)
         with pytest.raises(PermissionError):
             cache.cache_path.open("w")
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-14T06:18:34.927151471Z"
+exclude-newer = "2026-06-14T15:18:51.121031131Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -964,7 +964,8 @@ tests = [
     { name = "import-linter", version = "2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyfakefs" },
+    { name = "pyfakefs", version = "5.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyfakefs", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "pytest-voluptuous" },
@@ -1024,7 +1025,7 @@ tests = [
     { name = "factory-boy", specifier = ">=3.3.1" },
     { name = "import-linter" },
     { name = "jsonschema" },
-    { name = "pyfakefs", specifier = ">=5.2.0,<5.6.0" },
+    { name = "pyfakefs", specifier = ">=5.7.0" },
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "pytest-voluptuous" },
@@ -2669,11 +2670,28 @@ wheels = [
 
 [[package]]
 name = "pyfakefs"
-version = "5.5.0"
+version = "5.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/c1/9aba92f9fecb2b81a83efd516d028c6ddcbd3cebdfb3ecba42b9c858f5e8/pyfakefs-5.5.0.tar.gz", hash = "sha256:7448aaa07142f892d0a4eb52a5ed3206a9f02c6599e686cd97d624c18979c154", size = 205510, upload-time = "2024-05-12T06:42:07.54Z" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/1c/4b9489847535a41e074d108bfb86119ab463aa3012f4cb8f6b7f9154e00a/pyfakefs-5.10.2.tar.gz", hash = "sha256:8ae0e5421e08de4e433853a4609a06a1835f4bc2a3ce13b54f36713a897474ba", size = 231379, upload-time = "2025-11-04T20:19:04.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/63/844e40b064d9b31c62e35029f034737929931c254a6b20312f36b14ee0e9/pyfakefs-5.5.0-py3-none-any.whl", hash = "sha256:8dbf203ab7bef1529f11f7d41b9478b898e95bf9f3b71262163aac07a518cd76", size = 219967, upload-time = "2024-05-12T06:42:04.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/3a15447a8630a6bb79cf1ecd9e323a72b28830cb9f367494bedcd045059d/pyfakefs-5.10.2-py3-none-any.whl", hash = "sha256:6ff0e84653a71efc6a73f9ee839c3141e3a7cdf4e1fb97666f82ac5b24308d64", size = 246305, upload-time = "2025-11-04T20:19:02.583Z" },
+]
+
+[[package]]
+name = "pyfakefs"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0d/c80012ee6e885c293ad63c5f5b049d3ef3fd2b32bbe6fa8739145f392ec6/pyfakefs-6.2.0.tar.gz", hash = "sha256:e59a36db447bf509ce9c97ab3d1510c08cc51895c5311325a560a5e5b5dc1940", size = 228273, upload-time = "2026-04-12T13:38:50.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/80/97571ac8295289c267367b7b60aadeae1a9a841e83f0a96ad9b65d1dd3c0/pyfakefs-6.2.0-py3-none-any.whl", hash = "sha256:0968a49db692694ffed420e54a9f1cbae4636637b880e8ab09c8ccc0f11bd7ae", size = 241113, upload-time = "2026-04-12T13:38:48.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

ggshield already *installed* on Python 3.13 (`requires-python` is uncapped) but 3.13 was neither tested nor advertised, and the dev/test suite crashed there because the locked `pyfakefs` 5.5.0 is not 3.13-compatible.

- Widen the `pyfakefs` constraint to `>=5.7.0` and re-lock. uv forks it to **6.2.0** on Python ≥3.10 and **5.10.2** on 3.9 (pyfakefs 6.x dropped 3.9 support).
- Add `'3.13'` to the CI build/test matrix in `.github/workflows/ci.yml`.
- Add the `Programming Language :: Python :: 3.13` trove classifier.

`requires-python` is **left uncapped on purpose** — capping it would make pip/uv silently pin 3.13-only users to a stale ggshield. No runtime code changes are needed: ggshield imports none of the stdlib modules removed in 3.13 (PEP 594). Track 2 (a 3.13-based frozen binary) is intentionally out of scope — the release binary is built on Python 3.10 and is self-contained.

## Test plan

- [x] Full unit suite passes on **Python 3.13** (2146 passed, run serially as CI does)
- [x] Full unit suite passes on **Python 3.12** — no regression from the pyfakefs 6.2.0 bump (2146 passed)
- [x] `uv sync --locked --group dev --group tests` consistent on 3.13
- [x] `pip install` of the built wheel into a clean 3.13-only venv works; `ggshield --version` / `--help` run; compiled deps (`cryptography`, `cffi`, `charset-normalizer`) import — all from cp313 wheels (nothing built from sdist)
- [x] No GitLab mirror leak in `uv.lock`; pre-commit hooks pass

Closes END-561