### PR TITLE
ci: add codecov.yml to stop false project reds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+# Tuned for ggshield's 15-job CI matrix (3 OS × 5 Python), each uploading coverage.xml.
+codecov:
+  notify:
+    after_n_builds: 15 # wait for every matrix upload before posting, else partial uploads read as coverage drops
+    wait_for_ci: true
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true # not a required gate: report coverage, never red on cross-matrix merge variance
+    patch:
+      default:
+        target: 80% # new code must be tested; mirrors the per-job `coverage report --fail-under=80`
+comment:
+  require_changes: true # only comment when coverage actually moves


### PR DESCRIPTION
## Summary

Adds a `codecov.yml` to ggshield (previously none, so codecov ran on zero-tolerance defaults). On the 15-job matrix (3 OS × 5 Python), `codecov/project` false-failed on partial uploads + cross-matrix variance — e.g. #1309 showed `project 93.36% (-0.31%)` red while `patch` was 100%.

- `project` → `informational: true`: reports coverage but never reds. It isn't a required check; the real floor stays the per-job `coverage report --fail-under=80`.
- `after_n_builds: 15` + `wait_for_ci: true`: wait for all matrix uploads before posting.
- `patch.target: 80%`: keeps the meaningful "is new code tested?" gate.
- `comment.require_changes: true`: only comment when coverage moves.

Validated against codecov's validator (returns `Valid!`).

Refs END-595