### PR TITLE
fix(migration): improve deprecation message and migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Only metadata such as call time, request size and scan mode is stored from scans
   - [Manual setup](#manual-setup)
 - [Getting started](#getting-started)
   - [Secrets](#secrets)
+  - [Migrating a legacy configuration file](#migrating-a-legacy-configuration-file)
 - [Integrations](#integrations)
   - [AI coding assistants](#ai-coding-assistants)
 - [Learn more](#learn-more)
@@ -207,6 +208,22 @@ You can now use `ggshield` to search for secrets:
 - in Docker images (`docker` command must be available): `ggshield secret scan docker ubuntu:22.04`
 - in Pypi packages (`pip` command must be available): `ggshield secret scan pypi flask`
 - and more, have a look at `ggshield secret scan --help` output for details.
+
+## Migrating a legacy configuration file
+
+If `ggshield` reports that your `.gitguardian.yaml` (or `.gitguardian.yml`) config file uses a deprecated format, migrate it to the latest version with:
+
+```shell
+ggshield config migrate
+```
+
+By default, this looks for the configuration file in the current directory, so run it from the directory containing the file. To run it from anywhere, point `ggshield` to the file explicitly:
+
+```shell
+ggshield --config-path path/to/.gitguardian.yaml config migrate
+```
+
+The previous version of the file is kept as a `.old` backup next to it.
 
 # Integrations
 

--- a/changelog.d/20260628_175100_alexis.drai_fix_config_migrate_wrong_dir.md
+++ b/changelog.d/20260628_175100_alexis.drai_fix_config_migrate_wrong_dir.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield config migrate` now reports a clear, actionable error when no configuration file is found (for example when run from the wrong directory), instead of crashing with a raw traceback. The deprecation message pointing to this command now also includes the path to the file and shows how to migrate it from anywhere with `--config-path`.

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -4,17 +4,19 @@
 
 1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
-1. Install the [pre-commit framework](https://pre-commit.com/#install)
+2. Install the [pre-commit framework](https://pre-commit.com/#install)
 
-1. Fork and clone the repository
+3. Fork and clone the repository
 
-1. Install dev packages and environment
+4. Install dev packages and environment
 
    ```sh
-   uv sync
+   uv venv .venv
+   source .venv/bin/activate
+   uv sync --all-groups
    ```
 
-1. Install pre-commit hooks
+5. Install pre-commit hooks
 
    ```sh
    pre-commit install

--- a/doc/dev/getting-started.md
+++ b/doc/dev/getting-started.md
@@ -11,9 +11,8 @@
 4. Install dev packages and environment
 
    ```sh
-   uv venv .venv
-   source .venv/bin/activate
    uv sync --all-groups
+   source .venv/bin/activate
    ```
 
 5. Install pre-commit hooks

--- a/ggshield/cmd/config/config_migrate.py
+++ b/ggshield/cmd/config/config_migrate.py
@@ -4,6 +4,7 @@ import click
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.core.errors import UnexpectedError
 
 
 @click.command()
@@ -14,6 +15,13 @@ def config_migrate_cmd(ctx: click.Context, **kwargs: Any) -> int:
     Migrate configuration file to the latest version
     """
     config = ContextObj.get(ctx).config
+
+    if not config._config_path.exists():
+        raise UnexpectedError(
+            f"No configuration file found at {config._config_path}.\n"
+            "Run this command from the directory containing your configuration file, or point ggshield to it with"
+            " `ggshield --config-path <path> config migrate`."
+        )
 
     # Clear all deprecation messages, so that they do not show up when we quit
     config.user_config.deprecation_messages = []

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -216,7 +216,7 @@ def _load_config_dict(
     elif config_version == 1:
         deprecation_messages.append(
             f"{config_path} uses a deprecated configuration file format."
-            " Run `ggshield config migrate` to migrate it to the latest version."
+            f" Run `ggshield --config-path {config_path} config migrate` to migrate it to the latest version."
         )
         dct = convert_v1_config_dict(dct, deprecation_messages)
     else:

--- a/tests/unit/cmd/test_config_migrate.py
+++ b/tests/unit/cmd/test_config_migrate.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import yaml
 
 from ggshield.__main__ import cli
-from tests.unit.conftest import assert_invoke_ok
+from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
 
 V1_CONFIG_CONTENT = """
@@ -91,3 +91,37 @@ def test_config_migrate_cmd(cli_fs_runner):
     # Check backup is unchanged
     assert ".gitguardian.yaml.old" in result.stdout
     assert Path(".gitguardian.yaml.old").read_text() == V1_CONFIG_CONTENT
+
+
+def test_config_migrate_cmd_no_config_file(cli_fs_runner):
+    """
+    GIVEN no configuration file in the current directory
+    WHEN `ggshield config migrate` is called
+    THEN it fails with an actionable error message
+    """
+    result = cli_fs_runner.invoke(cli, ["config", "migrate"])
+
+    assert_invoke_exited_with(result, 128)
+    assert "No configuration file found" in result.output
+    assert "--config-path" in result.output
+
+
+def test_config_migrate_cmd_with_config_path(cli_fs_runner):
+    """
+    GIVEN a v1 config file in another directory
+    WHEN `ggshield config migrate` is called with `--config-path`
+    THEN the file is migrated regardless of the current directory
+    """
+    config_path = Path("subdir") / ".gitguardian.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text(V1_CONFIG_CONTENT)
+
+    result = cli_fs_runner.invoke(
+        cli, ["--config-path", str(config_path), "config", "migrate"]
+    )
+    assert_invoke_ok(result)
+
+    with config_path.open() as f:
+        dct = yaml.safe_load(f)
+    assert normalize_config_dict(dct) == normalize_config_dict(V2_CONFIG_DICT)
+    assert Path("subdir/.gitguardian.yaml.old").read_text() == V1_CONFIG_CONTENT


### PR DESCRIPTION
## Context

Fixes #355

When a `.gitguardian.yaml` uses the deprecated v1 format, ggshield tells the user to run `ggshield config migrate`. But that command resolves the config file relative to the current directory, so running it from anywhere else makes it crash with an opaque error instead of a helpful message

```
Traceback (most recent call last):
  File "/home/beavuck/.local/bin/ggshield", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/ggshield/__main__.py", line 194, in main
    return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/beavuck/.local/share/pipx/venvs/ggshield/lib/python3.12/site-packages/ggshield/cmd/config/config_migrate.py", line 28, in config_migrate_cmd
    config._config_path.rename(old_path)
  File "/usr/lib/python3.12/pathlib.py", line 1365, in rename
    os.rename(self, target)
FileNotFoundError: [Errno 2] No such file or directory: '.gitguardian.yaml' -> '.gitguardian.yaml.old'
exit: 1

```

The deprecation message itself gives no hint either that the working directory matters

## What has been done
  
- **Raise a helpful error when no config file is found.** `config migrate` now checks the resolved config path up front and, if it's missing, exits with a clear `UnexpectedError` explaining how to fix it (run from the right directory, or pass `--config-path`) instead of crashing with a raw traceback, and returns the correct `128` exit code instead of the misleading `1` that the unhandled crash produced
- **Make the deprecation message even more useful.** It now includes the path of the deprecated file and shows the directory-independent form: `ggshield --config-path <path> config migrate`
- **Document the migration flow** in `README.md`, as per the issue description (#355)
- **Tests:** one test covering the new helpful error when the file is absent, and one regression test confirming the `--config-path` remedy works from another directory (the workflow the new message now recommends)
- Out of scope: one small `doc/dev/getting-started.md` tidy-up is riding along in this branch. Happy to pull it into its own PR if you'd prefer it kept separate

## Validation

- install dev packages and env
   ```sh
   uv venv .venv
   source .venv/bin/activate
   uv sync --all-groups
   ```
- Create a v1 config in a directory, e.g.:
   ```shell 
   mkdir /tmp/ggcfg && printf 'all-policies: true\nshow-secrets: true\n' > /tmp/ggcfg/.gitguardian.yaml
   ```
- From a directory with no gg config file in it or any parent, try to migrate → it should exit with a clear "No configuration file found..." message mentioning `--config-path`, exit `128`
   ```shell
   cd /tmp
   ggshield config migrate; echo "exit: $?"
   ```
- Try again, but with the `--config-path` option this time → it should work from anywhere, exit `0`
   ```shell
   ggshield --config-path /tmp/ggcfg/.gitguardian.yaml config migrate; echo "exit: $?"
   ```
- Run any command that loads the legacy file → you should see a mention of the `--config-path` option
   ```shell
   ggshield --config-path /tmp/ggcfg/.gitguardian.yaml.old config list
   ```
- Back in the repo, run the new tests → all green (except some python deprecation warnings)
   ```shell
   cd ~/path/to/local/ggshield/repo
   uv run pytest tests/unit/cmd/test_config_migrate.py -vvv
   ```

## PR check list

- [x] All tests pass
- [x] Linters are happy
- [x] Changes include tests
- [x] PR has a changelog entry