### PR TITLE
fix(scripts): give shell-specific PATH guidance after install

### DIFF
--- a/changelog.d/20260623_210128_clement.tourriere_warn_path_after_install.md
+++ b/changelog.d/20260623_210128_clement.tourriere_warn_path_after_install.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- The Linux/macOS install script now prints shell-specific guidance when `~/.local/bin` is not on your `PATH` (the exact line to add for your shell — zsh/bash/fish/other — plus a reminder to restart your terminal), shown at the end of the run instead of a generic note buried mid-install.
+- The Linux/macOS install script now prints shell-specific guidance, as a visible warning, when `ggshield` won't be callable yet: either `~/.local/bin` is not on your `PATH`, or an older `ggshield` install shadows the new one. In both cases it gives the exact line to add for your shell (zsh/bash/fish/other) plus a reminder to restart your terminal, shown at the end of the run instead of a generic note buried mid-install.

--- a/changelog.d/20260623_210128_clement.tourriere_warn_path_after_install.md
+++ b/changelog.d/20260623_210128_clement.tourriere_warn_path_after_install.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The Linux/macOS install script now prints shell-specific guidance when `~/.local/bin` is not on your `PATH` (the exact line to add for your shell — zsh/bash/fish/other — plus a reminder to restart your terminal), shown at the end of the run instead of a generic note buried mid-install.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -39,6 +39,12 @@ The script installs the standalone build (detecting OS/arch, including Rosetta 2
 - **Windows** → `%LOCALAPPDATA%\Programs\ggshield`, added to your user PATH (no
   admin). `-Method msi` installs the system-wide MSI instead (requires admin).
 
+On Linux/macOS, `~/.local/bin` is not on everyone's `PATH` (notably macOS, and
+Debian/Ubuntu add it only when the directory already existed at login). When it
+isn't, the script doesn't fail — it prints, for your shell, the exact line to
+add and reminds you to **restart your terminal** afterwards. Set `GGSHIELD_BIN_DIR`
+to a directory already on your `PATH` to skip that step.
+
 The download is **checksum-verified** against the digest GitHub publishes for
 each asset (the install aborts if it cannot be verified). [Build provenance
 attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -332,6 +332,9 @@ emit_plugin_hint() {
 # Uses $SHELL (the login shell) rather than $0: this script always runs under
 # bash (curl | bash), which says nothing about the shell the user reopens.
 emit_path_hint() {
+    # The headline goes through warn() (bold yellow, stderr) so it stands out;
+    # as an indented "# ..." comment it blended into the command block below and
+    # users missed it. The commands stay on stdout, unprefixed, to copy-paste cleanly.
     # reload defaults to `source` (zsh/bash); `.` is the POSIX form for the
     # generic-sh fallback. Paths are double-quoted in the emitted commands so a
     # BIN_DIR/rc with spaces still copy-pastes correctly.
@@ -339,7 +342,7 @@ emit_path_hint() {
     case "$(basename "${SHELL:-sh}")" in
     fish)
         # fish persists PATH via universal variables — no file edit, no restart.
-        printf '    # %s is not on your PATH; add it permanently with:\n' "$BIN_DIR"
+        warn "$BIN_DIR is not on your PATH. Add it permanently with:"
         printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
         return 0
         ;;
@@ -363,7 +366,7 @@ emit_path_hint() {
         reload="."
         ;;
     esac
-    printf '    # %s is not on your PATH; add it, then restart your terminal:\n' "$BIN_DIR"
+    warn "$BIN_DIR is not on your PATH. Add it, then restart your terminal:"
     printf '    echo '\''export PATH="%s:$PATH"'\'' >> "%s"\n' "$BIN_DIR" "$rc"
     printf '    # (or apply it to the current shell now: %s "%s")\n' "$reload" "$rc"
     return 0

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -13,6 +13,11 @@
 
 set -euo pipefail
 
+# Every install path (and every PATH hint) is derived from $HOME; fail early
+# with a clear message rather than building paths like /.local/bin under set -u.
+# die() is not defined yet, so emit raw.
+[ -n "${HOME:-}" ] || { printf '\033[1;31merror:\033[0m HOME is not set\n' >&2; exit 1; }
+
 GITHUB_REPO="GitGuardian/ggshield"
 DEFAULT_INSTANCE="https://dashboard.gitguardian.com"
 EU_INSTANCE="https://dashboard.eu1.gitguardian.com"
@@ -25,6 +30,9 @@ STATE_FILE="$STATE_DIR/state"
 
 ASSUME_YES=0
 INSTALL_ONLY=0
+# Set when BIN_DIR is not on PATH, so the final summary can tell the user how to
+# expose it (see emit_path_hint).
+PATH_NEEDS_SETUP=0
 PLUGINS=()
 # honor GITGUARDIAN_INSTANCE like ggshield does; --instance overrides it
 INSTANCE="${GITGUARDIAN_INSTANCE:-}"
@@ -269,12 +277,11 @@ other install methods in scripts/install/README.md" ;;
     fi
     ln -sf "$bin" "$BIN_DIR/ggshield"
 
+    # Defer the "not on PATH" guidance to the very end (emit_path_hint) so it is
+    # the last thing the user sees, not buried before the auth/plugin output.
     case ":$PATH:" in
     *":$BIN_DIR:"*) ;;
-    *)
-        warn "$BIN_DIR is not in your PATH. Add this to your shell profile:"
-        warn "  export PATH=\"$BIN_DIR:\$PATH\""
-        ;;
+    *) PATH_NEEDS_SETUP=1 ;;
     esac
     GGSHIELD="$BIN_DIR/ggshield"
 }
