### PR TITLE
fix(plugin): surface enabled plugins that fail to load (END-620)

### DIFF
--- a/changelog.d/20260625_144931_clement.tourriere_surface_plugin_load_failures.md
+++ b/changelog.d/20260625_144931_clement.tourriere_surface_plugin_load_failures.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- An enabled plugin that fails to load (for example when a native dependency is missing) is no longer silently ignored. `ggshield` now prints a warning naming the plugin and the reason its commands are unavailable, and `ggshield plugin list` reports the failure status.

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -221,6 +221,16 @@ def _register_plugin_commands() -> None:
         _deferred_warnings.append(f"Failed to register plugin commands: {e}")
 
 
+# Emitted before Click dispatches: a failed load leaves the command unregistered,
+# so Click rejects it as unknown and the group callback never runs to warn.
+def _warn_about_failed_plugins() -> None:
+    for name, reason in _load_plugins().get_load_failures().items():
+        ui.display_warning(
+            "Plugin '%s' is enabled but failed to load: %s. Its commands are "
+            "unavailable; run `ggshield plugin list` for status." % (name, reason)
+        )
+
+
 def _set_color(ctx: click.Context):
     """
     Helper function to override the default click default output color setting.
@@ -330,6 +340,11 @@ def main(args: Optional[List[str]] = None) -> Any:
 
     force_utf8_output()
     setup_truststore()
+
+    # cli.main() has not yet consumed _GGSHIELD_COMPLETE, so skip the warning
+    # during shell completion to avoid leaking it into completion output.
+    if "_GGSHIELD_COMPLETE" not in os.environ:
+        _warn_about_failed_plugins()
 
     show_crash_log = getenv_bool("GITGUARDIAN_CRASH_LOG")
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -125,6 +125,13 @@ def install_cmd(
     Install from a GitHub Actions artifact (requires GITHUB_TOKEN):
 
         ggshield plugin install https://github.com/owner/repo/actions/runs/123/artifacts/456
+
+    Multi-user or scheduled hosts:
+
+        A per-user install places ggshield under the installing user's home,
+        which other users — including root and cron/systemd jobs — may not be
+        able to reach. To run scans as another user or on a schedule, install
+        and enable as that user, or use a system-wide install.
     """
     # Signature verification is strict by default. The only override is the
     # explicit per-command --allow-unsigned flag.

--- a/ggshield/cmd/plugin/manage.py
+++ b/ggshield/cmd/plugin/manage.py
@@ -24,6 +24,11 @@ def enable_cmd(ctx: click.Context, plugin_name: str, **kwargs: Any) -> None:
     Enabled plugins are loaded when ggshield starts and their
     features become available.
 
+    Enablement is per-user: it is stored in your user config
+    (~/.config/ggshield/enterprise_config.yaml). Enable the plugin as the
+    user that runs scans — a plugin enabled for one user (or for root) is
+    not available to another.
+
     Example:
 
         ggshield plugin enable tokenscanner

--- a/ggshield/cmd/plugin/plugin_list.py
+++ b/ggshield/cmd/plugin/plugin_list.py
@@ -10,6 +10,7 @@ from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core import ui
 from ggshield.core.config.enterprise_config import EnterpriseConfig
 from ggshield.core.plugin.downloader import PluginDownloader
+from ggshield.core.plugin.hooks import get_plugin_registry
 from ggshield.core.plugin.loader import PluginLoader
 
 
@@ -44,16 +45,23 @@ def list_cmd(ctx: click.Context, **kwargs: Any) -> None:
 
     ui.display_heading("Installed Plugins")
 
+    registry = get_plugin_registry()
+    load_failures = registry.get_load_failures() if registry else {}
+
     for plugin in discovered:
         status_parts = []
 
         if plugin.version:
             status_parts.append(f"v{plugin.version}")
 
-        if plugin.is_enabled:
-            status_parts.append("enabled")
-        else:
+        if not plugin.is_enabled:
             status_parts.append("disabled")
