### PR TITLE
test: deflake the unit suite under pytest -n auto

### DIFF
--- a/ggshield/core/ui/log_utils.py
+++ b/ggshield/core/ui/log_utils.py
@@ -50,8 +50,12 @@ def set_log_handler(filename: Optional[str] = None) -> None:
 
 
 def _reset_log_handler():
-    """Remove our log handler. Used by reset.reset()."""
+    """Remove our log handler and re-enable logging. Used by reset.reset()."""
     global _log_handler
+    # __main__.main() calls disable_logs() on every run, including from unit
+    # tests; re-enable here so logging isn't left globally disabled for the next
+    # test (which would silence its caplog assertions).
+    logging.disable(logging.NOTSET)
     if _log_handler:
         logging.getLogger().removeHandler(_log_handler)
         _log_handler = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -723,8 +723,11 @@ def no_api_key(monkeypatch):
     monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def cache() -> Cache:
+    # Function-scoped so it is built after _isolate_cache_path has redirected
+    # CACHE_PATH into the test's tmp_path (a session cache would write the
+    # shared .cache_ggshield into the CWD).
     c = Cache()
     c.purge()
     return c
@@ -824,6 +827,18 @@ def clear_cache():
     _get_git_path.cache_clear()
     _git_rev_parse_absolute.cache_clear()
     read_git_file.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_path(monkeypatch, tmp_path):
+    """Point the secrets cache into the test's tmp_path.
+
+    Without this, ``Cache()`` writes ``.cache_ggshield`` relative to the CWD,
+    which all xdist workers share, leading to interleaved/corrupted JSON.
+    """
+    monkeypatch.setattr(
+        "ggshield.core.cache.CACHE_PATH", str(tmp_path / ".cache_ggshield")
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/core/test_cache.py
+++ b/tests/unit/core/test_cache.py
@@ -14,6 +14,17 @@ from ggshield.utils.os import cd
 from tests.repository import Repository
 
 
+@pytest.fixture(autouse=True)
+def _isolate_cache_path():
+    """Opt out of conftest's CACHE_PATH redirection.
+
+    These tests exercise Cache's path/gitignore behaviour and manage the cache
+    location themselves (via isolated_fs or cd into tmp_path), so the default
+    relative ``./.cache_ggshield`` must be kept.
+    """
+    yield
+
+
 @pytest.mark.usefixtures("isolated_fs")
 class TestCache:
     def test_defaults(self):


### PR DESCRIPTION
## What

Fixes two independent causes of unit-suite flakiness under `pytest -n auto` (each reproduced deterministically). These were the intermittent "Run unit tests" failures on `main`.

### 1. Global `logging.disable()` leaking between tests
`__main__.main()` calls `disable_logs()` (a process-wide `logging.disable()`) on every run, including when unit tests invoke it via `main(args=...)`. The per-test UI reset (`reset()`, run by an autouse fixture) removed the log handler but never reverted the disable — so logging stayed globally disabled for later tests in the same xdist worker, and `caplog`-based tests captured nothing and failed with `IndexError: list index out of range` (e.g. `test_load_last_check_time_swallows_errors`, the `test_id_cache` cannot-be-read/written tests).

→ Re-enable logging in `_reset_log_handler()` so every test starts with logging on.

### 2. Shared `.cache_ggshield` corrupted by concurrent workers
`Cache()` writes `CACHE_PATH` (`"./.cache_ggshield"`, relative to the CWD) non-atomically with no per-test isolation. Under `-n auto` all workers share the repo-root CWD, so they concurrently read/write the same file → interleaved/corrupted JSON → `UnexpectedError` in ~30 tests (`test_secret_scanner`, `test_cmd_ai`, `test_install`). The corrupt file is even written into the working tree.

→ Autouse fixture redirecting `ggshield.core.cache.CACHE_PATH` into each test's `tmp_path`; the `cache` fixture becomes function-scoped so it is built after that redirect. `test_cache.py` opts out (it exercises the real relative path via `isolated_fs`/`cd`).

## Verification
- Each cause reproduced deterministically, then confirmed fixed.
- Full unit suite under `pytest -n auto` run repeatedly (11×+ across the change): **2178 passed, 0 failed, 0 errors** every run (previously ~10–40% of runs failed).
- No `.cache_ggshield` left in the repo root; lint clean.

Test-only change; no production behaviour affected (`reset()` is unit-test-only).