### PR TITLE
feat(machine): surface git core.hooksPath overrides that shadow ggshield

### DIFF
--- a/changelog.d/20260626_100000_achille.mascia_hookspath_shadow.md
+++ b/changelog.d/20260626_100000_achille.mascia_hookspath_shadow.md
@@ -1,0 +1,4 @@
+### Added
+
+- `ggshield machine doctor` now detects when a higher-precedence git `core.hooksPath` (a repo-local or user-global one, e.g. Husky or lefthook) shadows the ggshield git hook. Git uses only the most-specific `core.hooksPath`, so such an override silently bypasses ggshield's system/global hook — doctor reports it as a failed "Git hook precedence" check (per repo) instead of giving a false sense of coverage.
+- `ggshield machine setup` warns at install time when a `core.hooksPath` override takes precedence in the current context, so its git hook would be shadowed there.

--- a/ggshield/cmd/install.py
+++ b/ggshield/cmd/install.py
@@ -11,7 +11,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
 from ggshield.core.dirs import get_data_dir, get_system_data_dir
 from ggshield.core.errors import UnexpectedError
-from ggshield.utils.git_shell import check_git_dir, git
+from ggshield.utils.git_shell import GitError, check_git_dir, get_git_root, git
 from ggshield.verticals.ai.installation import (
     AGENTS,
     check_ai_hook_authentication,
@@ -33,6 +33,10 @@ if [ -f "$_ggshield_local_hook" ]; then
     fi
 fi
 """
+
+# The line `create_hook` writes into every ggshield-managed hook script; its presence
+# is how we recognize a hook (or hooks dir) as ggshield's own.
+GGSHIELD_HOOK_MARKER = "ggshield secret scan"
 
 
 @click.command(context_settings={"ignore_unknown_options": True})
@@ -168,6 +172,85 @@ def get_system_hook_dir_path() -> Optional[Path]:
     except subprocess.CalledProcessError:
         return None
     return Path(click.format_filename(out)).expanduser()
+
+
+def get_configured_hook_dir_path() -> Optional[Path]:
+    """Return the ``core.hooksPath`` git would actually use in the current context.
+
+    Resolves git's normal precedence (local repo > global user > system). A relative
+    ``core.hooksPath`` (e.g. Husky's ``.husky/_``) is resolved against the repository
+    root, the way git itself interprets it, so the path is usable regardless of the
+    current working directory. Returns ``None`` when no ``core.hooksPath`` is
+    configured anywhere (git then uses ``.git/hooks``) or when git cannot be queried,
+    so callers — including the gating ``machine doctor`` — never crash on a git error.
+    """
+    try:
+        out = git(["config", "--get", "core.hooksPath"], ignore_git_config=False)
+    except (subprocess.CalledProcessError, GitError, OSError):
+        return None
+    path = Path(click.format_filename(out)).expanduser()
+    if not path.is_absolute():
+        repo_root = _get_repo_root()
+        if repo_root is not None:
+            path = repo_root / path
+    return path
+
+
+def _get_repo_root() -> Optional[Path]:
+    """Return the working tree root, or ``None`` when git cannot resolve it."""
+    try:
+        return get_git_root()
+    except (GitError, OSError):
+        return None
+
+
+def hook_invokes_ggshield(hook_path: Path) -> bool:
+    """Whether ``hook_path`` is an existing hook script that runs ggshield.
+
+    Single source of truth for recognizing a ggshield-managed hook by the marker line
+    ``create_hook`` writes. ``errors="ignore"`` only covers decoding, so an unreadable
+    file (permissions, a race between the ``is_file`` check and the read, a special
+    file) is treated as "not ggshield's" rather than crashing the gating ``doctor``.
+    """
+    try:
+        return hook_path.is_file() and GGSHIELD_HOOK_MARKER in hook_path.read_text(
+            errors="ignore"
+        )
+    except OSError:
+        return False
+
+
+def is_ggshield_hook_dir(hook_dir: Path) -> bool:
+    """Whether ``hook_dir`` holds (or, for Husky, sources) ggshield hook scripts.
+
+    For a Husky ``.husky/_`` directory the runnable hook lives in the parent
+    ``.husky/`` — that is where ``ggshield install --mode local`` writes its content
+    and what Husky's ``_`` wrappers source — so the parent is inspected too.
+    """
+    candidate_dirs = [hook_dir]
+    if is_husky_hooks_path(hook_dir):
+        candidate_dirs.append(hook_dir.parent)
+    return any(
+        hook_invokes_ggshield(directory / hook_type)
+        for directory in candidate_dirs
+        for hook_type in ("pre-commit", "pre-push")
+    )
+
+
+def get_shadowing_hooks_path() -> Optional[Path]:
+    """Return the effective ``core.hooksPath`` if it shadows ggshield's hook.
+
+    Git uses exactly one hooks directory — the most specific ``core.hooksPath`` wins.
+    So a repo-local or user-global ``core.hooksPath`` pointing at a non-ggshield
+    directory (e.g. Husky's ``.husky/_``) takes precedence over ggshield's
+    system/global install, and ggshield's hook never runs in that context. Returns
+    that overriding path, or ``None`` when ggshield's hook is the effective one (or no
+    ``core.hooksPath`` override is configured at all).
+    """
+    effective = get_configured_hook_dir_path()
+    if effective is None or is_ggshield_hook_dir(effective):
+        return None
+    return effective
 
 
 def install_local(hook_type: str, force: bool, append: bool) -> int:

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -9,7 +9,9 @@ from ggshield.cmd.install import (
     get_default_global_hook_dir_path,
     get_default_system_hook_dir_path,
     get_global_hook_dir_path,
+    get_shadowing_hooks_path,
     get_system_hook_dir_path,
+    hook_invokes_ggshield,
 )
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
@@ -52,16 +54,20 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     """
     Check that this machine's ggshield protections are correctly set up.
 
-    Verifies the AI hooks and git hooks are installed, that the GitGuardian token
-    is reachable and carries the scopes the configured protections need (including
-    `honeytokens:write`, granted only on Business or Enterprise plans), and — when
-    the `machine_scan` plugin is installed — that the token has the endpoint scope
-    (also Business/Enterprise-only) and the native scanner loads.
+    Verifies the AI hooks and git hooks are installed, that no higher-precedence
+    `core.hooksPath` override (e.g. Husky or lefthook) shadows ggshield's git hook
+    in the current context, that the GitGuardian token is reachable and carries the
+    scopes the configured protections need (including `honeytokens:write`, granted
+    only on Business or Enterprise plans), and — when the `machine_scan` plugin is
+    installed — that the token has the endpoint scope (also Business/Enterprise-only)
+    and the native scanner loads.
 
     This is read-only: it never installs, scans, or changes anything. Each failed
-    check prints how to fix it (hooks via `ggshield machine setup`, scopes via a
-    token that carries them, the plugin via `ggshield plugin install`). Exits
-    non-zero if any check fails, so it can gate an MDM rollout.
+    check prints how to fix it (hooks via `ggshield machine setup` — except a
+    shadowing `core.hooksPath`, which git precedence means must be integrated into
+    that hook manager or unset; scopes via a token that carries them; the plugin via
+    `ggshield plugin install`). Exits non-zero if any check fails, so it can gate an
+    MDM rollout.
     """
     config = ContextObj.get(ctx).config
 
@@ -71,6 +77,7 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     checks: List[Check] = [auth_check]
     checks.append(_check_ai_hooks())
     checks.append(_check_git_hooks())
+    checks.append(_check_git_hooks_precedence())
     checks.extend(_check_scopes(scopes, plugin_installed))
     if plugin_installed:
         checks.append(_check_plugin_native())
@@ -139,14 +146,32 @@ def _check_git_hooks() -> Check:
     return Check("Git hooks", True, "global/system pre-commit and pre-push configured")
 
 
+def _check_git_hooks_precedence() -> Check:
+    """Catch a `core.hooksPath` override that shadows ggshield's hook.
+
+    Git uses only the most-specific `core.hooksPath`, so a repo-local or user-global
+    one (e.g. Husky) silently bypasses ggshield's system/global hook — installed but
+    never run. This is per-context: run in a repo to check that repo. Note this is the
+    one thing `machine setup` cannot fix (git precedence); the hook must be integrated
+    into the other tool, or the override unset.
+    """
+    shadow = get_shadowing_hooks_path()
+    if shadow is None:
+        return Check(
+            "Git hook precedence", True, "no core.hooksPath override shadows ggshield"
+        )
+    return Check(
+        "Git hook precedence",
+        False,
+        f"core.hooksPath points to {shadow} (e.g. Husky/lefthook) — git uses it "
+        "instead, so ggshield's hook will NOT run in this context",
+        fix="integrate ggshield into that hook manager, or unset the overriding "
+        "core.hooksPath; commits are still scanned server-side by GitGuardian",
+    )
+
+
 def _ggshield_hook_present(hook_dirs: List[Any], hook_type: str) -> bool:
-    for hook_dir in hook_dirs:
-        hook_path = hook_dir / hook_type
-        if hook_path.is_file() and "ggshield secret scan" in hook_path.read_text(
-            errors="ignore"
-        ):
-            return True
-    return False
+    return any(hook_invokes_ggshield(hook_dir / hook_type) for hook_dir in hook_dirs)
 
 
 def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[Check]:

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -7,7 +7,9 @@ from ggshield.cmd.install import (
     get_default_global_hook_dir_path,
     get_default_system_hook_dir_path,
     get_global_hook_dir_path,
+    get_shadowing_hooks_path,
     get_system_hook_dir_path,
+    hook_invokes_ggshield,
     install_global,
     install_system,
 )
@@ -154,7 +156,7 @@ def _setup_git_hooks(system: bool) -> bool:
     for hook_type in _GIT_HOOK_TYPES:
         hook_path = hook_dir / hook_type
         if hook_path.is_file():
-            if "ggshield secret scan" in hook_path.read_text(errors="ignore"):
+            if hook_invokes_ggshield(hook_path):
                 click.echo(f"  {scope} {hook_type} hook already configured")
             else:
                 ui.display_warning(
@@ -167,6 +169,18 @@ def _setup_git_hooks(system: bool) -> bool:
         except Exception as exc:  # one hook failure must not abort the whole setup
             ui.display_warning(f"  could not install {scope} {hook_type} hook: {exc}")
             ok = False
+
+    # A higher-precedence core.hooksPath (repo-local or user-global, e.g. Husky)
+    # silently shadows what we just installed — git would run it instead. We cannot
+    # out-rank it (git precedence), so surface it rather than give false coverage.
+    shadow = get_shadowing_hooks_path()
+    if shadow is not None:
+        ui.display_warning(
+            f"  a core.hooksPath override ({shadow}) takes precedence here, so "
+            "ggshield's hook will not run in that context. Integrate ggshield into "
+            "that hook manager or unset the override (`ggshield machine doctor` flags "
+            "this per repo)."
+        )
     return ok
 
 

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -9,6 +10,7 @@ from ggshield.cmd.machine.doctor import (
     _check_ai_hooks,
     _check_auth_and_scopes,
     _check_git_hooks,
+    _check_git_hooks_precedence,
     _check_plugin_native,
     _check_scopes,
     _is_plugin_installed,
@@ -34,6 +36,9 @@ class TestDoctorCommand:
             f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", ai_ok)
         ), patch(
             f"{BASE}._check_git_hooks", return_value=Check("Git hooks", git_ok)
+        ), patch(
+            f"{BASE}._check_git_hooks_precedence",
+            return_value=Check("Git hook precedence", True),
         ), patch(
             f"{BASE}._check_scopes", return_value=[Check("Scope", True)]
         ), patch(
@@ -239,3 +244,17 @@ class TestPluginChecks:
             check = _check_plugin_native()
         assert check.ok is False
         assert "bad arch" in check.detail
+
+
+class TestCheckGitHooksPrecedence:
+    def test_ok_when_no_shadow(self):
+        with patch(f"{BASE}.get_shadowing_hooks_path", return_value=None):
+            assert _check_git_hooks_precedence().ok is True
+
+    def test_fail_when_shadowed(self):
+        shadow = Path("/repo/.husky/_")
+        with patch(f"{BASE}.get_shadowing_hooks_path", return_value=shadow):
+            check = _check_git_hooks_precedence()
+        assert check.ok is False
+        # Use the rendered path (backslashes on Windows) so the assertion is portable.
+        assert str(shadow) in check.detail

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -1,5 +1,7 @@
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from ggshield.__main__ import cli
@@ -217,6 +219,13 @@ class TestMachineSetupOrchestration:
 class TestSetupGitHooks:
     BASE = "ggshield.cmd.machine.setup"
 
+    @pytest.fixture(autouse=True)
+    def _no_shadow(self):
+        # Pin the core.hooksPath shadow check so these tests don't shell out to the
+        # real `git config`. Tests that exercise it override this.
+        with patch(f"{self.BASE}.get_shadowing_hooks_path", return_value=None):
+            yield
+
     # ``is_root`` is pinned False so the per-user branch is deterministic even when
     # the test runs as root (e.g. a CI container).
     @patch(f"{BASE}.is_root", return_value=False)
@@ -289,6 +298,24 @@ class TestSetupGitHooks:
         mock_dir.return_value = tmp_path
         assert _setup_git_hooks(system=False) is True  # root implies system scope
         assert mock_install.call_count == 2
+
+    @patch(f"{BASE}.is_root", return_value=False)
+    @patch(f"{BASE}.install_global")
+    @patch(f"{BASE}.get_global_hook_dir_path", return_value=None)
+    @patch(f"{BASE}.get_default_global_hook_dir_path")
+    def test_warns_when_a_core_hookspath_override_shadows(
+        self, mock_dir, _mock_cfg, _mock_install, _mock_root, tmp_path, capsys
+    ):
+        from ggshield.cmd.machine.setup import _setup_git_hooks
+
+        mock_dir.return_value = tmp_path
+        with patch(
+            f"{self.BASE}.get_shadowing_hooks_path",
+            return_value=Path("/repo/.husky/_"),
+        ):
+            _setup_git_hooks(system=False)
+        captured = capsys.readouterr()
+        assert "core.hooksPath override" in captured.out + captured.err
 
 
 class TestHoneytokenPlant:

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -596,3 +596,131 @@ class TestLocalHookSnippet:
 
         assert result.returncode == 0, result.stderr
         assert sentinel.exists()
+
+
+class TestHooksPathShadow:
+    BASE = "ggshield.cmd.install"
+
+    def test_configured_hook_dir_path_returns_value(self):
+        from ggshield.cmd.install import get_configured_hook_dir_path
+
+        # Pin _get_repo_root to None so the value is returned verbatim (no
+        # relative-path resolution); on Windows "/some/hooks" is not absolute and
+        # would otherwise be resolved against the repo root.
+        with patch(f"{self.BASE}.git", return_value="/some/hooks"), patch(
+            f"{self.BASE}._get_repo_root", return_value=None
+        ):
+            assert get_configured_hook_dir_path() == Path("/some/hooks")
+
+    def test_configured_hook_dir_path_none_when_unset(self):
+        from ggshield.cmd.install import get_configured_hook_dir_path
+
+        with patch(
+            f"{self.BASE}.git",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            assert get_configured_hook_dir_path() is None
+
+    def test_is_ggshield_hook_dir_true(self, tmp_path):
+        from ggshield.cmd.install import is_ggshield_hook_dir
+
+        (tmp_path / "pre-commit").write_text(
+            "#!/bin/sh\nggshield secret scan pre-commit\n"
+        )
+        assert is_ggshield_hook_dir(tmp_path) is True
+
+    def test_is_ggshield_hook_dir_false_for_foreign(self, tmp_path):
+        from ggshield.cmd.install import is_ggshield_hook_dir
+
+        (tmp_path / "pre-commit").write_text("#!/bin/sh\nother-tool\n")
+        assert is_ggshield_hook_dir(tmp_path) is False
+
+    def test_shadow_none_when_no_override(self):
+        from ggshield.cmd.install import get_shadowing_hooks_path
+
+        with patch(f"{self.BASE}.get_configured_hook_dir_path", return_value=None):
+            assert get_shadowing_hooks_path() is None
+
+    def test_shadow_none_when_effective_is_ggshield(self, tmp_path):
+        from ggshield.cmd.install import get_shadowing_hooks_path
+
+        (tmp_path / "pre-commit").write_text(
+            "#!/bin/sh\nggshield secret scan pre-commit\n"
+        )
+        with patch(f"{self.BASE}.get_configured_hook_dir_path", return_value=tmp_path):
+            assert get_shadowing_hooks_path() is None
+
+    def test_shadow_returns_path_when_foreign(self, tmp_path):
+        from ggshield.cmd.install import get_shadowing_hooks_path
+
+        husky = tmp_path / ".husky" / "_"
+        husky.mkdir(parents=True)
+        with patch(f"{self.BASE}.get_configured_hook_dir_path", return_value=husky):
+            assert get_shadowing_hooks_path() == husky
+
+    def test_configured_hook_dir_path_none_on_any_git_error(self):
+        from ggshield.cmd.install import get_configured_hook_dir_path
+        from ggshield.utils.git_shell import GitCommandTimeoutExpired
+
+        with patch(f"{self.BASE}.git", side_effect=GitCommandTimeoutExpired("boom")):
+            assert get_configured_hook_dir_path() is None
+
+    def test_configured_hook_dir_path_resolves_relative_against_repo_root(
+        self, tmp_path
+    ):
+        from ggshield.cmd.install import get_configured_hook_dir_path
+
+        with patch(f"{self.BASE}.git", return_value=".husky/_"), patch(
+            f"{self.BASE}._get_repo_root", return_value=tmp_path
+        ):
+            assert get_configured_hook_dir_path() == tmp_path / ".husky" / "_"
+
+    def test_configured_hook_dir_path_relative_unchanged_without_repo_root(self):
+        from ggshield.cmd.install import get_configured_hook_dir_path
+
+        with patch(f"{self.BASE}.git", return_value=".husky/_"), patch(
+            f"{self.BASE}._get_repo_root", return_value=None
+        ):
+            assert get_configured_hook_dir_path() == Path(".husky/_")
+
+    def test_is_ggshield_hook_dir_true_for_husky_parent(self, tmp_path):
+        from ggshield.cmd.install import is_ggshield_hook_dir
+
+        husky = tmp_path / ".husky"
+        wrappers = husky / "_"
+        wrappers.mkdir(parents=True)
+        # Husky's `_` wrapper does not run ggshield directly...
+        (wrappers / "pre-commit").write_text("#!/bin/sh\n. ../pre-commit\n")
+        # ...but the user hook ggshield writes into the parent does.
+        (husky / "pre-commit").write_text(
+            "#!/bin/sh\nggshield secret scan pre-commit\n"
+        )
+        assert is_ggshield_hook_dir(wrappers) is True
+
+    def test_is_ggshield_hook_dir_false_for_husky_without_ggshield(self, tmp_path):
+        from ggshield.cmd.install import is_ggshield_hook_dir
+
+        husky = tmp_path / ".husky"
+        wrappers = husky / "_"
+        wrappers.mkdir(parents=True)
+        (wrappers / "pre-commit").write_text("#!/bin/sh\n. ../pre-commit\n")
+        (husky / "pre-commit").write_text("#!/bin/sh\nnpx lint-staged\n")
+        assert is_ggshield_hook_dir(wrappers) is False
+
+    def test_hook_invokes_ggshield(self, tmp_path):
+        from ggshield.cmd.install import hook_invokes_ggshield
+
+        ours = tmp_path / "pre-commit"
+        ours.write_text("#!/bin/sh\nggshield secret scan pre-commit\n")
+        assert hook_invokes_ggshield(ours) is True
+        assert hook_invokes_ggshield(tmp_path / "pre-push") is False
+
+    def test_hook_invokes_ggshield_false_on_oserror(self, tmp_path):
+        from ggshield.cmd.install import hook_invokes_ggshield
+
+        ours = tmp_path / "pre-commit"
+        ours.write_text("#!/bin/sh\nggshield secret scan pre-commit\n")
+        # An unreadable file (permissions, race, special file) must not crash the
+        # caller — `errors="ignore"` only covers decoding, not the read itself.
+        with patch.object(Path, "read_text", side_effect=OSError("denied")):
+            assert hook_invokes_ggshield(ours) is False


### PR DESCRIPTION
## Context

When `machine setup` installs git hooks machine-wide (system `core.hooksPath`, #1327), git's config precedence (**local > global > system**) means a repo that has its **own** `core.hooksPath` — Husky, lefthook, a corporate setup — silently **wins**, and ggshield's hook never runs there. Git uses exactly one hooks directory, so we cannot out-rank a more-specific override; there's no "system hook that also runs."

We can't *force* it (git precedence is a hard wall, and local hooks are bypassable anyway — the real backstop is GitGuardian's server-side scanning). So the fix is to **stop the silent gap**: surface it instead of giving a false sense of coverage.

## What this PR does

- **`machine doctor`** gains a **"Git hook precedence"** check. It resolves the *effective* `core.hooksPath` (`git config --get core.hooksPath`, respecting precedence) and, if a non-ggshield directory is in effect, reports ✗ — naming the shadowing path (e.g. `.husky/_`) and how to fix it (integrate ggshield into that hook manager, or unset the override; commits are still scanned server-side). Per-context: run it in a repo to check that repo. ✓ when nothing shadows ggshield.
- **`machine setup`** warns at install time when a `core.hooksPath` override takes precedence in the current context, so the operator knows its hook will be shadowed there.

Shared helpers in `cmd/install.py`: `get_configured_hook_dir_path()` (effective path), `is_ggshield_hook_dir()`, `get_shadowing_hooks_path()`.

## What it does NOT do

It does not (and cannot) make ggshield run in a repo that has its own `core.hooksPath` — git won't allow a lower-precedence hook to run alongside. That's a per-repo integration (add ggshield to the other tool) or a server-side concern. This PR makes the gap **visible**, not closed.

## Validation

Tested at runtime:
- doctor in a repo with `git config core.hooksPath .husky/_` → ✗ "core.hooksPath points to .husky/_ … ggshield's hook will NOT run"; in a clean repo → ✓.
- setup with such an override present → installs the hook, then warns "a core.hooksPath override (.husky/_) takes precedence here …".

Unit: `get_configured_hook_dir_path` / `is_ggshield_hook_dir` / `get_shadowing_hooks_path` (install), the doctor precedence check, and the setup warning. Existing `TestSetupGitHooks` pinned so they don't shell out to real `git config`. black/isort/flake8/pyright + import-linter clean.

## PR check list

- [x] The changes include tests (unit)
- [x] Changelog entry added (`changelog.d/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
