### PR TITLE
build(deps): bump pyjwt to 2.13.0 and idna to 3.18 for security

### DIFF
--- a/changelog.d/20260623_113411_benjamin.rigaud_bump_pyjwt_idna_security.md
+++ b/changelog.d/20260623_113411_benjamin.rigaud_bump_pyjwt_idna_security.md
@@ -1,0 +1,3 @@
+### Security
+
+- Bumped `pyjwt` to 2.13.0 (clears CVE-2026-48526, CVE-2026-32597, CVE-2026-48522 and CVE-2026-48524) and `idna` to 3.18 (clears CVE-2026-45409). Both still support Python 3.9, so the fixes apply on every supported interpreter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "oauthlib~=3.2.1",
     "packaging>=22.0",
     "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@2c89d05d6ca1abd4f660bb0cd656216c12c200b1",
-    "pyjwt~=2.6.0",
+    "pyjwt>=2.13.0,<3",
     "python-dotenv~=0.21.0",
     "pyyaml~=6.0.1",
     "requests~=2.32.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-20T10:57:10.954903665Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1094,7 +1094,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
     { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=2c89d05d6ca1abd4f660bb0cd656216c12c200b1" },
-    { name = "pyjwt", specifier = "~=2.6.0" },
+    { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-dotenv", specifier = "~=0.21.0" },
     { name = "pyyaml", specifier = "~=6.0.1" },
     { name = "requests", specifier = "~=2.32.0" },
@@ -1300,11 +1300,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2887,11 +2887,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.6.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/65/db64904a7f23e12dbf0565b53de01db04d848a497c6c9b87e102f74c9304/PyJWT-2.6.0.tar.gz", hash = "sha256:69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd", size = 72984, upload-time = "2022-10-20T01:09:12.296Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/46/505f0dd53c14096f01922bf93a7abb4e40e29a06f858abbaa791e6954324/PyJWT-2.6.0-py3-none-any.whl", hash = "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14", size = 20316, upload-time = "2022-10-20T01:09:09.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- **pyjwt** 2.6.0 → **2.13.0** (pin relaxed `~=2.6.0` → `>=2.13.0,<3`)
- **idna** 3.11 → **3.18** (transitive, lock-only)

Both fix versions still support **Python 3.9**, so — unlike the urllib3/cryptography bumps — these clear their advisories on *every* supported interpreter (single locked version, no 3.9 fork residue).

## Why

| Package | Clears | Note |
|---|---|---|
| pyjwt 2.13.0 | CVE-2026-48526 (HS256 forgery via public-key JWK), CVE-2026-32597 (unknown `crit` headers), CVE-2026-48522 + CVE-2026-48524 (PyJWKClient SSRF/DoS) | floor raised to `>=2.13.0` so `pip install ggshield` users get the fix |
| idna 3.18 | CVE-2026-45409 (`idna.encode` DoS) | ≥ the 3.15 patch |

## Practical impact

Low. ggshield only uses `jwt.decode(..., options={"verify_signature": False})` (HMSL expiry check) — no `PyJWKClient`, no signature/algorithm handling — so the pyjwt CVEs weren't reachable; idna is transitive (via requests) for the operator-configured host. This is hygiene + clearing the alert backlog.

## Verification

- 928 unit tests pass locally (HMSL + cmd/hmsl + core) on Python 3.12.
- Lock diff is contained to pyjwt + idna; both resolve to a single version across all forks.

Supersedes Dependabot PRs #1286 and #1246.