### PR TITLE
Remove number of duplicates from report

### DIFF
--- a/ggshield/cmd/ai/discover.py
+++ b/ggshield/cmd/ai/discover.py
@@ -134,7 +134,6 @@ def _summarize_discovery(config: AIDiscovery, report: BackfillReport) -> Dict[st
         "history": {
             "parsed": report.parsed,
             "ingested": report.ingested,
-            "duplicates": report.duplicates,
             "skipped": report.skipped,
         },
     }
@@ -197,6 +196,5 @@ def print_summary(summary: Dict[str, Any]) -> None:
         click.echo(f"  • Parsed {history['parsed']:,} events")
         click.echo(
             f"  • Recorded {history['ingested']:,} events "
-            f"({history['duplicates']:,} already known, "
-            f"{history.get('skipped', 0):,} skipped)"
+            f"({history.get('skipped', 0):,} skipped)"
         )

--- a/ggshield/verticals/ai/history.py
+++ b/ggshield/verticals/ai/history.py
@@ -19,7 +19,6 @@ BATCH_SIZE = 500
 class BackfillReport:
     parsed: int = 0
     ingested: int = 0
-    duplicates: int = 0
     skipped: int = 0
     error: Optional[str] = None
 
@@ -43,7 +42,6 @@ def backfill_mcp_history(client: GGClient, ai_config: AIDiscovery) -> BackfillRe
             report.error = response.detail
             return False
         report.ingested += response.ingested
-        report.duplicates += response.duplicates
         report.skipped += response.skipped
         activities.clear()
         return True

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -411,7 +411,7 @@ class TestDiscoverCmd:
     @patch("ggshield.cmd.ai.discover.save_discovery_cache")
     @patch(
         "ggshield.cmd.ai.discover.backfill_mcp_history",
-        return_value=BackfillReport(parsed=3, ingested=3, duplicates=0),
+        return_value=BackfillReport(parsed=3, ingested=3),
     )
     def test_history_flag_invokes_backfill_and_surfaces_summary(
         self,
@@ -478,7 +478,7 @@ class TestDiscoverCmd:
     @patch("ggshield.cmd.ai.discover.save_discovery_cache")
     @patch(
         "ggshield.cmd.ai.discover.backfill_mcp_history",
-        return_value=BackfillReport(parsed=4, ingested=2, duplicates=1, skipped=1),
+        return_value=BackfillReport(parsed=4, ingested=2, skipped=1),
     )
     def test_json_output_includes_history_block(
         self,
@@ -496,7 +496,6 @@ class TestDiscoverCmd:
         assert parsed["history"] == {
             "parsed": 4,
             "ingested": 2,
-            "duplicates": 1,
             "skipped": 1,
         }
 

--- a/tests/unit/verticals/ai/test_history.py
+++ b/tests/unit/verticals/ai/test_history.py
@@ -71,7 +71,6 @@ class TestBackfillMCPHistory:
         assert len(sent) == 2
         assert report.parsed == 2
         assert report.ingested == 2
-        assert report.duplicates == 0
         assert report.skipped == 0
 
     def test_runs_every_time(self, tmp_path) -> None:


### PR DESCRIPTION
## Context

The MCP activity data will be migrated and its ingestion will change. Knowing which line was already in the dataset will no longer be possible.

To preserve schema compatibility, the platform will still return `duplicates: 0`, but to avoid misleading the user, this information is no longer shown.