### PR TITLE
feat(machine): add `machine audit` to scan exposure and report posture

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -58,7 +58,9 @@ ignore_imports =
 	ggshield.cmd.install.** -> ggshield.verticals.install
 	ggshield.cmd.install.** -> ggshield.verticals.install.**
 	ggshield.cmd.machine.** -> ggshield.verticals.ai.agents
+	ggshield.cmd.machine.** -> ggshield.verticals.ai.discovery
 	ggshield.cmd.machine.** -> ggshield.verticals.ai.installation
+	ggshield.cmd.machine.** -> ggshield.verticals.honeytoken.posture
 	ggshield.cmd.machine.** -> ggshield.verticals.machine
 	ggshield.cmd.machine.** -> ggshield.verticals.machine.**
 	ggshield.cmd.plugin.** -> ggshield.core.plugin

--- a/changelog.d/20260624_100000_achille.mascia_machine_audit.md
+++ b/changelog.d/20260624_100000_achille.mascia_machine_audit.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield machine audit` is the read-only counterpart to `ggshield machine setup`: in one command it discovers AI/MCP usage, scans this machine for secrets (when the `machine_scan` plugin is installed), and reports which protections are in place (AI hooks, git hooks, honeytoken). It never changes anything — run `ggshield machine setup` to fix gaps. Each section is on by default; drop one with `--no-ai` / `--no-secrets` / `--no-posture`, and `--history` also backfills historical MCP tool calls during discovery.

--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -4,25 +4,13 @@ for tools, resources, and prompts.
 """
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 import click
-from pygitguardian.models import AIDiscovery
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
-from ggshield.core import ui
-from ggshield.core.client import create_client_from_config
-from ggshield.core.errors import APIKeyCheckError, UnknownInstanceError
-from ggshield.core.text_utils import STYLE, format_text, pluralize
-from ggshield.verticals.ai.agents import AGENTS
-from ggshield.verticals.ai.discovery import (
-    discover_ai_configuration,
-    save_discovery_cache,
-    submit_ai_discovery,
-)
-from ggshield.verticals.ai.history import BackfillReport, backfill_mcp_history
-from ggshield.verticals.ai.models import Scope
+from ggshield.verticals.ai.discovery import print_summary, run_discovery
 
 
 @click.command(name="discover")
@@ -58,145 +46,12 @@ def discover_cmd(
       ggshield ai discover --json
       ggshield ai discover --history
     """
-
-    config = discover_ai_configuration()
-
-    ctx_obj = ContextObj.get(ctx)
-    try:
-        client = create_client_from_config(ctx_obj.config)
-    except (APIKeyCheckError, UnknownInstanceError) as exc:
-        ui.display_warning(
-            f"Skipping upload of AI discovery to GitGuardian ({exc}). "
-            "Authenticate with `ggshield auth login` to enable upload."
-        )
+    config = ContextObj.get(ctx).config
+    summary = run_discovery(config, scan_history=scan_history)
+    if summary is None:
         return
-
-    backfill_report = BackfillReport()
-    try:
-        config = submit_ai_discovery(client, config)
-        save_discovery_cache(config)
-        if scan_history:
-            backfill_report = backfill_mcp_history(client, config)
-    except Exception as exc:
-        if "missing the following scope:" in str(exc):
-            scope = str(exc).split("missing the following scope:")[1].strip()
-            reason = f'this command requires the {scope} scope. Run ggshield auth login --scopes "{scope}" to grant it.'
-        else:
-            reason = str(exc)
-        ui.display_warning(f"Could not upload AI discovery to GitGuardian: {reason}")
-
-    # Summarize after sending to GIM, so we can benefit from its fixes.
-    summary = _summarize_discovery(config, backfill_report)
 
     if use_json:
         click.echo(json.dumps(summary, indent=2))
     else:
         print_summary(summary)
-
-
-def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[str, Any]:
-    """Summarize what we want to show of the discovery."""
-    servers = []
-    for server in config.servers:
-        projects = set()
-        agents = set()
-        installed_globally = False
-        for conf in server.configurations:
-            agents.add(conf.agent)
-            if conf.scope == Scope.USER:
-                installed_globally = True
-            elif conf.project:
-                projects.add(conf.project)
-        servers.append(
-            {
-                # If we don't have a display name, any configuration name
-                # is probably less confusing than our deduplication key
-                "name": server.display_name or server.configurations[0].name,
-                "installed_globally": installed_globally,
-                "projects": sorted(projects),
-                "agents": sorted(AGENTS[name].display_name for name in agents),
-            }
-        )
-    servers = sorted(servers, key=lambda x: x["name"])
-    agents = sorted(
-        (
-            {
-                "name": AGENTS[agent.name].display_name,
-                "hooks_installed": agent.hooks_installed,
-            }
-            for agent in config.agents
-        ),
-        key=lambda x: x["name"],
-    )
-    return {
-        "agents": agents,
-        "servers": servers,
-        "history": {
-            "parsed": report.parsed,
-            "ingested": report.ingested,
-            "duplicates": report.duplicates,
-            "skipped": report.skipped,
-        },
-    }
-
-
-def print_summary(summary: Dict[str, Any]) -> None:
-    """Print the summary of the discovery."""
-    agents: List[Dict[str, Any]] = summary.get("agents", [])
-    servers: List[Dict[str, Any]] = summary.get("servers", [])
-
-    nb_servers = len(servers)
-    nb_agents = len(agents)
-
-    if nb_servers == 0:
-        click.echo(format_text("No MCP servers discovered", STYLE["no_secret"]))
-        return
-
-    def _format_agent(agent: Dict[str, Any]) -> str:
-        name = format_text(agent.get("name", "unknown"), STYLE["heading"])
-        status = "hooks installed" if agent.get("hooks_installed") else "no hooks"
-        return f"{name} ({status})"
-
-    click.echo(
-        f"\n{format_text('Agents discovered:', STYLE['key'])} "
-        f"{', '.join(_format_agent(agent) for agent in agents) if agents else 'none'} "
-        f"({nb_agents} {pluralize('agent', nb_agents)})"
-    )
-    click.echo(
-        f"{format_text('MCP servers found:', STYLE['key'])} "
-        f"{nb_servers} {pluralize('server', nb_servers)}\n"
-    )
-
-    for server in servers:
-        name = server.get("name", "unknown")
-        installed_globally = server.get("installed_globally", False)
-        projects: List[str] = server.get("projects", [])
-        server_agents: List[str] = server.get("agents", [])
-
-        start = format_text(">", STYLE["detector_line_start"])
-        server_name = format_text(name, STYLE["detector"])
-        agents_names = ", ".join(
-            format_text(agent, STYLE["heading"]) for agent in server_agents
-        )
-        click.echo(f"{start} {server_name} ({agents_names})")
-
-        indent = "   "
-        scope = "user" if installed_globally else "project"
-        click.echo(f"{indent}{format_text('Scope:', STYLE['key'])} {scope}")
-        if projects:
-            click.echo(f"{indent}{format_text('Projects:', STYLE['key'])}")
-            for j, project in enumerate(projects):
-                connector = "└─" if j == len(projects) - 1 else "├─"
-                click.echo(f"{indent}{connector} {project}")
-
-    click.echo()
-
-    history = summary.get("history")
-    if history and history.get("parsed"):
-        click.echo(f"{format_text('Backfilling MCP usage history…', STYLE['key'])}")
-        click.echo(f"  • Parsed {history['parsed']:,} events")
-        click.echo(
-            f"  • Recorded {history['ingested']:,} events "
-            f"({history['duplicates']:,} already known, "
-            f"{history.get('skipped', 0):,} skipped)"
-        )

--- a/ggshield/cmd/machine/__init__.py
+++ b/ggshield/cmd/machine/__init__.py
@@ -2,18 +2,21 @@ from typing import Any
 
 import click
 
+from ggshield.cmd.machine.audit import audit_cmd
 from ggshield.cmd.machine.setup import setup_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 
 
-@click.group(commands={"setup": setup_cmd})
+@click.group(commands={"setup": setup_cmd, "audit": audit_cmd})
 @add_common_options()
 def machine_group(**kwargs: Any) -> None:
     """
     Scan and protect this machine.
 
-    `setup` sets up all of this machine's protections (AI hooks, git hooks, and
-    a honeytoken) in one idempotent command. Secret and endpoint scanning
-    (`scan`) is provided by the `machine_scan` plugin and merges into this group
-    when it is installed.
+    `setup` sets up all of this machine's protections (AI hooks, git hooks, and a
+    honeytoken) in one idempotent command. `audit` is its read-only counterpart: it
+    discovers AI/MCP usage, scans for secrets, and reports protection posture without
+    changing anything. Secret and endpoint scanning (`scan`) is provided by the
+    `machine_scan` plugin and merges into this group when it is installed; `audit`
+    runs that scan too when the plugin is present.
     """

--- a/ggshield/cmd/machine/audit.py
+++ b/ggshield/cmd/machine/audit.py
@@ -1,0 +1,163 @@
+from typing import Any, Optional
+
+import click
+
+from ggshield.cmd.install import (
+    get_default_global_hook_dir_path,
+    get_global_hook_dir_path,
+)
+from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core import ui
+from ggshield.verticals.ai.discovery import print_summary, run_discovery
+from ggshield.verticals.ai.installation import ai_hook_posture
+from ggshield.verticals.honeytoken.posture import honeytoken_posture
+
+
+_GIT_HOOK_TYPES = ("pre-commit", "pre-push")
+
+
+@click.command(name="audit")
+@click.option(
+    "--no-ai",
+    is_flag=True,
+    help="Do not run AI/MCP discovery.",
+)
+@click.option(
+    "--no-secrets",
+    is_flag=True,
+    help="Do not run the machine secret scan.",
+)
+@click.option(
+    "--no-posture",
+    is_flag=True,
+    help="Do not report this machine's protection posture.",
+)
+@click.option(
+    "--history",
+    "scan_history",
+    is_flag=True,
+    help="Also backfill historical MCP tool calls during AI discovery.",
+)
+@add_common_options()
+@click.pass_context
+def audit_cmd(
+    ctx: click.Context,
+    no_ai: bool,
+    no_secrets: bool,
+    no_posture: bool,
+    scan_history: bool,
+    **kwargs: Any,
+) -> int:
+    """
+    Audit this machine's exposure and protection posture (read-only).
+
+    The read counterpart to `machine setup`: in one run it discovers AI/MCP usage,
+    scans for secrets at rest (when the `machine_scan` plugin is installed), and
+    reports which ggshield protections are in place. It never changes anything — run
+    `ggshield machine setup` to fix any gaps.
+
+    Each section is on by default; drop one with `--no-ai`, `--no-secrets`, or
+    `--no-posture`.
+    """
+    exit_code = 0
+
+    if not no_ai:
+        _audit_ai(ctx, scan_history)
+
+    if not no_secrets:
+        # The secret scan is the only section that can flag findings/errors; its
+        # exit code is the command's exit code so CI/MDM can gate on it. Discovery
+        # and posture are informational — they warn but never change the result.
+        exit_code = _audit_secrets(ctx) or exit_code
+
+    if not no_posture:
+        _audit_posture(ctx)
+
+    return exit_code
+
+
+def _audit_ai(ctx: click.Context, scan_history: bool) -> None:
+    """Run AI/MCP discovery and print its summary (best-effort upload)."""
+    click.echo(click.style("AI & MCP discovery", bold=True))
+    config = ContextObj.get(ctx).config
+    summary = run_discovery(config, scan_history=scan_history)
+    if summary is not None:
+        print_summary(summary)
+
+
+def _audit_secrets(ctx: click.Context) -> int:
+    """Run the native secret scan if the `machine_scan` plugin is installed.
+
+    The scan is owned by the plugin and merged into this same `machine` group, so we
+    reach it at runtime as a sibling command (the pattern `machine setup` uses to
+    invoke `honeytoken plant`). Without the plugin there is nothing to run — print a
+    hint and succeed rather than fail.
+    """
+    click.echo(click.style("Secret scan", bold=True))
+    scan_cmd = _find_sibling_scan(ctx)
+    if scan_cmd is None:
+        ui.display_info(
+            "Secret scanning needs the machine_scan plugin — run "
+            "`ggshield plugin install machine_scan`."
+        )
+        return 0
+    return ctx.invoke(scan_cmd) or 0
+
+
+def _find_sibling_scan(ctx: click.Context) -> Optional[click.Command]:
+    """Look up the plugin-provided `scan` command in this `machine` group, if present."""
+    parent = ctx.parent
+    group = parent.command if parent is not None else None
+    if isinstance(group, click.Group):
+        return group.commands.get("scan")
+    return None
+
+
+def _audit_posture(ctx: click.Context) -> None:
+    """Report which protections are in place (read-only)."""
+    click.echo(click.style("Protection posture", bold=True))
+    _posture_ai_hooks()
+    _posture_git_hooks()
+    _posture_honeytoken(ctx)
+    click.echo("Run `ggshield machine setup` to configure anything missing.")
+
+
+def _posture_ai_hooks() -> None:
+    statuses = ai_hook_posture()
+    if not statuses:
+        click.echo("  AI hooks: no AI coding assistants detected")
+        return
+    for status in statuses:
+        state = "installed" if status.installed else "missing"
+        click.echo(f"  AI hook [{status.display_name}]: {state}")
+
+
+def _posture_git_hooks() -> None:
+    hook_dir = get_global_hook_dir_path() or get_default_global_hook_dir_path()
+    for hook_type in _GIT_HOOK_TYPES:
+        hook_path = hook_dir / hook_type
+        if hook_path.is_file():
+            if "ggshield secret scan" in hook_path.read_text(errors="ignore"):
+                state = "installed"
+            else:
+                state = "present but not ggshield"
+        else:
+            state = "missing"
+        click.echo(f"  git {hook_type} hook: {state}")
+
+
+def _posture_honeytoken(ctx: click.Context) -> None:
+    config = ContextObj.get(ctx).config
+    posture = honeytoken_posture(config)
+    if not posture.checked:
+        click.echo(f"  honeytoken: not checked ({posture.detail})")
+        return
+    if posture.planted == 0 and posture.missing == 0:
+        click.echo("  honeytoken: none configured for this machine")
+    elif posture.missing == 0:
+        click.echo(f"  honeytoken: planted ({posture.planted})")
+    else:
+        click.echo(
+            f"  honeytoken: {posture.planted} planted, {posture.missing} missing"
+        )

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -5,17 +5,27 @@ MCP Discovery - Discovers MCP server configurations and manages probe result cac
 from collections import defaultdict
 from pathlib import Path
 from time import perf_counter
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+import click
 from pygitguardian import GGClient
 from pygitguardian.models import AgentInfo, AIDiscovery, Detail, MCPServer
 
-from ggshield.core.errors import UnexpectedError
+from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
+from ggshield.core.config import Config
+from ggshield.core.errors import (
+    APIKeyCheckError,
+    UnexpectedError,
+    UnknownInstanceError,
+)
+from ggshield.core.text_utils import STYLE, format_text, pluralize
 
 from .agents import AGENTS
 from .cache import has_changed_from, load_discovery_cache, save_discovery_cache
+from .history import BackfillReport, backfill_mcp_history
 from .installation import are_hooks_installed_globally
-from .models import MCPConfiguration
+from .models import MCPConfiguration, Scope
 from .user import get_user_info
 
 
@@ -134,3 +144,154 @@ def _get_display_name(configurations: List[MCPConfiguration]) -> Optional[str]:
         if configuration.display_name:
             return configuration.display_name
     return None
+
+
+def run_discovery(
+    config: Config, *, scan_history: bool = False
+) -> Optional[Dict[str, Any]]:
+    """Discover AI/MCP configuration, submit it to GitGuardian, return a summary.
+
+    Shared by ``ggshield ai discover`` and ``ggshield machine audit``. Discovery
+    itself is local; the upload is best-effort. Returns ``None`` (after warning) when
+    no API client can be built — there is nothing to summarize without the server's
+    enrichment. A failed *upload* (e.g. a missing scope) still returns the local
+    summary, mirroring the previous ``ai discover`` behavior.
+    """
+    discovery = discover_ai_configuration()
+
+    try:
+        client = create_client_from_config(config)
+    except (APIKeyCheckError, UnknownInstanceError) as exc:
+        ui.display_warning(
+            f"Skipping upload of AI discovery to GitGuardian ({exc}). "
+            "Authenticate with `ggshield auth login` to enable upload."
+        )
+        return None
+
+    backfill_report = BackfillReport()
+    try:
+        discovery = submit_ai_discovery(client, discovery)
+        save_discovery_cache(discovery)
+        if scan_history:
+            backfill_report = backfill_mcp_history(client, discovery)
+    except Exception as exc:
+        if "missing the following scope:" in str(exc):
+            scope = str(exc).split("missing the following scope:")[1].strip()
+            reason = (
+                f"this command requires the {scope} scope. "
+                f'Run ggshield auth login --scopes "{scope}" to grant it.'
+            )
+        else:
+            reason = str(exc)
+        ui.display_warning(f"Could not upload AI discovery to GitGuardian: {reason}")
+
+    # Summarize after sending to GIM, so we can benefit from its fixes.
+    return _summarize_discovery(discovery, backfill_report)
+
+
+def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[str, Any]:
+    """Summarize what we want to show of the discovery."""
+    servers = []
+    for server in config.servers:
+        projects = set()
+        agents = set()
+        installed_globally = False
+        for conf in server.configurations:
+            agents.add(conf.agent)
+            if conf.scope == Scope.USER:
+                installed_globally = True
+            elif conf.project:
+                projects.add(conf.project)
+        servers.append(
+            {
+                # If we don't have a display name, any configuration name
+                # is probably less confusing than our deduplication key
+                "name": server.display_name or server.configurations[0].name,
+                "installed_globally": installed_globally,
+                "projects": sorted(projects),
+                "agents": sorted(AGENTS[name].display_name for name in agents),
+            }
+        )
+    servers = sorted(servers, key=lambda x: x["name"])
+    agents = sorted(
+        (
+            {
+                "name": AGENTS[agent.name].display_name,
+                "hooks_installed": agent.hooks_installed,
+            }
+            for agent in config.agents
+        ),
+        key=lambda x: x["name"],
+    )
+    return {
+        "agents": agents,
+        "servers": servers,
+        "history": {
+            "parsed": report.parsed,
+            "ingested": report.ingested,
+            "duplicates": report.duplicates,
+            "skipped": report.skipped,
+        },
+    }
+
+
+def print_summary(summary: Dict[str, Any]) -> None:
+    """Print the summary of the discovery."""
+    agents: List[Dict[str, Any]] = summary.get("agents", [])
+    servers: List[Dict[str, Any]] = summary.get("servers", [])
+
+    nb_servers = len(servers)
+    nb_agents = len(agents)
+
+    if nb_servers == 0:
+        click.echo(format_text("No MCP servers discovered", STYLE["no_secret"]))
+        return
+
+    def _format_agent(agent: Dict[str, Any]) -> str:
+        name = format_text(agent.get("name", "unknown"), STYLE["heading"])
+        status = "hooks installed" if agent.get("hooks_installed") else "no hooks"
+        return f"{name} ({status})"
+
+    click.echo(
+        f"\n{format_text('Agents discovered:', STYLE['key'])} "
+        f"{', '.join(_format_agent(agent) for agent in agents) if agents else 'none'} "
+        f"({nb_agents} {pluralize('agent', nb_agents)})"
+    )
+    click.echo(
+        f"{format_text('MCP servers found:', STYLE['key'])} "
+        f"{nb_servers} {pluralize('server', nb_servers)}\n"
+    )
+
+    for server in servers:
+        name = server.get("name", "unknown")
+        installed_globally = server.get("installed_globally", False)
+        projects: List[str] = server.get("projects", [])
+        server_agents: List[str] = server.get("agents", [])
+
+        start = format_text(">", STYLE["detector_line_start"])
+        server_name = format_text(name, STYLE["detector"])
+        agents_names = ", ".join(
+            format_text(agent, STYLE["heading"]) for agent in server_agents
+        )
+        click.echo(f"{start} {server_name} ({agents_names})")
+
+        indent = "   "
+        scope = "user" if installed_globally else "project"
+        click.echo(f"{indent}{format_text('Scope:', STYLE['key'])} {scope}")
+        if projects:
+            click.echo(f"{indent}{format_text('Projects:', STYLE['key'])}")
+            for j, project in enumerate(projects):
+                connector = "└─" if j == len(projects) - 1 else "├─"
+                click.echo(f"{indent}{connector} {project}")
+
+    click.echo()
+
+    history = summary.get("history")
+    if history and history.get("parsed"):
+        click.echo(f"{format_text('Backfilling MCP usage history…', STYLE['key'])}")
+        click.echo(f"  • Parsed {history['parsed']:,} events")
+        click.echo(
+            f"  • Recorded {history['ingested']:,} events "
+            f"({history['duplicates']:,} already known, "
+            f"{history.get('skipped', 0):,} skipped)"
+        )

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -14,11 +14,7 @@ from pygitguardian.models import AgentInfo, AIDiscovery, Detail, MCPServer
 from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
 from ggshield.core.config import Config
-from ggshield.core.errors import (
-    APIKeyCheckError,
-    UnexpectedError,
-    UnknownInstanceError,
-)
+from ggshield.core.errors import APIKeyCheckError, UnexpectedError, UnknownInstanceError
 from ggshield.core.text_utils import STYLE, format_text, pluralize
 
 from .agents import AGENTS

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -236,6 +236,30 @@ def are_hooks_installed_globally(agent_name: str) -> Tuple[bool, Optional[str]]:
 
 
 @dataclass
+class AgentHookStatus:
+    """Whether the ggshield AI hook is installed for one detected assistant."""
+
+    display_name: str
+    installed: bool
+
+
+def ai_hook_posture() -> List[AgentHookStatus]:
+    """Read-only AI-hook posture: for each detected assistant, is the hook installed?
+
+    Drives the posture section of ``ggshield machine audit``. Only assistants present
+    on this machine are reported; it never writes anything.
+    """
+    statuses = []
+    for agent in AGENTS.values():
+        if agent.is_present():
+            installed, _command = are_hooks_installed_globally(agent.name)
+            statuses.append(
+                AgentHookStatus(display_name=agent.display_name, installed=installed)
+            )
+    return statuses
+
+
+@dataclass
 class SetupSummary:
     """Outcome of configuring AI hooks across one or more agents."""
 

--- a/ggshield/verticals/honeytoken/aws_profile.py
+++ b/ggshield/verticals/honeytoken/aws_profile.py
@@ -285,6 +285,26 @@ def _atomic_write_path(path: Path, parser: ConfigUpdater) -> None:
 # --- public API -------------------------------------------------------------------
 
 
+def profile_present(
+    path: Path, section: str, expected_access_key_id: Optional[str] = None
+) -> bool:
+    """Read-only: whether ``section`` exists on disk (optionally holding our key).
+
+    Used by ``ggshield machine audit`` to report honeytoken posture. Never writes,
+    and never raises — an absent or unparseable file reads as "not present" so the
+    posture report cannot crash on a malformed ``~/.aws`` file.
+    """
+    try:
+        parser = _load_path(path)
+    except (PlacementError, OSError):
+        return False
+    if not parser.has_section(section):
+        return False
+    if expected_access_key_id is None:
+        return True
+    return _get_value(parser, section, _ACCESS_KEY) == expected_access_key_id
+
+
 def require_safe_backend() -> None:
     """Fail closed on POSIX without dir fds: the only alternative is TOCTOU-prone path
     ops, and POSIX is where the root fan-out makes that exploitable. Windows is exempt.

--- a/ggshield/verticals/honeytoken/posture.py
+++ b/ggshield/verticals/honeytoken/posture.py
@@ -1,0 +1,86 @@
+"""Read-only honeytoken posture for ``ggshield machine audit``.
+
+Whether a honeytoken decoy is actually present on this machine can only be answered
+with the server: the decoy's filename and profile name live in the endpoint-deployment
+config, not on disk. This module lists the desired deployments (a GET — it never mints
+anything) and checks each decoy against the filesystem. It never writes, and degrades
+to "not checked" rather than failing when unauthenticated or the API is unavailable.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ggshield.core.client import create_client_from_config
+from ggshield.core.config import Config
+from ggshield.verticals.honeytoken.aws_profile import (
+    SUPPORTED_METHODS,
+    profile_present,
+    resolve_placement,
+)
+from ggshield.verticals.honeytoken.endpoint_deployments import (
+    DeploymentAction,
+    EndpointDeploymentsClient,
+    EndpointDeploymentsError,
+)
+from ggshield.verticals.honeytoken.targets import machine_info_for, resolve_targets
+
+
+@dataclass
+class HoneytokenPosture:
+    """Outcome of the honeytoken posture check.
+
+    ``checked`` is False when we could not determine the state (no auth, missing
+    scope, API error); ``detail`` then explains why. Otherwise ``planted`` and
+    ``missing`` count desired decoys found / absent on disk.
+    """
+
+    checked: bool
+    planted: int = 0
+    missing: int = 0
+    detail: Optional[str] = None
+
+
+def honeytoken_posture(config: Config) -> HoneytokenPosture:
+    """Report whether the machine's honeytoken decoys are present on disk (read-only)."""
+    try:
+        targets = resolve_targets(None, None)
+    except Exception as exc:  # noqa: BLE001 - posture must never crash the audit
+        return HoneytokenPosture(False, detail=f"could not resolve target ({exc})")
+    if not targets:
+        return HoneytokenPosture(False, detail="no target user")
+
+    try:
+        gg_client = create_client_from_config(config)
+    except Exception as exc:  # noqa: BLE001 - typically unauthenticated
+        return HoneytokenPosture(False, detail=str(exc))
+
+    client = EndpointDeploymentsClient(
+        gg_client.session, config.api_url, config.api_key
+    )
+
+    planted = missing = 0
+    for target in targets:
+        try:
+            deployments = client.list(
+                machine_info_for(target.username)["machine_id"], target.username
+            )
+        except EndpointDeploymentsError as exc:
+            detail = "authentication / scope error" if exc.is_auth else str(exc)
+            return HoneytokenPosture(False, detail=detail)
+
+        for item in deployments:
+            if item.action is not DeploymentAction.WRITE:
+                continue
+            if item.method not in SUPPORTED_METHODS:
+                continue
+            try:
+                path, section = resolve_placement(item.method, item.config, target.home)
+            except Exception:  # noqa: BLE001 - skip a placement we can't resolve
+                continue
+            expected = item.token.access_token_id if item.token else None
+            if profile_present(path, section, expected):
+                planted += 1
+            else:
+                missing += 1
+
+    return HoneytokenPosture(True, planted=planted, missing=missing)

--- a/scripts/generate-import-linter-config.py
+++ b/scripts/generate-import-linter-config.py
@@ -73,6 +73,9 @@ STATIC_CONFIG = {
                 # Machine setup configures AI hooks for all detected agents
                 "ggshield.cmd.machine.** -> ggshield.verticals.ai.installation",
                 "ggshield.cmd.machine.** -> ggshield.verticals.ai.agents",
+                # Machine audit reuses AI discovery and honeytoken posture
+                "ggshield.cmd.machine.** -> ggshield.verticals.ai.discovery",
+                "ggshield.cmd.machine.** -> ggshield.verticals.honeytoken.posture",
                 # AI hook command import logic to scan AI hook payloads
                 "ggshield.cmd.secret.scan.ai_hook -> ggshield.verticals.ai.hooks",
             ],

--- a/tests/unit/cmd/machine/test_audit.py
+++ b/tests/unit/cmd/machine/test_audit.py
@@ -206,3 +206,38 @@ class TestPostureSections:
     def test_honeytoken_none_configured(self, capsys):
         out = self._honeytoken(capsys, HoneytokenPosture(True, planted=0, missing=0))
         assert "none configured" in out
+
+
+class TestAuditAiSection:
+    def test_prints_summary_when_discovery_returns_one(self):
+        from ggshield.cmd.machine.audit import _audit_ai
+
+        with patch(f"{BASE}.ContextObj"), patch(
+            f"{BASE}.run_discovery", return_value={"agents": []}
+        ) as m_run, patch(f"{BASE}.print_summary") as m_print:
+            _audit_ai(MagicMock(), scan_history=True)
+        m_run.assert_called_once()
+        assert m_run.call_args.kwargs["scan_history"] is True
+        m_print.assert_called_once_with({"agents": []})
+
+    def test_skips_print_when_discovery_returns_none(self):
+        from ggshield.cmd.machine.audit import _audit_ai
+
+        with patch(f"{BASE}.ContextObj"), patch(
+            f"{BASE}.run_discovery", return_value=None
+        ), patch(f"{BASE}.print_summary") as m_print:
+            _audit_ai(MagicMock(), scan_history=False)
+        m_print.assert_not_called()
+
+
+class TestAuditPostureSection:
+    def test_runs_all_three_posture_checks(self):
+        from ggshield.cmd.machine.audit import _audit_posture
+
+        with patch(f"{BASE}._posture_ai_hooks") as m_ai, patch(
+            f"{BASE}._posture_git_hooks"
+        ) as m_git, patch(f"{BASE}._posture_honeytoken") as m_ht:
+            _audit_posture(MagicMock())
+        m_ai.assert_called_once()
+        m_git.assert_called_once()
+        m_ht.assert_called_once()

--- a/tests/unit/cmd/machine/test_audit.py
+++ b/tests/unit/cmd/machine/test_audit.py
@@ -1,0 +1,208 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import click
+from click.testing import CliRunner
+
+from ggshield.__main__ import cli
+from ggshield.verticals.ai.installation import AgentHookStatus
+from ggshield.verticals.honeytoken.posture import HoneytokenPosture
+from tests.unit.conftest import assert_invoke_ok
+
+
+BASE = "ggshield.cmd.machine.audit"
+
+
+class TestMachineAuditCommand:
+    def test_audit_appears_in_machine_help(self, cli_fs_runner: CliRunner):
+        result = cli_fs_runner.invoke(cli, ["machine", "--help"])
+        assert_invoke_ok(result)
+        assert "audit" in result.output
+
+
+class TestMachineAuditOrchestration:
+    """`machine audit` runs all three sections by default; flags drop one."""
+
+    AI = f"{BASE}._audit_ai"
+    SECRETS = f"{BASE}._audit_secrets"
+    POSTURE = f"{BASE}._audit_posture"
+
+    def _run(self, cli_fs_runner, args, secrets_rc=0):
+        with patch(self.AI) as m_ai, patch(
+            self.SECRETS, return_value=secrets_rc
+        ) as m_sec, patch(self.POSTURE) as m_pos:
+            result = cli_fs_runner.invoke(cli, ["machine", "audit", *args])
+        return result, m_ai, m_sec, m_pos
+
+    def test_runs_all_sections_by_default(self, cli_fs_runner: CliRunner):
+        result, m_ai, m_sec, m_pos = self._run(cli_fs_runner, [])
+        assert_invoke_ok(result)
+        m_ai.assert_called_once()
+        m_sec.assert_called_once()
+        m_pos.assert_called_once()
+
+    def test_no_ai_skips_ai(self, cli_fs_runner: CliRunner):
+        result, m_ai, m_sec, m_pos = self._run(cli_fs_runner, ["--no-ai"])
+        assert_invoke_ok(result)
+        m_ai.assert_not_called()
+        m_sec.assert_called_once()
+        m_pos.assert_called_once()
+
+    def test_no_secrets_skips_secrets(self, cli_fs_runner: CliRunner):
+        result, m_ai, m_sec, m_pos = self._run(cli_fs_runner, ["--no-secrets"])
+        assert_invoke_ok(result)
+        m_sec.assert_not_called()
+        m_ai.assert_called_once()
+        m_pos.assert_called_once()
+
+    def test_no_posture_skips_posture(self, cli_fs_runner: CliRunner):
+        result, m_ai, m_sec, m_pos = self._run(cli_fs_runner, ["--no-posture"])
+        assert_invoke_ok(result)
+        m_pos.assert_not_called()
+
+    def test_exit_code_propagates_from_secret_scan(self, cli_fs_runner: CliRunner):
+        result, _m_ai, _m_sec, _m_pos = self._run(cli_fs_runner, [], secrets_rc=7)
+        assert result.exit_code == 7
+
+    def test_history_flag_forwarded_to_ai(self, cli_fs_runner: CliRunner):
+        result, m_ai, _m_sec, _m_pos = self._run(cli_fs_runner, ["--history"])
+        assert_invoke_ok(result)
+        # _audit_ai(ctx, scan_history) — second positional arg is the history flag.
+        assert m_ai.call_args.args[1] is True
+
+
+class TestSiblingScan:
+    """The native secret scan is reached as a sibling of `audit` in the group."""
+
+    def _ctx(self, has_scan: bool):
+        group = click.Group("machine")
+        if has_scan:
+
+            @click.command(name="scan")
+            def scan() -> None:  # pragma: no cover - never executed in this test
+                pass
+
+            group.add_command(scan)
+        return SimpleNamespace(parent=SimpleNamespace(command=group))
+
+    def test_finds_scan_when_present(self):
+        from ggshield.cmd.machine.audit import _find_sibling_scan
+
+        assert _find_sibling_scan(self._ctx(has_scan=True)) is not None
+
+    def test_returns_none_when_absent(self):
+        from ggshield.cmd.machine.audit import _find_sibling_scan
+
+        assert _find_sibling_scan(self._ctx(has_scan=False)) is None
+
+    def test_returns_none_without_parent_group(self):
+        from ggshield.cmd.machine.audit import _find_sibling_scan
+
+        assert _find_sibling_scan(SimpleNamespace(parent=None)) is None
+
+
+class TestAuditSecrets:
+    def test_no_plugin_prints_hint_and_succeeds(self, capsys):
+        from ggshield.cmd.machine.audit import _audit_secrets
+
+        group = click.Group("machine")  # no `scan` registered
+        ctx = MagicMock()
+        ctx.parent.command = group
+
+        assert _audit_secrets(ctx) == 0
+        ctx.invoke.assert_not_called()
+        captured = capsys.readouterr()
+        assert "machine_scan plugin" in captured.out + captured.err
+
+    def test_invokes_plugin_scan_when_present(self):
+        from ggshield.cmd.machine.audit import _audit_secrets
+
+        @click.command(name="scan")
+        def scan() -> None:  # pragma: no cover
+            pass
+
+        group = click.Group("machine")
+        group.add_command(scan)
+        ctx = MagicMock()
+        ctx.parent.command = group
+        ctx.invoke.return_value = 0
+
+        assert _audit_secrets(ctx) == 0
+        ctx.invoke.assert_called_once()
+        assert ctx.invoke.call_args.args[0] is scan
+
+
+class TestPostureSections:
+    def test_ai_hooks_reports_installed_and_missing(self, capsys):
+        from ggshield.cmd.machine.audit import _posture_ai_hooks
+
+        with patch(
+            f"{BASE}.ai_hook_posture",
+            return_value=[
+                AgentHookStatus("Claude Code", True),
+                AgentHookStatus("Cursor", False),
+            ],
+        ):
+            _posture_ai_hooks()
+        out = capsys.readouterr().out
+        assert "Claude Code]: installed" in out
+        assert "Cursor]: missing" in out
+
+    def test_ai_hooks_none_detected(self, capsys):
+        from ggshield.cmd.machine.audit import _posture_ai_hooks
+
+        with patch(f"{BASE}.ai_hook_posture", return_value=[]):
+            _posture_ai_hooks()
+        assert "no AI coding assistants detected" in capsys.readouterr().out
+
+    def test_git_hooks_installed_foreign_and_missing(self, capsys, tmp_path):
+        from ggshield.cmd.machine.audit import _posture_git_hooks
+
+        (tmp_path / "pre-commit").write_text(
+            "#!/bin/sh\nggshield secret scan pre-commit\n"
+        )
+        (tmp_path / "pre-push").write_text("#!/bin/sh\nother-tool\n")
+        with patch(f"{BASE}.get_global_hook_dir_path", return_value=None), patch(
+            f"{BASE}.get_default_global_hook_dir_path", return_value=tmp_path
+        ):
+            _posture_git_hooks()
+        out = capsys.readouterr().out
+        assert "git pre-commit hook: installed" in out
+        assert "git pre-push hook: present but not ggshield" in out
+
+    def test_git_hooks_missing(self, capsys, tmp_path):
+        from ggshield.cmd.machine.audit import _posture_git_hooks
+
+        with patch(f"{BASE}.get_global_hook_dir_path", return_value=None), patch(
+            f"{BASE}.get_default_global_hook_dir_path", return_value=tmp_path
+        ):
+            _posture_git_hooks()
+        out = capsys.readouterr().out
+        assert "git pre-commit hook: missing" in out
+        assert "git pre-push hook: missing" in out
+
+    def _honeytoken(self, capsys, posture):
+        from ggshield.cmd.machine.audit import _posture_honeytoken
+
+        ctx = MagicMock()
+        with patch(f"{BASE}.honeytoken_posture", return_value=posture), patch(
+            f"{BASE}.ContextObj"
+        ):
+            _posture_honeytoken(ctx)
+        return capsys.readouterr().out
+
+    def test_honeytoken_not_checked(self, capsys):
+        out = self._honeytoken(capsys, HoneytokenPosture(False, detail="no auth"))
+        assert "honeytoken: not checked (no auth)" in out
+
+    def test_honeytoken_planted(self, capsys):
+        out = self._honeytoken(capsys, HoneytokenPosture(True, planted=2, missing=0))
+        assert "honeytoken: planted (2)" in out
+
+    def test_honeytoken_partial(self, capsys):
+        out = self._honeytoken(capsys, HoneytokenPosture(True, planted=1, missing=1))
+        assert "1 planted, 1 missing" in out
+
+    def test_honeytoken_none_configured(self, capsys):
+        out = self._honeytoken(capsys, HoneytokenPosture(True, planted=0, missing=0))
+        assert "none configured" in out

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -13,8 +13,8 @@ from pygitguardian.models import (
 )
 
 from ggshield.__main__ import cli
-from ggshield.cmd.ai.discover import print_summary
 from ggshield.core.errors import APIKeyCheckError, MissingTokenError
+from ggshield.verticals.ai.discovery import print_summary
 from ggshield.verticals.ai.history import BackfillReport
 from ggshield.verticals.ai.models import Scope, Transport
 
@@ -217,15 +217,15 @@ class TestAiHookCmd:
 
 class TestDiscoverCmd:
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     def test_default_output(
         self,
         mock_save: MagicMock,
@@ -240,15 +240,15 @@ class TestDiscoverCmd:
         mock_discover.assert_called_once()
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     def test_json_flag(
         self,
         mock_save: MagicMock,
@@ -265,11 +265,11 @@ class TestDiscoverCmd:
         assert "servers" in parsed
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
     @patch(
-        "ggshield.cmd.ai.discover.create_client_from_config",
+        "ggshield.verticals.ai.discovery.create_client_from_config",
         side_effect=APIKeyCheckError("https://api.gitguardian.com", "no key"),
     )
     def test_auth_failure_shows_warning(
@@ -282,12 +282,12 @@ class TestDiscoverCmd:
         assert "Skipping upload" in result.output or "warning" in result.output.lower()
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
         side_effect=RuntimeError("API error"),
     )
     def test_api_submission_failure_shows_warning(
@@ -300,13 +300,13 @@ class TestDiscoverCmd:
         assert "Could not upload" in result.output or "warning" in result.output.lower()
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
     )
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     def test_text_output_with_servers(
         self,
         mock_save: MagicMock,
@@ -362,13 +362,13 @@ class TestDiscoverCmd:
         assert "/home/user/project-b" in result.output
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
     )
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     def test_json_output_with_servers(
         self,
         mock_save: MagicMock,
@@ -403,14 +403,14 @@ class TestDiscoverCmd:
         assert parsed["servers"][0]["installed_globally"] is True
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
-    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.submit_ai_discovery")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     @patch(
-        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        "ggshield.verticals.ai.discovery.backfill_mcp_history",
         return_value=BackfillReport(parsed=3, ingested=3, duplicates=0),
     )
     def test_history_flag_invokes_backfill_and_surfaces_summary(
@@ -443,13 +443,13 @@ class TestDiscoverCmd:
         assert "3" in result.output and "MCP" in result.output
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
-    @patch("ggshield.cmd.ai.discover.submit_ai_discovery")
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
-    @patch("ggshield.cmd.ai.discover.backfill_mcp_history")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.submit_ai_discovery")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.backfill_mcp_history")
     def test_history_skipped_without_flag(
         self,
         mock_backfill: MagicMock,
@@ -467,17 +467,17 @@ class TestDiscoverCmd:
         mock_backfill.assert_not_called()
 
     @patch(
-        "ggshield.cmd.ai.discover.discover_ai_configuration",
+        "ggshield.verticals.ai.discovery.discover_ai_configuration",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.create_client_from_config")
+    @patch("ggshield.verticals.ai.discovery.create_client_from_config")
     @patch(
-        "ggshield.cmd.ai.discover.submit_ai_discovery",
+        "ggshield.verticals.ai.discovery.submit_ai_discovery",
         return_value=_discovery(),
     )
-    @patch("ggshield.cmd.ai.discover.save_discovery_cache")
+    @patch("ggshield.verticals.ai.discovery.save_discovery_cache")
     @patch(
-        "ggshield.cmd.ai.discover.backfill_mcp_history",
+        "ggshield.verticals.ai.discovery.backfill_mcp_history",
         return_value=BackfillReport(parsed=4, ingested=2, duplicates=1, skipped=1),
     )
     def test_json_output_includes_history_block(

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -11,8 +11,10 @@ import pytest
 from ggshield.core.errors import UnexpectedError
 from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor
 from ggshield.verticals.ai.installation import (
+    AgentHookStatus,
     InstallationStats,
     _fill_dict,
+    ai_hook_posture,
     are_hooks_installed_globally,
     build_hook_command,
     install_hooks,
@@ -556,3 +558,44 @@ class TestBuildHookCommand:
         ):
             with _simulate_platform([argv0, "install"], windows=False):
                 assert build_hook_command() == f"{argv0} secret scan ai-hook"
+
+
+class _FakeAgent:
+    """Minimal stand-in for an Agent for posture tests."""
+
+    def __init__(self, name: str, display_name: str, present: bool):
+        self.name = name
+        self.display_name = display_name
+        self._present = present
+
+    def is_present(self) -> bool:
+        return self._present
+
+
+class TestAiHookPosture:
+    AGENTS_PATH = "ggshield.verticals.ai.installation.AGENTS"
+    HOOKS_PATH = "ggshield.verticals.ai.installation.are_hooks_installed_globally"
+
+    def test_reports_only_present_agents(self):
+        fakes = {
+            "a": _FakeAgent("a", "Agent A", present=True),
+            "b": _FakeAgent("b", "Agent B", present=False),
+        }
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(
+            self.HOOKS_PATH, return_value=(True, "cmd")
+        ):
+            statuses = ai_hook_posture()
+        assert statuses == [AgentHookStatus(display_name="Agent A", installed=True)]
+
+    def test_reports_installed_flag(self):
+        fakes = {"a": _FakeAgent("a", "Agent A", present=True)}
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(
+            self.HOOKS_PATH, return_value=(False, None)
+        ):
+            statuses = ai_hook_posture()
+        assert statuses == [AgentHookStatus(display_name="Agent A", installed=False)]
+
+    def test_empty_when_no_agents_present(self):
+        fakes = {"a": _FakeAgent("a", "Agent A", present=False)}
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(self.HOOKS_PATH):
+            assert ai_hook_posture() == []

--- a/tests/unit/verticals/honeytoken/test_aws_profile.py
+++ b/tests/unit/verticals/honeytoken/test_aws_profile.py
@@ -13,6 +13,7 @@ from ggshield.verticals.honeytoken.aws_profile import (
     RemoveOutcome,
     WriteOutcome,
     aws_path,
+    profile_present,
     remove_aws_profile,
     resolve_placement,
     write_aws_profile,
@@ -528,3 +529,35 @@ def test_write_cleans_up_temp_on_failure(tmp_path, monkeypatch):
     leftover = [p.name for p in path.parent.iterdir() if p.name.startswith(".plant.")]
     assert leftover == []
     assert path.read_text() == original
+
+
+# --- profile_present (read-only posture check) -------------------------------------
+
+
+def test_profile_present_true_when_section_exists(tmp_path):
+    path = tmp_path / "credentials"
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    assert profile_present(path, "gg") is True
+
+
+def test_profile_present_false_when_file_absent(tmp_path):
+    assert profile_present(tmp_path / "credentials", "gg") is False
+
+
+def test_profile_present_false_when_section_absent(tmp_path):
+    path = tmp_path / "credentials"
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    assert profile_present(path, "other") is False
+
+
+def test_profile_present_matches_expected_access_key(tmp_path):
+    path = tmp_path / "credentials"
+    write_aws_profile(path, "gg", _creds("K1", "S1"), force=False)
+    assert profile_present(path, "gg", expected_access_key_id="K1") is True
+    assert profile_present(path, "gg", expected_access_key_id="OTHER") is False
+
+
+def test_profile_present_false_on_unparseable_file(tmp_path):
+    path = tmp_path / "credentials"
+    path.write_text("this is = not [valid INI [[[")
+    assert profile_present(path, "gg") is False

--- a/tests/unit/verticals/honeytoken/test_posture.py
+++ b/tests/unit/verticals/honeytoken/test_posture.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ggshield.verticals.honeytoken.endpoint_deployments import (
+    Deployment,
+    DeploymentAction,
+    DeploymentMethod,
+    EndpointDeploymentsError,
+    HoneytokenCreds,
+    PlacementConfig,
+)
+from ggshield.verticals.honeytoken.posture import HoneytokenPosture, honeytoken_posture
+
+
+BASE = "ggshield.verticals.honeytoken.posture"
+
+
+def _target(username="alice"):
+    return SimpleNamespace(username=username, home=Path("/home") / username)
+
+
+def _deployment(action, *, method=DeploymentMethod.AWS_CREDENTIALS):
+    return Deployment(
+        id="d1",
+        action=action,
+        method=method,
+        config=PlacementConfig(filename="credentials", profile_name="gg"),
+        token=HoneytokenCreds(access_token_id="K1", secret_key="S1"),
+    )
+
+
+def _config():
+    return MagicMock(api_url="https://api.gitguardian.com", api_key="tok")
+
+
+def test_not_checked_when_no_targets():
+    with patch(f"{BASE}.resolve_targets", return_value=[]):
+        result = honeytoken_posture(_config())
+    assert result == HoneytokenPosture(False, detail="no target user")
+
+
+def test_not_checked_when_resolve_targets_raises():
+    with patch(f"{BASE}.resolve_targets", side_effect=LookupError("boom")):
+        result = honeytoken_posture(_config())
+    assert result.checked is False
+    assert "boom" in (result.detail or "")
+
+
+def test_not_checked_when_client_creation_fails():
+    with patch(f"{BASE}.resolve_targets", return_value=[_target()]), patch(
+        f"{BASE}.create_client_from_config", side_effect=RuntimeError("no auth")
+    ):
+        result = honeytoken_posture(_config())
+    assert result.checked is False
+    assert "no auth" in (result.detail or "")
+
+
+def test_not_checked_on_auth_error():
+    with patch(f"{BASE}.resolve_targets", return_value=[_target()]), patch(
+        f"{BASE}.create_client_from_config", return_value=MagicMock()
+    ), patch(f"{BASE}.machine_info_for", return_value={"machine_id": "m1"}), patch(
+        f"{BASE}.EndpointDeploymentsClient"
+    ) as mock_client:
+        mock_client.return_value.list.side_effect = EndpointDeploymentsError(
+            "denied", status_code=403
+        )
+        result = honeytoken_posture(_config())
+    assert result.checked is False
+    assert "authentication / scope error" in (result.detail or "")
+
+
+def test_counts_planted_and_missing():
+    deployments = [
+        _deployment(DeploymentAction.WRITE),
+        _deployment(DeploymentAction.WRITE),
+        _deployment(DeploymentAction.DELETE),  # ignored
+        _deployment(DeploymentAction.WRITE, method=DeploymentMethod.UNKNOWN),  # skipped
+    ]
+    with patch(f"{BASE}.resolve_targets", return_value=[_target()]), patch(
+        f"{BASE}.create_client_from_config", return_value=MagicMock()
+    ), patch(f"{BASE}.machine_info_for", return_value={"machine_id": "m1"}), patch(
+        f"{BASE}.EndpointDeploymentsClient"
+    ) as mock_client, patch(
+        f"{BASE}.resolve_placement", return_value=(Path("/home/alice/.aws/x"), "gg")
+    ), patch(
+        f"{BASE}.profile_present", side_effect=[True, False]
+    ):
+        mock_client.return_value.list.return_value = deployments
+        result = honeytoken_posture(_config())
+    assert result == HoneytokenPosture(True, planted=1, missing=1)


### PR DESCRIPTION
## Context

`machine setup` (#1320) shipped as the definitive "set up all protections" command. This adds its read-only twin: a single command to see what's exposed on a machine and whether its protections are actually in place — the kind of read an MDM-deploying security engineer wants per fleet machine.

## What this PR does

- Adds **`ggshield machine audit`**, a read-only umbrella command. In one run, each section on by default:
  - **AI/MCP discovery** — discovers agents + MCP servers and uploads to GitGuardian (best-effort).
  - **Secret scan** — runs the native `machine_scan` scan when the plugin is installed; without it, prints a one-line install hint (not an error).
  - **Protection posture** — reports whether AI hooks, global git hooks, and a honeytoken are in place, then nudges `machine setup` for anything missing.
  - Toggles: `--no-ai` / `--no-secrets` / `--no-posture`. `--history` also backfills historical MCP tool calls during discovery.
- **Exit code** reflects the secret scan only (so CI/MDM can gate on findings); discovery and posture are informational and only warn.
- **No plugin loader / satori coordination.** Audit reaches the plugin-owned `scan` at runtime as a sibling command (`ctx.invoke`) — the same pattern `machine setup` uses to invoke `honeytoken plant`. `machine scan` keeps its full flag surface, untouched, for power users who want fine-grained control.
- **`ai discover` is unchanged** and stays first-class; its body is factored into a shared `run_discovery()` helper that `machine audit` reuses.
- Internal: `ai_hook_posture()` (AI hooks) and a read-only `profile_present()` (honeytoken on-disk check) helpers; new `verticals/honeytoken/posture.py`; documented import-linter exceptions for the new cmd→vertical reuse.

## Notes / follow-ups

- **Honeytoken posture needs the `honeytokens:read` scope.** It can't be checked locally (the decoy's profile name lives in the endpoint-deployment config), so it does a read-only `GET` (never mints) and checks the result on disk. Without auth or the scope it degrades to "honeytoken: not checked (…)" rather than failing.
- Out of scope: a unified `--json` across all three sections (the native scan owns its own output stream); folding `machine inventory` (NHI) into the sweep; a `PluginCapability.MACHINE_SCAN` capability API (only worthwhile if a second scanner appears).

## Validation

```
ggshield machine audit
ggshield machine audit --no-secrets --no-posture   # AI discovery only
ggshield machine audit --no-ai --no-secrets        # posture only
ggshield machine --help
```

Tested locally:
- **Unit:** 492 passing (audit orchestration + per-section isolation, sibling-scan lookup with/without plugin, exit-code propagation, posture states, and `ai discover` parity after the shared-runner refactor).
- **Runtime (real CLI):** posture-only (graceful honeytoken degrade), no-plugin hint path (`machine --help` drops `scan`), AI discovery (39 servers / 4 agents), and secret-scan delegation to the native plugin scan — all observed.
- black / isort / flake8 / pyright clean; import-linter both contracts KEPT.

## PR check list

- [x] The changes include tests (unit)
- [x] Changelog entry added (`changelog.d/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
