### PR TITLE
feat(ai): send hook installation status

### DIFF
--- a/changelog.d/20260618_162321_paul.petit.ext_HEAD.md
+++ b/changelog.d/20260618_162321_paul.petit.ext_HEAD.md
@@ -1,0 +1,3 @@
+### Added
+
+- AI discovery now sends whether hooks are installed globally, per agent.

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -96,14 +96,12 @@ def discover_cmd(
 
 def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[str, Any]:
     """Summarize what we want to show of the discovery."""
-    agent_names = set()
     servers = []
     for server in config.servers:
         projects = set()
         agents = set()
         installed_globally = False
         for conf in server.configurations:
-            agent_names.add(conf.agent)
             agents.add(conf.agent)
             if conf.scope == Scope.USER:
                 installed_globally = True
@@ -120,8 +118,18 @@ def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[st
             }
         )
     servers = sorted(servers, key=lambda x: x["name"])
+    agents = sorted(
+        (
+            {
+                "name": AGENTS[agent.name].display_name,
+                "hooks_installed": agent.hooks_installed,
+            }
+            for agent in config.agents
+        ),
+        key=lambda x: x["name"],
+    )
     return {
-        "agents": [AGENTS[name].display_name for name in agent_names],
+        "agents": agents,
         "servers": servers,
         "history": {
             "parsed": report.parsed,
@@ -134,7 +142,7 @@ def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[st
 
 def print_summary(summary: Dict[str, Any]) -> None:
     """Print the summary of the discovery."""
-    agents: List[str] = summary.get("agents", [])
+    agents: List[Dict[str, Any]] = summary.get("agents", [])
     servers: List[Dict[str, Any]] = summary.get("servers", [])
 
     nb_servers = len(servers)
@@ -144,9 +152,14 @@ def print_summary(summary: Dict[str, Any]) -> None:
         click.echo(format_text("No MCP servers discovered", STYLE["no_secret"]))
         return
 
+    def _format_agent(agent: Dict[str, Any]) -> str:
+        name = format_text(agent.get("name", "unknown"), STYLE["heading"])
+        status = "hooks installed" if agent.get("hooks_installed") else "no hooks"
+        return f"{name} ({status})"
+
     click.echo(
         f"\n{format_text('Agents discovered:', STYLE['key'])} "
-        f"{', '.join(format_text(agent, STYLE['heading']) for agent in agents) if agents else 'none'} "
+        f"{', '.join(_format_agent(agent) for agent in agents) if agents else 'none'} "
         f"({nb_agents} {pluralize('agent', nb_agents)})"
     )
     click.echo(

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -45,6 +45,10 @@ def has_changed_from(current: AIDiscovery, other: AIDiscovery) -> bool:
     if current.user != other.user:
         return True
 
+    # 1b. agent hook installation status
+    if current.agents != other.agents:
+        return True
+
     # 2. MCP configurations should be the same (both in number and content)
     other_configurations = _confs_by_key(other)
     new_configurations = _confs_by_key(current)

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -8,12 +8,13 @@ from time import perf_counter
 from typing import Dict, List, Optional
 
 from pygitguardian import GGClient
-from pygitguardian.models import AIDiscovery, Detail, MCPServer
+from pygitguardian.models import AgentInfo, AIDiscovery, Detail, MCPServer
 
 from ggshield.core.errors import UnexpectedError
 
 from .agents import AGENTS
 from .cache import has_changed_from, load_discovery_cache, save_discovery_cache
+from .installation import are_hooks_installed_globally
 from .models import MCPConfiguration
 from .user import get_user_info
 
@@ -58,6 +59,19 @@ def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
     for agent in AGENTS.values():
         mcp_configurations.extend(agent.discover_mcp_configurations(projects))
 
+    # Hook installation status
+    agents = []
+    for agent in AGENTS.values():
+        if agent.is_present():
+            installed, command = are_hooks_installed_globally(agent.name)
+            agents.append(
+                AgentInfo(
+                    name=agent.name,
+                    hooks_installed=installed,
+                    hooks_command=command,
+                )
+            )
+
     # Merge MCP configurations into servers
     servers = _merge_mcp_configurations(mcp_configurations)
 
@@ -74,6 +88,7 @@ def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
     return AIDiscovery(
         user=user,
         servers=servers,
+        agents=agents,
         discovery_duration=discovery_duration,
     )
 

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -5,20 +5,29 @@ import sys
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 import click
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.core.errors import UnexpectedError
 
-from .agents import AGENTS
+from .agents import AGENTS, Agent
 
 
 @dataclass
 class InstallationStats:
-    added: int
-    already_present: int
+    added: int = 0
+    already_present: int = 0
+    command: str = ""
+
+
+@dataclass
+class BuildConfigResult:
+    agent: Agent
+    settings_path: Path
+    new_config: Dict[str, Any]
+    stats: InstallationStats
 
 
 def build_hook_command() -> str:
@@ -64,6 +73,43 @@ def install_hooks(
     Returns an error code (0 on success, 1 on failure)
     """
 
+    result = build_hook_config(name, mode, force)
+    settings_path = result.settings_path
+    new_config = result.new_config
+    stats = result.stats
+    display_name = result.agent.display_name
+    # Ensure parent directory exists
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write the updated config
+    with settings_path.open("w", encoding="utf-8") as f:
+        json.dump(new_config, f, indent=2)
+        f.write("\n")
+
+    # Report what happened
+    styled_path = click.style(settings_path, fg="yellow", bold=True)
+    if stats.added == 0 and stats.already_present > 0:
+        click.echo(f"{display_name} hooks already installed in {styled_path}")
+    elif stats.added > 0 and stats.already_present > 0:
+        click.echo(f"{display_name} hooks updated in {styled_path}")
+    else:
+        click.echo(f"{display_name} hooks successfully added in {styled_path}")
+
+    return 0
+
+
+def build_hook_config(
+    name: str, mode: Literal["local", "global"], force: bool = False
+) -> BuildConfigResult:
+    """Build the hook configuration for the AI hook.
+
+    Args:
+        name: Name of the AI coding tool
+        mode: Mode of the hook installation
+
+    Returns the updated hook configuration and statistics
+    """
+
     try:
         agent = AGENTS[name]
     except KeyError:
@@ -91,6 +137,7 @@ def install_hooks(
     stats = InstallationStats(
         added=0,
         already_present=0,
+        command="",
     )
 
     stats = _fill_dict(
@@ -102,24 +149,12 @@ def install_hooks(
         locator=agent.settings_locate,
     )
 
-    # Ensure parent directory exists
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write the updated config
-    with settings_path.open("w", encoding="utf-8") as f:
-        json.dump(existing_config, f, indent=2)
-        f.write("\n")
-
-    # Report what happened
-    styled_path = click.style(settings_path, fg="yellow", bold=True)
-    if stats.added == 0 and stats.already_present > 0:
-        click.echo(f"{agent.display_name} hooks already installed in {styled_path}")
-    elif stats.added > 0 and stats.already_present > 0:
-        click.echo(f"{agent.display_name} hooks updated in {styled_path}")
-    else:
-        click.echo(f"{agent.display_name} hooks successfully added in {styled_path}")
-
-    return 0
+    return BuildConfigResult(
+        agent=agent,
+        settings_path=settings_path,
+        new_config=existing_config,
+        stats=stats,
+    )
 
 
 def _fill_dict(
@@ -172,8 +207,10 @@ def _fill_dict(
             if key not in config:
                 config[key] = value
             # for stats
-            if "ggshield" in str(config.get(key, "")):
+            cmd = config.get(key, "")
+            if isinstance(cmd, str) and "ggshield" in cmd:
                 stats.already_present += 1
+                stats.command = cmd
             # Update if needed
             if overwrite:
                 config[key] = value
@@ -182,3 +219,12 @@ def _fill_dict(
                 stats.added += 1
 
     return stats
+
+
+def are_hooks_installed_globally(agent_name: str) -> Tuple[bool, Optional[str]]:
+    """Whether the ggshield AI hooks are installed in this agent's global settings file."""
+    result = build_hook_config(agent_name, "global")
+    return (
+        result.stats.added == 0,
+        result.stats.command if result.stats.added == 0 else None,
+    )

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -384,3 +384,7 @@ class Agent(ABC):
                     continue
         except OSError:
             yield from []
+
+    def is_present(self) -> bool:
+        """Whether the agent is present on the machine"""
+        return self.config_folder.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "marshmallow-dataclass~=8.7.0",
     "oauthlib~=3.2.1",
     "packaging>=22.0",
-    "pygitguardian~=1.32.0",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@2c89d05d6ca1abd4f660bb0cd656216c12c200b1",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from pygitguardian.models import (
+    AgentInfo,
     AIDiscovery,
     MCPConfiguration,
     MCPPromptInfo,
@@ -196,6 +197,39 @@ class TestAIDiscoveryHasChangedFrom:
     def test_empty_servers_returns_false(self):
         a = AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
         b = AIDiscovery(user=_user(), servers=[], discovery_duration=0.1)
+        assert has_changed_from(a, b) is False
+
+    def test_changed_hook_installation_returns_true(self):
+        cfg = _cfg()
+        a = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            agents=[AgentInfo(name="cursor", hooks_installed=True)],
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            agents=[AgentInfo(name="cursor", hooks_installed=False)],
+            discovery_duration=0.1,
+        )
+        assert has_changed_from(a, b) is True
+
+    def test_same_hook_installation_returns_false(self):
+        cfg = _cfg()
+        agents = [AgentInfo(name="cursor", hooks_installed=True)]
+        a = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            agents=agents,
+            discovery_duration=0.1,
+        )
+        b = AIDiscovery(
+            user=_user(),
+            servers=[_server(configurations=[cfg])],
+            agents=list(agents),
+            discovery_duration=0.2,
+        )
         assert has_changed_from(a, b) is False
 
 

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -4,7 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import click
 from click.testing import CliRunner
-from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
+from pygitguardian.models import (
+    AgentInfo,
+    AIDiscovery,
+    MCPConfiguration,
+    MCPServer,
+    UserInfo,
+)
 
 from ggshield.__main__ import cli
 from ggshield.cmd.ai.discover import print_summary
@@ -30,8 +36,16 @@ def _user():
     )
 
 
-def _discovery(servers: Optional[List[MCPServer]] = None):
-    return AIDiscovery(user=_user(), servers=servers or [], discovery_duration=0.1)
+def _discovery(
+    servers: Optional[List[MCPServer]] = None,
+    agents: Optional[List[AgentInfo]] = None,
+):
+    return AIDiscovery(
+        user=_user(),
+        servers=servers or [],
+        agents=agents or [],
+        discovery_duration=0.1,
+    )
 
 
 def _server(
@@ -372,7 +386,8 @@ class TestDiscoverCmd:
                         _config(agent="cursor", scope=Scope.USER),
                     ],
                 ),
-            ]
+            ],
+            agents=[AgentInfo(name="cursor", hooks_installed=True)],
         )
         mock_discover.return_value = discovery
         mock_submit.return_value = discovery
