### PR TITLE
fix(ci): vendor sigstore trust root so Chocolatey can extract the nupkg

### DIFF
--- a/ggshield/core/plugin/_sigstore_trusted_root.py
+++ b/ggshield/core/plugin/_sigstore_trusted_root.py
@@ -1,0 +1,142 @@
+"""Vendored copy of sigstore's production TUF trust root.
+
+ggshield verifies plugin signatures against this embedded copy of sigstore's
+production ``trusted_root.json`` instead of reading sigstore's own ``_store``
+resource. sigstore 4.x ships that file under a URL-encoded directory
+(``https%3A%2F%2Ftuf-repo-cdn.sigstore.dev``) whose ``%`` path characters break
+Chocolatey's server-side .nupkg extraction, which silently blocked every Windows
+release since 1.50.2.
+
+Refresh when bumping sigstore: copy the production ``trusted_root.json`` out of
+the new wheel. ``test_embedded_trusted_root_matches_sigstore`` fails if this
+drifts from the installed sigstore.
+"""
+
+TRUSTED_ROOT_JSON = r"""
+{
+  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+  "tlogs": [
+    {
+      "baseUrl": "https://rekor.sigstore.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-01-12T11:53:27Z"
+        }
+      },
+      "logId": {
+        "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+      }
+    },
+    {
+      "baseUrl": "https://log2025-1.rekor.sigstore.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MCowBQYDK2VwAyEAt8rlp1knGwjfbcXAYPYAkn0XiLz1x8O4t0YkEhie244=",
+        "keyDetails": "PKIX_ED25519",
+        "validFor": {
+          "start": "2025-09-23T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "zxGZFVvd0FEmjR8WrFwMdcAJ9vtaY/QXf44Y1wUeP6A="
+      }
+    }
+  ],
+  "certificateAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ=="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2021-03-07T03:20:29Z",
+        "end": "2022-12-31T23:59:59.999Z"
+      }
+    },
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="
+          },
+          {
+            "rawBytes": "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2022-04-13T20:06:15Z"
+      }
+    }
+  ],
+  "ctlogs": [
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/test",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-03-14T00:00:00Z",
+          "end": "2022-10-31T23:59:59.999Z"
+        }
+      },
+      "logId": {
+        "keyId": "CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/2022",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-10-20T00:00:00Z"
+        }
+      },
+      "logId": {
+        "keyId": "3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4="
+      }
+    }
+  ],
+  "timestampAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore-tsa-selfsigned"
+      },
+      "uri": "https://timestamp.sigstore.dev/api/v1/timestamp",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICEDCCAZagAwIBAgIUOhNULwyQYe68wUMvy4qOiyojiwwwCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTA0MDgwNjU5NDNaFw0zNTA0MDYwNjU5NDNaMC4xFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEVMBMGA1UEAxMMc2lnc3RvcmUtdHNhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4ra2Z8hKNig2T9kFjCAToGG30jky+WQv3BzL+mKvh1SKNR/UwuwsfNCg4sryoYAd8E6isovVA3M4aoNdm9QDi50Z8nTEyvqgfDPtTIwXItfiW/AFf1V7uwkbkAoj0xxco2owaDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFIn9eUOHz9BlRsMCRscsc1t9tOsDMB8GA1UdIwQYMBaAFJjsAe9/u1H/1JUeb4qImFMHic6/MBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMAoGCCqGSM49BAMDA2gAMGUCMDtpsV/6KaO0qyF/UMsX2aSUXKQFdoGTptQGc0ftq1csulHPGG6dsmyMNd3JB+G3EQIxAOajvBcjpJmKb4Nv+2Taoj8Uc5+b6ih6FXCCKraSqupe07zqswMcXJTe1cExvHvvlw=="
+          },
+          {
+            "rawBytes": "MIIB9zCCAXygAwIBAgIUV7f0GLDOoEzIh8LXSW80OJiUp14wCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTA0MDgwNjU5NDNaFw0zNTA0MDYwNjU5NDNaMDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQUQNtfRT/ou3YATa6wB/kKTe70cfJwyRIBovMnt8RcJph/COE82uyS6FmppLLL1VBPGcPfpQPYJNXzWwi8icwhKQ6W/Qe2h3oebBb2FHpwNJDqo+TMaC/tdfkv/ElJB72jRTBDMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSY7AHvf7tR/9SVHm+KiJhTB4nOvzAKBggqhkjOPQQDAwNpADBmAjEAwGEGrfGZR1cen1R8/DTVMI943LssZmJRtDp/i7SfGHmGRP6gRbuj9vOK3b67Z0QQAjEAuT2H673LQEaHTcyQSZrkp4mX7WwkmF+sVbkYY5mXN+RMH13KUEHHOqASaemYWK/E"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2025-07-04T00:00:00Z"
+      }
+    }
+  ]
+}
+"""

