### PR TITLE
fix(cli): fail fast with a clear message on Python < 3.9

### DIFF
--- a/changelog.d/20260629_115844_clement.tourriere_python_version_guard.md
+++ b/changelog.d/20260629_115844_clement.tourriere_python_version_guard.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- ggshield now exits with a clear, actionable message when it is started on a Python interpreter older than 3.9 (for instance the system Python 3.6 shipped on RHEL 8 / CentOS 8), instead of crashing with a cryptic `ModuleNotFoundError` deep in startup.

--- a/ggshield/__init__.py
+++ b/ggshield/__init__.py
@@ -1,1 +1,26 @@
+import sys as _sys
+
+
 __version__ = "1.52.2"
+
+_MIN_PYTHON = (3, 9)
+
+
+# Runs on the (possibly pre-3.9) interpreter itself, so it must avoid 3.7+ syntax
+# (f-strings, evaluated annotations) or it crashes before explaining why.
+def _ensure_supported_python(
+    version_info: "tuple[int, ...]" = _sys.version_info[:2],
+) -> None:
+    if tuple(version_info[:2]) < _MIN_PYTHON:
+        _sys.stderr.write(
+            "ggshield requires Python %d.%d or newer, but it is running on "
+            "Python %d.%d.\n"
+            "Reinstall it on a supported interpreter, for example:\n"
+            "    uv tool install --python 3.12 ggshield\n"
+            "    pipx install --python 3.12 ggshield\n"
+            % (_MIN_PYTHON[0], _MIN_PYTHON[1], version_info[0], version_info[1])
+        )
+        raise SystemExit(1)
+
+
+_ensure_supported_python()

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -68,7 +68,11 @@ EOF
 }
 
 read_version() {
-    VERSION=$(grep -o "[0-9]*\.[0-9]*\.[0-9]*" "$ROOT_DIR/ggshield/__init__.py")
+    # Match the full `__version__ = "X.Y.Z"` assignment, not just any X.Y.Z in
+    # the file: other lines (type hints, examples in messages, ...) can hold
+    # version-like substrings that would otherwise corrupt VERSION.
+    VERSION=$(sed -n 's/^__version__ *= *"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+        "$ROOT_DIR/ggshield/__init__.py")
     if [ -n "$VERSION_SUFFIX" ] ; then
         VERSION="${VERSION}${VERSION_SUFFIX}"
     fi

--- a/tests/unit/test_python_version_guard.py
+++ b/tests/unit/test_python_version_guard.py
@@ -1,0 +1,32 @@
+"""The import-time guard rejects pre-3.9 interpreters with a clear message."""
+
+from __future__ import annotations
+
+import pytest
+
+import ggshield
+
+
+# Real pre-3.9 interpreters ggshield can actually start under: the message only
+# prints if this module *parses*, which excludes Python 2.x (the annotations in
+# ggshield/__init__.py are 3.x-only syntax). 3.6-3.8 parse it fine.
+@pytest.mark.parametrize("version", [(3, 6, 0), (3, 7, 5), (3, 8, 18)])
+def test_rejects_unsupported_python(version, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        ggshield._ensure_supported_python(version)
+
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "Python 3.9 or newer" in err
+    # reports the actual running version, and points at a fix for both installers
+    assert "Python %d.%d" % (version[0], version[1]) in err
+    assert "uv tool install --python 3.12 ggshield" in err
+    assert "pipx install --python 3.12 ggshield" in err
+
+
+@pytest.mark.parametrize(
+    "version", [(3, 9, 0), (3, 11, 9), (3, 12, 1), (3, 13, 0), (4, 0)]
+)
+def test_accepts_supported_python(version):
+    # Must not raise on 3.9+ (this is what runs on every supported install).
+    ggshield._ensure_supported_python(version)


### PR DESCRIPTION
`requires-python` is already `>=3.9`, but `uv tool install` / pipx can still place ggshield on an old *system* interpreter (e.g. Python 3.6 on RHEL 8 / CentOS 8 / openSUSE Leap 15), where it dies with a cryptic `ModuleNotFoundError: No module named 'dataclasses'` deep in startup.

This adds an import-time guard in `ggshield/__init__.py` that exits with a clear, actionable message (pointing at both `uv` and `pipx`) before any 3.7+ import is reached (kept free of 3.7+ syntax so it runs on the old interpreter itself).

Tests: `tests/unit/test_python_version_guard.py` (rejects 3.6/3.7/3.8 with the message; accepts 3.9+). Python 2.x is intentionally not covered: its annotations are 3.x-only syntax, so the module fails at parse time and the guard is never reached. Reviewed via Codex.

Internal ref: END-618 (surfaced by the satori install matrix).