@@ -382,7 +397,7 @@ class TestDiscoverCmd:
 
         assert result.exit_code == 0
         parsed = json.loads(result.output)
-        assert parsed["agents"] == ["Cursor"]
+        assert parsed["agents"] == [{"name": "Cursor", "hooks_installed": True}]
         assert len(parsed["servers"]) == 1
         assert parsed["servers"][0]["name"] == "My MCP"
         assert parsed["servers"][0]["installed_globally"] is True
@@ -505,7 +520,7 @@ class TestPrintSummary:
 
     def test_single_global_server(self):
         summary: Dict[str, Any] = {
-            "agents": ["Cursor"],
+            "agents": [{"name": "Cursor", "hooks_installed": True}],
             "servers": [
                 {
                     "name": "my-server",
@@ -523,10 +538,32 @@ class TestPrintSummary:
         assert "1 agent" in result.output
         assert "my-server" in result.output
         assert "Scope: user" in result.output
+        assert "hooks installed" in result.output
+
+    def test_agent_without_hooks_shows_no_hooks(self):
+        summary: Dict[str, Any] = {
+            "agents": [{"name": "Cursor", "hooks_installed": False}],
+            "servers": [
+                {
+                    "name": "my-server",
+                    "installed_globally": True,
+                    "projects": [],
+                }
+            ],
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                _echo_summary_cmd, args=[], input=json.dumps(summary)
+            )
+        assert "no hooks" in result.output
 
     def test_multiple_servers_with_projects(self):
         summary: Dict[str, Any] = {
-            "agents": ["Cursor", "Claude Code"],
+            "agents": [
+                {"name": "Cursor", "hooks_installed": True},
+                {"name": "Claude Code", "hooks_installed": False},
+            ],
             "servers": [
                 {
                     "name": "server-a",

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -69,10 +69,18 @@ class TestMergeMcpConfigurations:
 
 
 class TestDiscoverAIConfiguration:
+    @patch(
+        "ggshield.verticals.ai.discovery.are_hooks_installed_globally",
+        return_value=(False, None),
+    )
     @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
     @patch("ggshield.verticals.ai.discovery.AGENTS")
     def test_aggregates_agents(
-        self, mock_agents: MagicMock, mock_user_info: MagicMock, tmp_path: Path
+        self,
+        mock_agents: MagicMock,
+        mock_user_info: MagicMock,
+        mock_hooks: MagicMock,
+        tmp_path: Path,
     ):
         agent1 = MagicMock()
         agent1.discover_project_directories.return_value = iter([tmp_path / "p1"])
@@ -92,10 +100,53 @@ class TestDiscoverAIConfiguration:
         assert len(result.servers) == 2
         assert result.discovery_duration > 0
 
+    @patch("ggshield.verticals.ai.discovery.are_hooks_installed_globally")
+    @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
+    @patch("ggshield.verticals.ai.discovery.AGENTS")
+    def test_reports_present_agents_hook_status(
+        self,
+        mock_agents: MagicMock,
+        mock_user_info: MagicMock,
+        mock_hooks: MagicMock,
+    ):
+        # Present agent, hooks installed
+        agent1 = MagicMock()
+        agent1.name = "cursor"
+        agent1.discover_project_directories.return_value = iter([])
+        agent1.discover_mcp_configurations.return_value = []
+        agent1.discover_capabilities.return_value = False
+        agent1.is_present.return_value = True
+
+        # Not present: must not appear in the agents list
+        agent2 = MagicMock()
+        agent2.name = "claude-code"
+        agent2.discover_project_directories.return_value = iter([])
+        agent2.discover_mcp_configurations.return_value = []
+        agent2.discover_capabilities.return_value = False
+        agent2.is_present.return_value = False
+
+        mock_agents.values.return_value = [agent1, agent2]
+        mock_hooks.side_effect = lambda name: {
+            "cursor": (True, "ggshield secret scan ai-hook"),
+        }.get(name, (False, None))
+
+        result = discover_ai_configuration()
+
+        assert [
+            (a.name, a.hooks_installed, a.hooks_command) for a in result.agents
+        ] == [("cursor", True, "ggshield secret scan ai-hook")]
+
+    @patch(
+        "ggshield.verticals.ai.discovery.are_hooks_installed_globally",
+        return_value=(False, None),
+    )
     @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
     @patch("ggshield.verticals.ai.discovery.AGENTS")
     def test_stops_capability_discovery_at_first_success(
-        self, mock_agents: MagicMock, mock_user_info: MagicMock
+        self,
+        mock_agents: MagicMock,
+        mock_user_info: MagicMock,
+        mock_hooks: MagicMock,
     ):
         agent1 = MagicMock()
         agent1.discover_project_directories.return_value = iter([])

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -13,6 +13,7 @@ from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor
 from ggshield.verticals.ai.installation import (
     InstallationStats,
     _fill_dict,
+    are_hooks_installed_globally,
     build_hook_command,
     install_hooks,
 )
@@ -140,7 +141,9 @@ class TestFillDict:
             config, template, COMMAND, overwrite=True, stats=stats, locator=_locator
         )
         assert config == expected
-        assert stats == InstallationStats(added=1, already_present=1)
+        assert stats == InstallationStats(
+            added=1, already_present=1, command="ggshield already"
+        )
 
     def test_list_match_found_leaves_existing_object_overwrite_false(self):
         """When locator finds a match in list and overwrite is False, existing value is kept."""
@@ -152,7 +155,9 @@ class TestFillDict:
             config, template, COMMAND, overwrite=False, stats=stats, locator=_locator
         )
         assert config == expected
-        assert stats == InstallationStats(added=0, already_present=1)
+        assert stats == InstallationStats(
+            added=0, already_present=1, command="ggshield already"
+        )
 
     def test_multiple_lists(self):
         config = {
@@ -181,7 +186,9 @@ class TestFillDict:
             config, template, COMMAND, overwrite=False, stats=stats, locator=_locator
         )
         assert config == expected
-        assert stats == InstallationStats(added=2, already_present=1)
+        assert stats == InstallationStats(
+            added=2, already_present=1, command="ggshield already"
+        )
 
     def test_template_list_must_have_exactly_one_element(self):
         """Template list value must have exactly one element (raises ValueError otherwise)."""
@@ -432,6 +439,50 @@ class TestInstallHooks:
             code = install_hooks("cursor", mode="local", force=True)
 
         assert code == 0
+
+
+class TestAreHooksInstalledGlobally:
+    """Unit tests for the are_hooks_installed_globally function."""
+
+    @patch(
+        "ggshield.verticals.ai.installation.build_hook_command", return_value=COMMAND
+    )
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_detects_installed_global_hooks(
+        self, mock_home: Any, mock_cmd: Any, tmp_path: Path
+    ):
+        mock_home.return_value = tmp_path
+
+        installed, command = are_hooks_installed_globally("claude-code")
+        assert installed is False
+        assert command is None
+
+        install_hooks("claude-code", mode="global")
+
+        installed, command = are_hooks_installed_globally("claude-code")
+        assert installed is True
+        assert command == COMMAND
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_no_settings_file_returns_false(self, mock_home: Any, tmp_path: Path):
+        mock_home.return_value = tmp_path
+        installed, command = are_hooks_installed_globally("cursor")
+        assert installed is False
+        assert command is None
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_settings_without_ggshield_returns_false(
+        self, mock_home: Any, tmp_path: Path
+    ):
+        mock_home.return_value = tmp_path
+        settings = tmp_path / ".cursor" / "hooks.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(
+            json.dumps({"hooks": {"preToolUse": [{"command": "other-tool"}]}})
+        )
+        installed, command = are_hooks_installed_globally("cursor")
+        assert installed is False
+        assert command is None
 
 
 @contextlib.contextmanager

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-20T06:04:06.037613923Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1093,7 +1093,7 @@ requires-dist = [
     { name = "oauthlib", specifier = "~=3.2.1" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", specifier = "~=1.32.0" },
+    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=2c89d05d6ca1abd4f660bb0cd656216c12c200b1" },
     { name = "pyjwt", specifier = "~=2.6.0" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
@@ -2823,7 +2823,7 @@ wheels = [
 [[package]]
 name = "pygitguardian"
 version = "1.32.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=2c89d05d6ca1abd4f660bb0cd656216c12c200b1#2c89d05d6ca1abd4f660bb0cd656216c12c200b1" }
 dependencies = [
     { name = "marshmallow", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "marshmallow", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2831,10 +2831,6 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/58/17a8fb8459871f0a7a758a64f492a282a1251b629789a6f72d80a6831fc4/pygitguardian-1.32.0.tar.gz", hash = "sha256:2bc9880c139dee3692bff369a10d42e99f58e4122358ce0d632b51e250e90252", size = 57374, upload-time = "2026-06-16T13:27:06.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/4a/b26702ad735fa24b0b93bfbb64cbe6a4a761304a767e8b3ce4b890dd8f6d/pygitguardian-1.32.0-py3-none-any.whl", hash = "sha256:7f0549565a4a7ef13be2ced9b2fd787cfe402bdd169c3e40e8057a63e0c06bf6", size = 23910, upload-time = "2026-06-16T13:27:05.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

We want to be able to show in the dashboard which agent has its hooks globally installed.

## What has been done

- reuse and complete the installation logic to be able to surface whether a hook configuration is already correct or should be installed/modified.
- send the result during an AI discovery

## Validation

```
ggshield ai discover
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
