### PR TITLE
feat(ai): send number of secrets detected by ai agent hook

### DIFF
--- a/changelog.d/20260622_173553_paul.beslin-ext_ai_hook_secrets_count.md
+++ b/changelog.d/20260622_173553_paul.beslin-ext_ai_hook_secrets_count.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- AI hooks now send an event to the GitGuardian API when they detect a secret, with some metadata, excluding the secret value.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -16,6 +16,7 @@ from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
 from ggshield.verticals.ai.mcp import send_mcp_activity
+from ggshield.verticals.ai.secret_block import send_secret_block
 
 from .agents import AGENTS
 from .models import Agent, EventType, HookPayload, HookResult, Tool
@@ -315,6 +316,15 @@ class AIHookScanner:
         result = self._scan_payloads(payloads)
         payload = result.payload
 
+        # Report number of secrets found and blocked by the hook
+        if result.block and result.nbr_secrets > 0:
+            send_secret_block(
+                self.scanner.client,
+                payload,
+                result.detectors,
+                result.nbr_secrets,
+            )
+
         # Sometimes the secret has already leaked to the agent. Notify the user.
         if result.block and payload.agent.has_secret_already_leaked(payload):
             self._send_secret_notification(result)
@@ -381,6 +391,7 @@ class AIHookScanner:
             message=message,
             nbr_secrets=len(secrets),
             payload=payload,
+            detectors=sorted({secret.detector_display_name for secret in secrets}),
         )
 
     @staticmethod

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -60,6 +60,9 @@ class HookResult:
     # Set when the action is allowed but the user must be warned,
     # typically because the scan could not run at all.
     warning: str = ""
+    # Display names of the detectors that matched, when the action was blocked
+    # because it contained secrets.
+    detectors: List[str] = field(default_factory=list)
 
     @classmethod
     def allow(cls, payload: "HookPayload") -> "HookResult":

--- a/ggshield/verticals/ai/secret_block.py
+++ b/ggshield/verticals/ai/secret_block.py
@@ -1,0 +1,40 @@
+import logging
+from typing import List
+
+from pygitguardian import GGClient
+from pygitguardian.models import SecretBlockRequest
+
+from ggshield.verticals.ai.user import get_user_info
+
+from .models import HookPayload
+
+
+logger = logging.getLogger(__name__)
+
+
+def send_secret_block(
+    client: GGClient,
+    payload: HookPayload,
+    detectors: List[str],
+    secret_count: int,
+) -> None:
+    """Report a secret blocked by an AI hook to the GitGuardian API.
+
+    Best effort: a failure here must never break the hook. This is only called
+    on the (rare) block path, where the agent is already halted for the user to
+    remove the secret, so the extra round-trip is not on the hot path.
+    """
+    try:
+        request = SecretBlockRequest(
+            user=get_user_info(),
+            tool=payload.raw.get("tool_name", ""),
+            agent=payload.agent.name,
+            cwd=payload.raw.get("cwd", ""),
+            secret_count=secret_count,
+            detectors=detectors,
+            timestamp=payload.timestamp,
+        )
+        client.log_secret_block(request)
+    except Exception as exc:
+        # Best effort: never propagate telemetry failures to the agent.
+        logger.debug("Secret block report failed: %s", exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "marshmallow-dataclass~=8.7.0",
     "oauthlib~=3.2.1",
     "packaging>=22.0",
-    "pygitguardian~=1.32.0",
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@a6330fc1c43d3b2fdb741e682dbc740ebe72c83c",
     "pyjwt~=2.6.0",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -126,6 +126,45 @@ class TestAIHookScannerScanContent:
         assert "remove the secrets from your prompt" in result.message
 
 
+class TestAIHookScannerSecretBlock:
+    """scan() reports a secret-block event on the block path, best-effort."""
+
+    @patch("ggshield.verticals.ai.hooks.send_secret_block")
+    def test_secret_block_reports_event(self, mock_send: MagicMock):
+        scanner = AIHookScanner(_mock_scanner(["sk-xxx"]))
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo sk-xxx"},
+            "cwd": "/home/dev/project",
+            "session_id": "427ae0c5-0862-4e14-aa2c-12fad909c323",
+            "transcript_path": "/home/user/.claude/projects/foo/session.jsonl",
+        }
+
+        scanner.scan(json.dumps(data))
+
+        mock_send.assert_called_once()
+        _client, payload, detectors, secret_count = mock_send.call_args[0]
+        assert detectors == ["dummy-detector"]
+        assert secret_count == 1
+        assert payload.raw.get("tool_name") == "Bash"
+        assert payload.raw.get("cwd") == "/home/dev/project"
+
+    @patch("ggshield.verticals.ai.hooks.send_secret_block")
+    def test_allow_does_not_report(self, mock_send: MagicMock):
+        scanner = AIHookScanner(_mock_scanner([]))
+        data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "hello world",
+            "transcript_path": "/home/user/.claude/projects/foo/session.jsonl",
+            "cursor_version": "1.2.3",
+        }
+
+        scanner.scan(json.dumps(data))
+
+        mock_send.assert_not_called()
+
+
 class TestHasAlreadyBeenSeen:
     def test_first_call_is_not_duplicate(self):
         assert has_already_been_seen('{"hook_event_name": "PreToolUse"}') is False

