### PR TITLE
fix(core): detect prefixed SaaS hosts under gitguardian domains

### DIFF
--- a/changelog.d/20260622_161928_benjamin.rigaud_fix_prefixed_saas_host_detection.md
+++ b/changelog.d/20260622_161928_benjamin.rigaud_fix_prefixed_saas_host_detection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- A GitGuardian-hosted (SaaS) instance whose dashboard/API hostname carries a `dashboard-` / `api-` prefix is now correctly detected as SaaS. Its API URL is built by swapping the host instead of getting a spurious `/exposed` prefix, so API calls reach the backend instead of the static frontend.

--- a/ggshield/core/url_utils.py
+++ b/ggshield/core/url_utils.py
@@ -18,10 +18,17 @@ def is_saas_netloc(netloc: str) -> bool:
     API URLs. Self-hosted instances use the ``/exposed`` path prefix instead —
     even when deployed under a gitguardian domain, so the domain suffix alone is
     not enough to identify SaaS.
+
+    Some SaaS deployments expose the dashboard/API as ``dashboard-<id>.*`` /
+    ``api-<id>.*`` hosts, which are SaaS-mode too, so the first label may also be
+    a ``dashboard-`` / ``api-`` prefix rather than the bare word.
     """
     if not any(netloc.endswith("." + domain) for domain in GITGUARDIAN_DOMAINS):
         return False
-    return netloc.split(".", 1)[0] in ("dashboard", "api")
+    first_label = netloc.split(".", 1)[0]
+    return first_label in ("dashboard", "api") or first_label.startswith(
+        ("dashboard-", "api-")
+    )
 
 
 def clean_url(url: str, warn: bool = False) -> ParseResult:

--- a/tests/unit/core/test_url_utils.py
+++ b/tests/unit/core/test_url_utils.py
@@ -1,7 +1,12 @@
 import pytest
 from click import UsageError
 
-from ggshield.core.url_utils import api_to_dashboard_url, dashboard_to_api_url, urljoin
+from ggshield.core.url_utils import (
+    api_to_dashboard_url,
+    dashboard_to_api_url,
+    is_saas_netloc,
+    urljoin,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,6 +24,11 @@ from ggshield.core.url_utils import api_to_dashboard_url, dashboard_to_api_url, 
         [
             "https://selfhosted.gitguardian.tech/exposed",
             "https://selfhosted.gitguardian.tech",
+        ],
+        # Prefixed SaaS host (api-<id>): host swap, no /exposed.
+        [
+            "https://api-1234.example.gitguardian.tech",
+            "https://dashboard-1234.example.gitguardian.tech",
         ],
         ["https://example.com/exposed", "https://example.com"],
         ["https://example.com/exposed/", "https://example.com"],
@@ -55,6 +65,11 @@ def test_api_to_dashboard_url(api_url, dashboard_url):
             "https://selfhosted.gitguardian.tech",
             "https://selfhosted.gitguardian.tech/exposed",
         ],
+        # Prefixed SaaS host (dashboard-<id>): host swap, no /exposed.
+        [
+            "https://dashboard-1234.example.gitguardian.tech",
+            "https://api-1234.example.gitguardian.tech",
+        ],
         ["https://example.com/", "https://example.com/exposed"],
         ["https://example.com/", "https://example.com/exposed"],
         [
@@ -90,6 +105,29 @@ def test_unexpected_path_api_url(api_url):
 def test_unexpected_path_dashboard_url(dashboard_url):
     with pytest.raises(UsageError, match="got an unexpected path"):
         api_to_dashboard_url(dashboard_url)
+
+
+@pytest.mark.parametrize(
+    ["netloc", "expected"],
+    [
+        # Bare dashboard/api hosts under a gitguardian domain are SaaS.
+        ("dashboard.gitguardian.com", True),
+        ("api.gitguardian.com", True),
+        ("dashboard.staging.gitguardian.tech", True),
+        # Prefixed dashboard-<id>/api-<id> first labels are SaaS too.
+        ("dashboard-1234.example.gitguardian.tech", True),
+        ("api-1234.example.gitguardian.tech", True),
+        # Self-hosted instance under a gitguardian domain is NOT SaaS.
+        ("selfhosted.gitguardian.tech", False),
+        # "dashboard" must be a whole label, not a prefix of a longer word.
+        ("dashboarding.gitguardian.tech", False),
+        # Hosts outside the gitguardian domains are never SaaS.
+        ("dashboard.example.com", False),
+        ("example.com", False),
+    ],
+)
+def test_is_saas_netloc(netloc, expected):
+    assert is_saas_netloc(netloc) is expected
 
 
 def test_urljoin_empty_base_raises_value_error():


### PR DESCRIPTION
## Summary

`is_saas_netloc` only treated a host as SaaS when its first DNS label was exactly `dashboard`/`api`. SaaS deployments that expose the dashboard/API on `dashboard-<id>.*` / `api-<id>.*` hosts were therefore classified as self-hosted, so `dashboard_to_api_url` appended the `/exposed` prefix and requests reached the static frontend instead of the API backend.

This extends `is_saas_netloc` to also match a first label that starts with `dashboard-` / `api-`, so those hosts are detected as SaaS and the API URL is built via the host swap. Self-hosted hosts under a gitguardian domain (no such prefix) keep the `/exposed` path, so the prior self-hosted behaviour is preserved — the `-` separator is required, so `selfhosted.*` and `dashboarding.*` stay non-SaaS.

## Test plan

- [x] `pytest tests/unit/core/test_url_utils.py` — 35 passed (new `test_is_saas_netloc` classification matrix + round-trip cases for prefixed hosts)
- [x] `pytest` for adjacent modules (`core/config`, `core/plugin/client`) — 97 passed
- [x] `black` / `isort` / `flake8` clean