--- a/ggshield/core/plugin/signature.py
+++ b/ggshield/core/plugin/signature.py
@@ -21,16 +21,17 @@ Verification modes (these decide how a result is handled, not how it is computed
 import enum
 import functools
 import logging
+import tempfile
 from dataclasses import dataclass
-from importlib.resources import as_file, files
 from pathlib import Path
 from typing import List, Optional
-from urllib.parse import quote
 
 from sigstore.errors import VerificationError
 from sigstore.models import Bundle, TrustedRoot
 from sigstore.verify import Verifier
 from sigstore.verify.policy import AllOf, GitHubWorkflowRepository, OIDCIssuer
+
+from ggshield.core.plugin._sigstore_trusted_root import TRUSTED_ROOT_JSON
 
 
 logger = logging.getLogger(__name__)
@@ -104,39 +105,31 @@ def get_bundle_path(wheel_path: Path) -> Optional[Path]:
     return None
 
 
-# Hardcode sigstore's production TUF URL rather than importing the private
-# sigstore._internal.tuf.DEFAULT_TUF_URL, so a refactor of that module can't
-# break our import. The value is stable and rarely (if ever) changes.
+# Only used by the freshness test, to find sigstore's own trusted_root.json
+# (under its URL-encoded _store dir) and compare it to our vendored copy.
 _SIGSTORE_PROD_TUF_URL = "https://tuf-repo-cdn.sigstore.dev"
 
 
 @functools.lru_cache(maxsize=1)
 def _bundled_verifier() -> Verifier:
-    """Build a Verifier pinned to the trust root bundled in our sigstore release.
+    """Build a Verifier pinned to a vendored copy of sigstore's production trust root.
 
-    We deliberately do NOT use ``Verifier.production(offline=True)``: in offline
-    mode sigstore reads its shared on-disk TUF target cache and only seeds the
-    embedded root when that cache is *absent* (sigstore ``_internal/tuf.py``
-    ``TrustUpdater``), so a stale root left by earlier sigstore use on the
-    machine would be used instead. We always verify against the root shipped in
-    the pinned sigstore distribution: deterministic, and it never touches the
-    network (the network refresh is what fails on locked-down / proxied networks
-    with "failed to refresh TUF metadata").
+    We verify against ``_sigstore_trusted_root.TRUSTED_ROOT_JSON`` -- a copy of
+    sigstore's production ``trusted_root.json`` committed in ggshield -- instead
+    of sigstore's own ``_store`` resource. sigstore 4.x ships that file under a
+    URL-encoded directory (``https%3A%2F%2Ftuf-repo-cdn.sigstore.dev``) whose
+    ``%`` path characters break Chocolatey's server-side .nupkg extraction;
+    reading our own copy keeps those names out of the bundle. It is
+    also deterministic and never touches the network -- the TUF refresh behind
+    ``Verifier.production`` is what fails on locked-down / proxied networks with
+    "failed to refresh TUF metadata".
 
-    Resolves the same embedded resource sigstore's own ``read_embedded`` reads
-    (``sigstore._store/<quoted-tuf-url>/trusted_root.json``); the dedicated unit
-    test fails loudly if a sigstore upgrade relocates it.
+    ``TrustedRoot.from_file`` is sigstore's only public constructor, so the
+    embedded JSON is materialised to a temp file to load it.
     """
-    # sigstore exposes no public API to load its embedded trust root without the
-    # on-disk TUF cache, so read the bundled root straight from its package data
-    # -- the same sigstore._store resource sigstore's own read_embedded uses.
-    # TestBundledVerifier fails loudly if a sigstore upgrade relocates it.
-    embedded = (
-        files("sigstore._store")
-        / quote(_SIGSTORE_PROD_TUF_URL, safe="")
-        / "trusted_root.json"
-    )
-    with as_file(embedded) as trusted_root_path:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        trusted_root_path = Path(tmp_dir) / "trusted_root.json"
+        trusted_root_path.write_text(TRUSTED_ROOT_JSON)
         trusted_root = TrustedRoot.from_file(str(trusted_root_path))
     return Verifier(trusted_root=trusted_root)
 

--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -47,6 +47,11 @@ windows_build_chocolatey_package() {
     cp "$ROOT_DIR/LICENSE" choco-package/tools/LICENSE.txt
     sed -i "s/__VERSION__/$VERSION/" choco-package/ggshield.nuspec
 
+    # sigstore 4.x's _store dirs are named with %-encoded URLs (https%3A%2F%2F...)
+    # that break Chocolatey's server-side .nupkg extraction; ggshield uses its own
+    # vendored trust root, so drop them.
+    rm -rf choco-package/tools/_internal/sigstore/_store/https%3A*
+
     choco pack choco-package/* --version $VERSION --outdir $PACKAGES_DIR
 
     info "Chocolatey package created in $PACKAGES_DIR/ggshield.$VERSION.nupkg"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ ignore = E203, E704, W503
 exclude = **/snapshots/*.py, .venv, build
 per-file-ignores =
     tests/unit/conftest.py: E501
+    ggshield/core/plugin/_sigstore_trusted_root.py: E501

--- a/tests/unit/core/plugin/test_signature.py
+++ b/tests/unit/core/plugin/test_signature.py
@@ -1,5 +1,6 @@
 """Tests for plugin signature verification."""
 
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
@@ -315,12 +316,10 @@ class TestBundledVerifier:
     """Guards the private-sigstore wiring that pins the bundled trust root."""
 
     def test_resolves_embedded_root_and_skips_production(self) -> None:
-        # Exercises the real embedded-root resolution
-        # (files / as_file / TrustedRoot.from_file): fails loudly if a sigstore
-        # upgrade relocates the embedded _store or changes the production TUF URL.
-        # Verifier itself is mocked so no real verifier/network is built; we
-        # only assert it is constructed from a trusted_root, never via the
-        # cache/network-backed production() path.
+        # Exercises the real embedded-root resolution (our vendored
+        # TRUSTED_ROOT_JSON -> TrustedRoot.from_file). Verifier itself is mocked
+        # so no real verifier/network is built; we only assert it is constructed
+        # from a trusted_root, never via the cache/network-backed production().
         from ggshield.core.plugin.signature import _bundled_verifier
 
         _bundled_verifier.cache_clear()
@@ -336,3 +335,44 @@ class TestBundledVerifier:
         mock_verifier_cls.assert_called_once()
         assert "trusted_root" in mock_verifier_cls.call_args.kwargs
         mock_verifier_cls.production.assert_not_called()
+
+    def test_builds_real_verifier_from_embedded_root(self) -> None:
+        # End-to-end (no mocks): the vendored TRUSTED_ROOT_JSON must parse into a
+        # real TrustedRoot and build a real, offline Verifier.
+        from sigstore.verify import Verifier
+
+        from ggshield.core.plugin.signature import _bundled_verifier
+
+        _bundled_verifier.cache_clear()
+        try:
+            verifier = _bundled_verifier()
+        finally:
+            _bundled_verifier.cache_clear()
+
+        assert isinstance(verifier, Verifier)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 10),
+        reason=(
+            "Python < 3.10 resolves sigstore 4.1.x, which ships an older trusted "
+            "root than the 4.2.x bundled in the released binaries (built on 3.10); "
+            "we vendor the 4.2.x root."
+        ),
+    )
+    def test_embedded_trusted_root_matches_sigstore(self) -> None:
+        # The vendored copy must track the trusted_root.json shipped by the installed
+        # sigstore; if a bump rotates the root this fails -> refresh
+        # _sigstore_trusted_root.py.
+        import json
+        from importlib.resources import files
+        from urllib.parse import quote
+
+        from ggshield.core.plugin._sigstore_trusted_root import TRUSTED_ROOT_JSON
+        from ggshield.core.plugin.signature import _SIGSTORE_PROD_TUF_URL
+
+        sigstore_root = (
+            files("sigstore._store")
+            / quote(_SIGSTORE_PROD_TUF_URL, safe="")
+            / "trusted_root.json"
+        ).read_text()
+        assert json.loads(TRUSTED_ROOT_JSON) == json.loads(sigstore_root)


### PR DESCRIPTION
## Context

The Chocolatey channel has been stuck on **1.50.1** since 2026-04-29 — every `choco push` since 1.50.2 fails with **HTTP 409** during server-side extraction. Root cause: **sigstore 4.x** ships its production TUF trust root under a URL-encoded directory `sigstore/_store/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/`; the `%2F`/`%3A` in that path break Chocolatey's `.nupkg` extraction. Confirmed by Chocolatey maintainer **gep13** in chocolatey/home#399.

## What has been done

- **Vendor the trust root** — add `ggshield/core/plugin/_sigstore_trusted_root.py` (a copy of sigstore's prod `trusted_root.json`) and make `_bundled_verifier()` load it via a temp file, instead of reading `sigstore/_store/https%3A…`. **Behaviour-preserving** (same trust root, offline, no network).
- **Strip the offending dirs** — `windows_build_chocolatey_package()` removes `_store/https%3A*` before `choco pack` (Chocolatey-only; other channels keep the full bundle).
- **Guards** — a freshness test fails if the vendored root drifts from the installed sigstore (gated to py>=3.10, the version the released binaries bundle); an end-to-end test builds a real offline `Verifier` from the vendored root.
- `setup.cfg` — per-file `E501` ignore for the embedded-data module (matches the existing `conftest.py` entry).

## Validation

- `uv run --group tests pytest tests/unit/core/plugin/test_signature.py` → **17 passed**.
- `flake8` / `black --check` / `isort --check` clean.
- Simulated the choco strip on the real `ggshield.1.52.2.nupkg` → **0** `%`-encoded entries remain; `sigstore._store` import unaffected.

> Note: this fixes *packaging*. The burned **1.51.0–1.52.2** version numbers still need clearing by Chocolatey (chocolatey/home#399) or a fresh release to actually re-populate the channel.

## PR check list

- [x] Tests included (freshness + real-verifier guards)
- [x] `skip-changelog` — behaviour-preserving refactor + release-pipeline fix, no end-user CLI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