+        elif plugin.name in load_failures:
+            status_parts.append(
+                f"enabled, FAILED TO LOAD: {load_failures[plugin.name]}"
+            )
+        else:
+            status_parts.append("enabled")
 
         source = (
             downloader.get_plugin_source(plugin.name) if plugin.wheel_path else None

--- a/ggshield/core/plugin/loader.py
+++ b/ggshield/core/plugin/loader.py
@@ -251,14 +251,17 @@ class PluginLoader:
             try:
                 plugin = self._load_plugin(discovered)
                 if plugin is None:
+                    registry.record_load_failure(discovered.name, "could not be loaded")
                     continue
 
                 if not self._check_version_compatibility(plugin.metadata):
-                    logger.warning(
-                        "Plugin %s requires ggshield >= %s, skipping",
-                        plugin.metadata.name,
-                        plugin.metadata.min_ggshield_version,
+                    reason = (
+                        "requires ggshield >= %s" % plugin.metadata.min_ggshield_version
                     )
+                    logger.warning(
+                        "Plugin %s %s, skipping", plugin.metadata.name, reason
+                    )
+                    registry.record_load_failure(discovered.name, reason)
                     continue
 
                 plugin.on_load()
@@ -273,6 +276,7 @@ class PluginLoader:
 
             except Exception as e:
                 logger.warning("Failed to load plugin %s: %s", discovered.name, e)
+                registry.record_load_failure(discovered.name, str(e))
 
         return registry
 
@@ -371,8 +375,10 @@ class PluginLoader:
             plugin_class = getattr(module, class_name)
             return plugin_class()
         except Exception as e:
-            logger.warning("Failed to load wheel %s: %s", wheel_path, e)
-            return None
+            # Propagate so load_enabled_plugins records the real reason, e.g. a
+            # native ABI mismatch (manylinux wheel on a musl host).
+            logger.debug("Wheel load failed for %s: %s", wheel_path, e)
+            raise
 
     def _prune_stale_extract_dirs(self, keep_dir: Path) -> None:
         """Remove stale extraction dirs for the same plugin cache bucket."""

--- a/ggshield/core/plugin/registry.py
+++ b/ggshield/core/plugin/registry.py
@@ -16,10 +16,19 @@ class PluginRegistry:
 
     _plugins: Dict[str, GGShieldPlugin] = field(default_factory=dict)
     _commands: List[click.Command] = field(default_factory=list)
+    _load_failures: Dict[str, str] = field(default_factory=dict)
 
     def register_plugin(self, plugin: GGShieldPlugin) -> None:
         """Register a loaded plugin."""
         self._plugins[plugin.metadata.name] = plugin
+
+    def record_load_failure(self, name: str, reason: str) -> None:
+        """Record that an enabled plugin failed to load (commands unavailable)."""
+        self._load_failures[name] = reason
+
+    def get_load_failures(self) -> Dict[str, str]:
+        """Map of enabled-but-failed plugin name -> failure reason."""
+        return self._load_failures.copy()
 
     def register_command(self, command: click.Command) -> None:
         """Register a CLI command provided by a plugin."""

--- a/tests/unit/cmd/plugin/test_list.py
+++ b/tests/unit/cmd/plugin/test_list.py
@@ -12,6 +12,7 @@ from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
 from ggshield.core.plugin.client import PluginSource, PluginSourceType
 from ggshield.core.plugin.loader import DiscoveredPlugin
+from ggshield.core.plugin.registry import PluginRegistry
 
 
 def _run_list(cli_fs_runner, plugins, source_for_name=None, signature_label=None):
@@ -55,6 +56,37 @@ class TestPluginList:
         assert result.exit_code == ExitCode.SUCCESS
         assert "No plugins installed" in result.output
         assert "ggshield plugin status" in result.output
+
+    def test_list_flags_enabled_plugin_that_failed_to_load(self, cli_fs_runner):
+        """
+        GIVEN an enabled plugin recorded as failed-to-load in the registry
+        WHEN running 'ggshield plugin list'
+        THEN its line says "FAILED TO LOAD" with the reason, not just "enabled"
+        """
+        plugins = [
+            DiscoveredPlugin(
+                name="machine_scan",
+                entry_point=mock.MagicMock(),
+                wheel_path=None,
+                is_installed=True,
+                is_enabled=True,
+                version="0.59.0",
+            ),
+        ]
+        registry = PluginRegistry()
+        registry.record_load_failure(
+            "machine_scan", "manylinux wheel cannot load on a musl host"
+        )
+
+        with mock.patch.object(
+            plugin_list_module, "get_plugin_registry", return_value=registry
+        ):
+            result = _run_list(cli_fs_runner, plugins)
+
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "machine_scan" in result.output
+        assert "FAILED TO LOAD" in result.output
+        assert "musl host" in result.output
 
     def test_list_pip_plugin_without_wheel(self, cli_fs_runner):
         """

--- a/tests/unit/core/plugin/test_load_failures.py
+++ b/tests/unit/core/plugin/test_load_failures.py
@@ -1,0 +1,125 @@
+"""An enabled plugin that fails to load is recorded, not silently swallowed."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ggshield.core.config.enterprise_config import EnterpriseConfig
+from ggshield.core.plugin.loader import DiscoveredPlugin, PluginLoader
+
+
+def _enabled(name: str = "machine_scan") -> DiscoveredPlugin:
+    return DiscoveredPlugin(
+        name=name,
+        entry_point=MagicMock(),
+        wheel_path=None,
+        is_installed=True,
+        is_enabled=True,
+        version="0.59.0",
+    )
+
+
+def test_load_failure_is_recorded_and_commands_not_registered():
+    loader = PluginLoader(EnterpriseConfig())
+    with patch.object(PluginLoader, "discover_plugins", return_value=[_enabled()]):
+        with patch.object(
+            PluginLoader,
+            "_load_plugin",
+            side_effect=ImportError(
+                "Error relocating …: gnu_get_libc_version: symbol not found"
+            ),
+        ):
+            registry = loader.load_enabled_plugins()
+
+    failures = registry.get_load_failures()
+    assert "machine_scan" in failures
+    assert "symbol not found" in failures["machine_scan"]
+    assert registry.get_commands() == []
+
+
+def test_one_plugin_failing_does_not_block_the_others():
+    good, bad = _enabled("good"), _enabled("bad")
+    good_plugin = MagicMock()
+    good_plugin.metadata.name = "good"
+    good_plugin.metadata.version = "1.0.0"
+
+    def load(discovered: DiscoveredPlugin) -> MagicMock:
+        if discovered.name == "bad":
+            raise RuntimeError("boom")
+        return good_plugin
+
+    loader = PluginLoader(EnterpriseConfig())
+    # bad is first: a loop that aborted on failure would never reach good.
+    with patch.object(PluginLoader, "discover_plugins", return_value=[bad, good]):
+        with patch.object(PluginLoader, "_load_plugin", side_effect=load):
+            with patch.object(
+                PluginLoader, "_check_version_compatibility", return_value=True
+            ):
+                registry = loader.load_enabled_plugins()
+
+    assert registry.get_load_failures() == {"bad": "boom"}
+    assert registry.get_plugin("good") is good_plugin
+
+
+def test_wheel_import_failure_records_real_reason(tmp_path):
+    discovered = DiscoveredPlugin(
+        name="machine_scan",
+        entry_point=None,
+        wheel_path=tmp_path / "machine_scan.whl",
+        is_installed=True,
+        is_enabled=True,
+        version="0.59.0",
+    )
+    loader = PluginLoader(EnterpriseConfig())
+    with patch.object(PluginLoader, "discover_plugins", return_value=[discovered]):
+        with patch.object(
+            PluginLoader,
+            "_load_from_wheel",
+            side_effect=ImportError("Error relocating libsatori.so: symbol not found"),
+        ):
+            registry = loader.load_enabled_plugins()
+
+    assert "symbol not found" in registry.get_load_failures()["machine_scan"]
+
+
+def test_none_load_result_is_recorded_as_failure():
+    loader = PluginLoader(EnterpriseConfig())
+    with patch.object(PluginLoader, "discover_plugins", return_value=[_enabled()]):
+        with patch.object(PluginLoader, "_load_plugin", return_value=None):
+            registry = loader.load_enabled_plugins()
+
+    assert registry.get_load_failures()["machine_scan"] == "could not be loaded"
+    assert registry.get_commands() == []
+
+
+def test_version_incompatible_plugin_is_recorded_as_failure():
+    plugin = MagicMock()
+    plugin.metadata.name = "machine_scan"
+    plugin.metadata.min_ggshield_version = "99.0.0"
+
+    loader = PluginLoader(EnterpriseConfig())
+    with patch.object(PluginLoader, "discover_plugins", return_value=[_enabled()]):
+        with patch.object(PluginLoader, "_load_plugin", return_value=plugin):
+            with patch.object(
+                PluginLoader, "_check_version_compatibility", return_value=False
+            ):
+                registry = loader.load_enabled_plugins()
+
+    assert "requires ggshield >= 99.0.0" in registry.get_load_failures()["machine_scan"]
+    assert registry.get_commands() == []
+
+
+def test_disabled_plugin_is_not_a_load_failure():
+    disabled = DiscoveredPlugin(
+        name="machine_scan",
+        entry_point=MagicMock(),
+        wheel_path=None,
+        is_installed=True,
+        is_enabled=False,
+        version="0.59.0",
+    )
+    loader = PluginLoader(EnterpriseConfig())
+    with patch.object(PluginLoader, "discover_plugins", return_value=[disabled]):
+        registry = loader.load_enabled_plugins()
+
+    assert registry.get_load_failures() == {}

--- a/tests/unit/core/plugin/test_loader.py
+++ b/tests/unit/core/plugin/test_loader.py
@@ -1009,14 +1009,13 @@ myplugin = other:Plugin
 
         assert result is None
 
-    def test_load_from_wheel_handles_exception(self, tmp_path: Path) -> None:
-        """Test that _load_from_wheel returns None on exception."""
+    def test_load_from_wheel_propagates_import_error(self, tmp_path: Path) -> None:
+        """A failed import must propagate so the loader can record the reason."""
         import zipfile
 
         config = EnterpriseConfig()
         loader = PluginLoader(config, signature_mode=SignatureVerificationMode.DISABLED)
 
-        # Create wheel with entry point
         wheel_path = tmp_path / "test-1.0.0.whl"
         with zipfile.ZipFile(wheel_path, "w") as zf:
             zf.writestr(
@@ -1024,14 +1023,12 @@ myplugin = other:Plugin
                 "[ggshield.plugins]\ntest = test:Plugin\n",
             )
 
-        # Module import will fail
         with patch(
             "ggshield.core.plugin.loader.importlib.import_module",
             side_effect=ImportError("Module not found"),
         ):
-            result = loader._load_from_wheel(wheel_path)
-
-        assert result is None
+            with pytest.raises(ImportError, match="Module not found"):
+                loader._load_from_wheel(wheel_path)
 
     def test_extract_cache_avoids_user_home_for_sudo_e(
         self, tmp_path: Path, monkeypatch

--- a/tests/unit/test_main_plugin_registration.py
+++ b/tests/unit/test_main_plugin_registration.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 import click
+import pytest
 
 
 def test_register_plugin_commands_skips_conflicts(monkeypatch) -> None:
@@ -86,3 +87,58 @@ def test_add_or_merge_skips_non_group_conflict() -> None:
 
     assert root.commands["auth"] is not plugin_cmd
     assert any("conflicts with an existing command" in msg for msg in warnings)
+
+
+def test_warn_about_failed_plugins_emits_one_warning_per_failure(monkeypatch) -> None:
+    import ggshield.__main__ as main_module
+    from ggshield.core.plugin.registry import PluginRegistry
+
+    registry = PluginRegistry()
+    registry.record_load_failure("machine_scan", "error relocating libsatori.so")
+    monkeypatch.setattr(main_module, "_load_plugins", lambda: registry)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(main_module.ui, "display_warning", warnings.append)
+
+    main_module._warn_about_failed_plugins()
+
+    assert len(warnings) == 1
+    assert "machine_scan" in warnings[0]
+    assert "failed to load" in warnings[0].lower()
+
+
+def test_warn_about_failed_plugins_silent_when_none(monkeypatch) -> None:
+    import ggshield.__main__ as main_module
+    from ggshield.core.plugin.registry import PluginRegistry
+
+    monkeypatch.setattr(main_module, "_load_plugins", lambda: PluginRegistry())
+
+    warnings: list[str] = []
+    monkeypatch.setattr(main_module.ui, "display_warning", warnings.append)
+
+    main_module._warn_about_failed_plugins()
+
+    assert warnings == []
+
+
+def test_main_warns_then_click_rejects_unknown_plugin_command(
+    monkeypatch, capsys
+) -> None:
+    """End to end: the warning prints AND Click still rejects the missing command."""
+    import ggshield.__main__ as main_module
+    from ggshield.core.plugin.registry import PluginRegistry
+
+    registry = PluginRegistry()
+    registry.record_load_failure("machine_scan", "error relocating libsatori.so")
+    monkeypatch.setattr(main_module, "_load_plugins", lambda: registry)
+    monkeypatch.setattr(main_module, "_register_plugin_commands", lambda: None)
+    monkeypatch.setattr(main_module, "force_utf8_output", lambda: None)
+    monkeypatch.setattr(main_module, "setup_truststore", lambda: None)
+
+    with pytest.raises(SystemExit):
+        main_module.main(["machine", "scan"])
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "machine_scan" in combined
+    assert "No such command" in combined


### PR DESCRIPTION
## Problem

The `machine_scan` endpoint plugin ships a native (PyO3) extension. When an **enabled** plugin fails to load in the field — e.g. a manylinux wheel installed on a musl/Alpine host raises an `ImportError` during import — the loader caught it, logged at `WARNING` (invisible at the default UI level), and moved on.

The user then runs `ggshield machine scan` and gets a bare:

```
Error: No such command 'machine'.
```

…while `ggshield plugin list` still shows the plugin as **enabled**. Confusing and unactionable — this was hit during endpoint-protection rollout.

## Fix

Make a failed load **visible and explained**:

- **`PluginRegistry`** records load failures (`record_load_failure` / `get_load_failures`).
- **`load_enabled_plugins`** records a failure on the version-incompatibility path, the generic exception path, and when the load returns `None`.
- **`_load_from_wheel`** now *propagates* import/load errors instead of swallowing them to `None`, so the real reason (e.g. native ABI mismatch) reaches the registry — this was the actual field scenario and the previous version still missed it.
- **`main()`** warns about each failed plugin **before Click dispatches**. The old code warned inside the group callback `cli()`, which Click never runs when the command is unknown — so the reported case showed no hint. Now the warning fires regardless.
- **`ggshield plugin list`** shows `enabled, FAILED TO LOAD: <reason>` instead of `enabled`.

A healthy plugin is unaffected; one plugin failing does not block the others.

### Example after this change

```
Plugin 'machine_scan' is enabled but failed to load: <reason>. Its commands are unavailable; run `ggshield plugin list` for status.
Error: No such command 'machine'.
```

## Tests

- `tests/unit/core/plugin/test_load_failures.py` (new): failure recorded + commands not registered; one failure doesn't block others (failing plugin ordered first); wheel import error records the real reason; `None` load recorded; disabled plugin is not a failure.
- `tests/unit/core/plugin/test_loader.py`: `test_load_from_wheel_propagates_import_error` (was `…_handles_exception`, now asserts propagation).
- `tests/unit/cmd/plugin/test_list.py`: `FAILED TO LOAD` shown for an enabled-but-failed plugin.
- `tests/unit/test_main_plugin_registration.py`: `_warn_about_failed_plugins` emits one warning per failure / silent when none; end-to-end test runs the real `cli.main` for an unknown plugin command and asserts the warning **and** "No such command" both appear.

Full unit suite green. Reviewed with Codex (two blockers found and fixed; both re-confirmed resolved).

## Follow-up (out of scope)

Top-level plugin-loading/register failures still route through `_deferred_warnings`, flushed only in the group callback — so a whole-registry load failure stays invisible on the unknown-command path. Pre-existing and separate from the per-plugin path fixed here; worth a follow-up ticket.