### PR TITLE
fix(install): make provenance check opt-in

### DIFF
--- a/changelog.d/20260624_120200_benjamin.rigaud_fix_install_attestation_failopen.md
+++ b/changelog.d/20260624_120200_benjamin.rigaud_fix_install_attestation_failopen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The install scripts no longer fail when an outdated or unauthenticated `gh` cannot verify the build provenance attestation (the cause of installs aborting with `unsupported tlog public key type: PKIX_ED25519` on a `gh` older than 2.56.0). Build-provenance verification is now opt-in on both `install.sh` and `install.ps1`: the install relies on the mandatory sha256 checksum by default and prints the manual `gh attestation verify` command. Set `GGSHIELD_REQUIRE_ATTESTATION=1` (or `true`/`yes`/`on`) to require it — that runs the check and fails the install if `gh` is missing, older than 2.56.0, unauthenticated, or the provenance does not verify.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -40,8 +40,12 @@ The script installs the standalone build (detecting OS/arch, including Rosetta 2
   admin). `-Method msi` installs the system-wide MSI instead (requires admin).
 
 The download is **checksum-verified** against the digest GitHub publishes for
-each asset (the install aborts if it cannot be verified), and — when `gh` is
-available — against the release's [build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
+each asset (the install aborts if it cannot be verified). [Build provenance
+attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+verification is **opt-in**: set `GGSHIELD_REQUIRE_ATTESTATION=1` to also verify
+it with `gh` (>= 2.56.0, authenticated) and fail the install if it cannot be
+verified. By default the script does not invoke `gh`; it prints the manual
+`gh attestation verify` command instead.
 
 Alpine/musl is not supported (the standalone build is glibc-only) — use the
 Docker image `gitguardian/ggshield` or `pipx install ggshield`.
@@ -100,13 +104,14 @@ printed `ggshield auth login` command.
 
 ### Environment variables
 
-| Variable               | Effect                                                        |
-| ---------------------- | ------------------------------------------------------------- |
-| `GGSHIELD_VERSION`     | same as `--version`                                           |
-| `GITGUARDIAN_INSTANCE` | instance to authenticate against (same as `--instance`)       |
-| `GITGUARDIAN_API_KEY`  | authenticate with this API key instead of the browser login   |
-| `GGSHIELD_BIN_DIR`     | symlink dir (default `~/.local/bin`)                          |
-| `GGSHIELD_OPT_DIR`     | extraction dir (default `~/.local/share/ggshield-standalone`) |
+| Variable                       | Effect                                                                                                                                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GGSHIELD_VERSION`             | same as `--version`                                                                                                                                       |
+| `GITGUARDIAN_INSTANCE`         | instance to authenticate against (same as `--instance`)                                                                                                   |
+| `GITGUARDIAN_API_KEY`          | authenticate with this API key instead of the browser login                                                                                               |
+| `GGSHIELD_BIN_DIR`             | symlink dir (default `~/.local/bin`)                                                                                                                      |
+| `GGSHIELD_OPT_DIR`             | extraction dir (default `~/.local/share/ggshield-standalone`)                                                                                             |
+| `GGSHIELD_REQUIRE_ATTESTATION` | set to `1` to require `gh` build-provenance verification (needs `gh` >= 2.56.0, authenticated); fails the install if it cannot be verified (default: off) |
 
 ## Other install methods
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -75,7 +75,7 @@ function Get-AssetDigest($assetName) {
     return $null
 }
 
-# Fail closed: a download we cannot verify is never installed.
+# sha256 is mandatory and fails closed; gh provenance is opt-in (Test-Attestation).
 function Test-Download($file, $assetName) {
     $expected = Get-AssetDigest $assetName
     if (-not $expected) {
@@ -85,14 +85,43 @@ function Test-Download($file, $assetName) {
     $actual = (Get-FileHash -Algorithm SHA256 -Path $file).Hash
     if ($actual -ne $expected) { Die "checksum mismatch for $assetName" }
 
-    # opportunistic build provenance check; older gh has no `attestation`
-    if ((Get-Command gh -ErrorAction SilentlyContinue) -and
-        (Invoke-Native gh attestation --help) -eq 0 -and
-        (Invoke-Native gh auth status) -eq 0) {
-        Say 'Verifying build provenance attestation'
-        if ((Invoke-Native gh attestation verify $file --repo $GithubRepo) -ne 0) {
-            Die "artifact attestation verification failed for $assetName"
-        }
+    Test-Attestation $file $assetName
+}
+
+# 1/true/yes/on (any case, surrounding whitespace ignored) enable it; unset/empty/
+# 0/false/no/off disable; warn on anything else and treat as off.
+function Test-RequireAttestation {
+    $raw = "$env:GGSHIELD_REQUIRE_ATTESTATION"
+    $v = $raw.Trim().ToLowerInvariant()
+    if ([string]::IsNullOrEmpty($v)) { return $false }
+    if ($v -in @('1', 'true', 'yes', 'on')) { return $true }
+    if ($v -in @('0', 'false', 'no', 'off')) { return $false }
+    Warn "unrecognized GGSHIELD_REQUIRE_ATTESTATION value '$raw'; treating as off (use 1 to require)"
+    return $false
+}
+
+# Build-provenance verification is opt-in and OFF by default; see install.sh for
+# the rationale (ambient gh, and a public lookup still needs an authenticated gh,
+# so running it automatically is fragile — END-609). When opted in, fail closed if
+# gh is missing, too old, unauthenticated, or the provenance does not verify.
+function Test-Attestation($file, $assetName) {
+    if (-not (Test-RequireAttestation)) {
+        Say 'Skipping build provenance check (set GGSHIELD_REQUIRE_ATTESTATION=1 to require it). To verify a downloaded asset yourself:'
+        Write-Host "    gh attestation verify <asset> --repo $GithubRepo"
+        return
+    }
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Die 'GGSHIELD_REQUIRE_ATTESTATION is set but gh is not installed (need gh >= 2.56.0)'
+    }
+    if ((Invoke-Native gh attestation --help) -ne 0) {
+        Die "GGSHIELD_REQUIRE_ATTESTATION is set but this gh is too old for 'gh attestation' (need >= 2.56.0)"
+    }
+    if ((Invoke-Native gh auth status) -ne 0) {
+        Die "GGSHIELD_REQUIRE_ATTESTATION is set but gh is not authenticated; run 'gh auth login'"
+    }
+    Say 'Verifying build provenance attestation'
+    if ((Invoke-Native gh attestation verify $file --repo $GithubRepo) -ne 0) {
+        Die "build provenance verification failed for ${assetName}: it does not match $GithubRepo"
     }
 }
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -53,6 +53,11 @@ Environment:
                        flow (token login; combine with --instance)
   GGSHIELD_BIN_DIR     symlink dir (default ~/.local/bin)
   GGSHIELD_OPT_DIR     extraction dir (default ~/.local/share/ggshield-standalone)
+  GGSHIELD_REQUIRE_ATTESTATION
+                       set to 1 (or true/yes/on) to require gh build-provenance
+                       verification on top of the sha256 check; fails the install
+                       if gh is missing, older than 2.56.0, unauthenticated, or
+                       cannot verify the artifact (default: off)
 EOF
 }
 
@@ -153,7 +158,7 @@ asset_http_status() {
         2>/dev/null || echo 000
 }
 
-# Fail closed: a download we cannot verify is never installed.
+# sha256 is mandatory and fails closed; gh provenance is opt-in (verify_attestation).
 verify_download() {
     local file="$1" asset="$2" digest sum_tool
     digest=$(asset_digest "$asset")
@@ -171,14 +176,50 @@ verify_download() {
     echo "${digest#sha256:}  $file" | $sum_tool -c - >/dev/null ||
         die "checksum mismatch for $asset"
 
-    # older gh releases have no `attestation` subcommand
-    if command -v gh >/dev/null 2>&1 &&
-        gh attestation --help >/dev/null 2>&1 &&
-        gh auth status >/dev/null 2>&1; then
-        say "Verifying build provenance attestation"
-        gh attestation verify "$file" --repo "$GITHUB_REPO" >/dev/null ||
-            die "artifact attestation verification failed for $asset"
+    verify_attestation "$file" "$asset"
+}
+
+# 1/true/yes/on (any case, surrounding whitespace ignored) enable it; unset/empty/
+# 0/false/no/off disable; warn on anything else and treat as off, so a typo'd
+# opt-in is never silently ignored.
+require_attestation() {
+    local v="${GGSHIELD_REQUIRE_ATTESTATION:-}"
+    v="${v#"${v%%[![:space:]]*}"}" # strip leading whitespace
+    v="${v%"${v##*[![:space:]]}"}" # strip trailing whitespace
+    case "$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    '' | 0 | false | no | off) return 1 ;;
+    *)
+        warn "unrecognized GGSHIELD_REQUIRE_ATTESTATION value '$GGSHIELD_REQUIRE_ATTESTATION'; treating as off (use 1 to require)"
+        return 1
+        ;;
+    esac
+}
+
+# Build-provenance verification is opt-in and OFF by default. gh is not a ggshield
+# dependency, its version/auth/network state is ambient, and even a public lookup
+# needs an authenticated gh — running it automatically is fragile (END-609) and
+# usually can't run anyway, while the mandatory sha256 already covers integrity.
+# When opted in, fail closed if gh is missing, too old, unauthenticated, or the
+# provenance does not verify.
+verify_attestation() {
+    local file="$1" asset="$2"
+
+    if ! require_attestation; then
+        say "Skipping build provenance check (set GGSHIELD_REQUIRE_ATTESTATION=1 to require it). To verify a downloaded asset yourself:"
+        printf '    gh attestation verify <asset> --repo %s\n' "$GITHUB_REPO"
+        return 0
     fi
+
+    command -v gh >/dev/null 2>&1 ||
+        die "GGSHIELD_REQUIRE_ATTESTATION is set but gh is not installed (need gh >= 2.56.0)"
+    gh attestation --help >/dev/null 2>&1 ||
+        die "GGSHIELD_REQUIRE_ATTESTATION is set but this gh is too old for 'gh attestation' (need >= 2.56.0; e.g. 'brew upgrade gh')"
+    gh auth status >/dev/null 2>&1 ||
+        die "GGSHIELD_REQUIRE_ATTESTATION is set but gh is not authenticated; run 'gh auth login'"
+    say "Verifying build provenance attestation"
+    gh attestation verify "$file" --repo "$GITHUB_REPO" >/dev/null ||
+        die "build provenance verification failed for $asset: it does not match $GITHUB_REPO"
 }
 
 install_tarball() {


### PR DESCRIPTION
Fixes END-609: the install aborted because `gh attestation verify` fails when `gh` is older than 2.56.0 — its bundled `sigstore-go` can't parse the Ed25519 (`PKIX_ED25519`) tlog key in Sigstore's trusted root. The installers ran `gh` automatically and failed closed, so an outdated (or unauthenticated) `gh` on `$PATH` blocked the whole install even though the sha256 checksum had already matched.

Following @clement-tourriere's review: `gh` is not a ggshield dependency, and a public attestation lookup still needs an authenticated `gh`, so running it automatically is fragile and usually can't run anyway. **Build-provenance verification is now opt-in, in both `install.sh` and `install.ps1`:**

- **Default:** mandatory sha256 (fail-closed) only; `gh` is not invoked. The installer prints the manual `gh attestation verify` command.
- **`GGSHIELD_REQUIRE_ATTESTATION=1`** (also accepts `true`/`yes`/`on`): runs `gh attestation verify` and **fails the install** if `gh` is missing, older than 2.56.0, unauthenticated, or the provenance doesn't verify.

Also addressed from review:
- **Windows parity** — `install.ps1` got the same opt-in design (it previously had the identical fail-closed bug).
- **No silent foot-gun** — a non-`1` truthy value (`true`/`yes`/`on`) now enables it too, and an unrecognized value warns instead of silently skipping.
- **Clearer errors** — an explicit `gh auth status` precheck distinguishes "not logged in" from a real provenance mismatch.
- **Docs** — `scripts/install/README.md` now describes the opt-in behavior and documents `GGSHIELD_REQUIRE_ATTESTATION`.

Verified: 8/8 unit cases on the gate logic; earlier end-to-end runs with real `gh` binaries (default skips without invoking gh; strict dies clearly on missing/old/unauthenticated gh and verifies on 2.95.0); `bash -n` + shellcheck clean on `install.sh`. `install.ps1` was not lintable locally (no pwsh).

Refs: END-609
