### PR TITLE
feat(secret): add --filename-only flag to send only basenames

### DIFF
--- a/changelog.d/20260630_000000_philippe.gablain_filename_only_flag.md
+++ b/changelog.d/20260630_000000_philippe.gablain_filename_only_flag.md
@@ -1,0 +1,3 @@
+### Added
+
+- New `--filename-only` flag for `ggshield secret scan`: when set, only the file name (not its full path) is sent to GitGuardian, so incidents record just the filename (e.g. `config.py` instead of `src/app/config.py`). Recursive scanning still works.

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -150,6 +150,20 @@ _all_secrets = click.option(
 )
 
 
+_filename_only_option = click.option(
+    "--filename-only",
+    is_flag=True,
+    # The default value **must** be set to None.
+    # Each command or subcommand calls create_config_callback to gather option values.
+    # If the option is placed early in the command line, the value may be overridden
+    # later on with False if no default is defined.
+    default=None,
+    help="Send only the file name (not the full path) to GitGuardian, so incidents "
+    "record just the filename.",
+    callback=create_config_callback("secret", "filename_only"),
+)
+
+
 def _source_uuid_callback(
     ctx: click.Context, param: click.Parameter, value: Optional[str]
 ) -> Optional[str]:
@@ -184,6 +198,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         _with_incident_details_option(cmd)
         instance_option(cmd)
         _all_secrets(cmd)
+        _filename_only_option(cmd)
         _source_uuid_option(cmd)
         return cmd
 

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -50,6 +50,10 @@ class SecretConfig(FilteredConfig):
     # of blocking git operations when the GitGuardian server is unreachable or
     # returns a 5xx. Defaults to True so upgrades keep blocking behavior.
     fail_on_server_error: bool = True
+    # When True, only the file name (not its full path) is sent to GitGuardian,
+    # so incidents record just the filename (e.g. `config.py` instead of
+    # `src/app/config.py`).
+    filename_only: bool = False
 
     def add_ignored_match(self, secret: IgnoredMatch) -> None:
         """
@@ -80,6 +84,7 @@ class SecretConfig(FilteredConfig):
                     str(self.source_uuid) if self.source_uuid is not None else None
                 ),
                 "fail_on_server_error": self.fail_on_server_error,
+                "filename_only": self.filename_only,
             }
         )
 

--- a/ggshield/verticals/secret/secret_scanner.py
+++ b/ggshield/verticals/secret/secret_scanner.py
@@ -92,6 +92,17 @@ class SecretScanner:
 
             return self._collect_results(scanner_ui, chunks_for_futures)
 
+    def _document_filename(self, scannable: Scannable) -> str:
+        """
+        Compute the filename sent to the API for `scannable`, truncated to the maximum
+        length the API accepts. When `filename_only` is set, only the basename is sent
+        so incidents don't record the full path.
+        """
+        filename = scannable.filename
+        if self.secret_config.filename_only:
+            filename = os.path.basename(filename) or filename
+        return filename[-_API_PATH_MAX_LENGTH:]
+
     def _scan_chunk(
         self, executor: concurrent.futures.ThreadPoolExecutor, chunk: List[Scannable]
     ) -> ScanFuture:
@@ -100,7 +111,7 @@ class SecretScanner:
         """
         # `documents` is a version of `chunk` suitable for `GGClient.multi_content_scan()`
         documents = [
-            {"document": x.content, "filename": x.filename[-_API_PATH_MAX_LENGTH:]}
+            {"document": x.content, "filename": self._document_filename(x)}
             for x in chunk
         ]
 

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -558,6 +558,46 @@ class TestScanDirectory:
             for arg in scan_mock.call_args[0]
         )
 
