### PR TITLE
feat(machine): install git hooks machine-wide when setup runs as root

### DIFF
--- a/changelog.d/20260624_160000_achille.mascia_machine_setup_system_hooks.md
+++ b/changelog.d/20260624_160000_achille.mascia_machine_setup_system_hooks.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield machine setup` now installs git hooks **machine-wide** (for every user) when run as root or with the new `--system` flag, instead of only for the invoking user. This makes MDM/fleet deployments work as expected: a single root-run `machine setup` sets git's system `core.hooksPath`, so every user on the machine is covered. Without root (and without `--system`) it keeps installing per-user as before.

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -9,7 +9,7 @@ from click import UsageError
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
-from ggshield.core.dirs import get_data_dir
+from ggshield.core.dirs import get_data_dir, get_system_data_dir
 from ggshield.core.errors import UnexpectedError
 from ggshield.utils.git_shell import check_git_dir, git
 from ggshield.verticals.ai.installation import (
@@ -126,6 +126,49 @@ def get_global_hook_dir_path() -> Optional[Path]:
     return Path(click.format_filename(out)).expanduser()
 
 
+def install_system(hook_type: str, force: bool, append: bool) -> int:
+    """System-wide (all users) pre-commit/pre-push hook installation.
+
+    Sets git's ``--system`` ``core.hooksPath`` to a shared, world-readable directory
+    so every user on the machine inherits the hook from a single install — the right
+    behavior when ``machine setup`` runs as root under an MDM. Requires write access
+    to the system git config and data dir (i.e. root).
+    """
+    hook_dir_path = get_system_hook_dir_path()
+
+    if not hook_dir_path:
+        hook_dir_path = get_default_system_hook_dir_path()
+        git(
+            ["config", "--system", "core.hooksPath", str(hook_dir_path)],
+            ignore_git_config=False,
+        )
+
+    return create_hook(
+        hook_dir_path=hook_dir_path,
+        force=force,
+        local_hook_support=True,
+        hook_type=hook_type,
+        append=append,
+        world_readable=True,
+    )
+
+
+def get_default_system_hook_dir_path() -> Path:
+    """Return the machine-wide directory in which ggshield creates its system hooks."""
+    return get_system_data_dir() / "git-hooks"
+
+
+def get_system_hook_dir_path() -> Optional[Path]:
+    """Return the hooks path defined in git system config (if it exists)."""
+    try:
+        out = git(
+            ["config", "--system", "--get", "core.hooksPath"], ignore_git_config=False
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return Path(click.format_filename(out)).expanduser()
+
+
 def install_local(hook_type: str, force: bool, append: bool) -> int:
     """Local pre-commit/pre-push hook installation."""
     check_git_dir()
@@ -181,9 +224,21 @@ def create_hook(
     local_hook_support: bool,
     hook_type: str,
     append: bool,
+    world_readable: bool = False,
 ) -> int:
-    """Create hook directory (if needed) and pre-commit/pre-push file."""
+    """Create hook directory (if needed) and pre-commit/pre-push file.
+
+    ``world_readable`` makes the directory and hook script readable and executable by
+    every user (0755) instead of owner-only (0700) — required for a system-wide
+    install, where the hook runs as each committing user.
+    """
     hook_dir_path.mkdir(parents=True, exist_ok=True)
+    if world_readable:
+        # A system-scoped hooks dir must be traversable + readable by all users.
+        try:
+            os.chmod(hook_dir_path, 0o755)
+        except OSError:
+            pass
     hook_path = hook_dir_path / hook_type
 
     if hook_path.is_dir():
@@ -209,7 +264,7 @@ def create_hook(
             f.write("\n")
 
         f.write(f'ggshield secret scan {hook_type} "$@"\n')
-        os.chmod(hook_path, 0o700)
+        os.chmod(hook_path, 0o755 if world_readable else 0o700)
 
     click.echo(
         f"{hook_type} successfully added in"

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Tuple
 
 import click
@@ -15,6 +14,7 @@ from ggshield.cmd.install import (
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.utils.os import is_root
 from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.installation import (
     check_ai_hook_authentication,
@@ -140,7 +140,7 @@ def _setup_git_hooks(system: bool) -> bool:
     overwritten. Returns False if any hook failed to install.
     """
     click.echo(click.style("Git hooks", bold=True))
-    use_system = system or _is_root()
+    use_system = system or is_root()
     if use_system:
         scope = "system"
         hook_dir = get_system_hook_dir_path() or get_default_system_hook_dir_path()
@@ -168,15 +168,6 @@ def _setup_git_hooks(system: bool) -> bool:
             ui.display_warning(f"  could not install {scope} {hook_type} hook: {exc}")
             ok = False
     return ok
-
-
-def _is_root() -> bool:
-    """Whether ggshield runs as root (POSIX). Selects machine-wide git hooks.
-
-    On non-POSIX platforms there is no ``geteuid``; the per-user path is used unless
-    ``--system`` is passed explicitly.
-    """
-    return hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 def _setup_honeytokens(ctx: click.Context) -> bool:

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Tuple
 
 import click
@@ -5,8 +6,11 @@ import click
 from ggshield.cmd.honeytoken.plant import plant_cmd
 from ggshield.cmd.install import (
     get_default_global_hook_dir_path,
+    get_default_system_hook_dir_path,
     get_global_hook_dir_path,
+    get_system_hook_dir_path,
     install_global,
+    install_system,
 )
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
@@ -54,6 +58,13 @@ _GIT_HOOK_TYPES = ("pre-commit", "pre-push")
     metavar="ASSISTANT",
     help="Skip these assistants when configuring the AI hook (repeatable).",
 )
+@click.option(
+    "--system",
+    "system",
+    is_flag=True,
+    help="Install the git hooks machine-wide (all users) instead of for the "
+    "current user. Implied when running as root, e.g. under an MDM.",
+)
 @add_common_options()
 @click.pass_context
 def setup_cmd(
@@ -63,6 +74,7 @@ def setup_cmd(
     no_honeytokens: bool,
     agents: Tuple[str, ...],
     exclude_agents: Tuple[str, ...],
+    system: bool,
     **kwargs: Any,
 ) -> int:
     """
@@ -75,7 +87,8 @@ def setup_cmd(
 
     Each protection is on by default; drop one with `--no-ai-hooks`,
     `--no-git-hooks`, or `--no-honeytokens`. `--agent` / `--exclude-agent`
-    narrow which assistants get the AI hook.
+    narrow which assistants get the AI hook. When run as root (or with
+    `--system`), the git hooks are installed machine-wide for every user.
     """
     if agents and exclude_agents:
         raise click.UsageError("--agent and --exclude-agent cannot be used together.")
@@ -87,7 +100,7 @@ def setup_cmd(
             failed = True
 
     if not no_git_hooks:
-        if not _setup_git_hooks():
+        if not _setup_git_hooks(system):
             failed = True
 
     if not no_honeytokens:
@@ -115,32 +128,55 @@ def _setup_ai_hooks(
     return summary.failed == 0
 
 
-def _setup_git_hooks() -> bool:
-    """Install the global git pre-commit/pre-push hooks, idempotently.
+def _setup_git_hooks(system: bool) -> bool:
+    """Install the git pre-commit/pre-push hooks, idempotently.
+
+    Per-user (``global``) by default. Machine-wide (``system``) when ``--system`` is
+    given or ggshield runs as root: it sets git's system ``core.hooksPath`` once so
+    every user on the machine is covered — the right behavior for MDM, where a
+    per-user (root-only) install would protect nobody who actually commits.
 
     A hook already wired to ggshield is left as-is; a foreign hook is never
     overwritten. Returns False if any hook failed to install.
     """
     click.echo(click.style("Git hooks", bold=True))
-    hook_dir = get_global_hook_dir_path() or get_default_global_hook_dir_path()
+    use_system = system or _is_root()
+    if use_system:
+        scope = "system"
+        hook_dir = get_system_hook_dir_path() or get_default_system_hook_dir_path()
+        installer = install_system
+    else:
+        scope = "global"
+        hook_dir = get_global_hook_dir_path() or get_default_global_hook_dir_path()
+        installer = install_global
+
     ok = True
     for hook_type in _GIT_HOOK_TYPES:
         hook_path = hook_dir / hook_type
         if hook_path.is_file():
             if "ggshield secret scan" in hook_path.read_text(errors="ignore"):
-                click.echo(f"  global {hook_type} hook already configured")
+                click.echo(f"  {scope} {hook_type} hook already configured")
             else:
                 ui.display_warning(
-                    f"  a non-ggshield global {hook_type} hook is present; "
+                    f"  a non-ggshield {scope} {hook_type} hook is present; "
                     "left untouched"
                 )
             continue
         try:
-            install_global(hook_type=hook_type, force=False, append=False)
+            installer(hook_type=hook_type, force=False, append=False)
         except Exception as exc:  # one hook failure must not abort the whole setup
-            ui.display_warning(f"  could not install global {hook_type} hook: {exc}")
+            ui.display_warning(f"  could not install {scope} {hook_type} hook: {exc}")
             ok = False
     return ok
+
+
+def _is_root() -> bool:
+    """Whether ggshield runs as root (POSIX). Selects machine-wide git hooks.
+
+    On non-POSIX platforms there is no ``geteuid``; the per-user path is used unless
+    ``--system`` is passed explicitly.
+    """
+    return hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 def _setup_honeytokens(ctx: click.Context) -> bool:

--- a/ggshield/core/dirs.py
+++ b/ggshield/core/dirs.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from platformdirs import user_cache_dir, user_config_dir, user_data_dir
+from platformdirs import site_data_dir, user_cache_dir, user_config_dir, user_data_dir
 
 from ggshield.utils.git_shell import NotAGitDirectory, get_git_root
 
@@ -42,6 +42,19 @@ def get_data_dir() -> Path:
         return Path(
             user_data_dir(appname=APPNAME, appauthor=APPAUTHOR)
         )  # pragma: no cover
+
+
+def get_system_data_dir() -> Path:
+    """Machine-wide (all users) data dir, e.g. for system-scoped git hooks.
+
+    The system counterpart to :func:`get_data_dir`; used when ``machine setup`` runs
+    as root and installs git hooks for every user on the machine.
+    """
+    try:
+        # See tests/conftest.py for details
+        return Path(os.environ["GG_SYSTEM_DATA_DIR"])
+    except KeyError:
+        return Path(site_data_dir(appname=APPNAME, appauthor=APPAUTHOR))
 
 
 def get_plugins_dir(*, create: bool = False) -> Path:

--- a/ggshield/utils/os.py
+++ b/ggshield/utils/os.py
@@ -52,6 +52,16 @@ def parse_os_release(os_release_path: Path) -> Tuple[str, str]:
         return error_tuple
 
 
+def is_root() -> bool:
+    """Whether the process runs as the POSIX superuser (euid 0).
+
+    Always False where there is no ``geteuid`` (e.g. Windows). Used to decide
+    machine-wide behavior, such as planting honeytokens for every user or
+    installing git hooks system-wide.
+    """
+    return hasattr(os, "geteuid") and os.geteuid() == 0
+
+
 @contextmanager
 def cd(newdir: Union[str, Path]) -> Iterator[None]:
     """

--- a/ggshield/verticals/honeytoken/targets.py
+++ b/ggshield/verticals/honeytoken/targets.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional
 
 from ggshield.core.dirs import get_user_home_dir
 from ggshield.core.machine_id import _get_hostname, _get_machine_id, _get_username
+from ggshield.utils.os import is_root  # re-exported for cmd.honeytoken.plant
 from ggshield.verticals.honeytoken.aws_profile import (
     PlacementError,
     open_aws_dir_fd,
@@ -50,10 +51,6 @@ class Target:
     home: Path
     # Numeric uid for chown when running as root (None when not needed/known).
     uid: Optional[int]
-
-
-def is_root() -> bool:
-    return hasattr(os, "geteuid") and os.geteuid() == 0
 
 
 def machine_info_for(username: str) -> Dict[str, str]:

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -217,9 +217,9 @@ class TestMachineSetupOrchestration:
 class TestSetupGitHooks:
     BASE = "ggshield.cmd.machine.setup"
 
-    # ``_is_root`` is pinned False so the per-user branch is deterministic even when
+    # ``is_root`` is pinned False so the per-user branch is deterministic even when
     # the test runs as root (e.g. a CI container).
-    @patch(f"{BASE}._is_root", return_value=False)
+    @patch(f"{BASE}.is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
@@ -232,7 +232,7 @@ class TestSetupGitHooks:
         assert _setup_git_hooks(system=False) is True
         assert mock_install.call_count == 2  # pre-commit + pre-push
 
-    @patch(f"{BASE}._is_root", return_value=False)
+    @patch(f"{BASE}.is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
@@ -249,7 +249,7 @@ class TestSetupGitHooks:
         assert _setup_git_hooks(system=False) is True
         mock_install.assert_not_called()
 
-    @patch(f"{BASE}._is_root", return_value=False)
+    @patch(f"{BASE}.is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
@@ -264,7 +264,7 @@ class TestSetupGitHooks:
         assert _setup_git_hooks(system=False) is True
         mock_install.assert_not_called()
 
-    @patch(f"{BASE}._is_root", return_value=False)
+    @patch(f"{BASE}.is_root", return_value=False)
     @patch(f"{BASE}.install_system")
     @patch(f"{BASE}.get_system_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_system_hook_dir_path")
@@ -277,7 +277,7 @@ class TestSetupGitHooks:
         assert _setup_git_hooks(system=True) is True
         assert mock_install.call_count == 2  # install_system, not install_global
 
-    @patch(f"{BASE}._is_root", return_value=True)
+    @patch(f"{BASE}.is_root", return_value=True)
     @patch(f"{BASE}.install_system")
     @patch(f"{BASE}.get_system_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_system_hook_dir_path")

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -199,25 +199,45 @@ class TestMachineSetupOrchestration:
         result, _m_ai, _m_git, _m_ht = self._run(cli_fs_runner, [], git=False)
         assert result.exit_code == 1
 
+    def test_system_flag_forwarded_to_git_hooks(self, cli_fs_runner: CliRunner):
+        result, _m_ai, m_git, _m_ht = self._run(
+            cli_fs_runner, ["--system", "--no-ai-hooks", "--no-honeytokens"]
+        )
+        assert_invoke_ok(result)
+        m_git.assert_called_once_with(True)
+
+    def test_git_hooks_default_to_non_system(self, cli_fs_runner: CliRunner):
+        result, _m_ai, m_git, _m_ht = self._run(
+            cli_fs_runner, ["--no-ai-hooks", "--no-honeytokens"]
+        )
+        assert_invoke_ok(result)
+        m_git.assert_called_once_with(False)
+
 
 class TestSetupGitHooks:
     BASE = "ggshield.cmd.machine.setup"
 
+    # ``_is_root`` is pinned False so the per-user branch is deterministic even when
+    # the test runs as root (e.g. a CI container).
+    @patch(f"{BASE}._is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
-    def test_installs_absent_hooks(self, mock_dir, _mock_cfg, mock_install, tmp_path):
+    def test_installs_absent_hooks(
+        self, mock_dir, _mock_cfg, mock_install, _mock_root, tmp_path
+    ):
         from ggshield.cmd.machine.setup import _setup_git_hooks
 
         mock_dir.return_value = tmp_path  # empty dir -> both hooks absent
-        assert _setup_git_hooks() is True
+        assert _setup_git_hooks(system=False) is True
         assert mock_install.call_count == 2  # pre-commit + pre-push
 
+    @patch(f"{BASE}._is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
     def test_skips_existing_ggshield_hooks(
-        self, mock_dir, _mock_cfg, mock_install, tmp_path
+        self, mock_dir, _mock_cfg, mock_install, _mock_root, tmp_path
     ):
         from ggshield.cmd.machine.setup import _setup_git_hooks
 
@@ -226,22 +246,49 @@ class TestSetupGitHooks:
             (tmp_path / hook_type).write_text(
                 f"#!/bin/sh\nggshield secret scan {hook_type}\n"
             )
-        assert _setup_git_hooks() is True
+        assert _setup_git_hooks(system=False) is True
         mock_install.assert_not_called()
 
+    @patch(f"{BASE}._is_root", return_value=False)
     @patch(f"{BASE}.install_global")
     @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
     @patch(f"{BASE}.get_default_global_hook_dir_path")
     def test_leaves_foreign_hooks_untouched(
-        self, mock_dir, _mock_cfg, mock_install, tmp_path
+        self, mock_dir, _mock_cfg, mock_install, _mock_root, tmp_path
     ):
         from ggshield.cmd.machine.setup import _setup_git_hooks
 
         mock_dir.return_value = tmp_path
         (tmp_path / "pre-commit").write_text("#!/bin/sh\nother-tool\n")
         (tmp_path / "pre-push").write_text("#!/bin/sh\nggshield secret scan pre-push\n")
-        assert _setup_git_hooks() is True
+        assert _setup_git_hooks(system=False) is True
         mock_install.assert_not_called()
+
+    @patch(f"{BASE}._is_root", return_value=False)
+    @patch(f"{BASE}.install_system")
+    @patch(f"{BASE}.get_system_hook_dir_path", return_value=None)
+    @patch(f"{BASE}.get_default_system_hook_dir_path")
+    def test_system_scope_via_flag(
+        self, mock_dir, _mock_cfg, mock_install, _mock_root, tmp_path
+    ):
+        from ggshield.cmd.machine.setup import _setup_git_hooks
+
+        mock_dir.return_value = tmp_path
+        assert _setup_git_hooks(system=True) is True
+        assert mock_install.call_count == 2  # install_system, not install_global
+
+    @patch(f"{BASE}._is_root", return_value=True)
+    @patch(f"{BASE}.install_system")
+    @patch(f"{BASE}.get_system_hook_dir_path", return_value=None)
+    @patch(f"{BASE}.get_default_system_hook_dir_path")
+    def test_system_scope_when_root(
+        self, mock_dir, _mock_cfg, mock_install, _mock_root, tmp_path
+    ):
+        from ggshield.cmd.machine.setup import _setup_git_hooks
+
+        mock_dir.return_value = tmp_path
+        assert _setup_git_hooks(system=False) is True  # root implies system scope
+        assert mock_install.call_count == 2
 
 
 class TestHoneytokenPlant:

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -1,4 +1,7 @@
 import os
+import stat
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -447,3 +450,70 @@ class TestInstallAIHook:
             assert _is_interactive() is True
             stdout.isatty.return_value = False
             assert _is_interactive() is False
+
+
+@pytest.fixture()
+def custom_system_paths(tmp_path, monkeypatch):
+    """Redirect git's system config + ggshield's system data dir to temp locations,
+    so system-scope hooks can be tested without root or touching /etc."""
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(tmp_path / "system-git-config"))
+    monkeypatch.setenv("GG_SYSTEM_DATA_DIR", str(tmp_path / "system-data"))
+    yield
+
+
+class TestInstallSystem:
+    """`install_system` installs git hooks machine-wide (used by `machine setup` as root)."""
+
+    def test_writes_hook_and_system_hookspath(self, custom_system_paths):
+        from ggshield.cmd.install import (
+            get_default_system_hook_dir_path,
+            install_system,
+        )
+
+        assert install_system("pre-commit", force=False, append=False) == 0
+        hook_path = get_default_system_hook_dir_path() / "pre-commit"
+        assert hook_path.is_file()
+        hook_str = hook_path.read_text()
+        assert "if [ -f .git/hooks/pre-commit ]; then" in hook_str
+        assert "ggshield secret scan pre-commit" in hook_str
+
+        out = subprocess.check_output(
+            ["git", "config", "--system", "--get", "core.hooksPath"], text=True
+        ).strip()
+        assert out == str(get_default_system_hook_dir_path())
+
+    def test_honors_existing_system_hookspath(self, tmp_path, custom_system_paths):
+        from ggshield.cmd.install import install_system
+
+        custom = tmp_path / "shared-hooks"
+        subprocess.run(
+            ["git", "config", "--system", "core.hooksPath", str(custom)], check=True
+        )
+        assert install_system("pre-push", force=False, append=False) == 0
+        assert (custom / "pre-push").is_file()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode bits")
+    def test_hook_is_world_readable(self, custom_system_paths):
+        from ggshield.cmd.install import (
+            get_default_system_hook_dir_path,
+            install_system,
+        )
+
+        install_system("pre-commit", force=False, append=False)
+        hook_dir = get_default_system_hook_dir_path()
+        assert stat.S_IMODE((hook_dir / "pre-commit").stat().st_mode) == 0o755
+        assert stat.S_IMODE(hook_dir.stat().st_mode) == 0o755
+
+
+class TestSystemDataDir:
+    def test_env_override(self, tmp_path, monkeypatch):
+        from ggshield.core.dirs import get_system_data_dir
+
+        monkeypatch.setenv("GG_SYSTEM_DATA_DIR", str(tmp_path))
+        assert get_system_data_dir() == tmp_path
+
+    def test_default_uses_site_data_dir(self, monkeypatch):
+        from ggshield.core.dirs import get_system_data_dir
+
+        monkeypatch.delenv("GG_SYSTEM_DATA_DIR", raising=False)
+        assert get_system_data_dir().name == "ggshield"

--- a/tests/unit/utils/test_os.py
+++ b/tests/unit/utils/test_os.py
@@ -103,3 +103,23 @@ def test_cd_context_manager(tmpdir):
     with cd(tmpdir):
         assert os.getcwd() == tmpdir
     assert os.getcwd() == prev
+
+
+class TestIsRoot:
+    def test_true_when_euid_zero(self, monkeypatch):
+        from ggshield.utils import os as os_utils
+
+        monkeypatch.setattr(os_utils.os, "geteuid", lambda: 0, raising=False)
+        assert os_utils.is_root() is True
+
+    def test_false_when_euid_nonzero(self, monkeypatch):
+        from ggshield.utils import os as os_utils
+
+        monkeypatch.setattr(os_utils.os, "geteuid", lambda: 501, raising=False)
+        assert os_utils.is_root() is False
+
+    def test_false_without_geteuid(self, monkeypatch):
+        from ggshield.utils import os as os_utils
+
+        monkeypatch.delattr(os_utils.os, "geteuid", raising=False)
+        assert os_utils.is_root() is False


### PR DESCRIPTION
## Context

A security engineer deploying ggshield via MDM flagged that `machine setup`'s git-hook step is per-user. MDM runs as **root**, and `git config --global` writes to *root's* `~/.gitconfig` — so the hooks protect nobody who actually commits. (The honeytoken step already fans out across user homes when root; the git-hook step did not.)

## What this PR does

- `ggshield machine setup` now installs git hooks **machine-wide** when running **as root** or with the new **`--system`** flag, instead of only for the invoking user.
  - **As root / MDM** → sets git's **`--system` `core.hooksPath`** (one `/etc/gitconfig` entry) → every user on the machine is covered by a single install, for all their repos, now and in the future. No per-repo files, no repo scanning — it's git's one hooks-path pointer.
  - **Normal user, no flag** → unchanged: per-user (`--global`), affects only that user.
  - Selection is `--system or os.geteuid() == 0`.
- The shared system hooks dir and scripts are created **world-readable/executable (0755)** — the hook runs as each committing user — vs the per-user `0700`.

## Implementation

- `core/dirs.py`: `get_system_data_dir()` — site-wide data dir (`platformdirs.site_data_dir`: `/Library/Application Support/ggshield` on macOS, `/usr/local/share/ggshield` on Linux), with a `GG_SYSTEM_DATA_DIR` override for tests.
- `cmd/install.py`: `install_system()`, `get_system_hook_dir_path()`, `get_default_system_hook_dir_path()`; `create_hook(..., world_readable=False)` controls the 0755 vs 0700 mode of the dir + script.
- `cmd/machine/setup.py`: `--system` flag, `_is_root()`, and `_setup_git_hooks(system)` selecting system vs global scope. The idempotency/foreign-hook handling is unchanged across both scopes.

## Notes

- `--system` writing `/etc/gitconfig` needs root; as a normal user it fails unless redirected (that's how the tests exercise it — `GIT_CONFIG_SYSTEM` + `GG_SYSTEM_DATA_DIR`).
- System scope is a machine-wide **default**: git precedence is local > global > system, so a user/repo with its own `core.hooksPath` (e.g. Husky) still wins.

## Validation

```
# system scope without needing root (redirected):
GIT_CONFIG_SYSTEM=$TMP/sys GG_SYSTEM_DATA_DIR=$TMP/data \
  ggshield machine setup --system --no-ai-hooks --no-honeytokens
git config --system --get core.hooksPath   # -> $TMP/data/git-hooks ; scripts are 0755
```

- New unit tests: system-scope via `--system`, root-implies-system, flag-forwarding, per-user path pinned non-root (CI-deterministic), world-readable perms, `install_system` end-to-end, and `get_system_data_dir` override/default.
- black / isort / flake8 / pyright clean; import-linter both contracts KEPT.

## PR check list

- [x] The changes include tests (unit)
- [x] Changelog entry added (`changelog.d/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
