### PR TITLE
fix(install): harden install/uninstall scripts for non-interactive use

### DIFF
--- a/changelog.d/20260624_170514_benjamin.rigaud_uninstall_no_tty.md
+++ b/changelog.d/20260624_170514_benjamin.rigaud_uninstall_no_tty.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `uninstall.sh` no longer crashes and removes nothing when run with no controlling terminal (CI, cron, MDM/launchd/systemd rollback, containers). The confirmation prompt now detects an unusable `/dev/tty` and exits asking for `-y`, instead of aborting on an unbound variable under `set -u`.
+- The standalone installer no longer silently ignores `--plugin` when combined with `--install-only`; it warns that the plugin was not installed (because `--install-only` skips authentication) and prints the command to run later.
+
+### Changed
+
+- The install-scripts README documents `-y`/`--yes` and `bash -s -- --purge -y` for unattended uninstall.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -157,3 +157,16 @@ Removing ggshield's configuration, cache and data is opt-in:
 | Linux / macOS | Windows  | Removes                                                           |
 | ------------- | -------- | ----------------------------------------------------------------- |
 | `--purge`     | `-Purge` | config, cache and data (`~/.gitguardian.yaml`, plugins, scan DBs) |
+
+Pass flags through the pipe with `bash -s --`:
+
+```sh
+curl -sSfL \
+  https://raw.githubusercontent.com/GitGuardian/ggshield/main/scripts/install/uninstall.sh |
+  bash -s -- --purge -y
+```
+
+The uninstaller prompts before removing anything. In a **non-interactive
+context** (CI, cron, an MDM/`launchd`/`systemd` rollback, a container with no
+terminal) it cannot prompt, so it exits without removing anything; pass
+`-y`/`--yes` (`-Yes` on Windows) to proceed unattended.

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -358,6 +358,11 @@ post_install() {
     fi
 
     if [ "$INSTALL_ONLY" = 1 ]; then
+        # plugin install is auth-gated and --install-only skips auth, so any
+        # --plugin is deferred, not installed now: say so rather than silently
+        # dropping the flag.
+        [ ${#PLUGINS[@]} -gt 0 ] &&
+            warn "--plugin not installed: --install-only skips authentication; run the steps below once authenticated"
         say "ggshield is installed. To finish setup:"
         emit_auth_hint
         emit_plugin_hint

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -41,10 +41,13 @@ die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 
 confirm() {
     [ "$ASSUME_YES" = 1 ] && return 0
-    local reply
+    local reply=""
     if [ -t 0 ]; then
         read -r -p "$1 [y/N] " reply
-    elif [ -e /dev/tty ]; then
+    elif { : </dev/tty; } 2>/dev/null; then
+        # the node can exist yet be unopenable (container/CI, no controlling
+        # tty); test the actual open so we reach the -y hint instead of dying
+        # on `reply` unbound under set -u
         read -r -p "$1 [y/N] " reply </dev/tty
     else
         die "cannot prompt for '$1' (no TTY). Re-run with -y"


### PR DESCRIPTION
Found in exploratory session ES-3 (END-616). Three fixes to the standalone install/uninstall scripts, all about non-interactive (CI / MDM / container) use.

## Changes

- **`uninstall.sh` — fix non-interactive crash (Major).** `confirm()` tested `[ -e /dev/tty ]`, but the node exists in a container/CI with no controlling terminal, so the `</dev/tty` read failed, `reply` was left unset, and `set -u` aborted before the "Re-run with -y" hint — both the default and `--purge` uninstalls removed nothing. Now tests that `/dev/tty` is actually *openable* and defaults `reply`, so the non-interactive path reaches the friendly `die`.
- **`install.sh` — `--plugin` under `--install-only`.** `--install-only` skips auth and plugin install is auth-gated, so `--plugin` was deferred silently. Now warns the plugin was not installed and points to the printed follow-up steps.
- **README** — documents `-y/--yes` and `bash -s -- --purge -y` for unattended uninstall.

## Verification

- Reproduced the crash (`reply: unbound variable`, exit 1, nothing removed), then confirmed: default no-TTY → clean "Re-run with -y", exit 1; `--purge -y` no-TTY → removes cleanly, exit 0; interactive (pty) `y` → removes.
- `install.sh --plugin … --install-only` → warns *and* still prints the `ggshield plugin install` hint; no spurious warning when no `--plugin` is given.
- `shellcheck` 0.11.0 clean; `bash -n` clean.

Refs: END-616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
