### PR TITLE
feat: send machine identifiers on scan route

### DIFF
--- a/changelog.d/20260625_000000_paul.beslin.ext_send_machine_identifiers.md
+++ b/changelog.d/20260625_000000_paul.beslin.ext_send_machine_identifiers.md
@@ -1,0 +1,3 @@
+### Added
+
+- Scan requests now include `Machine-Id` and `Machine-Username` headers

--- a/ggshield/core/machine_id.py
+++ b/ggshield/core/machine_id.py
@@ -15,6 +15,7 @@ import socket
 import subprocess
 import sys
 import uuid
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -35,6 +36,7 @@ def _get_hostname() -> str:
         return "unknown"
 
 
+@lru_cache(maxsize=1)
 def _get_username() -> str:
     try:
         return getpass.getuser()
@@ -137,6 +139,7 @@ def _get_windows_system_id() -> Optional[str]:
     return None
 
 
+@lru_cache(maxsize=1)
 def _get_machine_id() -> str:
 
     # In case Satori generated a machine id, use it.

--- a/ggshield/core/scan/scan_context.py
+++ b/ggshield/core/scan/scan_context.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, Union
 
 from ggshield import __version__
 from ggshield.core.git_hooks.ci.repository import get_repository_url_from_ci
+from ggshield.core.machine_id import _get_machine_id, _get_username
 from ggshield.utils.git_shell import get_repository_url_from_path
 from ggshield.utils.os import get_os_info
 
@@ -47,6 +48,8 @@ class ScanContext:
             "OS-Name": self.os_name,
             "OS-Version": self.os_version,
             "Python-Version": self.python_version,
+            "Machine-Id": _get_machine_id(),
+            "Machine-Username": _get_username(),
         }
         repo_url = self._get_repository_url()
         if repo_url is not None:

--- a/tests/unit/core/scan/test_scan_context.py
+++ b/tests/unit/core/scan/test_scan_context.py
@@ -37,6 +37,38 @@ def _assert_no_repo_url_in_headers(context: ScanContext):
     assert context.get_http_headers().get("GGShield-Repository-URL") is None
 
 
+@pytest.mark.parametrize(
+    "scan_mode", [ScanMode.PATH, ScanMode.CI, ScanMode.PRE_COMMIT, ScanMode.AI_HOOK]
+)
+@mock.patch(
+    "ggshield.core.scan.scan_context.get_repository_url_from_ci", return_value=None
+)
+@mock.patch("ggshield.core.scan.scan_context._get_username", return_value="alice")
+@mock.patch(
+    "ggshield.core.scan.scan_context._get_machine_id", return_value="machine-42"
+)
+def test_machine_identity_sent_on_every_scan(
+    _mid: mock.MagicMock,
+    _usr: mock.MagicMock,
+    _ci_url: mock.MagicMock,
+    scan_mode: ScanMode,
+    tmp_path: Path,
+) -> None:
+    """
+    GIVEN any scan mode
+    WHEN building the HTTP headers
+    THEN machine id and username ride along so the backend can identify the endpoint
+    """
+    context = ScanContext(
+        scan_mode=scan_mode,
+        command_path="ggshield secret scan",
+        target_path=tmp_path,
+    )
+    headers = context.get_http_headers()
+    assert headers["GGShield-Machine-Id"] == "machine-42"
+    assert headers["GGShield-Machine-Username"] == "alice"
+
+
 def test_scan_context_no_repo(
     tmp_path: Path,
 ):

--- a/tests/unit/core/test_machine_id.py
+++ b/tests/unit/core/test_machine_id.py
@@ -16,6 +16,14 @@ from ggshield.core.machine_id import (
 )
 
 
+@pytest.fixture(autouse=True)
+def clear_machine_id_caches():
+    """Reset the lru_cache on cached helpers so each test sees its own mocks."""
+    _get_username.cache_clear()
+    _get_machine_id.cache_clear()
+    yield
+
+
 # ---------------------------------------------------------------------------
 # _get_hostname
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -343,6 +343,8 @@ def test_request_headers(scan_mock: Mock, client):
             "GGShield-OS-Name": os_name,
             "GGShield-OS-Version": os_version,
             "GGShield-Python-Version": platform.python_version(),
+            "GGShield-Machine-Id": ANY,
+            "GGShield-Machine-Username": ANY,
             "mode": "path",
             "scan_options": ANY,
         },


### PR DESCRIPTION
## Context

Emit machine id and username when running a scan.

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