+    @pytest.mark.parametrize("filename_only", (True, False))
+    @patch("pygitguardian.GGClient.multi_content_scan")
+    @my_vcr.use_cassette("test_scan_file")
+    def test_scan_path_filename_only(
+        self,
+        scan_mock: Mock,
+        filename_only,
+        cli_fs_runner: CliRunner,
+    ) -> None:
+        """
+        GIVEN a nested file to scan
+        WHEN executing a scan with or without --filename-only
+        THEN only the basename (resp. the full path) is sent to the API
+        """
+        path = Path("sub", "secret.txt")
+        path.parent.mkdir()
+        write_text(path, "Hello")
+
+        scan_result = MultiScanResult([])
+        scan_result.status_code = 200
+        scan_mock.return_value = scan_result
+
+        extra_args = ["--filename-only"] if filename_only else []
+        result = cli_fs_runner.invoke(
+            cli,
+            ["secret", "scan", "path", *extra_args, str(path)],
+        )
+        assert result.exit_code == ExitCode.SUCCESS, result.output
+
+        scan_mock.assert_called_once()
+        documents = scan_mock.call_args[0][0]
+        assert len(documents) == 1
+        sent_filename = documents[0]["filename"]
+        if filename_only:
+            assert sent_filename == "secret.txt"
+        else:
+            # The full (resolved) path is sent, not just the basename.
+            assert sent_filename != "secret.txt"
+            assert sent_filename.endswith(os.path.join("sub", "secret.txt"))
+
     @patch("pygitguardian.GGClient.multi_content_scan")
     @my_vcr.use_cassette("test_scan_context_repository.yaml")
     def test_scan_path_with_fallback_repository_url(

--- a/tests/unit/verticals/secret/test_secret_scanner.py
+++ b/tests/unit/verticals/secret/test_secret_scanner.py
@@ -352,6 +352,44 @@ def test_request_headers(scan_mock: Mock, client):
     )
 
 
+@pytest.mark.parametrize(
+    "filename_only,expected_filename",
+    [
+        pytest.param(True, "config.py", id="filename_only"),
+        pytest.param(False, "src/app/config.py", id="full_path"),
+    ],
+)
+@patch("pygitguardian.GGClient.multi_content_scan")
+def test_scan_filename_only(scan_mock: Mock, client, filename_only, expected_filename):
+    """
+    GIVEN a scannable with a nested path
+    WHEN SecretScanner.scan() is called with the filename_only option
+    THEN GGClient.multi_content_scan() receives only the basename as `filename`,
+    otherwise it receives the full path
+    """
+    scannable = StringScannable(url="src/app/config.py", content="content")
+
+    scan_result = ScanResult(policy_break_count=0, policy_breaks=[], policies=[])
+    multi_scan_result = MultiScanResult([scan_result])
+    multi_scan_result.status_code = 200
+    scan_mock.return_value = multi_scan_result
+
+    scanner = SecretScanner(
+        client=client,
+        cache=Cache(),
+        scan_context=ScanContext(
+            scan_mode=ScanMode.PATH,
+            command_path="ggshield",
+        ),
+        check_api_key=False,
+        secret_config=SecretConfig(filename_only=filename_only),
+    )
+    scanner.scan([scannable], scanner_ui=Mock())
+
+    documents = scan_mock.call_args[0][0]
+    assert documents == [{"document": "content", "filename": expected_filename}]
+
+
 @pytest.mark.parametrize("ignore_known_secrets", (True, False))
 @patch("pygitguardian.GGClient.multi_content_scan")
 def test_scan_ignore_known_secrets(scan_mock: Mock, client, ignore_known_secrets):


### PR DESCRIPTION
## Summary

This PR answers a specific need for a customer. For them, changing filename => fullpath in public API calls is like a regression. They use BYOS to scan logs and they identify log streams with filenames in different directories. Sending full paths instead of filenames break their flow and create too many occurrences. So this PR re-introduce the previous behavior as a optional flag.

Recent ggshield versions send the **full path** of scanned files to the GitGuardian API, so incidents record e.g. `src/app/config.py`. Some users want the older behavior where only the bare filename is recorded — for privacy or to avoid leaking local directory structure.

This adds an opt-in `--filename-only` flag for `ggshield secret scan` (config: `secret.filename_only`). When set, each document's path is stripped to its basename **in the API payload only**, so incidents record just the filename (e.g. `config.py`). Local terminal output keeps full paths so files remain easy to locate, and recursive scanning (`-r`) is unaffected.

The flag is added to the shared secret-scan options, so it works for all `secret scan` subcommands (`path`, `precommit`, `ci`, `docker`, …), consistent with `--show-secrets` etc. It also applies to the custom-source flow (`--source-uuid`).

## Changes

- `SecretConfig.filename_only` config field (+ reported in `dump_for_monitoring`)
- `--filename-only` CLI option in `secret_scan_common_options.py`
- `SecretScanner._document_filename()` helper that strips to basename when the flag is set, keeping the existing 256-char truncation

## Test plan

- New unit tests: `test_secret_scanner.py::test_scan_filename_only` and `test_path.py::test_scan_path_filename_only` (basename vs full path in the API payload).
- E2E verified against a local instance with custom sources (`--source-uuid`): the persisted incident `filepath` was the full absolute path without the flag, and only the basename (incl. nested `shared/folder/aa` → `aa`) with `--filename-only`.

Refs: SRC-5748

🤖 Generated with [Claude Code](https://claude.com/claude-code)