### PR TITLE
feat(auth): add --only-scopes flag and auth.login_scopes config

### DIFF
--- a/changelog.d/20260622_091042_benjamin.rigaud_auth_login_only_scopes.md
+++ b/changelog.d/20260622_091042_benjamin.rigaud_auth_login_only_scopes.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield auth login` gains a `--only-scopes` option that requests an exact set of scopes, replacing the defaults (unlike `--scopes`, which appends). This unblocks login on self-hosted instances where a default scope such as `endpoints:send` is unavailable, e.g. `ggshield auth login --only-scopes "scan nhi:send-inventory"`. The base scope set can also be pinned in the configuration file via `auth.login_scopes`.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -16,14 +16,18 @@ from ggshield.core.url_utils import clean_url
 from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
-def _warn_missing_scopes(client: GGClient) -> None:
+def _warn_missing_scopes(
+    client: GGClient, expected_scopes: Optional[List[str]] = None
+) -> None:
+    if expected_scopes is None:
+        expected_scopes = DEFAULT_SCOPES
     token_info = client.api_tokens()
     granted = (
         token_info.scopes
         if isinstance(token_info, APITokensResponse) and token_info.scopes
         else []
     )
-    missing = [s for s in DEFAULT_SCOPES if s not in granted]
+    missing = [s for s in expected_scopes if s not in granted]
     if missing:
         click.echo(
             "Warning: the following scopes were not granted: "
@@ -117,6 +121,20 @@ def print_default_instance_message(config: Config) -> None:
     metavar="SCOPES",
 )
 @click.option(
+    "--only-scopes",
+    "only_scopes",
+    required=False,
+    type=str,
+    help=(
+        "Space-separated list of scopes to request, replacing the defaults entirely"
+        " (unlike --scopes, which appends). Useful on self-hosted instances where a"
+        " default scope such as endpoints:send is not available, e.g."
+        ' --only-scopes "scan nhi:send-inventory". Takes precedence over --scopes and'
+        " over the auth.login_scopes config setting."
+    ),
+    metavar="SCOPES",
+)
+@click.option(
     "--sso-url",
     required=False,
     type=str,
@@ -144,6 +162,7 @@ def login_cmd(
     method: str,
     instance: Optional[str],
     scopes: Optional[str],
+    only_scopes: Optional[str],
     token_name: Optional[str],
     lifetime: Optional[int],
     sso_url: Optional[str],
@@ -168,7 +187,10 @@ def login_cmd(
 
     By default, the created token will have the `scan`, `honeytokens:check`,
     and `endpoints:send` scopes.
-    Use the `--scopes` option to request extra scopes. You can find the list of
+    Use the `--scopes` option to request extra scopes on top of those defaults, or
+    `--only-scopes` to request an exact set instead (useful on self-hosted instances
+    where a default scope such as `endpoints:send` is unavailable). The base set can
+    also be pinned in the config via `auth.login_scopes`. You can find the list of
     available scopes in [GitGuardian API documentation][1].
 
     If a valid personal access token is already configured, this command simply displays
@@ -189,23 +211,55 @@ def login_cmd(
                 "--scopes is reserved for the web login method.", param_hint="scopes"
             )
 
+        if only_scopes is not None:
+            raise click.BadParameter(
+                "--only-scopes is reserved for the web login method.",
+                param_hint="only-scopes",
+            )
+
         token_login(config, instance)
         return 0
 
     if method in ("web", "oob"):
-        extra_scopes = scopes.split(" ") if scopes else None
+        requested_scopes = _resolve_login_scopes(config, scopes, only_scopes)
         web_login(
             config,
             instance,
             token_name,
             lifetime,
             sso_url,
-            extra_scopes,
+            requested_scopes,
             no_browser=method == "oob",
         )
         return 0
 
     return 1
+
+
+def _resolve_login_scopes(
+    config: Config, scopes: Optional[str], only_scopes: Optional[str]
+) -> List[str]:
+    """
+    Resolve the scopes to request, following the precedence:
+      1. --only-scopes (CLI): exactly those, --scopes ignored
+      2. auth.login_scopes (config): base set, --scopes appended
+      3. built-in DEFAULT_SCOPES: base set, --scopes appended
+    """
+    if only_scopes is not None:
+        only = only_scopes.split()
+        if not only:
+            raise click.BadParameter(
+                "Provide at least one scope.", param_hint="only-scopes"
+            )
+        if scopes:
+            click.echo(
+                "Note: --scopes is ignored because --only-scopes is set.", err=True
+            )
+        return list(dict.fromkeys(only))
+
+    base = config.user_config.auth.login_scopes or DEFAULT_SCOPES
+    extras = scopes.split(" ") if scopes else []
+    return list(dict.fromkeys([*base, *extras]))
 
 
 def token_login(config: Config, instance: Optional[str]) -> None:
@@ -263,7 +317,7 @@ def web_login(
     token_name: Optional[str],
     lifetime: Optional[int],
     sso_url: Optional[str],
-    extra_scopes: Optional[List[str]],
+    scopes: List[str],
     no_browser: bool = False,
 ) -> None:
     instance, login_path = validate_login_path(instance=instance, sso_url=sso_url)
@@ -283,8 +337,8 @@ def web_login(
         token_name=token_name,
         lifetime=lifetime,
         login_path=login_path,
-        extra_scopes=extra_scopes,
+        scopes=scopes,
         no_browser=no_browser,
     )
-    _warn_missing_scopes(create_client_from_config(config))
+    _warn_missing_scopes(create_client_from_config(config), scopes)
     print_default_instance_message(config)

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -85,6 +85,17 @@ class SecretConfig(FilteredConfig):
 
 
 @marshmallow_dataclass.dataclass
+class AuthCmdConfig(FilteredConfig):
+    """
+    Holds user-defined settings for the `auth` commands.
+    """
+
+    # Scopes requested by `auth login`, replacing the built-in defaults.
+    # None means "use the built-in defaults".
+    login_scopes: Optional[List[str]] = None
+
+
+@marshmallow_dataclass.dataclass
 class UserConfig(FilteredConfig):
     """
     Holds all ggshield settings defined by the user in the .gitguardian.yaml files
@@ -97,6 +108,7 @@ class UserConfig(FilteredConfig):
     insecure: bool = False
     max_commits_for_hook: int = 50
     secret: SecretConfig = field(default_factory=SecretConfig)
+    auth: AuthCmdConfig = field(default_factory=AuthCmdConfig)
     debug: bool = False
 
     # If we hit any deprecated syntax when loading a configuration file, we do not

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -82,7 +82,7 @@ class OAuthClient:
         self._state = ""  # use the `state` property instead
         self._lifetime: Optional[int] = None
         self._login_path = "auth/login"
-        self._extra_scopes = []
+        self._scopes: List[str] = list(DEFAULT_SCOPES)
 
         # Fields updated by RequestHandler
         self._request_finished = False
@@ -107,7 +107,7 @@ class OAuthClient:
         token_name: Optional[str] = None,
         lifetime: Optional[int] = None,
         login_path: Optional[str] = None,
-        extra_scopes: Optional[List[str]] = None,
+        scopes: Optional[List[str]] = None,
         no_browser: bool = False,
     ) -> None:
         """
@@ -135,8 +135,8 @@ class OAuthClient:
             lifetime = self.default_token_lifetime
         self._lifetime = lifetime
 
-        if extra_scopes is not None:
-            self._extra_scopes = extra_scopes
+        if scopes is not None:
+            self._scopes = scopes
 
         self._no_browser = no_browser
 
@@ -238,7 +238,7 @@ class OAuthClient:
             "utm_medium": "login",
             "utm_campaign": "ggshield",
         }
-        unique_scopes = list(dict.fromkeys([*DEFAULT_SCOPES, *self._extra_scopes]))
+        unique_scopes = list(dict.fromkeys(self._scopes))
         return self._oauth_client.prepare_request_uri(
             uri=urljoin(self.dashboard_url, self._login_path),
             redirect_uri=self.redirect_uri,

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -14,7 +14,7 @@ from ggshield.core.errors import ExitCode, UnexpectedError
 from ggshield.utils.datetime import get_pretty_date
 from ggshield.verticals.auth import OAuthClient, OAuthError
 from ggshield.verticals.auth.oauth import OOB_REDIRECT_URI
-from tests.unit.conftest import assert_invoke_ok
+from tests.unit.conftest import assert_invoke_ok, write_yaml
 from tests.unit.request_mock import (
     RequestMock,
     create_html_response,
@@ -188,6 +188,17 @@ class TestAuthLoginToken:
         assert config.auth_config.get_instance(instance).account.token == token
 
         self._request_mock.assert_all_requests_happened()
+
+    def test_only_scopes_rejected_with_token_method(self, monkeypatch, cli_fs_runner):
+        """
+        GIVEN --method=token
+        WHEN --only-scopes is also passed
+        THEN the command rejects it (token login does not mint scopes)
+        """
+        cmd = ["auth", "login", "--method=token", "--only-scopes=scan"]
+        result = cli_fs_runner.invoke(cli, cmd, color=False, input="tok\n")
+        assert result.exit_code != 0
+        assert "only-scopes" in result.output
 
     def test_auth_login_token_default_instance(self, monkeypatch, cli_fs_runner):
         """
@@ -421,6 +432,7 @@ class TestAuthLoginWeb:
         # This is not a list because the --scopes argument takes a single
         # space-separated string
         self._scopes: Optional[str] = None
+        self._only_scopes: Optional[str] = None
 
         config = Config()
         assert len(config.auth_config.instances) == 0
@@ -725,6 +737,116 @@ class TestAuthLoginWeb:
 
         self._assert_config("mysupertoken")
 
+    def test_only_scopes_replaces_defaults(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN a call to `auth login` with `--only-scopes`
+        WHEN the browser is opened
+        THEN the URI requests exactly those scopes, replacing the defaults
+        """
+        self.prepare_mocks(monkeypatch, only_scopes="scan nhi:send-inventory")
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+
+        self._webbrowser_open_mock.assert_called_once()
+        self._assert_open_url(scope_set={"scan", "nhi:send-inventory"})
+
+    def test_only_scopes_wins_over_scopes(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN both `--scopes` and `--only-scopes`
+        WHEN the browser is opened
+        THEN `--only-scopes` wins and `--scopes` is ignored (with a note)
+        """
+        self.prepare_mocks(
+            monkeypatch, scopes="teams:read", only_scopes="scan nhi:send-inventory"
+        )
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+
+        self._webbrowser_open_mock.assert_called_once()
+        self._assert_open_url(scope_set={"scan", "nhi:send-inventory"})
+        assert "--scopes" in output and "ignored" in output
+
+    def test_only_scopes_empty_value_errors(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN `--only-scopes` with an empty value
+        WHEN the command runs
+        THEN it errors out before opening a browser
+        """
+        self.prepare_mocks(monkeypatch, only_scopes="   ")
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code != ExitCode.SUCCESS
+        self._webbrowser_open_mock.assert_not_called()
+        assert "only-scopes" in output
+
+    def test_only_scopes_suppresses_false_missing_warning(
+        self, cli_fs_runner, monkeypatch
+    ):
+        """
+        GIVEN `--only-scopes scan` and a backend granting exactly `scan`
+        WHEN the web login flow completes
+        THEN no missing-scope warning is shown (the default scopes the user did
+             not request must not be reported as missing)
+        """
+        self.prepare_mocks(
+            monkeypatch,
+            only_scopes="scan",
+            missing_scopes=["honeytokens:check", "endpoints:send"],
+        )
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+        assert "Warning: the following scopes were not granted" not in output
+
+    def test_login_scopes_config_used_as_base(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN `auth.login_scopes` set in the config file
+        WHEN the browser is opened
+        THEN the URI uses the configured scopes as the base instead of the defaults
+        """
+        write_yaml(
+            ".gitguardian.yaml",
+            {"version": 2, "auth": {"login_scopes": ["scan", "nhi:send-inventory"]}},
+        )
+        self.prepare_mocks(monkeypatch)
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+
+        self._webbrowser_open_mock.assert_called_once()
+        self._assert_open_url(scope_set={"scan", "nhi:send-inventory"})
+
+    def test_scopes_appends_to_config_base(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN `auth.login_scopes` in the config AND `--scopes` on the CLI
+        WHEN the browser is opened
+        THEN `--scopes` extras are appended to the configured base
+        """
+        write_yaml(
+            ".gitguardian.yaml",
+            {"version": 2, "auth": {"login_scopes": ["scan"]}},
+        )
+        self.prepare_mocks(monkeypatch, scopes="teams:read")
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+
+        self._webbrowser_open_mock.assert_called_once()
+        self._assert_open_url(scope_set={"scan", "teams:read"})
+
+    def test_only_scopes_overrides_config(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN `auth.login_scopes` in the config AND `--only-scopes` on the CLI
+        WHEN the browser is opened
+        THEN the CLI `--only-scopes` wins over the configured base
+        """
+        write_yaml(
+            ".gitguardian.yaml",
+            {"version": 2, "auth": {"login_scopes": ["scan", "nhi:send-inventory"]}},
+        )
+        self.prepare_mocks(monkeypatch, only_scopes="scan")
+        exit_code, output = self.run_cmd(cli_fs_runner)
+        assert exit_code == ExitCode.SUCCESS, output
+
+        self._webbrowser_open_mock.assert_called_once()
+        self._assert_open_url(scope_set={"scan"})
+
     def prepare_mocks(
         self,
         monkeypatch,
@@ -735,6 +857,7 @@ class TestAuthLoginWeb:
         sso_url=None,
         downsized_token: Optional[bool] = False,
         scopes: Optional[str] = None,
+        only_scopes: Optional[str] = None,
         missing_scopes: Optional[list] = None,
     ):
         """
@@ -757,6 +880,7 @@ class TestAuthLoginWeb:
         self._instance_url = instance_url
         self._sso_url = sso_url
         self._scopes = scopes
+        self._only_scopes = only_scopes
 
         # token name generated if passed as None
         self._generated_token_name = (
@@ -873,6 +997,9 @@ class TestAuthLoginWeb:
 
         if self._scopes is not None:
             cmd.append(f"--scopes={self._scopes}")
+
+        if self._only_scopes is not None:
+            cmd.append(f"--only-scopes={self._only_scopes}")
 
         # run cli command
         result = cli_fs_runner.invoke(cli, cmd, color=False, catch_exceptions=False)

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -37,6 +37,32 @@ class TestUserConfig:
         assert config.user_config.verbose is True
         assert config.user_config.secret.show_secrets is True
 
+    def test_login_scopes_default_is_none(self):
+        """
+        GIVEN no auth section in the config
+        WHEN the config is loaded
+        THEN auth.login_scopes defaults to None (use the built-in defaults)
+        """
+        config = Config()
+        assert config.user_config.auth.login_scopes is None
+
+    def test_login_scopes_parsed_from_config(self, local_config_path):
+        """
+        GIVEN an `auth.login_scopes` list in the config file
+        WHEN the config is loaded
+        THEN it is exposed on user_config.auth.login_scopes
+        """
+        write_yaml(
+            local_config_path,
+            {
+                "version": CURRENT_CONFIG_VERSION,
+                "auth": {"login_scopes": ["scan", "nhi:send-inventory"]},
+            },
+        )
+
+        config = Config()
+        assert config.user_config.auth.login_scopes == ["scan", "nhi:send-inventory"]
+
     def test_display_options_inheritance(self, local_config_path, global_config_path):
         write_yaml(
             local_config_path,


### PR DESCRIPTION
## What

Adds `--only-scopes` to `ggshield auth login` (requests an **exact** scope set, replacing the defaults) plus an `auth.login_scopes` config field to pin the base set in `.gitguardian.yaml`.

```bash
# self-hosted: avoid the never-grantable endpoints:send default
ggshield auth login --only-scopes "scan nhi:send-inventory"
```

## Why

Since v1.52.0, login requests `scan honeytokens:check endpoints:send` by default. On self-hosted, `endpoints:send` is never grantable (ClickHouse-backed; the backend raises `IS_ON_PREM`) and token creation is all-or-nothing, so login fails outright (END-581). The existing `--scopes` flag only **appends**, so it cannot drop a default scope.

## Precedence (base scope set; first match wins)

| Source (highest first) | Base scopes | `--scopes` extras applied? |
| -- | -- | -- |
| `--only-scopes` (CLI) | exactly those | ❌ ignored (stderr note) |
| `auth.login_scopes` (config) | the config list | ✅ appended |
| neither | `DEFAULT_SCOPES` | ✅ appended |

`--only-scopes` is rejected for `--method token`; an empty value errors. `_warn_missing_scopes` now compares granted scopes against the **effective requested set** instead of the hardcoded defaults.

## Config

```yaml
# .gitguardian.yaml
auth:
  login_scopes:
    - scan
    - nhi:send-inventory
```

## Testing

- 10 new unit tests (CLI replace/override/append, token-method rejection, empty-value error, false-warning suppression, config parse + base resolution).
- 272 passing across `tests/unit/cmd/auth/`, `verticals/auth/test_oauth.py`, `tests/unit/core/config/`.
- black / isort / flake8 / pyright clean on changed files.

Refs: END-583, END-581