### PR TITLE
docs: mark install script as recommended, add EU/self-hosted example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Only metadata such as call time, request size and scan mode is stored from scans
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Installation](#installation)
-  - [Install script](#install-script)
+  - [Install script (Recommended)](#install-script-recommended)
   - [macOS](#macos)
     - [Homebrew](#homebrew)
     - [Standalone .pkg package](#standalone-pkg-package)
@@ -57,11 +57,9 @@ ggshield" section of the "Getting started" page of ggshield public
 documentation.
 -->
 
-## Install script
+## Install script (Recommended)
 
-The quickest way to install `ggshield` is the install script. It detects your
-OS and architecture, installs the standalone build (no Python required), and
-can optionally authenticate and install plugins.
+The quickest way to install `ggshield`.
 
 Linux / macOS:
 
@@ -82,8 +80,11 @@ Or, if you prefer `curl` (bundled with Windows 10+):
 curl.exe -sSL https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/install.ps1 | powershell -NoProfile -ExecutionPolicy Bypass -Command -
 ```
 
-The script accepts options such as `--instance` (authenticate against a
-specific instance, e.g. the EU workspace) and `--plugin` (install a plugin).
+The script accepts options such as `--instance` and `--plugin` (install a
+plugin). For the EU workspace or a self-hosted instance, set the
+`GITGUARDIAN_INSTANCE` environment variable (or pass `--instance <URL>`)
+before running.
+
 See [`scripts/install/README.md`](scripts/install/README.md) for the full list
 of options, the other install methods, and how to uninstall.
 

--- a/changelog.d/20260619_101432_benjamin.rigaud_readme_install_recommended.md
+++ b/changelog.d/20260619_101432_benjamin.rigaud_readme_install_recommended.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The README marks the install script as the recommended install method and shows an example that authenticates against the EU workspace or a self-hosted instance.


### PR DESCRIPTION
Mirrors the public-docs *Step 1: Install* change ([END-375 / MR 2044](https://gitlab.gitguardian.ovh/gg-code/public-docs/-/merge_requests/2044)) back into the README, which carries a bidirectional "keep in sync" note with that section:

- Marks the install script as the **recommended** install method (heading + TOC anchor).
- Adds an example that authenticates against the EU workspace (or a self-hosted instance, using your own dashboard URL) via `--instance` / `-Instance`.

Refs: [END-511](https://linear.app/gitguardian/issue/END-511/simple-install-script-to-test-ggshield)