@@ -314,6 +321,51 @@ emit_auth_hint() {
 emit_plugin_hint() {
     [ ${#PLUGINS[@]} -gt 0 ] &&
         printf '    ggshield plugin install %s\n' "${PLUGINS[*]}"
+    return 0
+}
+
+# ~/.local/bin is the no-sudo convention, but it is not guaranteed to be on
+# PATH: macOS never adds it, and Debian/Ubuntu add it from ~/.profile only when
+# the directory already exists at login — so a brand-new install often needs a
+# shell restart. No sudo-less directory is on PATH across every distro and
+# macOS, so we install there and tell the user how to expose it, per shell.
+# Uses $SHELL (the login shell) rather than $0: this script always runs under
+# bash (curl | bash), which says nothing about the shell the user reopens.
+emit_path_hint() {
+    # reload defaults to `source` (zsh/bash); `.` is the POSIX form for the
+    # generic-sh fallback. Paths are double-quoted in the emitted commands so a
+    # BIN_DIR/rc with spaces still copy-pastes correctly.
+    local rc reload="source" f
+    case "$(basename "${SHELL:-sh}")" in
+    fish)
+        # fish persists PATH via universal variables — no file edit, no restart.
+        printf '    # %s is not on your PATH; add it permanently with:\n' "$BIN_DIR"
+        printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
+        return 0
+        ;;
+    zsh) rc="$HOME/.zshrc" ;;
+    bash)
+        if [ "$OS" = darwin ]; then
+            # macOS Terminal runs bash as a login shell, which reads the FIRST
+            # of these that exists. Appending to ~/.bash_profile when ~/.profile
+            # is the active file would shadow it, so reuse whichever exists.
+            rc="$HOME/.bash_profile"
+            for f in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+                if [ -e "$f" ]; then rc="$f"; break; fi
+            done
+        else
+            # Linux: interactive terminals read ~/.bashrc.
+            rc="$HOME/.bashrc"
+        fi
+        ;;
+    *)
+        rc="$HOME/.profile"
+        reload="."
+        ;;
+    esac
+    printf '    # %s is not on your PATH; add it, then restart your terminal:\n' "$BIN_DIR"
+    printf '    echo '\''export PATH="%s:$PATH"'\'' >> "%s"\n' "$BIN_DIR" "$rc"
+    printf '    # (or apply it to the current shell now: %s "%s")\n' "$reload" "$rc"
     return 0
 }
 
