### PR TITLE
refactor(machine): rename `machine healthcheck` to `machine doctor`

### DIFF
--- a/changelog.d/20260624_180000_achille.mascia_machine_doctor.md
+++ b/changelog.d/20260624_180000_achille.mascia_machine_doctor.md
@@ -1,0 +1,3 @@
+### Added
+
+- `ggshield machine doctor` checks that this machine's ggshield protections are correctly set up: the AI hooks and git hooks are installed, the GitGuardian token is reachable and carries the scopes the configured protections need (`scan`, plus `honeytokens:write` and — when the `machine_scan` plugin is installed — `endpoints:send`, both of which require a Business or Enterprise plan), and that the plugin's native scanner loads. It is read-only, prints a specific fix for each failed check, and exits non-zero if any check fails, so it can gate an MDM rollout.

--- a/changelog.d/20260624_180000_achille.mascia_machine_healthcheck.md
+++ b/changelog.d/20260624_180000_achille.mascia_machine_healthcheck.md
@@ -1,3 +1,0 @@
-### Added
-
-- `ggshield machine healthcheck` checks that this machine's ggshield protections are correctly set up: the AI hooks and git hooks are installed, the GitGuardian token is reachable and carries the scopes the configured protections need (`scan`, plus `honeytokens:write` and — when the `machine_scan` plugin is installed — `endpoints:send`, both of which require a Business or Enterprise plan), and that the plugin's native scanner loads. It is read-only, prints a specific fix for each failed check, and exits non-zero if any check fails, so it can gate an MDM rollout.

--- a/ggshield/cmd/machine/__init__.py
+++ b/ggshield/cmd/machine/__init__.py
@@ -2,19 +2,19 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.machine.healthcheck import healthcheck_cmd
+from ggshield.cmd.machine.doctor import doctor_cmd
 from ggshield.cmd.machine.setup import setup_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 
 
-@click.group(commands={"setup": setup_cmd, "healthcheck": healthcheck_cmd})
+@click.group(commands={"setup": setup_cmd, "doctor": doctor_cmd})
 @add_common_options()
 def machine_group(**kwargs: Any) -> None:
     """
     Scan and protect this machine.
 
     `setup` sets up all of this machine's protections (AI hooks, git hooks, and a
-    honeytoken) in one idempotent command. `healthcheck` checks that everything is
+    honeytoken) in one idempotent command. `doctor` checks that everything is
     correctly set up — AI hooks, git hooks, the token's scopes, and the
     `machine_scan` plugin when installed — without changing anything. Secret and
     endpoint scanning (`scan`) is provided by the `machine_scan` plugin and merges

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -45,10 +45,10 @@ class Check:
     fix: str = ""
 
 
-@click.command(name="healthcheck")
+@click.command(name="doctor")
 @add_common_options()
 @click.pass_context
-def healthcheck_cmd(ctx: click.Context, **kwargs: Any) -> int:
+def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Check that this machine's ggshield protections are correctly set up.
 

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -247,7 +247,7 @@ def ai_hook_posture() -> List[AgentHookStatus]:
     """Read-only AI-hook status: for each detected assistant, is the hook installed?
 
     Only assistants present on this machine are reported; it never writes anything.
-    Used by ``ggshield machine healthcheck``.
+    Used by ``ggshield machine doctor``.
     """
     statuses = []
     for agent in AGENTS.values():

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from pygitguardian.models import APITokensResponse, HealthCheckResponse
 
 from ggshield.__main__ import cli
-from ggshield.cmd.machine.healthcheck import (
+from ggshield.cmd.machine.doctor import (
     Check,
     _check_ai_hooks,
     _check_auth_and_scopes,
@@ -17,14 +17,14 @@ from ggshield.verticals.ai.installation import AgentHookStatus
 from tests.unit.conftest import assert_invoke_ok
 
 
-BASE = "ggshield.cmd.machine.healthcheck"
+BASE = "ggshield.cmd.machine.doctor"
 
 
-class TestHealthcheckCommand:
-    def test_healthcheck_appears_in_machine_help(self, cli_fs_runner: CliRunner):
+class TestDoctorCommand:
+    def test_doctor_appears_in_machine_help(self, cli_fs_runner: CliRunner):
         result = cli_fs_runner.invoke(cli, ["machine", "--help"])
         assert_invoke_ok(result)
-        assert "healthcheck" in result.output
+        assert "doctor" in result.output
 
     def _run(self, cli_fs_runner, *, auth_ok, ai_ok, git_ok, plugin_installed):
         auth = Check("Authentication", auth_ok)
@@ -39,7 +39,7 @@ class TestHealthcheckCommand:
         ), patch(
             f"{BASE}._check_plugin_native", return_value=Check("Plugin", True)
         ) as m_plugin:
-            result = cli_fs_runner.invoke(cli, ["machine", "healthcheck"])
+            result = cli_fs_runner.invoke(cli, ["machine", "doctor"])
         return result, m_plugin
 
     def test_exit_zero_when_all_pass(self, cli_fs_runner: CliRunner):


### PR DESCRIPTION
## What

Renames the unreleased `ggshield machine healthcheck` command to `ggshield machine doctor`. Pure rename — no behavior change.

- `ggshield/cmd/machine/healthcheck.py` → `doctor.py` (`healthcheck_cmd` → `doctor_cmd`, `name="doctor"`)
- Re-registered in the `machine` group as `doctor`
- Renamed the test module and the unreleased changelog fragment
- Updated the one docstring reference in `verticals/ai/installation.py`

## Why

`doctor` is the conventional name for a read-only "is everything set up correctly?" check (cf. `brew doctor`, `flutter doctor`) and reads better than `healthcheck`, which collides with the GitGuardian API health check (`HealthCheckResponse`). The command hasn't shipped, so this is a free rename with no migration path needed.

## Verification

- `tests/unit/cmd/machine/test_doctor.py` — 23 passed
- `tests/unit/verticals/ai/test_installation.py` — 47 passed
- `pre-commit run --files …` — all hooks pass (black, flake8, isort, pyright, import-linter)
- CLI smoke test: `ggshield machine doctor --help` works; `ggshield machine healthcheck` now errors with `No such command 'healthcheck'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)