### PR TITLE
fix(core): detect self-hosted instances under gitguardian domains

### DIFF
--- a/changelog.d/20260619_113819_benjamin.rigaud_fix_exposed_saas_detection.md
+++ b/changelog.d/20260619_113819_benjamin.rigaud_fix_exposed_saas_detection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- A self-hosted instance deployed under a `gitguardian.com` / `gitguardian.tech` domain is no longer misdetected as SaaS. Its API URL now correctly gets the `/exposed` prefix, so `ggshield auth login` and other API calls reach the backend instead of the static frontend.

--- a/ggshield/core/url_utils.py
+++ b/ggshield/core/url_utils.py
@@ -9,6 +9,21 @@ from .constants import ON_PREMISE_API_URL_PATH_PREFIX
 GITGUARDIAN_DOMAINS = ["gitguardian.com", "gitguardian.tech"]
 
 
+def is_saas_netloc(netloc: str) -> bool:
+    """
+    Whether ``netloc`` is a GitGuardian-hosted (SaaS) instance.
+
+    SaaS instances are ``dashboard.*`` / ``api.*`` hosts under a gitguardian.com
+    or gitguardian.tech domain, and use a host swap to go between dashboard and
+    API URLs. Self-hosted instances use the ``/exposed`` path prefix instead —
+    even when deployed under a gitguardian domain, so the domain suffix alone is
+    not enough to identify SaaS.
+    """
+    if not any(netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
+        return False
+    return netloc.split(".", 1)[0] in ("dashboard", "api")
+
+
 def clean_url(url: str, warn: bool = False) -> ParseResult:
     """
     Take a dashboard or API URL and removes trailing slashes and useless /v1
@@ -34,7 +49,7 @@ def validate_instance_url(url: str, warn: bool = False) -> ParseResult:
         or parsed_url.netloc.startswith("127.0.0.1")
     ):
         raise UsageError(f"Invalid scheme for dashboard URL '{url}', expected HTTPS")
-    if any(parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
+    if is_saas_netloc(parsed_url.netloc):
         if parsed_url.path:
             raise UsageError(
                 f"Invalid dashboard URL '{url}', got an unexpected path '{parsed_url.path}'"
@@ -50,7 +65,7 @@ def dashboard_to_api_url(dashboard_url: str, warn: bool = False) -> str:
     """
     parsed_url = validate_instance_url(dashboard_url, warn=warn)
 
-    if any(parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
+    if is_saas_netloc(parsed_url.netloc):
         parsed_url = parsed_url._replace(
             netloc=parsed_url.netloc.replace("dashboard", "api")
         )
@@ -69,9 +84,7 @@ def api_to_dashboard_url(api_url: str, warn: bool = False) -> str:
     parsed_url = clean_url(api_url, warn=warn)
     if parsed_url.scheme != "https" and not parsed_url.netloc.startswith("localhost"):
         raise UsageError(f"Invalid scheme for API URL '{api_url}', expected HTTPS")
-    if any(
-        parsed_url.netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS
-    ):  # SaaS
+    if is_saas_netloc(parsed_url.netloc):  # SaaS
         if parsed_url.path:
             raise UsageError(
                 f"Invalid API URL '{api_url}', got an unexpected path '{parsed_url.path}'"

--- a/tests/unit/core/test_url_utils.py
+++ b/tests/unit/core/test_url_utils.py
@@ -14,6 +14,12 @@ from ggshield.core.url_utils import api_to_dashboard_url, dashboard_to_api_url, 
             "https://api.gitguardian.com/?foo=bar",
             "https://dashboard.gitguardian.com?foo=bar",
         ],
+        # Self-hosted instance deployed under a gitguardian domain: it is NOT
+        # SaaS, so /exposed is stripped instead of being rejected as a path.
+        [
+            "https://selfhosted.gitguardian.tech/exposed",
+            "https://selfhosted.gitguardian.tech",
+        ],
         ["https://example.com/exposed", "https://example.com"],
         ["https://example.com/exposed/", "https://example.com"],
         [
@@ -42,6 +48,12 @@ def test_api_to_dashboard_url(api_url, dashboard_url):
         [
             "https://dashboard.gitguardian.com/?foo=bar",
             "https://api.gitguardian.com?foo=bar",
+        ],
+        # Self-hosted instance deployed under a gitguardian domain: it is NOT
+        # SaaS, so /exposed is appended instead of swapping the host.
+        [
+            "https://selfhosted.gitguardian.tech",
+            "https://selfhosted.gitguardian.tech/exposed",
         ],
         ["https://example.com/", "https://example.com/exposed"],
         ["https://example.com/", "https://example.com/exposed"],


### PR DESCRIPTION
## Context

`ggshield auth login` against a self-hosted instance **deployed under a GitGuardian-owned domain** (`*.gitguardian.com` / `*.gitguardian.tech`) fails: the token-claim POST goes to `https://<host>/v1/oauth/token` — **without** the `/exposed` API prefix — which nginx serves from the static frontend and answers with HTTP 405.

Root cause: `dashboard_to_api_url()` decided SaaS vs self-hosted purely by domain suffix (`GITGUARDIAN_DOMAINS`). A self-hosted instance deployed under a GitGuardian-owned domain is therefore treated as SaaS — the host-swap (`dashboard`→`api`) is a no-op and `/exposed` is never appended. Self-hosted customers use their own domains and were unaffected.

This is the follow-up to #1305 (END-579), which only made the resulting error legible.

Refs: END-580

## What has been done

- Added `is_saas_netloc()`: a host is SaaS only when it ends with a gitguardian domain **and** its first label is `dashboard`/`api`. Routed `dashboard_to_api_url`, `api_to_dashboard_url`, and `validate_instance_url` through it.
- Result: a self-hosted `*.gitguardian.tech` host → `…/exposed`; `dashboard.gitguardian.com` ↔ `api.gitguardian.com` and region variants unchanged (still SaaS).

Known limitation (acceptable): a self-hosted instance literally named `dashboard.<x>.gitguardian.tech` would still be misclassified — vanishingly unlikely.

## Validation

- `dashboard_to_api_url` of a self-hosted host under a gitguardian domain now appends `/exposed`, and round-trips via `api_to_dashboard_url`.
- SaaS cases and the existing "unexpected path" rejections (`api.gitguardian.com/exposed`) remain unchanged.
- `make unittest` (full suite, serial): all pass. `black` / `isort` / `flake8` / `pyright` clean.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