--- a/tests/unit/verticals/ai/test_secret_block.py
+++ b/tests/unit/verticals/ai/test_secret_block.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+from pygitguardian.models import SecretBlockRequest, UserInfo
+
+from ggshield.verticals.ai.models import EventType, HookPayload, Tool
+from ggshield.verticals.ai.secret_block import send_secret_block
+
+
+def _user() -> UserInfo:
+    return UserInfo(
+        hostname="host", username="user", machine_id="mid", user_email="u@e.com"
+    )
+
+
+def _payload() -> HookPayload:
+    agent = MagicMock()
+    agent.name = "claude"
+    return HookPayload(
+        event_type=EventType.PRE_TOOL_USE,
+        tool=Tool.OTHER,
+        content="content",
+        identifier="id",
+        agent=agent,
+        raw={"tool_name": "Write", "cwd": "/home/dev/project"},
+    )
+
+
+class TestSendSecretBlock:
+    @patch("ggshield.verticals.ai.secret_block.get_user_info")
+    def test_sends_expected_request(self, mock_user: MagicMock):
+        mock_user.return_value = _user()
+        client = MagicMock()
+        client.log_secret_block.return_value = None
+
+        send_secret_block(client, _payload(), ["AWS Keys", "GitHub Token"], 2)
+
+        client.log_secret_block.assert_called_once()
+        request = client.log_secret_block.call_args[0][0]
+        assert isinstance(request, SecretBlockRequest)
+        assert request.agent == "claude"
+        assert request.tool == "Write"
+        assert request.cwd == "/home/dev/project"
+        assert request.secret_count == 2
+        assert request.detectors == ["AWS Keys", "GitHub Token"]
+
+    @patch("ggshield.verticals.ai.secret_block.get_user_info")
+    def test_fail_open_swallows_errors(self, mock_user: MagicMock):
+        mock_user.return_value = _user()
+        client = MagicMock()
+        client.log_secret_block.side_effect = Exception("boom")
+
+        # Must not raise: a telemetry failure should never break the hook.
+        send_secret_block(client, _payload(), ["AWS Keys"], 1)

--- a/uv.lock
+++ b/uv.lock
@@ -1093,7 +1093,7 @@ requires-dist = [
     { name = "oauthlib", specifier = "~=3.2.1" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", specifier = "~=1.32.0" },
+    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=a6330fc1c43d3b2fdb741e682dbc740ebe72c83c" },
     { name = "pyjwt", specifier = "~=2.6.0" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
@@ -2823,7 +2823,7 @@ wheels = [
 [[package]]
 name = "pygitguardian"
 version = "1.32.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=a6330fc1c43d3b2fdb741e682dbc740ebe72c83c#a6330fc1c43d3b2fdb741e682dbc740ebe72c83c" }
 dependencies = [
     { name = "marshmallow", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "marshmallow", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2831,10 +2831,6 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/58/17a8fb8459871f0a7a758a64f492a282a1251b629789a6f72d80a6831fc4/pygitguardian-1.32.0.tar.gz", hash = "sha256:2bc9880c139dee3692bff369a10d42e99f58e4122358ce0d632b51e250e90252", size = 57374, upload-time = "2026-06-16T13:27:06.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/4a/b26702ad735fa24b0b93bfbb64cbe6a4a761304a767e8b3ce4b890dd8f6d/pygitguardian-1.32.0-py3-none-any.whl", hash = "sha256:7f0549565a4a7ef13be2ced9b2fd787cfe402bdd169c3e40e8057a63e0c06bf6", size = 23910, upload-time = "2026-06-16T13:27:05.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

Depends on https://github.com/GitGuardian/py-gitguardian/pull/185  
When an AI agent hook blocks a secret, an event is sent to the GitGuardian API with metadata on the hook execution (including the number of secrets detected, but not their values).

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
