### PR TITLE
feat: add agent name to headers sent to the scan route (for ai scans)

### DIFF
--- a/changelog.d/20260625_000001_paul.beslin.ext_agent_name_header.md
+++ b/changelog.d/20260625_000001_paul.beslin.ext_agent_name_header.md
@@ -1,0 +1,3 @@
+### Added
+
+- AI scan requests now include the agent name in the headers sent to the scan route.

--- a/ggshield/cmd/secret/scan/ai_hook.py
+++ b/ggshield/cmd/secret/scan/ai_hook.py
@@ -10,7 +10,11 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
 from ggshield.core.scan import ScanContext, ScanMode
-from ggshield.verticals.ai.hooks import AIHookScanner, emit_fail_open_response
+from ggshield.verticals.ai.hooks import (
+    AIHookScanner,
+    build_agent_headers,
+    emit_fail_open_response,
+)
 from ggshield.verticals.secret import SecretScanner
 
 
@@ -53,6 +57,7 @@ def ai_hook_cmd(
             scan_context=ScanContext(
                 scan_mode=ScanMode.AI_HOOK,
                 command_path=ctx.command_path,
+                extra_headers=build_agent_headers(stdin_content),
             ),
             secret_config=config.user_config.secret,
         )

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -240,6 +240,15 @@ def _detect_agent(data: Dict[str, Any]) -> Agent:
     raise ValueError("Unrecognized agent")
 
 
+def build_agent_headers(content: str) -> Dict[str, str]:
+    """Additional headers to identify the agent."""
+    try:
+        agent = _detect_agent(json.loads(content))
+        return {"Agent-Name": agent.name}
+    except Exception:
+        return {}
+
+
 def _parse_user_prompt(
     content: str, event_type: EventType, agent: Agent, timestamp: datetime
 ) -> List[HookPayload]:

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -8,10 +8,12 @@ import pytest
 from pygitguardian import GGClient
 from pygitguardian.models import MCPActivityResponse
 
+from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
 from ggshield.verticals.ai.hooks import (
     AIHookScanner,
+    build_agent_headers,
     find_filepaths,
     has_already_been_seen,
     parse_hook_input,
@@ -232,6 +234,54 @@ class TestAIHookScannerScan:
         scanner = AIHookScanner(_mock_scanner([]))
         with pytest.raises(ValueError):
             scanner._scan_payloads([])
+
+
+class TestBuildAgentHeaders:
+    """``build_agent_headers`` names the calling AI agent via GGShield-Agent-Name.
+
+    Machine identity (Machine-Id / Machine-Username) is sent on every scan by
+    ``ScanContext.get_http_headers`` — only the agent name is hook-specific.
+    """
+
+    AGENT_HEADER = "GGShield-Agent-Name"
+
+    def test_returns_only_the_agent_name(self):
+        """Just the unprefixed Agent-Name; machine identity is not the hook's job."""
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"command": "echo hello"},
+            "cwd": "/home/alice/project",
+            "transcript_path": "/home/user/.claude/projects/foo/session.jsonl",
+            "session_id": "427ae0c5-0862-4e14-aa2c-12fad909c323",
+        }
+        assert build_agent_headers(json.dumps(data)) == {"Agent-Name": "claude-code"}
+
+    def test_agent_name_flows_through_scan_context(self):
+        """Fed into ScanContext, the agent name becomes a prefixed header beside mode."""
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"command": "echo hello"},
+            "transcript_path": "/home/user/.claude/projects/foo/session.jsonl",
+            "session_id": "s",
+        }
+        ctx = ScanContext(
+            scan_mode=ScanMode.AI_HOOK,
+            command_path="ggshield secret scan ai-hook",
+            extra_headers=build_agent_headers(json.dumps(data)),
+        )
+        http_headers = ctx.get_http_headers()
+        assert http_headers[self.AGENT_HEADER] == "claude-code"
+        assert http_headers["mode"] == ScanMode.AI_HOOK.value
+
+    def test_unrecognized_agent_degrades_to_empty_dict(self):
+        """An unrecognized agent yields no headers rather than raising (fail-open)."""
+        assert build_agent_headers(json.dumps({"hook_event_name": "PreToolUse"})) == {}
+
+    def test_invalid_json_degrades_to_empty_dict(self):
+        """Malformed input yields no headers rather than raising (fail-open)."""
+        assert build_agent_headers("not json") == {}
 
 
 class TestMCPActivity:


### PR DESCRIPTION
## Context

Add the agent name to headers sent to the GitGuardian API when scanning a secret from an AI hook. 

<!--
Explain why you propose these changes. You can add links to GitHub issues here, if relevant.

For example:

When calling `ggshield foo bar`, the command fails. This PR fixes it.

See #123.
-->

## What has been done

<!--
If the changes are non-trivial, describe them to make it easier for reviewers to understand them.

For example:

- Refactor Foo to support Bar, this required doing x, y and z.
- Implement Bar.
-->

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- run `ggshield foo bar`, it should do x.
-->

## PR check list

- [ ] As much as possible, the changes include tests (unit and/or functional)
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
