### PR TITLE
fix(core): surface clear errors on non-JSON GitGuardian API responses

### DIFF
--- a/changelog.d/20260622_162503_benjamin.rigaud_fix_api_tokens_non_json.md
+++ b/changelog.d/20260622_162503_benjamin.rigaud_fix_api_tokens_non_json.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield api-status` (and any command that reads token scopes) now reports a clear error when the GitGuardian API answers with a non-JSON body, instead of crashing with a raw `JSONDecodeError` traceback. This typically happens when the instance URL is wrong and the dashboard serves its HTML on a `2xx`.

--- a/changelog.d/20260622_162503_benjamin.rigaud_fix_api_tokens_non_json.md
+++ b/changelog.d/20260622_162503_benjamin.rigaud_fix_api_tokens_non_json.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- `ggshield api-status` (and any command that reads token scopes) now reports a clear error when the GitGuardian API answers with a non-JSON body, instead of crashing with a raw `JSONDecodeError` traceback. This typically happens when the instance URL is wrong and the dashboard serves its HTML on a `2xx`.
+- `ggshield api-status`, `ggshield auth login` and any command that reads token scopes now report a clear error when the GitGuardian API answers with a non-JSON body, instead of crashing with a raw `JSONDecodeError` traceback. This typically happens when the instance URL is wrong and the dashboard serves its HTML on a `2xx`.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -8,7 +8,11 @@ from pygitguardian.models import APITokensResponse
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
-from ggshield.core.client import create_client, create_client_from_config
+from ggshield.core.client import (
+    create_client,
+    create_client_from_config,
+    safe_api_tokens,
+)
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import UnexpectedError
@@ -17,7 +21,12 @@ from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
 def _warn_missing_scopes(client: GGClient) -> None:
-    token_info = client.api_tokens()
+    try:
+        token_info = safe_api_tokens(client)
+    except UnexpectedError:
+        # Best-effort warning: don't fail a successful login if the token-info
+        # fetch hits a non-JSON response.
+        return
     granted = (
         token_info.scopes
         if isinstance(token_info, APITokensResponse) and token_info.scopes

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -12,6 +12,7 @@ from ggshield.core.client import (
     create_client,
     create_client_from_config,
     safe_api_tokens,
+    safe_response_json,
 )
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
@@ -23,15 +24,15 @@ from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 def _warn_missing_scopes(client: GGClient) -> None:
     try:
         token_info = safe_api_tokens(client)
-    except UnexpectedError:
-        # Best-effort warning: don't fail a successful login if the token-info
-        # fetch hits a non-JSON response.
+    except (UnexpectedError, requests.exceptions.RequestException):
+        # Best-effort warning: never fail an already-successful login if the
+        # token-info fetch errors out (non-JSON body, network blip, timeout...).
         return
-    granted = (
-        token_info.scopes
-        if isinstance(token_info, APITokensResponse) and token_info.scopes
-        else []
-    )
+    if not isinstance(token_info, APITokensResponse):
+        # An error Detail (e.g. 401/500) tells us nothing about scopes; don't
+        # warn that scopes are "missing" when we never managed to read them.
+        return
+    granted = token_info.scopes or []
     missing = [s for s in DEFAULT_SCOPES if s not in granted]
     if missing:
         click.echo(
@@ -253,7 +254,7 @@ def token_login(config: Config, instance: Optional[str]) -> None:
     if not response.ok:
         raise UnexpectedError("Authentication failed with token.")
 
-    api_token_data = response.json()
+    api_token_data = safe_response_json(response)
     scopes = api_token_data["scope"]
     if "scan" not in scopes:
         raise UnexpectedError("This token does not have the scan scope.")

--- a/ggshield/cmd/status.py
+++ b/ggshield/cmd/status.py
@@ -12,7 +12,7 @@ from ggshield.cmd.utils.common_options import (
     text_json_format_option,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
-from ggshield.core.client import create_client_from_config
+from ggshield.core.client import create_client_from_config, safe_api_tokens
 from ggshield.core.errors import UnexpectedError
 from ggshield.core.text_utils import STYLE, format_text
 
@@ -34,7 +34,7 @@ def status_cmd(ctx: click.Context, **kwargs: Any) -> int:
 
     token_scopes: Optional[List[str]] = None
     workspace_id: Optional[int] = None
-    token_response = client.api_tokens()
+    token_response = safe_api_tokens(client)
     if isinstance(token_response, APITokensResponse):
         token_scopes = token_response.scopes
         workspace_id = token_response.workspace_id

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 import urllib3
@@ -167,6 +167,28 @@ def create_session(
     return session
 
 
+def safe_api_tokens(client: GGClient) -> Union[APITokensResponse, Detail]:
+    """Call GGClient.api_tokens() but turn a non-JSON 2xx body into a clean error
+    instead of letting a raw JSONDecodeError escape.
+
+    pygitguardian's api_tokens() calls resp.json() unconditionally when resp.ok;
+    a wrong instance URL can answer a 2xx with the dashboard SPA's HTML, which
+    otherwise crashed callers with an opaque traceback. Mirrors the non-JSON
+    hardening already applied to the auth-login token-claim path.
+    """
+    try:
+        return client.api_tokens()
+    except requests.exceptions.JSONDecodeError as exc:
+        snippet = " ".join((getattr(exc, "doc", "") or "").split())[:100]
+        message = (
+            f"Unexpected non-JSON response from {client.base_uri}. "
+            "Check your instance URL settings."
+        )
+        if snippet:
+            message += f"\nResponse body: {snippet}"
+        raise UnexpectedError(message) from exc
+
+
 def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> None:
     """
     Raises APIKeyCheckError if the API key configured for the client is not usable
@@ -231,7 +253,7 @@ def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> 
     # Check token scopes if required_scopes is not empty
     if required_scopes:
         try:
-            response = client.api_tokens()
+            response = safe_api_tokens(client)
         except requests.exceptions.ConnectionError as e:
             raise ServiceUnavailableError(
                 message="Failed to connect to GitGuardian server. Check your"

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import requests
 import urllib3
@@ -167,26 +167,41 @@ def create_session(
     return session
 
 
+def _non_json_error(
+    url: Optional[str], exc: requests.exceptions.JSONDecodeError
+) -> UnexpectedError:
+    """Build a clear error for a non-JSON body, with a snippet of what came back."""
+    snippet = " ".join((getattr(exc, "doc", "") or "").split())[:100]
+    message = (
+        f"Unexpected non-JSON response from {url}. Check your instance URL settings."
+    )
+    if snippet:
+        message += f"\nResponse body: {snippet}"
+    return UnexpectedError(message)
+
+
 def safe_api_tokens(client: GGClient) -> Union[APITokensResponse, Detail]:
     """Call GGClient.api_tokens() but turn a non-JSON 2xx body into a clean error
     instead of letting a raw JSONDecodeError escape.
 
     pygitguardian's api_tokens() calls resp.json() unconditionally when resp.ok;
     a wrong instance URL can answer a 2xx with the dashboard SPA's HTML, which
-    otherwise crashed callers with an opaque traceback. Mirrors the non-JSON
-    hardening already applied to the auth-login token-claim path.
+    otherwise crashed callers with an opaque traceback.
     """
     try:
         return client.api_tokens()
     except requests.exceptions.JSONDecodeError as exc:
-        snippet = " ".join((getattr(exc, "doc", "") or "").split())[:100]
-        message = (
-            f"Unexpected non-JSON response from {client.base_uri}. "
-            "Check your instance URL settings."
-        )
-        if snippet:
-            message += f"\nResponse body: {snippet}"
-        raise UnexpectedError(message) from exc
+        raise _non_json_error(client.base_uri, exc) from exc
+
+
+def safe_response_json(response: requests.Response) -> Any:
+    """Parse a JSON response body, raising a clean UnexpectedError that names the
+    instance URL instead of letting a raw JSONDecodeError escape when the body is
+    not JSON (e.g. the dashboard SPA's HTML served on a wrong instance URL)."""
+    try:
+        return response.json()
+    except requests.exceptions.JSONDecodeError as exc:
+        raise _non_json_error(response.url, exc) from exc
 
 
 def check_client_api_key(client: GGClient, required_scopes: set[TokenScope]) -> None:

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -544,6 +544,11 @@ class RequestHandler(BaseHTTPRequestHandler):
             # escapes this handler thread is swallowed by socketserver, leaving
             # the main thread to mistake the callback for a success.
             self._handle_error(error.message)
+        except Exception as error:
+            # Catch-all for the same reason: any exception escaping this handler
+            # thread (e.g. a network error or a KeyError on a malformed body) is
+            # swallowed by socketserver and would be misread as a success.
+            self._handle_error(str(error))
         else:
             self._redirect(
                 urljoin(self.oauth_client.dashboard_url, "authenticated"),

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -18,6 +18,7 @@ from ggshield.core.client import (
     create_client,
     create_client_from_config,
     create_session,
+    safe_response_json,
 )
 from ggshield.core.config import Config, InstanceConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
@@ -363,7 +364,7 @@ class OAuthClient:
         ).get(endpoint="token")
         if not response.ok:
             raise OAuthError("The created token is invalid.")
-        return response.json()
+        return safe_response_json(response)
 
     def _save_token(self, api_token_data: Dict[str, Any]) -> None:
         """

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -6,8 +6,11 @@ from typing import Optional, Set
 from unittest.mock import Mock
 
 import pytest
+import requests.exceptions
+from pygitguardian import GGClient
 
 from ggshield.__main__ import cli
+from ggshield.cmd.auth.login import _warn_missing_scopes
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
@@ -1328,3 +1331,22 @@ class TestAuthLoginOob:
         result = cli_fs_runner.invoke(cli, cmd, color=False)
         assert result.exit_code != 0
         assert "'no-browser' is not one of 'token', 'web', 'oob'" in result.output
+
+
+def test_warn_missing_scopes_swallows_non_json_body(capsys):
+    """
+    GIVEN a just-logged-in client whose api_tokens() hits a non-JSON 2xx body
+    WHEN _warn_missing_scopes() is called (best-effort, post-login)
+    THEN it neither crashes nor prints a misleading "scopes not granted" warning
+    """
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "https://dashboard.example.com"
+    client_mock.api_tokens.side_effect = requests.exceptions.JSONDecodeError(
+        "Expecting value: line 1 column 1 (char 0)",
+        "<!doctype html><html></html>",
+        0,
+    )
+
+    _warn_missing_scopes(client_mock)  # must not raise
+
+    assert "scopes were not granted" not in capsys.readouterr().err

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 import requests.exceptions
 from pygitguardian import GGClient
+from pygitguardian.models import Detail
 
 from ggshield.__main__ import cli
 from ggshield.cmd.auth.login import _warn_missing_scopes
@@ -143,6 +144,30 @@ class TestAuthLoginToken:
                 assert "Authentication failed with token." in result.output
             assert instance not in config_instance_urls
 
+        self._request_mock.assert_all_requests_happened()
+
+    def test_auth_login_token_non_json_response(self, monkeypatch, cli_fs_runner):
+        """
+        GIVEN a wrong instance URL whose /v1/token answers a 2xx with HTML
+            (the dashboard SPA) instead of JSON
+        WHEN the auth login command is called with --method=token
+        THEN it fails with a clean error, not a raw JSONDecodeError traceback
+        """
+        token = "mysupertoken"
+        instance = "https://dashboard.gitguardian.com"
+        cmd = ["auth", "login", "--method=token", f"--instance={instance}"]
+        self._request_mock.add_GET(
+            TOKEN_ENDPOINT,
+            create_html_response(
+                "<!doctype html><html><body>GitGuardian</body></html>"
+            ),
+        )
+
+        result = cli_fs_runner.invoke(cli, cmd, color=False, input=token + "\n")
+
+        assert result.exit_code != 0
+        assert not isinstance(result.exception, requests.exceptions.JSONDecodeError)
+        assert "instance URL" in result.output
         self._request_mock.assert_all_requests_happened()
 
     def test_auth_login_token_missing_default_scopes(self, monkeypatch, cli_fs_runner):
@@ -1346,6 +1371,36 @@ def test_warn_missing_scopes_swallows_non_json_body(capsys):
         "<!doctype html><html></html>",
         0,
     )
+
+    _warn_missing_scopes(client_mock)  # must not raise
+
+    assert "scopes were not granted" not in capsys.readouterr().err
+
+
+def test_warn_missing_scopes_silent_on_error_detail(capsys):
+    """
+    GIVEN a client whose api_tokens() returns an error Detail (e.g. 401)
+    WHEN _warn_missing_scopes() is called
+    THEN it does not warn about "missing" scopes it never managed to read
+    """
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "https://dashboard.example.com"
+    client_mock.api_tokens.return_value = Detail("Unauthorized", 401)
+
+    _warn_missing_scopes(client_mock)
+
+    assert "scopes were not granted" not in capsys.readouterr().err
+
+
+def test_warn_missing_scopes_swallows_connection_error(capsys):
+    """
+    GIVEN a transient network error while fetching token info post-login
+    WHEN _warn_missing_scopes() is called (best-effort, after login succeeded)
+    THEN it neither crashes nor warns
+    """
+    client_mock = Mock(spec=GGClient)
+    client_mock.base_uri = "https://dashboard.example.com"
+    client_mock.api_tokens.side_effect = requests.exceptions.ConnectionError("boom")
 
     _warn_missing_scopes(client_mock)  # must not raise
 

--- a/tests/unit/cmd/test_status.py
+++ b/tests/unit/cmd/test_status.py
@@ -3,14 +3,16 @@ from unittest import mock
 
 import jsonschema
 import pytest
+import requests.exceptions
 from pygitguardian.models import APITokensResponse, Detail, HealthCheckResponse
 from pytest_voluptuous import S
 from voluptuous.validators import All, In, Match
 
 from ggshield.__main__ import cli
 from ggshield.core.config.config import ConfigSource
+from ggshield.core.errors import ExitCode
 from ggshield.utils.os import cd
-from tests.unit.conftest import assert_invoke_ok, my_vcr
+from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok, my_vcr
 
 
 def test_quota(cli_fs_runner, quota_json_schema):
@@ -238,3 +240,32 @@ def test_api_status_scopes_omitted_on_error(
     assert_invoke_ok(result)
     assert "Token scopes:" not in result.output
     assert "Workspace ID:" not in result.output
+
+
+@mock.patch(
+    "pygitguardian.GGClient.api_tokens",
+    side_effect=requests.exceptions.JSONDecodeError(
+        "Expecting value: line 1 column 1 (char 0)",
+        "<!doctype html><html><body>GitGuardian</body></html>",
+        0,
+    ),
+)
+@mock.patch(
+    "pygitguardian.GGClient.health_check",
+    return_value=HealthCheckResponse(detail="Valid API key.", status_code=200),
+)
+def test_api_status_reports_clean_error_on_non_json_body(
+    health_check_mock, api_tokens_mock, cli_fs_runner
+):
+    """
+    GIVEN an instance URL that returns a non-JSON 2xx body (e.g. the SPA HTML),
+        so api_tokens() would raise a raw JSONDecodeError
+    WHEN running api-status
+    THEN the command fails with a clean, actionable error mentioning the
+        instance URL, not a raw JSONDecodeError traceback
+    """
+    result = cli_fs_runner.invoke(cli, ["api-status"], color=False)
+
+    assert_invoke_exited_with(result, ExitCode.UNEXPECTED_ERROR)
+    assert "instance URL" in result.output
+    assert not isinstance(result.exception, requests.exceptions.JSONDecodeError)

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -20,6 +20,7 @@ from ggshield.core.client import (
     check_client_api_key,
     create_client_from_config,
     create_session,
+    safe_api_tokens,
 )
 from ggshield.core.config import Config
 from ggshield.core.errors import (
@@ -157,6 +158,85 @@ def test_check_client_api_key_with_source_uuid_unexpected_response():
     client_mock.api_tokens.return_value = "unexpected_response_type"
 
     with pytest.raises(UnexpectedError, match="Unexpected api_tokens response"):
+        check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
+
+
+# Body the dashboard SPA serves when the API URL is wrong (a 2xx with HTML).
+_NON_JSON_BODY = "<!doctype html><html><body>GitGuardian</body></html>"
+
+
+def _json_decode_error() -> requests.exceptions.JSONDecodeError:
+    """Build the error requests' Response.json() raises on a non-JSON body."""
+    return requests.exceptions.JSONDecodeError(
+        "Expecting value: line 1 column 1 (char 0)", _NON_JSON_BODY, 0
+    )
+
+
+def test_safe_api_tokens_passes_through_token_response():
+    """
+    GIVEN api_tokens() returning a valid APITokensResponse
+    WHEN safe_api_tokens() is called
+    THEN the response is returned unchanged
+    """
+    client_mock = _make_client_mock()
+    response = APITokensResponse.from_dict(
+        {
+            "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
+            "name": "test-name",
+            "workspace_id": 1,
+            "type": "personal_access_token",
+            "status": "active",
+            "created_at": "2023-01-01T00:00:00Z",
+            "scopes": [TokenScope.SCAN_CREATE_INCIDENTS.value],
+        }
+    )
+    client_mock.api_tokens.return_value = response
+
+    assert safe_api_tokens(client_mock) is response
+
+
+def test_safe_api_tokens_passes_through_detail():
+    """
+    GIVEN api_tokens() returning an error Detail (e.g. 401)
+    WHEN safe_api_tokens() is called
+    THEN the Detail is returned unchanged (callers keep their own handling)
+    """
+    client_mock = _make_client_mock()
+    detail = Detail("Unauthorized", 401)
+    client_mock.api_tokens.return_value = detail
+
+    assert safe_api_tokens(client_mock) is detail
+
+
+def test_safe_api_tokens_non_json_body_raises_clean_error():
+    """
+    GIVEN api_tokens() raising a raw JSONDecodeError on a non-JSON 2xx body
+    WHEN safe_api_tokens() is called
+    THEN it raises a clean UnexpectedError naming the instance URL,
+        not the raw JSONDecodeError
+    """
+    client_mock = _make_client_mock()
+    client_mock.api_tokens.side_effect = _json_decode_error()
+
+    with pytest.raises(UnexpectedError) as exc_info:
+        safe_api_tokens(client_mock)
+
+    message = str(exc_info.value)
+    assert client_mock.base_uri in message
+    assert "instance URL" in message
+
+
+def test_check_client_api_key_non_json_body_raises_clean_error():
+    """
+    GIVEN a valid API key but api_tokens() hitting a non-JSON 2xx body
+    WHEN check_client_api_key() is called with a required scope
+    THEN it raises a clean UnexpectedError instead of crashing with JSONDecodeError
+    """
+    client_mock = _make_client_mock()
+    client_mock.read_metadata.return_value = None  # Success
+    client_mock.api_tokens.side_effect = _json_decode_error()
+
+    with pytest.raises(UnexpectedError, match="instance URL"):
         check_client_api_key(client_mock, {TokenScope.SCAN_CREATE_INCIDENTS})
 
 

--- a/tests/unit/verticals/auth/test_oauth.py
+++ b/tests/unit/verticals/auth/test_oauth.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 from urllib import parse as urlparse
 
 import pytest
+import requests.exceptions
 
 from ggshield.core.config import Config
 from ggshield.core.errors import UnexpectedError
@@ -121,6 +122,40 @@ def test_request_handler_records_unexpected_error(monkeypatch):
 
     assert client._request_finished is True
     assert client._request_error_message == error_message
+
+
+def test_request_handler_records_arbitrary_exception(monkeypatch):
+    """
+    GIVEN a localhost OAuth callback whose processing raises an exception that
+          is neither OAuthError nor UnexpectedError (e.g. a network error, or a
+          KeyError on a malformed-but-valid-JSON body)
+    WHEN the local request handler processes the callback
+    THEN the error is still recorded on the client instead of escaping the
+         handler thread — socketserver would otherwise swallow it and
+         _wait_for_callback() would report a misleading success
+    """
+    client = OAuthClient(Config(), "https://dashboard.gitguardian.com")
+    error_message = "Connection reset by peer"
+
+    def raise_arbitrary(_callback_url):
+        raise requests.exceptions.ConnectionError(error_message)
+
+    monkeypatch.setattr(client, "process_callback", raise_arbitrary)
+
+    handler = RequestHandler.__new__(RequestHandler)
+    handler.oauth_client = client
+    handler.path = "/?code=some_code&state=some_state"
+    handler.send_response = Mock()
+    handler.send_header = Mock()
+    handler.end_headers = Mock()
+    handler.wfile = Mock()
+
+    # The handler must not let the exception escape the request thread.
+    handler.do_GET()
+
+    assert client._request_finished is True
+    assert client._request_error_message is not None
+    assert error_message in client._request_error_message
 
 
 def test_print_login_success_without_account_raises_cleanly():


### PR DESCRIPTION
## Summary

`ggshield api-status` (and other commands that read token scopes) crashed with a raw `requests.exceptions.JSONDecodeError` traceback when the GitGuardian API returned a **2xx with a non-JSON body** — e.g. the dashboard SPA's HTML, served when the instance URL is wrong. The same unguarded `response.json()` pattern existed in the `auth login` token-claim / token-validate paths.

Root cause is in pygitguardian (`GGClient.api_tokens()` calls `resp.json()` unconditionally on `resp.ok`), a pinned dependency — so this PR hardens the **ggshield** side. The complementary root-cause fix is in GitGuardian/py-gitguardian#184.

### Changes

**`api_tokens()` callers**
- New `safe_api_tokens()` (`core/client.py`): converts a non-JSON `JSONDecodeError` into a clean `UnexpectedError` naming the instance URL (+ a body snippet); passes `APITokensResponse` / `Detail` through unchanged.
- Routed through it: `api-status` (`cmd/status.py`), `check_client_api_key` (`core/client.py`), and the post-login `_warn_missing_scopes` (`cmd/auth/login.py`).

**Raw `response.json()` in the auth-login flow**
- New `safe_response_json()` (shares the `_non_json_error()` message builder with `safe_api_tokens`).
- Routed through it: `token_login()` (`auth login --method token`) and `OAuthClient._validate_access_token()`.

**`_warn_missing_scopes()` hardening**
- Swallows any `RequestException` — a post-login network blip must not crash an already-successful login.
- Skips the warning on an error `Detail` instead of reporting every default scope as "missing".

**Browser / localhost OAuth callback handler**
- `RequestHandler.do_GET()` gains a catch-all: any exception escaping the callback handler thread (not just `UnexpectedError`) is routed through `_handle_error()` instead of being swallowed by `socketserver` and misread as a login success.

## Test plan
- [x] `safe_api_tokens` / `safe_response_json` unit tests: non-JSON → clean error; valid response / error `Detail` pass through
- [x] `api-status`: non-JSON 2xx → exit 128 with an "instance URL" message, no raw traceback
- [x] `check_client_api_key`: non-JSON → clean `UnexpectedError`
- [x] `auth login --method token`: non-JSON 2xx → clean error, no traceback
- [x] `_warn_missing_scopes`: swallows non-JSON / `ConnectionError`; silent on an error `Detail`
- [x] `RequestHandler.do_GET`: an arbitrary callback exception is recorded (no swallowed false-success)
- [x] Existing scopes-omitted-on-error test still passes (normal error `Detail` tolerated)
- [x] Full unit suite: **2171 passed**; `black` / `isort` / `flake8` / `pyright` clean
