### PR TITLE
Install script: trim redundant curl --proto and fix Windows uninstall prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ can optionally authenticate and install plugins.
 Linux / macOS:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSfL \
+curl -sSfL \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
 ```
 

--- a/changelog.d/20260618_155005_benjamin.rigaud_trim_curl_proto_flag.md
+++ b/changelog.d/20260618_155005_benjamin.rigaud_trim_curl_proto_flag.md
@@ -1,0 +1,7 @@
+### Changed
+
+- The documented `curl | bash` install/uninstall one-liners no longer pass the redundant `--proto '=https'` and `--tlsv1.2` flags: the URLs are already `https://` and GitHub serves only TLS 1.2+, so they added nothing (`-sSfL`, including `-f`, is kept).
+
+### Fixed
+
+- Windows uninstaller: the `Remove the standalone ggshield at …?` confirmation now shows the install path. PowerShell treated the `?` in `$ZipDir?` as part of the variable name, so the path (and the `?`) were dropped from the prompt.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -9,7 +9,7 @@ cleanly uninstall it later. No admin/sudo required.
 Linux / macOS:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL \
+curl -sSfL \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
 ```
 
@@ -26,7 +26,7 @@ requires `powershell -ExecutionPolicy Bypass -File .\install.ps1`.
 Prefer inspecting before running:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL -o install.sh \
+curl -sSfL -o install.sh \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh
 less install.sh
 bash install.sh
@@ -59,7 +59,7 @@ Docker image `gitguardian/ggshield` or `pipx install ggshield`.
 Pass options through the pipe with `bash -s --`:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL \
+curl -sSfL \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
   bash -s -- --plugin <plugin_name>
 ```
@@ -83,7 +83,7 @@ ggshield authenticates against the US workspace
 on Windows) to target another one — for the EU workspace:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL \
+curl -sSfL \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh |
   bash -s -- --instance https://dashboard.eu1.gitguardian.com
 ```
@@ -131,7 +131,7 @@ trust boundary matters.
 Linux / macOS:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL \
+curl -sSfL \
   https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
 ```
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -5,7 +5,7 @@
 # Installs the standalone ggshield build into ~/.local/bin (no sudo), then
 # best-effort authenticates and installs any requested plugins.
 #
-#   curl --proto '=https' --tlsv1.2 -sSfL \
+#   curl -sSfL \
 #     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.sh | bash
 #
 # See scripts/install/README.md for options and other install methods.

--- a/scripts/install/uninstall.ps1
+++ b/scripts/install/uninstall.ps1
@@ -82,7 +82,7 @@ function Remove-Standalone {
             Warn 'ggshield installed another way (choco, a hand-run MSI, pipx, uv, pip) is left untouched'
             return
         }
-        if (-not (Confirm-Step "Remove the standalone ggshield at $ZipDir?")) { return }
+        if (-not (Confirm-Step "Remove the standalone ggshield at ${ZipDir}?")) { return }
         Assert-SafeZipDir
         Say "Removing $ZipDir"
         Remove-Item $ZipDir -Recurse -Force

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -7,7 +7,7 @@
 # It does not touch ggshield installed another way (Homebrew, apt/rpm, pipx,
 # uv, pip…). Pass --purge to also remove ggshield's config, cache and data.
 #
-#   curl --proto '=https' --tlsv1.2 -sSfL \
+#   curl -sSfL \
 #     https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh | bash
 
 set -euo pipefail


### PR DESCRIPTION
Two small install-script changes (both on END-511).

## 1. Trim redundant curl flags from the install commands (`docs`)

Every documented install/uninstall command targets a literal `https://` URL on GitHub, which serves only TLS 1.2+. So both `--proto '=https'` (curl uses the scheme from the URL) and `--tlsv1.2` (the handshake negotiates ≥1.2 regardless) are redundant. The commands keep `-sSfL` — in particular `-f`, so an HTTP error page is never piped into `bash`.

Scope: the top-level `README.md`, `scripts/install/README.md`, and the `install.sh` / `uninstall.sh` documented one-liners. The scripts' own download helpers (`fetch`, `asset_http_status`) keep `--proto '=https' --tlsv1.2` as cheap defense-in-depth.

## 2. Fix the missing path in the Windows uninstall prompt (`fix`)

`uninstall.ps1` prompted `Remove the standalone ggshield at $ZipDir?`. In PowerShell `?` is a valid variable-name character (it's why the automatic `$?` exists), so the parser read the name as `ZipDir?` — undefined, expands to empty. The prompt rendered as `Remove the standalone ggshield at  [y/N]`, with no path and no `?`. Bracing the name (`${ZipDir}?`) keeps `ZipDir` as the variable and `?` literal.

Verified in a real PowerShell container (7.4.2); the `?`-as-name-char grammar is identical on Windows PowerShell 5.1. AST confirms `$ZipDir?` parses to `VariablePath = ZipDir?`.

Refs: [END-511](https://linear.app/gitguardian/issue/END-511/simple-install-script-to-test-ggshield)