@@ -364,6 +416,7 @@ post_install() {
         [ ${#PLUGINS[@]} -gt 0 ] &&
             warn "--plugin not installed: --install-only skips authentication; run the steps below once authenticated"
         say "ggshield is installed. To finish setup:"
+        [ "$PATH_NEEDS_SETUP" = 1 ] && emit_path_hint
         emit_auth_hint
         emit_plugin_hint
         return 0
@@ -387,12 +440,15 @@ post_install() {
         plugins_pending=1
     fi
 
-    # Only nag about next steps when something actually remains.
-    if [ "$auth_ok" = 1 ] && [ "$plugins_pending" = 0 ]; then
+    # Only nag about next steps when something actually remains. A binary the
+    # shell cannot find by name is not "ready", so PATH setup counts too.
+    if [ "$auth_ok" = 1 ] && [ "$plugins_pending" = 0 ] && [ "$PATH_NEEDS_SETUP" = 0 ]; then
         say "ggshield is ready."
         return 0
     fi
     say "To finish setup:"
+    # PATH first: the other hints below assume ggshield is callable by name.
+    [ "$PATH_NEEDS_SETUP" = 1 ] && emit_path_hint
     [ "$auth_ok" = 0 ] && emit_auth_hint
     [ "$plugins_pending" = 1 ] && emit_plugin_hint
     return 0

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -33,6 +33,10 @@ INSTALL_ONLY=0
 # Set when BIN_DIR is not on PATH, so the final summary can tell the user how to
 # expose it (see emit_path_hint).
 PATH_NEEDS_SETUP=0
+# Set to the path of an older ggshield that resolves ahead of the fresh one
+# while BIN_DIR *is* on PATH; emit_path_hint then says "put BIN_DIR first"
+# rather than "add it".
+SHADOWED_BY=""
 PLUGINS=()
 # honor GITGUARDIAN_INSTANCE like ggshield does; --instance overrides it
 INSTANCE="${GITGUARDIAN_INSTANCE:-}"
@@ -329,8 +333,11 @@ emit_plugin_hint() {
 # the directory already exists at login — so a brand-new install often needs a
 # shell restart. No sudo-less directory is on PATH across every distro and
 # macOS, so we install there and tell the user how to expose it, per shell.
-# Uses $SHELL (the login shell) rather than $0: this script always runs under
-# bash (curl | bash), which says nothing about the shell the user reopens.
+# Also handles the "$SHADOWED_BY" case: BIN_DIR is on PATH but an older ggshield
+# sits ahead of it — the same fix (prepend BIN_DIR) resolves both, only the
+# wording differs. Uses $SHELL (the login shell) rather than $0: this script
+# always runs under bash (curl | bash), which says nothing about the shell the
+# user reopens.
 emit_path_hint() {
     # The headline goes through warn() (bold yellow, stderr) so it stands out;
     # as an indented "# ..." comment it blended into the command block below and
@@ -338,12 +345,23 @@ emit_path_hint() {
     # reload defaults to `source` (zsh/bash); `.` is the POSIX form for the
     # generic-sh fallback. Paths are double-quoted in the emitted commands so a
     # BIN_DIR/rc with spaces still copy-pastes correctly.
-    local rc reload="source" f
+    local rc reload="source" f headline
+    if [ -n "$SHADOWED_BY" ]; then
+        headline="an older ggshield at $SHADOWED_BY shadows the new one; put $BIN_DIR first on your PATH, then restart your terminal:"
+    else
+        headline="$BIN_DIR is not on your PATH. Add it, then restart your terminal:"
+    fi
     case "$(basename "${SHELL:-sh}")" in
     fish)
         # fish persists PATH via universal variables — no file edit, no restart.
-        warn "$BIN_DIR is not on your PATH. Add it permanently with:"
-        printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
+        # --move pulls BIN_DIR to the front when it is already present (shadow case).
+        if [ -n "$SHADOWED_BY" ]; then
+            warn "an older ggshield at $SHADOWED_BY shadows the new one; move $BIN_DIR to the front with:"
+            printf '    fish_add_path --move -- "%s"\n' "$BIN_DIR"
+        else
+            warn "$BIN_DIR is not on your PATH. Add it permanently with:"
+            printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
+        fi
         return 0
         ;;
     zsh) rc="$HOME/.zshrc" ;;
@@ -366,7 +384,9 @@ emit_path_hint() {
         reload="."
         ;;
     esac
-    warn "$BIN_DIR is not on your PATH. Add it, then restart your terminal:"
+    # Prepend BIN_DIR so it wins whether it was absent or merely behind an older
+    # install. A duplicate entry (shadow case) is harmless: the front one wins.
+    warn "$headline"
     printf '    echo '\''export PATH="%s:$PATH"'\'' >> "%s"\n' "$BIN_DIR" "$rc"
     printf '    # (or apply it to the current shell now: %s "%s")\n' "$reload" "$rc"
     return 0
@@ -405,11 +425,17 @@ post_install() {
     fi
     say "Installed: $version_out"
 
-    # a leftover from a previous install may shadow the fresh one on PATH
+    # A ggshield from a previous install (brew, pipx, manual) sitting earlier on
+    # PATH shadows the one we just linked. The fix is the same as "not on PATH" —
+    # put BIN_DIR first — so route it through emit_path_hint with wording that
+    # names the offending binary, instead of a dead-end "fix your PATH order".
+    # Only when BIN_DIR is actually on PATH (PATH_NEEDS_SETUP still 0): if it is
+    # absent, the "not on PATH" hint already prepends it and covers this too.
     local resolved
     resolved=$(command -v ggshield 2>/dev/null || true)
-    if [ -n "$resolved" ] && [ "$resolved" != "$GGSHIELD" ]; then
-        warn "another ggshield at $resolved shadows the one just installed ($GGSHIELD); fix your PATH order"
+    if [ "$PATH_NEEDS_SETUP" = 0 ] && [ -n "$resolved" ] && [ "$resolved" != "$GGSHIELD" ]; then
+        SHADOWED_BY="$resolved"
+        PATH_NEEDS_SETUP=1
     fi
 
     if [ "$INSTALL_ONLY" = 1 ]; then


### PR DESCRIPTION
## Context

Fixes [END-598](https://linear.app/gitguardian/issue/END-598/ggshield-not-in-path-after-install).

The `install.sh` script symlinks `ggshield` into `~/.local/bin`, which is **not on `PATH` everywhere**, so users sometimes can't run `ggshield` right after installing:

- **macOS** never adds `~/.local/bin` to `PATH` by default.
- **Debian/Ubuntu** add it from `~/.profile` *only if the directory already exists at login* — a fresh install creates it afterwards, so it isn't picked up until the shell is restarted (the most common cause of the report).

I checked whether we could just install into a directory that is *always* on `PATH`: there is **no sudo-less directory guaranteed on `PATH` across every Linux distro and macOS** (`/usr/local/bin` needs `sudo`, and on Apple Silicon Homebrew uses `/opt/homebrew/bin`, itself not on the stock macOS `PATH`). So we keep `~/.local/bin` (the no-sudo XDG/systemd convention) and make the guidance actionable instead — the approach other CLIs take. Windows (`install.ps1`) already edits the user `PATH` automatically and is unchanged.

## What has been done

- When `BIN_DIR` is not on `PATH`, the installer now prints **shell-specific** instructions at the **end** of the run (instead of a generic note buried before the auth/plugin output), detecting the login shell via `$SHELL`:
  - **zsh** → `~/.zshrc`
  - **bash** → `~/.bashrc` on Linux; on macOS the first existing of `~/.bash_profile` / `~/.bash_login` / `~/.profile` (avoids creating `~/.bash_profile` and silently shadowing an active `~/.profile`)
  - **fish** → `fish_add_path` (persistent, no restart needed)
  - **other / POSIX sh** → `~/.profile`, using `.` rather than the non-POSIX `source`
  - …each with a reminder to **restart the terminal** (plus a `source` one-liner to apply it immediately).
- Emitted commands quote the rc path so paths containing spaces copy-paste correctly.
- Added an early guard that fails with a clear message if `HOME` is unset (every install path derives from it).
- Documented the `PATH` behaviour in `scripts/install/README.md`.

The logic is flag-based (`PATH_NEEDS_SETUP`): set in `install_tarball`, surfaced at the end of `post_install`, listed before the auth/plugin hints (which assume `ggshield` is already callable), and folded into the "ggshield is ready." gate.

## Validation

- `bash -n scripts/install/install.sh` passes.
- Exercised the hint function across `SHELL` = zsh/bash/fish/dash and `OS` = linux/darwin, including the macOS rc-file selection (only `.profile` present → `.profile`; `.bash_profile` present → `.bash_profile`; none present → `.bash_profile`) and a path with spaces (quotes correctly).
- Verified the `HOME` guard: unset/empty `HOME` → exit 1 with a clear error; normal `--help` → exit 0.
- `pre-commit run --files …` passes for all changed files (prettier, trailing-whitespace, end-of-file-fixer).

To try it manually:
```sh
PATH="/usr/bin:/bin" GGSHIELD_BIN_DIR="$HOME/.local/bin" bash scripts/install/install.sh --install-only
# end of output shows the shell-specific "add to PATH, then restart" hint
```

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional) — n/a: pure shell installer change; validated manually as above (no shell test harness exists for these scripts).
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry