### PR TITLE
feat(machine): add `machine healthcheck` to verify protections are set up

### DIFF
--- a/changelog.d/20260624_180000_achille.mascia_machine_healthcheck.md
+++ b/changelog.d/20260624_180000_achille.mascia_machine_healthcheck.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield machine healthcheck` checks that this machine's ggshield protections are correctly set up: the AI hooks and git hooks are installed, the GitGuardian token is reachable and carries the scopes the configured protections need (`scan`, plus `honeytokens:write` and — when the `machine_scan` plugin is installed — `endpoints:send`, both of which require a Business or Enterprise plan), and that the plugin's native scanner loads. It is read-only, prints a specific fix for each failed check, and exits non-zero if any check fails, so it can gate an MDM rollout.

--- a/ggshield/cmd/machine/__init__.py
+++ b/ggshield/cmd/machine/__init__.py
@@ -2,18 +2,21 @@ from typing import Any
 
 import click
 
+from ggshield.cmd.machine.healthcheck import healthcheck_cmd
 from ggshield.cmd.machine.setup import setup_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 
 
-@click.group(commands={"setup": setup_cmd})
+@click.group(commands={"setup": setup_cmd, "healthcheck": healthcheck_cmd})
 @add_common_options()
 def machine_group(**kwargs: Any) -> None:
     """
     Scan and protect this machine.
 
-    `setup` sets up all of this machine's protections (AI hooks, git hooks, and
-    a honeytoken) in one idempotent command. Secret and endpoint scanning
-    (`scan`) is provided by the `machine_scan` plugin and merges into this group
-    when it is installed.
+    `setup` sets up all of this machine's protections (AI hooks, git hooks, and a
+    honeytoken) in one idempotent command. `healthcheck` checks that everything is
+    correctly set up — AI hooks, git hooks, the token's scopes, and the
+    `machine_scan` plugin when installed — without changing anything. Secret and
+    endpoint scanning (`scan`) is provided by the `machine_scan` plugin and merges
+    into this group when it is installed.
     """

--- a/ggshield/cmd/machine/healthcheck.py
+++ b/ggshield/cmd/machine/healthcheck.py
@@ -1,0 +1,251 @@
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, List, Optional
+
+import click
+from pygitguardian.models import APITokensResponse, HealthCheckResponse
+
+from ggshield.cmd.install import (
+    get_default_global_hook_dir_path,
+    get_default_system_hook_dir_path,
+    get_global_hook_dir_path,
+    get_system_hook_dir_path,
+)
+from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.client import create_client_from_config, safe_api_tokens
+from ggshield.core.plugin.hooks import get_plugin_registry
+from ggshield.verticals.ai.installation import ai_hook_posture
+
+
+PLUGIN_NAME = "machine_scan"
+# The native scanner module shipped in the machine_scan plugin wheel. Importing it
+# loads the compiled (Rust) extension, which is what we want to prove.
+_PLUGIN_NATIVE_MODULE = "satori_python"
+_GIT_HOOK_TYPES = ("pre-commit", "pre-push")
+
+# Scopes the configured protections need.
+_SCAN_SCOPE = "scan"  # the AI and git hooks run `ggshield secret scan`
+_HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
+_ENDPOINT_SCOPE = "endpoints:send"  # the machine_scan plugin uploads endpoint data
+
+
+@dataclass
+class Check:
+    """One readiness check and its outcome.
+
+    ``fix`` is the remediation shown when the check fails — it must be specific to
+    the check (hooks are fixed by `machine setup`, but scopes are fixed by getting a
+    token with the right scopes, not by re-running setup).
+    """
+
+    name: str
+    ok: bool
+    detail: str = ""
+    fix: str = ""
+
+
+@click.command(name="healthcheck")
+@add_common_options()
+@click.pass_context
+def healthcheck_cmd(ctx: click.Context, **kwargs: Any) -> int:
+    """
+    Check that this machine's ggshield protections are correctly set up.
+
+    Verifies the AI hooks and git hooks are installed, that the GitGuardian token
+    is reachable and carries the scopes the configured protections need (including
+    `honeytokens:write`, granted only on Business or Enterprise plans), and — when
+    the `machine_scan` plugin is installed — that the token has the endpoint scope
+    (also Business/Enterprise-only) and the native scanner loads.
+
+    This is read-only: it never installs, scans, or changes anything. Each failed
+    check prints how to fix it (hooks via `ggshield machine setup`, scopes via a
+    token that carries them, the plugin via `ggshield plugin install`). Exits
+    non-zero if any check fails, so it can gate an MDM rollout.
+    """
+    config = ContextObj.get(ctx).config
+
+    scopes, auth_check = _check_auth_and_scopes(config)
+    plugin_installed = _is_plugin_installed()
+
+    checks: List[Check] = [auth_check]
+    checks.append(_check_ai_hooks())
+    checks.append(_check_git_hooks())
+    checks.extend(_check_scopes(scopes, plugin_installed))
+    if plugin_installed:
+        checks.append(_check_plugin_native())
+
+    _render(checks)
+    return 0 if all(check.ok for check in checks) else 1
+
+
+def _check_auth_and_scopes(config: Any) -> "tuple[Optional[List[str]], Check]":
+    """Verify the token reaches GitGuardian and read its scopes (one set of calls)."""
+    login = "authenticate with `ggshield auth login`"
+    try:
+        client = create_client_from_config(config)
+        health = client.health_check()
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - report any auth/network failure as a check
+        return None, Check("Authentication", False, str(exc), fix=login)
+
+    if not isinstance(health, HealthCheckResponse) or health.status_code != 200:
+        detail = getattr(health, "detail", "unhealthy")
+        return None, Check("Authentication", False, str(detail), fix=login)
+
+    scopes: Optional[List[str]] = None
+    token = safe_api_tokens(client)
+    if isinstance(token, APITokensResponse):
+        scopes = token.scopes
+    return scopes, Check("Authentication", True, "token reaches GitGuardian")
+
+
+def _check_ai_hooks() -> Check:
+    statuses = ai_hook_posture()
+    if not statuses:
+        return Check("AI hooks", True, "no AI coding assistants detected")
+    missing = [status.display_name for status in statuses if not status.installed]
+    if missing:
+        return Check(
+            "AI hooks",
+            False,
+            f"not installed for: {', '.join(missing)}",
+            fix="run `ggshield machine setup`",
+        )
+    installed = ", ".join(status.display_name for status in statuses)
+    return Check("AI hooks", True, f"installed for: {installed}")
+
+
+def _check_git_hooks() -> Check:
+    """The hooks are OK if pre-commit and pre-push are wired to ggshield in the global
+    or system scope (a machine may use either, e.g. MDM installs system-wide)."""
+    hook_dirs = [
+        get_global_hook_dir_path() or get_default_global_hook_dir_path(),
+        get_system_hook_dir_path() or get_default_system_hook_dir_path(),
+    ]
+    missing = [
+        hook_type
+        for hook_type in _GIT_HOOK_TYPES
+        if not _ggshield_hook_present(hook_dirs, hook_type)
+    ]
+    if missing:
+        return Check(
+            "Git hooks",
+            False,
+            f"not configured: {', '.join(missing)}",
+            fix="run `ggshield machine setup` (use `--system` / run as root for all users)",
+        )
+    return Check("Git hooks", True, "global/system pre-commit and pre-push configured")
+
+
+def _ggshield_hook_present(hook_dirs: List[Any], hook_type: str) -> bool:
+    for hook_dir in hook_dirs:
+        hook_path = hook_dir / hook_type
+        if hook_path.is_file() and "ggshield secret scan" in hook_path.read_text(
+            errors="ignore"
+        ):
+            return True
+    return False
+
+
+def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[Check]:
+    if scopes is None:
+        return [
+            Check(
+                "Token scopes",
+                False,
+                "could not read the token's scopes",
+                fix="check the token is valid (`ggshield api-status`)",
+            )
+        ]
+
+    # Scopes are a property of the token, not of `machine setup` — fixing them means
+    # using a token that carries them (re-auth or a service-account token), not
+    # re-running setup. honeytokens:write and endpoints:send are additionally gated
+    # server-side on a paid plan (Business or Enterprise).
+    def _scope_fix(scope: str, *, paid_plan: bool = False) -> str:
+        account = " from a Business or Enterprise account" if paid_plan else ""
+        return (
+            f"use a token{account} that has the `{scope}` scope "
+            f"(re-run `ggshield auth login` or create a service-account token)"
+        )
+
+    checks = [
+        Check(
+            f"Scope `{_SCAN_SCOPE}`",
+            _SCAN_SCOPE in scopes,
+            "required by the AI and git hooks",
+            fix=_scope_fix(_SCAN_SCOPE),
+        ),
+        Check(
+            f"Scope `{_HONEYTOKEN_SCOPE}`",
+            _HONEYTOKEN_SCOPE in scopes,
+            "honeytoken protection — Business or Enterprise plans only",
+            fix=_scope_fix(_HONEYTOKEN_SCOPE, paid_plan=True),
+        ),
+    ]
+    if plugin_installed:
+        checks.append(
+            Check(
+                f"Scope `{_ENDPOINT_SCOPE}`",
+                _ENDPOINT_SCOPE in scopes,
+                "machine_scan plugin — Business or Enterprise plans only",
+                fix=_scope_fix(_ENDPOINT_SCOPE, paid_plan=True),
+            )
+        )
+    return checks
+
+
+def _is_plugin_installed() -> bool:
+    registry = get_plugin_registry()
+    return registry is not None and registry.get_plugin(PLUGIN_NAME) is not None
+
+
+def _check_plugin_native() -> Check:
+    """Prove the plugin's native scanner loads on this machine (signed, arch-specific
+    wheel + compiled extension), without running a scan."""
+    registry = get_plugin_registry()
+    plugin = registry.get_plugin(PLUGIN_NAME) if registry else None
+    version = ""
+    if plugin is not None:
+        try:
+            version = f" v{plugin.metadata.version}"
+        except Exception:  # noqa: BLE001 - version is cosmetic
+            version = ""
+    try:
+        native = import_module(_PLUGIN_NATIVE_MODULE)
+        native.Scanner(use_embedded=True)
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - any load failure means the plugin is unusable
+        return Check(
+            "Plugin (machine_scan)",
+            False,
+            f"installed{version} but the native scanner failed to load: {exc}",
+            fix="reinstall it with `ggshield plugin install machine_scan`",
+        )
+    return Check("Plugin (machine_scan)", True, f"native scanner loads{version}")
+
+
+def _render(checks: List[Check]) -> None:
+    for check in checks:
+        mark = click.style("✓", fg="green") if check.ok else click.style("✗", fg="red")
+        detail = f" — {check.detail}" if check.detail else ""
+        click.echo(f"  {mark} {check.name}{detail}")
+        if not check.ok and check.fix:
+            click.echo(f"      {click.style('↳ fix:', fg='yellow')} {check.fix}")
+    failed = [check for check in checks if not check.ok]
+    click.echo()
+    if failed:
+        click.echo(
+            click.style(
+                f"{len(failed)} check(s) failed — see the suggested fixes above.",
+                fg="red",
+                bold=True,
+            )
+        )
+    else:
+        click.echo(
+            click.style("This machine is correctly set up.", fg="green", bold=True)
+        )

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -236,6 +236,30 @@ def are_hooks_installed_globally(agent_name: str) -> Tuple[bool, Optional[str]]:
 
 
 @dataclass
+class AgentHookStatus:
+    """Whether the ggshield AI hook is installed for one detected assistant."""
+
+    display_name: str
+    installed: bool
+
+
+def ai_hook_posture() -> List[AgentHookStatus]:
+    """Read-only AI-hook status: for each detected assistant, is the hook installed?
+
+    Only assistants present on this machine are reported; it never writes anything.
+    Used by ``ggshield machine healthcheck``.
+    """
+    statuses = []
+    for agent in AGENTS.values():
+        if agent.is_present():
+            installed, _command = are_hooks_installed_globally(agent.name)
+            statuses.append(
+                AgentHookStatus(display_name=agent.display_name, installed=installed)
+            )
+    return statuses
+
+
+@dataclass
 class SetupSummary:
     """Outcome of configuring AI hooks across one or more agents."""
 

--- a/tests/unit/cmd/machine/test_healthcheck.py
+++ b/tests/unit/cmd/machine/test_healthcheck.py
@@ -51,7 +51,11 @@ class TestHealthcheckCommand:
 
     def test_exit_nonzero_when_a_check_fails(self, cli_fs_runner: CliRunner):
         result, _ = self._run(
-            cli_fs_runner, auth_ok=True, ai_ok=False, git_ok=True, plugin_installed=False
+            cli_fs_runner,
+            auth_ok=True,
+            ai_ok=False,
+            git_ok=True,
+            plugin_installed=False,
         )
         assert result.exit_code == 1
         assert "failed" in result.output
@@ -71,7 +75,9 @@ class TestHealthcheckCommand:
 
 class TestCheckAuthAndScopes:
     def _health(self, status_code, detail="ok"):
-        return MagicMock(spec=HealthCheckResponse, status_code=status_code, detail=detail)
+        return MagicMock(
+            spec=HealthCheckResponse, status_code=status_code, detail=detail
+        )
 
     def test_healthy_returns_scopes(self):
         client = MagicMock()

--- a/tests/unit/cmd/machine/test_healthcheck.py
+++ b/tests/unit/cmd/machine/test_healthcheck.py
@@ -1,0 +1,235 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from pygitguardian.models import APITokensResponse, HealthCheckResponse
+
+from ggshield.__main__ import cli
+from ggshield.cmd.machine.healthcheck import (
+    Check,
+    _check_ai_hooks,
+    _check_auth_and_scopes,
+    _check_git_hooks,
+    _check_plugin_native,
+    _check_scopes,
+    _is_plugin_installed,
+)
+from ggshield.verticals.ai.installation import AgentHookStatus
+from tests.unit.conftest import assert_invoke_ok
+
+
+BASE = "ggshield.cmd.machine.healthcheck"
+
+
+class TestHealthcheckCommand:
+    def test_healthcheck_appears_in_machine_help(self, cli_fs_runner: CliRunner):
+        result = cli_fs_runner.invoke(cli, ["machine", "--help"])
+        assert_invoke_ok(result)
+        assert "healthcheck" in result.output
+
+    def _run(self, cli_fs_runner, *, auth_ok, ai_ok, git_ok, plugin_installed):
+        auth = Check("Authentication", auth_ok)
+        with patch(
+            f"{BASE}._check_auth_and_scopes", return_value=(["scan"], auth)
+        ), patch(f"{BASE}._is_plugin_installed", return_value=plugin_installed), patch(
+            f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", ai_ok)
+        ), patch(
+            f"{BASE}._check_git_hooks", return_value=Check("Git hooks", git_ok)
+        ), patch(
+            f"{BASE}._check_scopes", return_value=[Check("Scope", True)]
+        ), patch(
+            f"{BASE}._check_plugin_native", return_value=Check("Plugin", True)
+        ) as m_plugin:
+            result = cli_fs_runner.invoke(cli, ["machine", "healthcheck"])
+        return result, m_plugin
+
+    def test_exit_zero_when_all_pass(self, cli_fs_runner: CliRunner):
+        result, _ = self._run(
+            cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=False
+        )
+        assert result.exit_code == 0
+        assert "correctly set up" in result.output
+
+    def test_exit_nonzero_when_a_check_fails(self, cli_fs_runner: CliRunner):
+        result, _ = self._run(
+            cli_fs_runner, auth_ok=True, ai_ok=False, git_ok=True, plugin_installed=False
+        )
+        assert result.exit_code == 1
+        assert "failed" in result.output
+
+    def test_plugin_check_skipped_without_plugin(self, cli_fs_runner: CliRunner):
+        _result, m_plugin = self._run(
+            cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=False
+        )
+        m_plugin.assert_not_called()
+
+    def test_plugin_check_runs_with_plugin(self, cli_fs_runner: CliRunner):
+        _result, m_plugin = self._run(
+            cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=True
+        )
+        m_plugin.assert_called_once()
+
+
+class TestCheckAuthAndScopes:
+    def _health(self, status_code, detail="ok"):
+        return MagicMock(spec=HealthCheckResponse, status_code=status_code, detail=detail)
+
+    def test_healthy_returns_scopes(self):
+        client = MagicMock()
+        client.health_check.return_value = self._health(200)
+        token = MagicMock(spec=APITokensResponse, scopes=["scan", "honeytokens:write"])
+        with patch(f"{BASE}.create_client_from_config", return_value=client), patch(
+            f"{BASE}.safe_api_tokens", return_value=token
+        ):
+            scopes, check = _check_auth_and_scopes(MagicMock())
+        assert check.ok is True
+        assert scopes == ["scan", "honeytokens:write"]
+
+    def test_unhealthy_fails_and_no_scopes(self):
+        client = MagicMock()
+        client.health_check.return_value = self._health(401, detail="bad token")
+        with patch(f"{BASE}.create_client_from_config", return_value=client):
+            scopes, check = _check_auth_and_scopes(MagicMock())
+        assert check.ok is False
+        assert "bad token" in check.detail
+        assert scopes is None
+
+    def test_client_error_fails_gracefully(self):
+        with patch(
+            f"{BASE}.create_client_from_config", side_effect=RuntimeError("no key")
+        ):
+            scopes, check = _check_auth_and_scopes(MagicMock())
+        assert check.ok is False
+        assert "no key" in check.detail
+        assert scopes is None
+
+
+class TestCheckAiHooks:
+    def test_all_installed(self):
+        with patch(
+            f"{BASE}.ai_hook_posture",
+            return_value=[AgentHookStatus("Claude Code", True)],
+        ):
+            assert _check_ai_hooks().ok is True
+
+    def test_some_missing(self):
+        with patch(
+            f"{BASE}.ai_hook_posture",
+            return_value=[
+                AgentHookStatus("Claude Code", True),
+                AgentHookStatus("Cursor", False),
+            ],
+        ):
+            check = _check_ai_hooks()
+        assert check.ok is False
+        assert "Cursor" in check.detail
+
+    def test_none_detected_is_ok(self):
+        with patch(f"{BASE}.ai_hook_posture", return_value=[]):
+            assert _check_ai_hooks().ok is True
+
+
+class TestCheckGitHooks:
+    def _patch_dirs(self, global_dir, system_dir):
+        return patch.multiple(
+            BASE,
+            get_global_hook_dir_path=MagicMock(return_value=None),
+            get_default_global_hook_dir_path=MagicMock(return_value=global_dir),
+            get_system_hook_dir_path=MagicMock(return_value=None),
+            get_default_system_hook_dir_path=MagicMock(return_value=system_dir),
+        )
+
+    def test_ok_when_present_in_global(self, tmp_path):
+        global_dir = tmp_path / "g"
+        global_dir.mkdir()
+        (system_dir := tmp_path / "s").mkdir()
+        for hook in ("pre-commit", "pre-push"):
+            (global_dir / hook).write_text(f"#!/bin/sh\nggshield secret scan {hook}\n")
+        with self._patch_dirs(global_dir, system_dir):
+            assert _check_git_hooks().ok is True
+
+    def test_ok_when_split_across_global_and_system(self, tmp_path):
+        (global_dir := tmp_path / "g").mkdir()
+        (system_dir := tmp_path / "s").mkdir()
+        (global_dir / "pre-commit").write_text("#!/bin/sh\nggshield secret scan x\n")
+        (system_dir / "pre-push").write_text("#!/bin/sh\nggshield secret scan x\n")
+        with self._patch_dirs(global_dir, system_dir):
+            assert _check_git_hooks().ok is True
+
+    def test_fail_when_missing(self, tmp_path):
+        (global_dir := tmp_path / "g").mkdir()
+        (system_dir := tmp_path / "s").mkdir()
+        with self._patch_dirs(global_dir, system_dir):
+            check = _check_git_hooks()
+        assert check.ok is False
+        assert "pre-commit" in check.detail and "pre-push" in check.detail
+
+    def test_fail_on_foreign_hook(self, tmp_path):
+        (global_dir := tmp_path / "g").mkdir()
+        (system_dir := tmp_path / "s").mkdir()
+        for hook in ("pre-commit", "pre-push"):
+            (global_dir / hook).write_text("#!/bin/sh\nother-tool\n")
+        with self._patch_dirs(global_dir, system_dir):
+            assert _check_git_hooks().ok is False
+
+
+class TestCheckScopes:
+    def test_none_scopes_fails(self):
+        checks = _check_scopes(None, plugin_installed=False)
+        assert len(checks) == 1 and checks[0].ok is False
+
+    def test_scan_and_honeytoken_reported(self):
+        checks = _check_scopes(["scan"], plugin_installed=False)
+        by_name = {c.name: c.ok for c in checks}
+        assert by_name["Scope `scan`"] is True
+        assert by_name["Scope `honeytokens:write`"] is False
+
+    def test_endpoint_scope_only_with_plugin(self):
+        without = _check_scopes(["scan"], plugin_installed=False)
+        assert not any("endpoints:send" in c.name for c in without)
+        with_plugin = _check_scopes(["scan", "endpoints:send"], plugin_installed=True)
+        endpoint = [c for c in with_plugin if "endpoints:send" in c.name]
+        assert endpoint and endpoint[0].ok is True
+
+
+class TestPluginChecks:
+    def test_is_plugin_installed_true(self):
+        registry = MagicMock()
+        registry.get_plugin.return_value = MagicMock()
+        with patch(f"{BASE}.get_plugin_registry", return_value=registry):
+            assert _is_plugin_installed() is True
+
+    def test_is_plugin_installed_false_no_registry(self):
+        with patch(f"{BASE}.get_plugin_registry", return_value=None):
+            assert _is_plugin_installed() is False
+
+    def test_is_plugin_installed_false_not_registered(self):
+        registry = MagicMock()
+        registry.get_plugin.return_value = None
+        with patch(f"{BASE}.get_plugin_registry", return_value=registry):
+            assert _is_plugin_installed() is False
+
+    def test_native_loads_ok(self):
+        registry = MagicMock()
+        registry.get_plugin.return_value = MagicMock(
+            metadata=MagicMock(version="1.2.3")
+        )
+        native = MagicMock()
+        with patch(f"{BASE}.get_plugin_registry", return_value=registry), patch(
+            f"{BASE}.import_module", return_value=native
+        ):
+            check = _check_plugin_native()
+        assert check.ok is True
+        assert "1.2.3" in check.detail
+        native.Scanner.assert_called_once()
+
+    def test_native_load_failure_reported(self):
+        registry = MagicMock()
+        registry.get_plugin.return_value = MagicMock(
+            metadata=MagicMock(version="1.2.3")
+        )
+        with patch(f"{BASE}.get_plugin_registry", return_value=registry), patch(
+            f"{BASE}.import_module", side_effect=ImportError("bad arch")
+        ):
+            check = _check_plugin_native()
+        assert check.ok is False
+        assert "bad arch" in check.detail

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -11,8 +11,10 @@ import pytest
 from ggshield.core.errors import UnexpectedError
 from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor
 from ggshield.verticals.ai.installation import (
+    AgentHookStatus,
     InstallationStats,
     _fill_dict,
+    ai_hook_posture,
     are_hooks_installed_globally,
     build_hook_command,
     install_hooks,
@@ -556,3 +558,44 @@ class TestBuildHookCommand:
         ):
             with _simulate_platform([argv0, "install"], windows=False):
                 assert build_hook_command() == f"{argv0} secret scan ai-hook"
+
+
+class _FakeAgent:
+    """Minimal stand-in for an Agent for posture tests."""
+
+    def __init__(self, name: str, display_name: str, present: bool):
+        self.name = name
+        self.display_name = display_name
+        self._present = present
+
+    def is_present(self) -> bool:
+        return self._present
+
+
+class TestAiHookPosture:
+    AGENTS_PATH = "ggshield.verticals.ai.installation.AGENTS"
+    HOOKS_PATH = "ggshield.verticals.ai.installation.are_hooks_installed_globally"
+
+    def test_reports_only_present_agents(self):
+        fakes = {
+            "a": _FakeAgent("a", "Agent A", present=True),
+            "b": _FakeAgent("b", "Agent B", present=False),
+        }
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(
+            self.HOOKS_PATH, return_value=(True, "cmd")
+        ):
+            statuses = ai_hook_posture()
+        assert statuses == [AgentHookStatus(display_name="Agent A", installed=True)]
+
+    def test_reports_installed_flag(self):
+        fakes = {"a": _FakeAgent("a", "Agent A", present=True)}
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(
+            self.HOOKS_PATH, return_value=(False, None)
+        ):
+            statuses = ai_hook_posture()
+        assert statuses == [AgentHookStatus(display_name="Agent A", installed=False)]
+
+    def test_empty_when_no_agents_present(self):
+        fakes = {"a": _FakeAgent("a", "Agent A", present=False)}
+        with patch.dict(self.AGENTS_PATH, fakes, clear=True), patch(self.HOOKS_PATH):
+            assert ai_hook_posture() == []


### PR DESCRIPTION
## Context

The counterpart to `ggshield machine setup`: a single read-only command an operator (or MDM) can run to confirm a machine's ggshield protections are correctly set up — **without scanning or changing anything**.

Supersedes #1326 (the earlier scan-based `machine audit`), which is closed in favor of this.

## What `machine healthcheck` checks

Each line is ✓/✗; the command exits non-zero if any check fails, so it can gate an MDM rollout.

- **Authentication** — the token reaches GitGuardian (`health_check`).
- **AI hooks** — installed for every detected assistant.
- **Git hooks** — `pre-commit`/`pre-push` wired to ggshield in the global *or* system scope.
- **Token scopes** — `scan` (used by the hooks); `honeytokens:write`; and, **only when the `machine_scan` plugin is installed**, `endpoints:send`. The last two require a **Business or Enterprise plan** — which is exactly how the plan is detected: the backend only grants those scopes to paid accounts (verified: `has_business_access = plan_type != FREE`), so checking the scope *is* the plan check, with no extra endpoint.
- **Plugin** (when installed) — the native scanner loads (import + instantiate), proving the signed, arch-specific wheel works on this machine. No scan.

## Per-check fixes (no "re-run setup" loop)

Each failed check prints its *actual* remediation — because `machine setup` does **not** change token scopes:

```
✗ Scope `honeytokens:write` — honeytoken protection — Business or Enterprise plans only
    ↳ fix: use a token from a Business or Enterprise account that has the `honeytokens:write` scope
           (re-run `ggshield auth login` or create a service-account token)
✗ Scope `endpoints:send` — machine_scan plugin — Business or Enterprise plans only
    ↳ fix: use a token from a Business or Enterprise account that has the `endpoints:send` scope …
```

Hooks → `machine setup`; scopes → a token that carries them; plugin → `ggshield plugin install`; auth → `ggshield auth login`.

## Implementation

- `cmd/machine/healthcheck.py` — the command + per-check helpers.
- `cmd/machine/__init__.py` — registers `healthcheck`.
- `verticals/ai/installation.py` — `ai_hook_posture()` (+ `AgentHookStatus`) for the AI-hook check.
- Reuses existing helpers (`safe_api_tokens`, the git-hook dir resolvers, the plugin registry). **No new import-linter exceptions.**

## Validation

```
ggshield machine healthcheck
ggshield machine --help
```

Tested locally:
- **Unit:** doctor/healthcheck command (exit codes, per-check, plugin-conditional), each check helper (auth healthy/unhealthy/error, AI hooks, git hooks global+system+foreign, scopes, plugin detect + native load/fail), and `ai_hook_posture`.
- **Runtime (real CLI):** real auth + plugin (flags the two missing paid-plan scopes, native scanner loads v0.59.0), no-plugin (endpoint/plugin lines drop), unauthenticated (graceful).
- black / isort / flake8 / pyright clean; import-linter both contracts KEPT.

## PR check list

- [x] The changes include tests (unit)
- [x] Changelog entry added (`changelog.d/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
