### PR TITLE
fix(ai): use the documented catch-all matcher for AI hooks

### DIFF
--- a/changelog.d/20260623_150000_achille.mascia_ai_hook_matcher.md
+++ b/changelog.d/20260623_150000_achille.mascia_ai_hook_matcher.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The AI hook configuration written for Claude Code, Codex, Copilot and VS Code now uses the documented catch-all matcher `"*"` instead of `".*"`. Re-running the install over an existing `".*"` configuration migrates it in place instead of adding a duplicate hook entry.

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -166,7 +166,7 @@ class Agent(ABC):
             "hooks": {
                 "PreToolUse": [
                     {
-                        "matcher": ".*",
+                        "matcher": "*",
                         "hooks": [
                             {
                                 "type": "command",
@@ -177,7 +177,7 @@ class Agent(ABC):
                 ],
                 "PostToolUse": [
                     {
-                        "matcher": ".*",
+                        "matcher": "*",
                         "hooks": [
                             {
                                 "type": "command",
@@ -188,7 +188,7 @@ class Agent(ABC):
                 ],
                 "UserPromptSubmit": [
                     {
-                        "matcher": ".*",
+                        "matcher": "*",
                         "hooks": [
                             {
                                 "type": "command",
@@ -221,6 +221,16 @@ class Agent(ABC):
             for obj in candidates:
                 if obj.get("matcher") == template["matcher"]:
                     return obj
+            # Migration: an earlier ggshield install may have written a
+            # different matcher value (we standardized ".*" -> "*"). Reuse the
+            # block that already holds a ggshield hook instead of appending a
+            # duplicate block with the new matcher.
+            for obj in candidates:
+                for hook in obj.get("hooks", []):
+                    if isinstance(hook, dict) and "ggshield" in str(
+                        hook.get("command", "")
+                    ):
+                        return obj
             return None
         for obj in candidates:
             command = obj.get("command", "")

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -256,6 +256,35 @@ class TestFlavorSettingsProperties:
         template = {"matcher": ".*"}
         assert claude.settings_locate(candidates, template) is None
 
+    def test_claude_settings_template_uses_catch_all_matcher(self):
+        """The template matcher must be '*' (Claude's match-all), not '.*'."""
+        matchers = [
+            block["matcher"]
+            for hooks in Claude().settings_template["hooks"].values()
+            for block in hooks
+        ]
+        assert matchers, "expected at least one matcher block"
+        assert all(matcher == "*" for matcher in matchers)
+
+    def test_claude_settings_locate_reuses_legacy_matcher_block(self):
+        """A block installed with the old '.*' matcher is reused, not duplicated.
+
+        Existing installs wrote 'matcher': '.*'. When setup re-runs with the new
+        '*' template, the legacy block (holding the ggshield hook) must be found
+        so we update it in place instead of appending a duplicate '*' block.
+        """
+        claude = Claude()
+        legacy_block = {
+            "matcher": ".*",
+            "hooks": [{"type": "command", "command": "ggshield secret scan ai-hook"}],
+        }
+        candidates = [
+            {"matcher": "Bash", "hooks": [{"command": "other"}]},
+            legacy_block,
+        ]
+        template = {"matcher": "*", "hooks": [{"command": "<COMMAND>"}]}
+        assert claude.settings_locate(candidates, template) is legacy_block
+
     def test_claude_settings_locate_no_matcher_no_match_returns_none(self):
         claude = Claude()
         candidates = [
@@ -352,6 +381,41 @@ class TestInstallHooks:
         assert "hooks" in config
         for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit"):
             assert key in config["hooks"]
+            assert config["hooks"][key][0]["matcher"] == "*"
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_install_claude_global_migrates_legacy_matcher(
+        self, mock_home: Any, tmp_path: Path
+    ):
+        """Re-installing over a legacy '.*' config must not duplicate the hook."""
+        mock_home.return_value = tmp_path
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        legacy = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "ggshield secret scan ai-hook",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        settings_path.write_text(json.dumps(legacy))
+
+        assert install_hooks("claude-code", mode="global") == 0
+
+        config = json.loads(settings_path.read_text())
+        # Still exactly one PreToolUse block (the legacy one reused), not two.
+        assert len(config["hooks"]["PreToolUse"]) == 1
+        block = config["hooks"]["PreToolUse"][0]
+        ggshield_hooks = [h for h in block["hooks"] if "ggshield" in h["command"]]
+        assert len(ggshield_hooks) == 1
 
     @patch("ggshield.verticals.ai.installation.get_user_home_dir")
     def test_install_copilot_global(self, mock_home: Any, tmp_path: Path):


### PR DESCRIPTION
## Context

A security engineer deploying AI hooks via MDM noted that ggshield writes `"matcher": ".*"` into the Claude hook config — non-standard and undocumented ([Slack thread](https://gitguardian.slack.com/archives/C0BAQGFKH4Y/p1781181048632349)). Per the hook spec, the match-all idiom is `"*"` (or omitted); `".*"` only works as an incidental catch-all regex.

This matcher lives in the **shared** `Agent.settings_template`, so it affects **Claude Code, Codex, Copilot and VS Code** (Copilot via VS Code). **Cursor is unaffected** — it overrides the template and has no `matcher`.

## What this PR does

- Switch the shared template's matcher from `".*"` to `"*"`.
- Make `settings_locate` reuse an existing ggshield hook block even when its matcher differs from the template (e.g. a legacy `".*"`), so re-running `install` / `machine setup` over an old config **migrates it in place** instead of appending a duplicate hook block.

## Validation

- New unit tests: template uses `*`; a legacy `.*` block is reused by `settings_locate`; re-installing over a legacy `.*` config does not duplicate the hook.
- 340 AI-vertical tests pass; black / isort / flake8 / pyright clean.

## Note for reviewers

`"*"` is the documented match-all for Claude Code. Codex / Copilot / VS Code share the same template (and hook schema), so it applies to them too — please confirm against their hook specs if you know of any divergence.

## PR check list

- [x] The changes include tests (unit)
- [x] Changelog entry added (`changelog.d/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
