### PR TITLE
fix(auth): surface clear error on non-JSON token-claim response

### DIFF
--- a/changelog.d/20260619_110946_benjamin.rigaud_fix_auth_login_assertion.md
+++ b/changelog.d/20260619_110946_benjamin.rigaud_fix_auth_login_assertion.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield auth login` now reports a clear error when the token-exchange step receives a non-JSON HTTP response, instead of crashing with an opaque `AssertionError` and a raw traceback.

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -447,8 +447,12 @@ class OAuthClient:
         """
         Output the login success message
         """
-        assert self.instance_config.account is not None
-        expire_at = self.instance_config.account.expire_at
+        account = self.instance_config.account
+        if account is None:
+            # Reached only if the flow ended without saving a token; surface a
+            # clean error instead of a bare AssertionError.
+            raise UnexpectedError("Login failed: no token was saved.")
+        expire_at = account.expire_at
 
         if expire_at is not None:
             str_date = get_pretty_date(expire_at)
@@ -533,7 +537,11 @@ class RequestHandler(BaseHTTPRequestHandler):
 
         try:
             self.oauth_client.process_callback(callback_url)
-        except OAuthError as error:
+        except (OAuthError, UnexpectedError) as error:
+            # UnexpectedError is raised e.g. when the token endpoint returns a
+            # non-JSON response. It must be caught here too: an exception that
+            # escapes this handler thread is swallowed by socketserver, leaving
+            # the main thread to mistake the callback for a success.
             self._handle_error(error.message)
         else:
             self._redirect(

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -1,10 +1,12 @@
+from unittest.mock import Mock
 from urllib import parse as urlparse
 
 import pytest
 
 from ggshield.core.config import Config
+from ggshield.core.errors import UnexpectedError
 from ggshield.verticals.auth import OAuthClient
-from ggshield.verticals.auth.oauth import _mask_code, get_error_param
+from ggshield.verticals.auth.oauth import RequestHandler, _mask_code, get_error_param
 
 
 @pytest.mark.parametrize(
@@ -85,3 +87,54 @@ def test_mask_code(code, expected):
     and short codes are fully masked
     """
     assert _mask_code(code) == expected
+
+
+def test_request_handler_records_unexpected_error(monkeypatch):
+    """
+    GIVEN a localhost OAuth callback whose token-claim step raises an
+          UnexpectedError (e.g. the server returned a non-JSON response)
+    WHEN the local request handler processes the callback
+    THEN the error is recorded on the client instead of escaping the handler
+         thread, so the main thread can surface it cleanly rather than later
+         tripping over a missing account (AssertionError)
+    """
+    client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
+    error_message = "Server response is not JSON (HTTP code: 405)."
+
+    def raise_unexpected(_callback_url):
+        raise UnexpectedError(error_message)
+
+    monkeypatch.setattr(client, "process_callback", raise_unexpected)
+
+    # Build the handler without its socket-bound __init__ (which would itself
+    # call handle()/do_GET()); stub only the HTTP response machinery do_GET uses.
+    handler = RequestHandler.__new__(RequestHandler)
+    handler.oauth_client = client
+    handler.path = "/?code=some_code&state=some_state"
+    handler.send_response = Mock()
+    handler.send_header = Mock()
+    handler.end_headers = Mock()
+    handler.wfile = Mock()
+
+    # The handler must not let the exception escape the request thread.
+    handler.do_GET()
+
+    assert client._request_finished is True
+    assert client._request_error_message == error_message
+
+
+def test_print_login_success_without_account_raises_cleanly():
+    """
+    GIVEN an OAuth flow that somehow reached the success message step without a
+          token having been saved (no account on the instance)
+    WHEN _print_login_success is called
+    THEN it raises a clean UnexpectedError instead of a bare AssertionError
+    """
+    client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
+    # The instance exists in the config (created before the client is used) but
+    # no token was ever saved, so its account is None.
+    client.config.auth_config.get_or_create_instance(client.instance)
+    assert client.instance_config.account is None
+
+    with pytest.raises(UnexpectedError):
+        client._print_login_success()


### PR DESCRIPTION
## Context

While testing the upcoming self-hosted release, `ggshield auth login` crashed with an opaque `AssertionError` and a raw `socketserver` traceback when the token-claim step received a non-JSON HTTP error response (the server returned HTTP 405).

Root cause: `_claim_token` raises `UnexpectedError` for a non-JSON response, but the callback handler `do_GET` only caught `OAuthError`. The `UnexpectedError` escaped the request-handler thread (swallowed by `socketserver`), so `_request_error_message` was never set, `_wait_for_callback` returned as if login had succeeded, and `_print_login_success` then tripped on `assert self.instance_config.account is not None`.

Refs: END-579

## What has been done

- `do_GET` now catches `UnexpectedError` in addition to `OAuthError` and routes it through `_handle_error`, so the error is recorded and the main thread raises it cleanly instead of mistaking the callback for a success.
- `_print_login_success` raises a clean `UnexpectedError` instead of a bare `assert` when no account was saved (defense-in-depth; also survives `python -O`).
- Added regression tests that exercise the real `RequestHandler.do_GET`. The existing web-flow harness bypasses it (its `FakeOAuthClient` calls `process_callback` directly in the main thread), which is why the existing garbage-response test passed while production crashed.

## Validation

- `ggshield auth login` against a server whose `/v1/oauth/token` returns a non-JSON error (e.g. an nginx 405) now prints a clear `Error: Server response is not JSON (HTTP code: 405).` and exits, instead of an `AssertionError` + traceback.
- `make unittest` (full suite, serial): all pass. `black` / `isort` / `flake8` / `pyright` clean.

## Out of scope / follow-up

This makes the failure legible but does not fix the underlying 405. For that instance the cause is that `dashboard_to_api_url` classifies hosts under `*.gitguardian.tech` as SaaS and drops the `/exposed` API prefix — tracked as a separate follow-up under END-579.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
