### PR TITLE
feat(scripts): offer to add the install dir to PATH instead of only printing it

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -1,0 +1,42 @@
+name: Install scripts
+
+# Only runs against scripts/install: the bats suite sources install.sh /
+# uninstall.sh and drives fish/nu/pwsh with fake stub binaries, so it needs
+# no real shell installed beyond bats itself, and no network.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/install/**'
+      - '.github/workflows/install-scripts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/install/**'
+      - '.github/workflows/install-scripts.yml'
+
+jobs:
+  bats:
+    name: bats (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Ubuntu 22.04's `bats` apt package is 1.2.1 (2019), missing features
+      # the test suite relies on (bats_require_minimum_version, `run !`).
+      # Install a current bats-core instead of depending on distro packaging.
+      - uses: bats-core/bats-action@4.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+
+      - name: Run install-script tests
+        run: bats scripts/install/tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,15 @@ repos:
     hooks:
       - id: isort
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # Scoped to scripts/install: the repo's other shell scripts
+        # (docker/, scripts/check-import-linter-config.sh) have pre-existing
+        # findings that are out of scope here.
+        files: ^scripts/install/.*\.sh$
+
   - repo: https://github.com/thlorenz/doctoc
     rev: v2.2.0
     hooks:

--- a/changelog.d/20260701_122859_benjamin.rigaud_configure_path_shell_profile.md
+++ b/changelog.d/20260701_122859_benjamin.rigaud_configure_path_shell_profile.md
@@ -1,0 +1,3 @@
+### Added
+
+- `install.sh` now offers to add the install dir to your `PATH` itself when it's missing, instead of only printing instructions: it detects bash, zsh, fish, and (independent of `$SHELL`) Nushell and PowerShell on Linux when installed, and updates the matching shell profile. Prompted with a default of yes, silent under `-y`, skippable with the new `--no-modify-path`. `uninstall.sh` reverses the edit.

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -41,9 +41,13 @@ The script installs the standalone build (detecting OS/arch, including Rosetta 2
 
 On Linux/macOS, `~/.local/bin` is not on everyone's `PATH` (notably macOS, and
 Debian/Ubuntu add it only when the directory already existed at login). When it
-isn't, the script doesn't fail — it prints, for your shell, the exact line to
-add and reminds you to **restart your terminal** afterwards. Set `GGSHIELD_BIN_DIR`
-to a directory already on your `PATH` to skip that step.
+isn't, the script offers to fix it — detecting your shell (bash, zsh, fish, and,
+independent of `$SHELL`, Nushell and PowerShell on Linux when installed) and
+updating its profile, prompted with a default of yes (silent under `-y`).
+Decline, or pass `--no-modify-path`, and it falls back to printing the exact
+line to add yourself, with a reminder to **restart your terminal** afterwards.
+Set `GGSHIELD_BIN_DIR` to a directory already on your `PATH` to skip this
+entirely. `uninstall.sh` reverses any profile edit it made.
 
 The download is **checksum-verified** against the digest GitHub publishes for
 each asset (the install aborts if it cannot be verified). [Build provenance
@@ -64,6 +68,9 @@ Docker image `gitguardian/ggshield` or `pipx install ggshield`.
     --version X.Y.Z ggshield version to install (default: latest)
     --install-only  install ggshield only, skip auth and plugins
     --plugin NAME   install this ggshield plugin (repeatable)
+    --no-modify-path
+                    don't offer to add the install dir to PATH; only print
+                    instructions
 ```
 
 Pass options through the pipe with `bash -s --`:

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -13,29 +13,33 @@
 
 set -euo pipefail
 
-# Every install path (and every PATH hint) is derived from $HOME; fail early
-# with a clear message rather than building paths like /.local/bin under set -u.
-# die() is not defined yet, so emit raw.
+# All paths derive from $HOME; fail early with a clear message (die() isn't defined yet).
 [ -n "${HOME:-}" ] || { printf '\033[1;31merror:\033[0m HOME is not set\n' >&2; exit 1; }
 
 GITHUB_REPO="GitGuardian/ggshield"
 DEFAULT_INSTANCE="https://dashboard.gitguardian.com"
 EU_INSTANCE="https://dashboard.eu1.gitguardian.com"
 
+# Trailing slash stripped so the PATH-membership test and the fish canonical
+# form (builtin realpath -s) match what a user-supplied dir with a slash yields.
 BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+BIN_DIR="${BIN_DIR%/}"
 # NOT ~/.local/share/ggshield: that is ggshield's own data dir (plugins…)
 OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+OPT_DIR="${OPT_DIR%/}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
 STATE_FILE="$STATE_DIR/state"
 
+# Trailing marker on each rc source line so uninstall strips exactly the lines
+# we added, regardless of the OPT_DIR they point at. Kept identical in uninstall.sh.
+PATH_SENTINEL="# ggshield-install PATH"
+
 ASSUME_YES=0
 INSTALL_ONLY=0
-# Set when BIN_DIR is not on PATH, so the final summary can tell the user how to
-# expose it (see emit_path_hint).
+NO_MODIFY_PATH=0
+# Set when BIN_DIR is not on PATH; drives the final emit_path_hint summary.
 PATH_NEEDS_SETUP=0
-# Set to the path of an older ggshield that resolves ahead of the fresh one
-# while BIN_DIR *is* on PATH; emit_path_hint then says "put BIN_DIR first"
-# rather than "add it".
+# Path of an older ggshield shadowing the fresh one when BIN_DIR is already on PATH.
 SHADOWED_BY=""
 PLUGINS=()
 # honor GITGUARDIAN_INSTANCE like ggshield does; --instance overrides it
@@ -58,6 +62,9 @@ Options:
                       also via GGSHIELD_VERSION env var)
       --install-only  install ggshield only, skip auth and plugins
       --plugin NAME   install this ggshield plugin (repeatable)
+      --no-modify-path
+                      don't offer to add the install dir to PATH; only print
+                      instructions
   -h, --help          show this help
 
 Environment:
@@ -85,8 +92,22 @@ need() {
     command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
-# A remote/headless session has no browser for the OAuth redirect; ggshield's
-# --method oob is the way out (reported by users behind SSH / VM port-forwarding).
+# BIN_DIR/OPT_DIR are interpolated into generated shell/nu/ps1/fish snippets and
+# sourced from an arbitrary cwd, so they must be absolute and free of chars that
+# could break out of those string contexts. Both arms die, so `case` (which is 0
+# on no match) never trips set -e as a trailing `&& die` would.
+assert_safe_path_value() {
+    case "$2" in
+    '' | [!/]*)
+        die "$1='$2' must be an absolute path (start with /)"
+        ;;
+    *[\"\'\`\$\;\\]* | *$'\n'*)
+        die "$1='$2' contains a quote, backtick, \$, ;, backslash, or newline, which cannot safely appear in a generated PATH snippet; use a plain path"
+        ;;
+    esac
+}
+
+# No browser for OAuth in a remote/headless session; ggshield's --method oob is the way out.
 is_headless() {
     [ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && return 0
     [ "$OS" = linux ] && [ -z "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && return 0
@@ -151,8 +172,7 @@ resolve_version() {
     [ -n "$VERSION" ] || die "could not resolve the latest version from the GitHub API"
 }
 
-# GitHub computes a sha256 digest for every release asset; pair each "name"
-# with the "digest" that follows it in the release JSON.
+# Pair each asset "name" with the "digest" that follows it in the release JSON.
 asset_digest() {
     local asset="$1"
     fetch "https://api.github.com/repos/$GITHUB_REPO/releases/tags/v$VERSION" |
@@ -160,9 +180,8 @@ asset_digest() {
         grep -A1 -F "\"$asset\"" | grep -o 'sha256:[0-9a-f]*' | head -1 || true
 }
 
-# HTTP status of an asset's download URL (HEAD, following redirects). Tells
-# "asset absent" (404) from "couldn't reach GitHub" (504/000/…). Deliberately
-# not the `fetch` wrapper: no -f, so 4xx still yields the code.
+# HEAD the asset URL to tell "absent" (404) from "unreachable" (504/000).
+# Not the `fetch` wrapper: no -f, so 4xx still yields a status code.
 asset_http_status() {
     curl --proto '=https' --tlsv1.2 -sIL -o /dev/null -w '%{http_code}' \
         --max-time 20 --retry 2 \
@@ -191,9 +210,7 @@ verify_download() {
     verify_attestation "$file" "$asset"
 }
 
-# 1/true/yes/on (any case, surrounding whitespace ignored) enable it; unset/empty/
-# 0/false/no/off disable; warn on anything else and treat as off, so a typo'd
-# opt-in is never silently ignored.
+# 1/true/yes/on enable it, unset/0/false/no/off disable; warn (not silently ignore) anything else.
 require_attestation() {
     local v="${GGSHIELD_REQUIRE_ATTESTATION:-}"
     v="${v#"${v%%[![:space:]]*}"}" # strip leading whitespace
@@ -208,12 +225,8 @@ require_attestation() {
     esac
 }
 
-# Build-provenance verification is opt-in and OFF by default. gh is not a ggshield
-# dependency, its version/auth/network state is ambient, and even a public lookup
-# needs an authenticated gh — running it automatically is fragile (END-609) and
-# usually can't run anyway, while the mandatory sha256 already covers integrity.
-# When opted in, fail closed if gh is missing, too old, unauthenticated, or the
-# provenance does not verify.
+# Opt-in, off by default: gh isn't a ggshield dependency and running it automatically
+# is fragile; the mandatory sha256 already covers integrity. Fails closed when opted in.
 verify_attestation() {
     local file="$1" asset="$2"
 
@@ -281,8 +294,7 @@ other install methods in scripts/install/README.md" ;;
     fi
     ln -sf "$bin" "$BIN_DIR/ggshield"
 
-    # Defer the "not on PATH" guidance to the very end (emit_path_hint) so it is
-    # the last thing the user sees, not buried before the auth/plugin output.
+    # Defer "not on PATH" guidance to the end (emit_path_hint), not buried before auth/plugin output.
     case ":$PATH:" in
     *":$BIN_DIR:"*) ;;
     *) PATH_NEEDS_SETUP=1 ;;
@@ -292,12 +304,24 @@ other install methods in scripts/install/README.md" ;;
 
 write_state() {
     mkdir -p "$STATE_DIR"
-    cat >"$STATE_FILE" <<EOF
+    # Preserve any path_* lines from a prior run: a reinstall only re-records them
+    # when PATH still needs setup, so otherwise an upgrade would orphan uninstall's target.
+    local existing_path_lines=""
+    if [ -f "$STATE_FILE" ]; then
+        existing_path_lines=$(grep '^path_' "$STATE_FILE" 2>/dev/null || true)
+    fi
+    {
+        cat <<EOF
 method=tarball
 version=${VERSION:-latest}
 opt_dir=$OPT_DIR
 bin_link=$BIN_DIR/ggshield
 EOF
+        # `if`, not `&&`: as the group's last statement, a false `&&` test would trip set -e.
+        if [ -n "$existing_path_lines" ]; then
+            printf '%s\n' "$existing_path_lines"
+        fi
+    } >"$STATE_FILE"
 }
 
 run_gg() {
@@ -311,8 +335,7 @@ run_gg() {
     fi
 }
 
-# Hints for steps that did NOT complete — only shown when something is left to
-# do (auth failed/skipped, a plugin failed, or --install-only).
+# Hints for steps that did NOT complete (auth failed/skipped, plugin failed, --install-only).
 emit_auth_hint() {
     local inst="${INSTANCE:-$DEFAULT_INSTANCE}"
     printf '    ggshield auth login --instance %s\n' "$inst"
@@ -328,68 +351,246 @@ emit_plugin_hint() {
     return 0
 }
 
-# ~/.local/bin is the no-sudo convention, but it is not guaranteed to be on
-# PATH: macOS never adds it, and Debian/Ubuntu add it from ~/.profile only when
-# the directory already exists at login — so a brand-new install often needs a
-# shell restart. No sudo-less directory is on PATH across every distro and
-# macOS, so we install there and tell the user how to expose it, per shell.
-# Also handles the "$SHADOWED_BY" case: BIN_DIR is on PATH but an older ggshield
-# sits ahead of it — the same fix (prepend BIN_DIR) resolves both, only the
-# wording differs. Uses $SHELL (the login shell) rather than $0: this script
-# always runs under bash (curl | bash), which says nothing about the shell the
-# user reopens.
+# ~/.local/bin isn't guaranteed to be on PATH (macOS never adds it; Debian/Ubuntu
+# only from login). Uses $SHELL, the login shell, not $0 (always bash under curl|bash).
+# SHADOWED_BY stays advisory-only: reordering PATH could fight a deliberate setup.
 emit_path_hint() {
-    # The headline goes through warn() (bold yellow, stderr) so it stands out;
-    # as an indented "# ..." comment it blended into the command block below and
-    # users missed it. The commands stay on stdout, unprefixed, to copy-paste cleanly.
-    # reload defaults to `source` (zsh/bash); `.` is the POSIX form for the
-    # generic-sh fallback. Paths are double-quoted in the emitted commands so a
-    # BIN_DIR/rc with spaces still copy-pastes correctly.
-    local rc reload="source" f headline
+    local login_shell
+    login_shell="$(basename "${SHELL:-sh}")"
+    if [ "$login_shell" = fish ]; then
+        emit_path_hint_fish
+    else
+        emit_path_hint_rc "$login_shell"
+    fi
+}
+
+# fish persists PATH via universal variables (no file edit, no restart needed);
+# --move pulls BIN_DIR to the front for the shadow case.
+print_fish_hint() {
+    if [ -n "$SHADOWED_BY" ]; then
+        warn "an older ggshield at $SHADOWED_BY shadows the new one; move $BIN_DIR to the front with:"
+        printf '    fish_add_path --move -- "%s"\n' "$BIN_DIR"
+    else
+        warn "$BIN_DIR is not on your PATH. Add it permanently with:"
+        printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
+    fi
+}
+
+emit_path_hint_fish() {
+    if [ -n "$SHADOWED_BY" ] || [ "$NO_MODIFY_PATH" = 1 ]; then
+        print_fish_hint
+        return 0
+    fi
+    warn "$BIN_DIR is not on your PATH."
+    if ! confirm_path_update; then
+        print_fish_hint
+        return 0
+    fi
+    if ! configure_fish; then
+        print_fish_hint
+        return 0
+    fi
+    configure_extra_shells
+    export PATH="$BIN_DIR:$PATH"
+    say "Restart your terminal to use ggshield directly."
+}
+
+# Headline via warn() (stderr, bold) so it isn't missed among the copy-pasteable
+# stdout commands below. Paths are double-quoted for a BIN_DIR/rc with spaces.
+print_rc_hint() {
+    local rc="$1" reload="$2" headline
     if [ -n "$SHADOWED_BY" ]; then
         headline="an older ggshield at $SHADOWED_BY shadows the new one; put $BIN_DIR first on your PATH, then restart your terminal:"
     else
         headline="$BIN_DIR is not on your PATH. Add it, then restart your terminal:"
     fi
-    case "$(basename "${SHELL:-sh}")" in
-    fish)
-        # fish persists PATH via universal variables — no file edit, no restart.
-        # --move pulls BIN_DIR to the front when it is already present (shadow case).
-        if [ -n "$SHADOWED_BY" ]; then
-            warn "an older ggshield at $SHADOWED_BY shadows the new one; move $BIN_DIR to the front with:"
-            printf '    fish_add_path --move -- "%s"\n' "$BIN_DIR"
-        else
-            warn "$BIN_DIR is not on your PATH. Add it permanently with:"
-            printf '    fish_add_path -- "%s"\n' "$BIN_DIR"
-        fi
-        return 0
-        ;;
+    warn "$headline"
+    # shellcheck disable=SC2016 # intentional: printing a literal command, not expanding it
+    printf '    echo '\''export PATH="%s:$PATH"'\'' >> "%s"\n' "$BIN_DIR" "$rc"
+    printf '    # (or apply it to the current shell now: %s "%s")\n' "$reload" "$rc"
+}
+
+emit_path_hint_rc() {
+    local login_shell="$1" rc reload="source"
+    case "$login_shell" in
     zsh) rc="$HOME/.zshrc" ;;
-    bash)
-        if [ "$OS" = darwin ]; then
-            # macOS Terminal runs bash as a login shell, which reads the FIRST
-            # of these that exists. Appending to ~/.bash_profile when ~/.profile
-            # is the active file would shadow it, so reuse whichever exists.
-            rc="$HOME/.bash_profile"
-            for f in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
-                if [ -e "$f" ]; then rc="$f"; break; fi
-            done
-        else
-            # Linux: interactive terminals read ~/.bashrc.
-            rc="$HOME/.bashrc"
-        fi
-        ;;
+    bash) rc="$(bash_rc_path)" ;;
     *)
         rc="$HOME/.profile"
         reload="."
         ;;
     esac
-    # Prepend BIN_DIR so it wins whether it was absent or merely behind an older
-    # install. A duplicate entry (shadow case) is harmless: the front one wins.
-    warn "$headline"
-    printf '    echo '\''export PATH="%s:$PATH"'\'' >> "%s"\n' "$BIN_DIR" "$rc"
-    printf '    # (or apply it to the current shell now: %s "%s")\n' "$reload" "$rc"
+
+    if [ -n "$SHADOWED_BY" ] || [ "$NO_MODIFY_PATH" = 1 ]; then
+        print_rc_hint "$rc" "$reload"
+        return 0
+    fi
+    warn "$BIN_DIR is not on your PATH."
+    if ! confirm_path_update; then
+        print_rc_hint "$rc" "$reload"
+        return 0
+    fi
+    if ! configure_rc "$rc"; then
+        print_rc_hint "$rc" "$reload"
+        return 0
+    fi
+    configure_extra_shells
+    export PATH="$BIN_DIR:$PATH"
+    say "Restart your terminal (or run: $reload \"$rc\") to use ggshield directly."
+}
+
+# Enter defaults to yes; a non-interactive run with no /dev/tty declines rather
+# than silently editing dotfiles without consent.
+confirm_path_update() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    local reply=""
+    if [ -t 0 ]; then
+        read -r -p "Add $BIN_DIR to your PATH now? [Y/n] " reply
+    elif { : </dev/tty; } 2>/dev/null; then
+        read -r -p "Add $BIN_DIR to your PATH now? [Y/n] " reply </dev/tty
+    else
+        return 1
+    fi
+    case "$reply" in
+    '' | y* | Y*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# nu/pwsh are rarely the login shell, so $SHELL can't detect them; configure them
+# whenever present instead. `|| true` keeps a write failure from tripping set -e.
+configure_extra_shells() {
+    command -v nu >/dev/null 2>&1 && { configure_nu || true; }
+    [ "$OS" = linux ] && command -v pwsh >/dev/null 2>&1 && { configure_pwsh || true; }
     return 0
+}
+
+# Records what this run touched so uninstall.sh can reverse it without re-detecting
+# the shell. Deduped: emit_path_hint can fire on repeated same-session reruns (PATH
+# still off), and write_state preserves prior path_* lines — a blind append would grow the file.
+record_path_state() {
+    mkdir -p "$STATE_DIR"
+    grep -qxF "$1" "$STATE_FILE" 2>/dev/null || printf '%s\n' "$1" >>"$STATE_FILE"
+}
+
+configure_fish() {
+    command -v fish >/dev/null 2>&1 || return 1
+    local canonical
+    # Record the form fish actually stores (builtin realpath -s: absolute, trailing
+    # slash and .. collapsed, symlinks NOT resolved) so uninstall can match it exactly.
+    # BIN_DIR travels through an env var, not string interpolation, so it can't become fish script.
+    # shellcheck disable=SC2016 # intentional: fish expands this, not bash
+    canonical=$(GGSHIELD_FISH_BIN_DIR="$BIN_DIR" fish -c 'builtin realpath -s -- "$GGSHIELD_FISH_BIN_DIR"' 2>/dev/null) || return 1
+    [ -n "$canonical" ] || return 1
+    # shellcheck disable=SC2016 # intentional: fish expands this, not bash
+    GGSHIELD_FISH_BIN_DIR="$BIN_DIR" fish -c 'fish_add_path -- "$GGSHIELD_FISH_BIN_DIR"' 2>/dev/null || return 1
+    # fish_add_path defaults to universal only when fish_user_paths doesn't already
+    # exist; a config.fish that manages it as a global makes the call above a no-op
+    # in this throwaway process. Confirm it persisted before claiming success.
+    # shellcheck disable=SC2016 # intentional: fish expands this, not bash
+    GGSHIELD_FISH_CANON="$canonical" fish -c 'contains -- "$GGSHIELD_FISH_CANON" $fish_user_paths' 2>/dev/null || return 1
+    record_path_state "path_fish_bin_dir=$canonical"
+    say "Added $BIN_DIR to PATH (fish universal variable)"
+}
+
+# Mirrors nushell's own config-dir resolution: $XDG_CONFIG_HOME wins when set,
+# else macOS defaults to ~/Library/Application Support, not ~/.config.
+nu_config_path() {
+    if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+        printf '%s/nushell/config.nu' "$XDG_CONFIG_HOME"
+    elif [ "$OS" = darwin ]; then
+        printf '%s/Library/Application Support/nushell/config.nu' "$HOME"
+    else
+        printf '%s/.config/nushell/config.nu' "$HOME"
+    fi
+}
+
+# The three configure_* below record the rc file BEFORE editing it: if the record
+# step failed after the edit, uninstall would never learn to strip the line and would
+# then delete OPT_DIR out from under a live `source`. Recorded-but-never-edited is
+# harmless (uninstall's strip finds no sentinel and no-ops).
+configure_nu() {
+    local cfg
+    cfg="$(nu_config_path)"
+    record_path_state "path_rc_file_nu=$cfg"
+    write_env_nu || return 1
+    append_line_once "$cfg" "source \"$OPT_DIR/env.nu\" $PATH_SENTINEL" || return 1
+    say "Added $BIN_DIR to PATH via $cfg"
+}
+
+configure_pwsh() {
+    local cfg="${XDG_CONFIG_HOME:-$HOME/.config}/powershell/profile.ps1"
+    record_path_state "path_rc_file_pwsh=$cfg"
+    write_env_ps1 || return 1
+    append_line_once "$cfg" ". \"$OPT_DIR/env.ps1\" $PATH_SENTINEL" || return 1
+    say "Added $BIN_DIR to PATH via $cfg"
+}
+
+configure_rc() {
+    local rc="$1"
+    record_path_state "path_rc_file=$rc"
+    write_env_sh || return 1
+    append_line_once "$rc" ". \"$OPT_DIR/env\" $PATH_SENTINEL" || return 1
+    say "Added $BIN_DIR to PATH via $rc"
+}
+
+# macOS bash login shells read the FIRST of these that exists; reuse whichever
+# does so we don't shadow it. Linux interactive shells read ~/.bashrc.
+bash_rc_path() {
+    if [ "$OS" = darwin ]; then
+        local f rc="$HOME/.bash_profile"
+        for f in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+            if [ -e "$f" ]; then
+                rc="$f"
+                break
+            fi
+        done
+        printf '%s' "$rc"
+    else
+        printf '%s' "$HOME/.bashrc"
+    fi
+}
+
+# Idempotent: skip if $line is already in $file.
+append_line_once() {
+    local file="$1" line="$2"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || return 1
+    touch "$file" 2>/dev/null || return 1
+    grep -qxF "$line" "$file" 2>/dev/null || printf '\n%s\n' "$line" 2>/dev/null >>"$file" || return 1
+}
+
+# A small sourced file, not a baked-in rc line: uninstall deletes it + one rc line,
+# and fixing the PATH logic later only means regenerating it.
+write_env_sh() {
+    mkdir -p "$OPT_DIR" 2>/dev/null || return 1
+    cat 2>/dev/null >"$OPT_DIR/env" <<EOF || return 1
+# ggshield shell setup
+case ":\${PATH}:" in
+*:"$BIN_DIR":*) ;;
+*) export PATH="$BIN_DIR:\$PATH" ;;
+esac
+EOF
+}
+
+write_env_nu() {
+    mkdir -p "$OPT_DIR" 2>/dev/null || return 1
+    cat 2>/dev/null >"$OPT_DIR/env.nu" <<EOF || return 1
+# ggshield shell setup
+\$env.PATH = (\$env.PATH | prepend "$BIN_DIR" | uniq)
+EOF
+}
+
+write_env_ps1() {
+    mkdir -p "$OPT_DIR" 2>/dev/null || return 1
+    # -cnotcontains: PowerShell's -notcontains is case-insensitive, which on a
+    # case-sensitive Linux filesystem would treat /x/.Local/bin as already present
+    # and skip adding the real /x/.local/bin.
+    cat 2>/dev/null >"$OPT_DIR/env.ps1" <<EOF || return 1
+# ggshield shell setup
+if ((\$env:PATH -split [IO.Path]::PathSeparator) -cnotcontains "$BIN_DIR") {
+    \$env:PATH = "$BIN_DIR" + [IO.Path]::PathSeparator + \$env:PATH
+}
+EOF
 }
 
 try_auth() {
@@ -425,12 +626,8 @@ post_install() {
     fi
     say "Installed: $version_out"
 
-    # A ggshield from a previous install (brew, pipx, manual) sitting earlier on
-    # PATH shadows the one we just linked. The fix is the same as "not on PATH" —
-    # put BIN_DIR first — so route it through emit_path_hint with wording that
-    # names the offending binary, instead of a dead-end "fix your PATH order".
-    # Only when BIN_DIR is actually on PATH (PATH_NEEDS_SETUP still 0): if it is
-    # absent, the "not on PATH" hint already prepends it and covers this too.
+    # An older ggshield earlier on PATH shadows the one we just linked; route through
+    # emit_path_hint (same fix as "not on PATH") only when BIN_DIR is already on PATH.
     local resolved
     resolved=$(command -v ggshield 2>/dev/null || true)
     if [ "$PATH_NEEDS_SETUP" = 0 ] && [ -n "$resolved" ] && [ "$resolved" != "$GGSHIELD" ]; then
@@ -439,9 +636,7 @@ post_install() {
     fi
 
     if [ "$INSTALL_ONLY" = 1 ]; then
-        # plugin install is auth-gated and --install-only skips auth, so any
-        # --plugin is deferred, not installed now: say so rather than silently
-        # dropping the flag.
+        # --install-only skips auth, so any --plugin is deferred rather than silently dropped.
         [ ${#PLUGINS[@]} -gt 0 ] &&
             warn "--plugin not installed: --install-only skips authentication; run the steps below once authenticated"
         say "ggshield is installed. To finish setup:"
@@ -451,14 +646,12 @@ post_install() {
         return 0
     fi
 
-    # Plugins need a working authentication, so only attempt them once auth
-    # succeeds; otherwise skip.
+    # Plugins need a working auth, so only attempt them once auth succeeds.
     local auth_ok=0 plugins_pending=0
     if try_auth; then
         auth_ok=1
         local plugin
-        # macOS ships bash 3.2, where "${arr[@]}" on an empty array trips
-        # `set -u`; the ${arr[@]+…} guard expands to nothing when empty.
+        # macOS ships bash 3.2: "${arr[@]}" on an empty array trips set -u without this guard.
         for plugin in ${PLUGINS[@]+"${PLUGINS[@]}"}; do
             say "Installing the $plugin plugin"
             run_gg plugin install "$plugin" ||
@@ -469,8 +662,7 @@ post_install() {
         plugins_pending=1
     fi
 
-    # Only nag about next steps when something actually remains. A binary the
-    # shell cannot find by name is not "ready", so PATH setup counts too.
+    # Only nag about next steps when something remains; PATH setup counts as unfinished too.
     if [ "$auth_ok" = 1 ] && [ "$plugins_pending" = 0 ] && [ "$PATH_NEEDS_SETUP" = 0 ]; then
         say "ggshield is ready."
         return 0
@@ -496,6 +688,7 @@ main() {
             VERSION="${1:?--version requires a value}"
             ;;
         --install-only) INSTALL_ONLY=1 ;;
+        --no-modify-path) NO_MODIFY_PATH=1 ;;
         --plugin)
             shift
             PLUGINS+=("${1:?--plugin requires a name}")
@@ -509,6 +702,9 @@ main() {
         shift
     done
 
+    assert_safe_path_value GGSHIELD_BIN_DIR "$BIN_DIR"
+    assert_safe_path_value GGSHIELD_OPT_DIR "$OPT_DIR"
+
     need curl
     need uname
     detect_platform
@@ -519,4 +715,8 @@ main() {
     post_install
 }
 
-main "$@"
+# Lets tests `source` this file without running main. BASH_SOURCE is empty (not unset)
+# when piped (curl|bash); a naive `:-` default would then wrongly skip main entirely.
+if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi

--- a/scripts/install/tests/path_config.bats
+++ b/scripts/install/tests/path_config.bats
@@ -1,0 +1,553 @@
+#!/usr/bin/env bats
+#
+# Functional tests for the PATH-configuration behavior in install.sh /
+# uninstall.sh. Sources the real functions into a sandboxed $HOME and drives
+# fish/nu/pwsh with fake stub binaries — needs no real shell, only bats.
+#
+#   bats scripts/install/tests/path_config.bats
+#
+# shellcheck disable=SC2034,SC2030,SC2031 # shellcheck treats each @test body
+# as a subshell, which it isn't — modifications made here do persist
+
+bats_require_minimum_version 1.5.0
+
+INSTALL_SH="$BATS_TEST_DIRNAME/../install.sh"
+UNINSTALL_SH="$BATS_TEST_DIRNAME/../uninstall.sh"
+
+setup() {
+    SANDBOX="$(mktemp -d)"
+    export HOME="$SANDBOX"
+    export XDG_CONFIG_HOME="$SANDBOX/.config"
+    FAKEBIN="$SANDBOX/fakebin"
+    mkdir -p "$FAKEBIN"
+    export PATH="$FAKEBIN:$PATH"
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+# Sources install.sh's functions without running main(). BIN_DIR/OS are set
+# afterwards the same way install_tarball()/detect_platform() would.
+load_install() {
+    # shellcheck disable=SC1090
+    source "$INSTALL_SH"
+    BIN_DIR="$HOME/.local/bin"
+    OS="${1:-linux}"
+}
+
+load_uninstall() {
+    # shellcheck disable=SC1090
+    source "$UNINSTALL_SH"
+}
+
+# Octal permission bits, portable across GNU (Linux CI) and BSD (macOS CI)
+# stat: their -c/-f flags and format specifiers are mutually incompatible.
+perm_bits() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1"
+}
+
+# A fake `fish` faithful enough for the four -c scripts install.sh/uninstall.sh
+# run, backing fish_user_paths with $FISH_STORE. Emulates fish's own trailing-
+# slash normalization (builtin realpath -s). Knobs via env:
+#   FISH_FAIL_ADD=1   fish_add_path exits non-zero
+#   FISH_NO_PERSIST=1 fish_add_path succeeds but stores nothing (config.fish
+#                     managing fish_user_paths as a global → throwaway no-op)
+install_fake_fish() {
+    export FISH_STORE="$SANDBOX/fish_user_paths"
+    : >"$FISH_STORE"
+    cat >"$FAKEBIN/fish" <<'SH'
+#!/bin/sh
+store="$FISH_STORE"
+script="$2"
+strip_slash() { s="$1"; while [ "$s" != "${s%/}" ]; do s="${s%/}"; done; printf '%s' "$s"; }
+case "$script" in
+*"set fish_user_paths"*)          # uninstall removal loop
+    # Honor what the fish script actually does: normalize only if it invokes
+    # realpath, so a code path that skips canonicalization is genuinely observable.
+    case "$script" in
+    *realpath*) target=$(strip_slash "$GGSHIELD_FISH_BIN_DIR") ;;
+    *) target="$GGSHIELD_FISH_BIN_DIR" ;;
+    esac
+    tmp="$store.tmp"; : >"$tmp"
+    while IFS= read -r line; do [ "$line" = "$target" ] || printf '%s\n' "$line" >>"$tmp"; done <"$store"
+    mv "$tmp" "$store"
+    ;;
+*realpath*)                        # canonicalize (builtin realpath -s)
+    strip_slash "$GGSHIELD_FISH_BIN_DIR"; printf '\n'
+    ;;
+*fish_add_path*)                   # add to fish_user_paths (dedup)
+    [ "${FISH_FAIL_ADD:-0}" = 1 ] && exit 1
+    [ "${FISH_NO_PERSIST:-0}" = 1 ] && exit 0
+    p=$(strip_slash "$GGSHIELD_FISH_BIN_DIR")
+    grep -qxF "$p" "$store" 2>/dev/null || printf '%s\n' "$p" >>"$store"
+    ;;
+*contains*)                        # persistence check
+    grep -qxF "$GGSHIELD_FISH_CANON" "$store" 2>/dev/null || exit 1
+    ;;
+esac
+exit 0
+SH
+    chmod +x "$FAKEBIN/fish"
+}
+
+# Regression test: `${BASH_SOURCE[0]}` alone trips "unbound variable" when piped
+# (no file on disk); `${BASH_SOURCE[0]:-}` alone then silently skips main() instead.
+@test "install.sh runs main() when piped via stdin, not just when sourced" {
+    run bash -s -- --help < "$INSTALL_SH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: install.sh"* ]]
+}
+
+@test "uninstall.sh runs main() when piped via stdin, not just when sourced" {
+    run bash -s -- --help < "$UNINSTALL_SH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: uninstall.sh"* ]]
+}
+
+@test "bash: configures PATH when missing, no prior rc file" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    run emit_path_hint_rc bash
+    [ "$status" -eq 0 ]
+    grep -qxF ". \"$OPT_DIR/env\" $PATH_SENTINEL" "$HOME/.bashrc"
+    grep -qF "$BIN_DIR" "$OPT_DIR/env"
+    grep -qxF "path_rc_file=$HOME/.bashrc" "$STATE_FILE"
+}
+
+@test "write_state preserves a previously-recorded path_rc_file across a reinstall" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    mkdir -p "$STATE_DIR"
+    write_state
+    emit_path_hint_rc bash
+    grep -qxF "path_rc_file=$HOME/.bashrc" "$STATE_FILE"
+
+    # Simulate a reinstall post-restart: write_state runs again, but
+    # emit_path_hint doesn't fire (nothing left to configure).
+    write_state
+    grep -qxF "path_rc_file=$HOME/.bashrc" "$STATE_FILE"
+}
+
+@test "bash: rerunning the same install is idempotent" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    emit_path_hint_rc bash
+    emit_path_hint_rc bash
+    [ "$(grep -c "ggshield-standalone/env" "$HOME/.bashrc")" -eq 1 ]
+}
+
+# F5: record_path_state must not re-append a line write_state already preserved.
+@test "state file does not accumulate duplicate path_ lines across same-session reruns" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    mkdir -p "$STATE_DIR"
+    write_state
+    emit_path_hint_rc bash
+    write_state           # preserves the path_rc_file line
+    emit_path_hint_rc bash # would blind-append it again without the dedup guard
+    [ "$(grep -c "^path_rc_file=$HOME/.bashrc$" "$STATE_FILE")" -eq 1 ]
+}
+
+@test "zsh: configures ~/.zshrc" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/zsh
+    run emit_path_hint_rc zsh
+    [ "$status" -eq 0 ]
+    grep -qxF ". \"$OPT_DIR/env\" $PATH_SENTINEL" "$HOME/.zshrc"
+}
+
+@test "--no-modify-path only prints instructions, writes nothing" {
+    load_install
+    ASSUME_YES=1 NO_MODIFY_PATH=1 SHELL=/bin/bash
+    run emit_path_hint_rc bash
+    [ "$status" -eq 0 ]
+    [ ! -e "$HOME/.bashrc" ]
+    [[ "$output" == *"not on your PATH"* ]]
+}
+
+@test "fish: runs fish_add_path and records a single self-contained state line" {
+    load_install
+    install_fake_fish
+    ASSUME_YES=1 SHELL=/usr/bin/fish
+    run emit_path_hint_fish
+    [ "$status" -eq 0 ]
+    grep -qxF "$BIN_DIR" "$FISH_STORE"
+    grep -qxF "path_fish_bin_dir=$BIN_DIR" "$STATE_FILE"
+    # The old two-line (path_shell_bin_dir + path_shell) scheme is gone.
+    run ! grep -q "^path_shell=" "$STATE_FILE"
+}
+
+@test "assert_safe_path_value rejects characters that could break out of a generated snippet" {
+    load_install
+    # shellcheck disable=SC1003 # '\' here is one literal backslash char, not a botched escape
+    for bad in '"' "'" '`' '$' ';' '\' $'\n'; do
+        run assert_safe_path_value TEST "/tmp/x${bad}y"
+        [ "$status" -ne 0 ]
+    done
+    run assert_safe_path_value TEST "/tmp/a-plain-path_123"
+    [ "$status" -eq 0 ]
+}
+
+# F4: relative dirs would land in profiles as `. "opt/env"`, resolved against
+# whatever cwd a future shell starts in.
+@test "assert_safe_path_value rejects relative paths and accepts absolute ones" {
+    load_install
+    for rel in "opt" "./rel" "../rel" ""; do
+        run assert_safe_path_value TEST "$rel"
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"absolute path"* ]]
+    done
+    run assert_safe_path_value TEST "/abs/path"
+    [ "$status" -eq 0 ]
+}
+
+# F4/F3: a user-supplied dir with a trailing slash must be normalized once at
+# startup so the PATH-membership test and the fish canonical form line up.
+@test "trailing slashes are stripped from BIN_DIR/OPT_DIR at startup" {
+    GGSHIELD_BIN_DIR="$HOME/.local/bin/" GGSHIELD_OPT_DIR="$HOME/opt/" run bash -c "
+        source '$INSTALL_SH'
+        printf 'bin=[%s]\nopt=[%s]\n' \"\$BIN_DIR\" \"\$OPT_DIR\"
+    "
+    [[ "$output" == *"bin=[$HOME/.local/bin]"* ]]
+    [[ "$output" == *"opt=[$HOME/opt]"* ]]
+}
+
+@test "main() rejects an unsafe GGSHIELD_BIN_DIR before touching the network" {
+    GGSHIELD_BIN_DIR='/tmp/x"; touch '"$SANDBOX"'/pwned; #' \
+        run bash "$INSTALL_SH" --install-only -y
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot safely appear"* ]]
+    [ ! -e "$SANDBOX/pwned" ]
+}
+
+@test "main() rejects a relative GGSHIELD_OPT_DIR before touching the network" {
+    GGSHIELD_OPT_DIR='opt' run bash "$INSTALL_SH" --install-only -y
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"absolute path"* ]]
+}
+
+@test "configure_fish passes BIN_DIR via env var, never interpolates it into the fish script text" {
+    load_install
+    # Emulate realpath so configure_fish proceeds; re-evaluate the other -c
+    # scripts as a shell would, so a leftover interpolation bug would fire.
+    cat >"$FAKEBIN/fish" <<'SH'
+#!/bin/sh
+case "$2" in
+*realpath*) printf '%s\n' "$GGSHIELD_FISH_BIN_DIR" ;;
+*) sh -c "$2" ;;
+esac
+SH
+    chmod +x "$FAKEBIN/fish"
+    BIN_DIR="/tmp/evil'; touch $SANDBOX/pwned; echo '"
+    run configure_fish
+    [ ! -e "$SANDBOX/pwned" ]
+}
+
+@test "fish: a failing fish_add_path falls back to the printed hint instead of a false success" {
+    load_install
+    install_fake_fish
+    export FISH_FAIL_ADD=1
+    ASSUME_YES=1 SHELL=/usr/bin/fish
+    run emit_path_hint_fish
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Add it permanently with"* ]]
+    [[ "$output" != *"Restart your terminal"* ]]
+    [ ! -f "$STATE_FILE" ]
+}
+
+# Bug B: a config.fish that manages fish_user_paths as a global makes the
+# throwaway `fish -c fish_add_path` a no-op; don't claim success or record it.
+@test "fish: does not record success when fish_add_path did not persist" {
+    load_install
+    install_fake_fish
+    export FISH_NO_PERSIST=1
+    ASSUME_YES=1 SHELL=/usr/bin/fish
+    run emit_path_hint_fish
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Add it permanently with"* ]]
+    [ ! -f "$STATE_FILE" ] || run ! grep -q "^path_fish_bin_dir=" "$STATE_FILE"
+}
+
+@test "bash: a write failure falls back to the printed hint instead of crashing" {
+    [ "$(id -u)" = 0 ] && skip "root ignores the permission bits this test relies on"
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    # OPT_DIR doesn't exist yet; making its parent unwritable makes write_env_sh's
+    # mkdir fail, without ever needing to touch OPT_DIR itself.
+    mkdir -p "$(dirname "$OPT_DIR")"
+    chmod 555 "$(dirname "$OPT_DIR")"
+    run emit_path_hint_rc bash
+    chmod 755 "$(dirname "$OPT_DIR")"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Add it, then restart your terminal"* ]]
+    [[ "$output" != *"Restart your terminal (or run"* ]]
+    # The rc file must not have been edited (record-first only wrote intent).
+    [ ! -e "$HOME/.bashrc" ]
+}
+
+@test "nu_config_path resolves per nushell's own XDG_CONFIG_HOME/OS precedence" {
+    load_install
+    XDG_CONFIG_HOME="" OS=darwin
+    [ "$(nu_config_path)" = "$HOME/Library/Application Support/nushell/config.nu" ]
+
+    XDG_CONFIG_HOME="$HOME/.myxdg"
+    [ "$(nu_config_path)" = "$HOME/.myxdg/nushell/config.nu" ]
+
+    XDG_CONFIG_HOME="" OS=linux
+    [ "$(nu_config_path)" = "$HOME/.config/nushell/config.nu" ]
+}
+
+@test "nushell: configured opportunistically when present, independent of \$SHELL" {
+    load_install
+    printf '#!/bin/sh\nexit 0\n' >"$FAKEBIN/nu"
+    chmod +x "$FAKEBIN/nu"
+    ASSUME_YES=1 SHELL=/bin/bash
+    run emit_path_hint_rc bash
+    [ "$status" -eq 0 ]
+    local nu_cfg="$XDG_CONFIG_HOME/nushell/config.nu"
+    grep -qxF "source \"$OPT_DIR/env.nu\" $PATH_SENTINEL" "$nu_cfg"
+    grep -qF "prepend" "$OPT_DIR/env.nu"
+}
+
+# A real bash subprocess, not `run FUNC`: bats' `run` disables errexit for the
+# whole call, so a same-shell run could never observe a set -e abort here.
+@test "nushell: a failing (e.g. read-only) config.nu doesn't abort the whole install" {
+    load_install # only to compute $OPT_DIR for the assertion below
+    printf '#!/bin/sh\nexit 0\n' >"$FAKEBIN/nu"
+    chmod +x "$FAKEBIN/nu"
+    mkdir -p "$XDG_CONFIG_HOME/nushell"
+    touch "$XDG_CONFIG_HOME/nushell/config.nu"
+    chmod 444 "$XDG_CONFIG_HOME/nushell/config.nu"
+    run bash -c "
+        source '$INSTALL_SH'
+        BIN_DIR=\"\$HOME/.local/bin\"
+        OS=linux
+        ASSUME_YES=1
+        SHELL=/bin/bash
+        emit_path_hint_rc bash
+    "
+    chmod 644 "$XDG_CONFIG_HOME/nushell/config.nu"
+    [ "$status" -eq 0 ]
+    # bash's own rc edit must still have gone through despite nu failing.
+    grep -qxF ". \"$OPT_DIR/env\" $PATH_SENTINEL" "$HOME/.bashrc"
+}
+
+@test "pwsh: configured on Linux when present" {
+    load_install linux
+    printf '#!/bin/sh\nexit 0\n' >"$FAKEBIN/pwsh"
+    chmod +x "$FAKEBIN/pwsh"
+    ASSUME_YES=1 SHELL=/bin/bash OS=linux
+    run emit_path_hint_rc bash
+    [ "$status" -eq 0 ]
+    grep -qxF ". \"$OPT_DIR/env.ps1\" $PATH_SENTINEL" "$XDG_CONFIG_HOME/powershell/profile.ps1"
+}
+
+@test "pwsh: NOT configured on macOS even when present" {
+    load_install darwin
+    printf '#!/bin/sh\nexit 0\n' >"$FAKEBIN/pwsh"
+    chmod +x "$FAKEBIN/pwsh"
+    ASSUME_YES=1 SHELL=/bin/bash OS=darwin
+    run emit_path_hint_rc bash
+    [ "$status" -eq 0 ]
+    [ ! -e "$XDG_CONFIG_HOME/powershell/profile.ps1" ]
+}
+
+# F6: -notcontains is case-insensitive; on a case-sensitive FS it would skip
+# adding the real dir when a case-variant is already on PATH.
+@test "pwsh: env.ps1 uses the case-sensitive -cnotcontains" {
+    load_install
+    write_env_ps1
+    grep -qF -- "-cnotcontains" "$OPT_DIR/env.ps1"
+    run ! grep -qE -- '[^c]notcontains' "$OPT_DIR/env.ps1"
+}
+
+@test "uninstall reverses a bash PATH edit without touching unrelated lines" {
+    load_install
+    ASSUME_YES=1 SHELL=/bin/bash
+    mkdir -p "$STATE_DIR"
+    write_state
+    emit_path_hint_rc bash
+    printf '\nexport MY_OTHER_TOOL=1\n' >>"$HOME/.bashrc"
+
+    load_uninstall
+    ASSUME_YES=1
+    run remove_standalone
+    [ "$status" -eq 0 ]
+    run ! grep -qF "ggshield-standalone" "$HOME/.bashrc"
+    grep -qxF "export MY_OTHER_TOOL=1" "$HOME/.bashrc"
+    [ ! -d "$OPT_DIR" ]
+}
+
+# F2: a line pointing at a *different* OPT_DIR (an earlier install) still carries
+# the sentinel and must be stripped, even though it's not the current opt_dir.
+@test "uninstall strips sentinel lines from any opt_dir, not just the recorded one" {
+    load_install
+    printf '. "%s/other-opt/env" %s\n' "$HOME" "$PATH_SENTINEL" >"$HOME/.bashrc"
+    printf 'export KEEP=1\n' >>"$HOME/.bashrc"
+    mkdir -p "$STATE_DIR"
+    printf 'opt_dir=%s/current-opt\npath_rc_file=%s/.bashrc\n' "$HOME" "$HOME" >"$STATE_FILE"
+
+    load_uninstall
+    ASSUME_YES=1
+    run remove_path_lines
+    [ "$status" -eq 0 ]
+    run ! grep -qF "other-opt/env" "$HOME/.bashrc"
+    grep -qxF "export KEEP=1" "$HOME/.bashrc"
+}
+
+@test "uninstall preserves a symlinked rc file (stow/chezmoi-style) and its permissions" {
+    load_install
+    # A name of its own: load_uninstall below re-sources uninstall.sh, which
+    # recomputes OPT_DIR from the environment (the default), clobbering this.
+    local install_opt_dir="$SANDBOX/opt"
+    mkdir -p "$install_opt_dir" "$SANDBOX/dotfiles"
+    printf 'export EXISTING=1\n. "%s/env" %s\n' "$install_opt_dir" "$PATH_SENTINEL" >"$SANDBOX/dotfiles/bashrc"
+    chmod 600 "$SANDBOX/dotfiles/bashrc"
+    ln -s "$SANDBOX/dotfiles/bashrc" "$HOME/.bashrc"
+    mkdir -p "$STATE_DIR"
+    printf 'opt_dir=%s\npath_rc_file=%s/.bashrc\n' "$install_opt_dir" "$HOME" >"$STATE_FILE"
+
+    load_uninstall
+    run remove_path_lines
+    [ "$status" -eq 0 ]
+    [ -L "$HOME/.bashrc" ]
+    [ "$(perm_bits "$SANDBOX/dotfiles/bashrc")" = 600 ]
+    grep -qxF "export EXISTING=1" "$SANDBOX/dotfiles/bashrc"
+    run ! grep -qF "$install_opt_dir" "$SANDBOX/dotfiles/bashrc"
+}
+
+# A real bash subprocess, not `run FUNC` (see the matching nushell test above):
+# bats' `run` disables errexit for the whole call it wraps.
+@test "uninstall's fish removal survives a failing fish -c instead of aborting" {
+    load_uninstall # only to compute $STATE_DIR for the setup below
+    printf '#!/bin/sh\nexit 1\n' >"$FAKEBIN/fish"
+    chmod +x "$FAKEBIN/fish"
+    mkdir -p "$STATE_DIR"
+    printf 'path_fish_bin_dir=%s/.local/bin\n' "$HOME" >"$STATE_DIR/state"
+    run bash -c "source '$UNINSTALL_SH'; remove_path_lines"
+    [ "$status" -eq 0 ]
+}
+
+@test "uninstall's rc removal survives a tmp-file write failure instead of aborting" {
+    load_install
+    OPT_DIR="$SANDBOX/opt"
+    mkdir -p "$OPT_DIR" "$SANDBOX/rcdir"
+    printf '. "%s/env" %s\n' "$OPT_DIR" "$PATH_SENTINEL" >"$SANDBOX/rcdir/.bashrc"
+    mkdir -p "$STATE_DIR"
+    printf 'opt_dir=%s\npath_rc_file=%s/rcdir/.bashrc\n' "$OPT_DIR" "$SANDBOX" >"$STATE_FILE"
+    chmod 555 "$SANDBOX/rcdir"
+
+    run bash -c "source '$UNINSTALL_SH'; remove_path_lines"
+    chmod 755 "$SANDBOX/rcdir"
+    [ "$status" -eq 0 ]
+    # Couldn't write through; the original must survive untouched, not be lost.
+    grep -qxF ". \"$OPT_DIR/env\" $PATH_SENTINEL" "$SANDBOX/rcdir/.bashrc"
+}
+
+# F1: if the strip can't be verified, deleting OPT_DIR would leave config.nu
+# sourcing a now-missing env.nu — which aborts nushell's entire config at parse
+# time. The env files must be kept (neutralized) instead of removed.
+@test "uninstall keeps env* as stubs when a strip fails, instead of bricking nushell" {
+    [ "$(id -u)" = 0 ] && skip "root ignores the permission bits this test relies on"
+    load_install
+    local opt="$SANDBOX/opt"
+    mkdir -p "$opt/ggshield-1.0-x/bin" "$SANDBOX/nudir"
+    # shellcheck disable=SC2016 # nushell literal — $env must NOT expand in bash
+    printf '$env.PATH = ($env.PATH | prepend "x")\n' >"$opt/env.nu"
+    printf 'source "%s/env.nu" %s\n' "$opt" "$PATH_SENTINEL" >"$SANDBOX/nudir/config.nu"
+    mkdir -p "$STATE_DIR"
+    printf 'opt_dir=%s\nbin_link=%s/.local/bin/ggshield\npath_rc_file_nu=%s/nudir/config.nu\n' \
+        "$opt" "$HOME" "$SANDBOX" >"$STATE_FILE"
+    chmod 555 "$SANDBOX/nudir" # make the tmp-file write (hence the strip) fail
+
+    load_uninstall
+    ASSUME_YES=1 GGSHIELD_OPT_DIR="$opt"
+    OPT_DIR="$opt"
+    run remove_standalone
+    chmod 755 "$SANDBOX/nudir"
+    [ "$status" -eq 0 ]
+    # env.nu kept (so the surviving `source` still resolves) but neutralized...
+    [ -f "$opt/env.nu" ]
+    run ! grep -qF "prepend" "$opt/env.nu"
+    # ...the binary tree and state are gone / kept for retry.
+    [ ! -d "$opt/ggshield-1.0-x" ]
+    [ -f "$STATE_FILE" ]
+}
+
+# F1 scenario (b): XDG_STATE_HOME differs between install and uninstall, so the
+# state file isn't found; OPT_DIR still exists. env* must survive.
+@test "uninstall keeps env* when the state file is missing but OPT_DIR exists" {
+    load_uninstall
+    local opt="$SANDBOX/opt"
+    mkdir -p "$opt/ggshield-1.0-x"
+    printf '# path shim\n' >"$opt/env"
+    ASSUME_YES=1
+    OPT_DIR="$opt" BIN_DIR="$HOME/.local/bin"
+    run remove_standalone
+    [ "$status" -eq 0 ]
+    [ -f "$opt/env" ]
+    [ ! -d "$opt/ggshield-1.0-x" ]
+}
+
+# F3: fish stores the canonicalized (trailing-slash-stripped) form; uninstall
+# must re-canonicalize the recorded value so it matches and gets removed.
+@test "uninstall removes the fish entry even when the recorded value had a trailing slash" {
+    load_install
+    install_fake_fish
+    printf '%s/.local/bin\n' "$HOME" >"$FISH_STORE"
+    printf '%s/other/bin\n' "$HOME" >>"$FISH_STORE"
+    mkdir -p "$STATE_DIR"
+    printf 'path_fish_bin_dir=%s/.local/bin/\n' "$HOME" >"$STATE_FILE" # note trailing slash
+
+    load_uninstall
+    run remove_path_lines
+    [ "$status" -eq 0 ]
+    run ! grep -qxF "$HOME/.local/bin" "$FISH_STORE"
+    grep -qxF "$HOME/other/bin" "$FISH_STORE" # unrelated entry untouched
+}
+
+# Bug A: install under a custom GGSHIELD_OPT_DIR, uninstall without it set. The
+# uninstaller must target the recorded dir, not the default, or it orphans the
+# real install and then deletes its state.
+@test "uninstall targets the recorded opt_dir/bin_link, not the current environment's defaults" {
+    load_install
+    local opt="$SANDBOX/custom-opt" bindir="$SANDBOX/custom-bin"
+    mkdir -p "$opt/ggshield-1.0-x/bin" "$bindir"
+    printf '#!/bin/sh\n' >"$opt/ggshield-1.0-x/bin/ggshield"
+    ln -s "$opt/ggshield-1.0-x/bin/ggshield" "$bindir/ggshield"
+    mkdir -p "$STATE_DIR"
+    printf 'opt_dir=%s\nbin_link=%s/ggshield\n' "$opt" "$bindir" >"$STATE_FILE"
+
+    load_uninstall # re-sources with default OPT_DIR/BIN_DIR (env unset)
+    ASSUME_YES=1
+    run remove_standalone
+    [ "$status" -eq 0 ]
+    [ ! -d "$opt" ]
+    [ ! -e "$bindir/ggshield" ]
+}
+
+@test "uninstall no longer rejects a pre-PR GGSHIELD_OPT_DIR containing a quote" {
+    load_uninstall
+    ASSUME_YES=1
+    OPT_DIR="$SANDBOX/it's-here"
+    mkdir -p "$OPT_DIR"
+    run remove_standalone
+    [ "$status" -eq 0 ]
+}
+
+@test "uninstall empties an rc file whose only content is the ggshield line, leaving no stray tmp file" {
+    load_install
+    OPT_DIR="$SANDBOX/opt"
+    mkdir -p "$OPT_DIR"
+    printf '. "%s/env" %s\n' "$OPT_DIR" "$PATH_SENTINEL" >"$HOME/.bashrc"
+    mkdir -p "$STATE_DIR"
+    printf 'path_rc_file=%s/.bashrc\n' "$HOME" >"$STATE_FILE"
+
+    load_uninstall
+    OPT_DIR="$SANDBOX/opt"
+    run remove_path_lines
+    [ "$status" -eq 0 ]
+    run ! grep -qF "$OPT_DIR" "$HOME/.bashrc"
+    [ ! -e "$HOME/.bashrc.ggshield-tmp" ]
+}

--- a/scripts/install/uninstall.sh
+++ b/scripts/install/uninstall.sh
@@ -13,11 +13,19 @@
 set -euo pipefail
 
 BIN_DIR="${GGSHIELD_BIN_DIR:-$HOME/.local/bin}"
+BIN_DIR="${BIN_DIR%/}"
 OPT_DIR="${GGSHIELD_OPT_DIR:-$HOME/.local/share/ggshield-standalone}"
+OPT_DIR="${OPT_DIR%/}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ggshield-install"
+
+# Must match install.sh: the trailing marker on every rc source line it added.
+PATH_SENTINEL="# ggshield-install PATH"
 
 ASSUME_YES=0
 PURGE=0
+# Set by remove_path_lines: 1 only if every recorded rc line was verifiably
+# stripped. Gates whether remove_standalone may delete OPT_DIR (see there).
+PATH_STRIP_VERIFIED=1
 
 usage() {
     cat <<EOF
@@ -58,26 +66,113 @@ confirm() {
     esac
 }
 
-# Never 'rm -rf' a misconfigured GGSHIELD_OPT_DIR (empty, /, $HOME, the bin dir).
+# Never 'rm -rf' a misconfigured OPT_DIR (empty, relative, /, $HOME, the bin dir).
+# Relative is rejected too: `rm -rf` would resolve it against the current cwd.
 assert_safe_optdir() {
     local p="${OPT_DIR%/}"
     case "$p" in
-    "" | "/" | "$HOME" | "${HOME%/}" | "$BIN_DIR" | "${BIN_DIR%/}")
-        die "refusing to remove unsafe GGSHIELD_OPT_DIR='$OPT_DIR'; point it at a dedicated directory" ;;
+    "" | [!/]*)
+        die "refusing to remove non-absolute OPT_DIR='$OPT_DIR'; use an absolute path" ;;
+    "/" | "$HOME" | "${HOME%/}" | "$BIN_DIR" | "${BIN_DIR%/}")
+        die "refusing to remove unsafe OPT_DIR='$OPT_DIR'; point it at a dedicated directory" ;;
     esac
 }
 
-# Remove the standalone install: the bin symlink (only when it points into our
-# own dir — uv/pipx also drop a ggshield shim in ~/.local/bin) and OPT_DIR.
+# Undo install.sh's PATH edits using what it recorded in the state file, not by
+# re-detecting the shell (env vars may differ by uninstall time). Best-effort, but
+# sets PATH_STRIP_VERIFIED=0 whenever a strip can't be confirmed, so the caller
+# knows not to delete OPT_DIR out from under a still-live `source` line.
+remove_path_lines() {
+    local state_file="$STATE_DIR/state" key value
+    # No state file: we can't know which rc files to strip, so nothing is verified.
+    [ -f "$state_file" ] || { PATH_STRIP_VERIFIED=0; return 0; }
+    while IFS='=' read -r key value; do
+        case "$key" in
+        path_rc_file | path_rc_file_nu | path_rc_file_pwsh)
+            [ -f "$value" ] || continue
+            # Strip by our own trailing sentinel, not by the OPT_DIR the line points
+            # at: opt_dir-independent, so lines from a prior install under a different
+            # OPT_DIR are removed too (and we never touch unrelated user lines).
+            #
+            # grep -v exits 1 both when nothing survives to output and when the >tmp
+            # redirect failed; indistinguishable, so treat both as best-effort.
+            local grep_status=0
+            # 2>/dev/null must precede the >tmp redirect, else its own failure prints
+            # before 2>/dev/null takes effect. Anchored $ so only lines ENDING in the
+            # sentinel match, never a user comment that merely contains the words.
+            grep -v "${PATH_SENTINEL}$" "$value" 2>/dev/null >"$value.ggshield-tmp" || grep_status=$?
+            case "$grep_status" in
+            # `cp`, not `mv` (replaces a symlinked rc file with a plain one) or `cat >`
+            # (truncates the destination before checking the source is readable): `cp`
+            # writes through symlinks, preserves permissions, and won't empty the rc
+            # file if the tmp file was never created.
+            0 | 1) cp "$value.ggshield-tmp" "$value" 2>/dev/null || PATH_STRIP_VERIFIED=0 ;;
+            *) PATH_STRIP_VERIFIED=0 ;;
+            esac
+            rm -f "$value.ggshield-tmp"
+            # Confirm the sentinel is actually gone; a swallowed cp/grep failure above
+            # would otherwise leave a live source line while we delete its target.
+            grep -q "${PATH_SENTINEL}$" "$value" 2>/dev/null && PATH_STRIP_VERIFIED=0
+            ;;
+        path_fish_bin_dir)
+            # fish stores paths canonicalized (builtin realpath -s); install recorded
+            # that exact form. Re-canonicalize here (idempotent) and drop the matching
+            # entry. Plain `set` (not -U) updates fish_user_paths in whatever scope it
+            # lives in; `set -a keep` preserves entries verbatim where `echo` would
+            # mangle newline/flag-like values. BIN_DIR travels via an env var, never
+            # interpolated into the fish script text.
+            command -v fish >/dev/null 2>&1 || continue
+            # shellcheck disable=SC2016 # intentional: fish expands this, not bash
+            GGSHIELD_FISH_BIN_DIR="$value" fish -c '
+                set -l target (builtin realpath -s -- $GGSHIELD_FISH_BIN_DIR)
+                set -l keep
+                for p in $fish_user_paths
+                    test "$p" != "$target"; and set -a keep $p
+                end
+                set fish_user_paths $keep' 2>/dev/null || true
+            ;;
+        esac
+    done <"$state_file"
+    return 0
+}
+
+# Overwrite any surviving env* with a comment-only stub: valid sh/nu/pwsh, so a
+# leftover `source`/`.` line still resolves (no nushell parse abort) but stops
+# touching PATH. Best-effort — an unwritable file is left intact (still resolvable).
+neutralize_env_files() {
+    local f
+    for f in env env.nu env.ps1; do
+        [ -f "$OPT_DIR/$f" ] || continue
+        printf '# ggshield uninstalled; this file is intentionally a no-op\n' \
+            2>/dev/null >"$OPT_DIR/$f" || true
+    done
+}
+
+# Removes the bin symlink (only if it points into our own dir — uv/pipx also
+# drop a shim in ~/.local/bin), OPT_DIR, and any PATH edit install.sh made.
 remove_standalone() {
+    # Prefer the recorded install targets over the current environment: GGSHIELD_OPT_DIR/
+    # GGSHIELD_BIN_DIR may be unset or different now, and acting on the wrong value would
+    # orphan the real install and then delete its state, making it unrecoverable.
+    local bin_link="$BIN_DIR/ggshield" k v
+    if [ -f "$STATE_DIR/state" ]; then
+        while IFS='=' read -r k v; do
+            case "$k" in
+            opt_dir) [ -n "$v" ] && OPT_DIR="${v%/}" ;;
+            bin_link) [ -n "$v" ] && bin_link="$v" ;;
+            esac
+        done <"$STATE_DIR/state"
+    fi
+
     assert_safe_optdir
     local owns_symlink=0 found=0
-    if [ -L "$BIN_DIR/ggshield" ]; then
-        case "$(readlink "$BIN_DIR/ggshield")" in
+    if [ -L "$bin_link" ]; then
+        case "$(readlink "$bin_link")" in
         "$OPT_DIR"/*) owns_symlink=1; found=1 ;;
         esac
     fi
     [ -d "$OPT_DIR" ] && found=1
+    [ -f "$STATE_DIR/state" ] && grep -q '^path_' "$STATE_DIR/state" 2>/dev/null && found=1
 
     if [ "$found" = 0 ]; then
         warn "no script-managed standalone install found in $OPT_DIR"
@@ -85,14 +180,23 @@ remove_standalone() {
         return 0
     fi
 
-    confirm "Remove the standalone ggshield ($OPT_DIR and its $BIN_DIR symlink)?" || return 0
+    confirm "Remove the standalone ggshield ($OPT_DIR and its symlink $bin_link)?" || return 0
     if [ "$owns_symlink" = 1 ]; then
-        say "Removing $BIN_DIR/ggshield"
-        rm -f "$BIN_DIR/ggshield"
+        say "Removing $bin_link"
+        rm -f "$bin_link"
     fi
-    say "Removing $OPT_DIR"
-    rm -rf "$OPT_DIR"
-    rm -rf "$STATE_DIR"
+    remove_path_lines
+    if [ "$PATH_STRIP_VERIFIED" = 1 ]; then
+        say "Removing $OPT_DIR"
+        rm -rf "$OPT_DIR"
+        rm -rf "$STATE_DIR"
+    else
+        warn "could not verify every shell-profile edit was removed; keeping $OPT_DIR/env* as no-op stubs so shell startup keeps working (re-run uninstall once fixed)"
+        neutralize_env_files
+        find "$OPT_DIR" -mindepth 1 -maxdepth 1 \
+            ! -name env ! -name env.nu ! -name env.ps1 -exec rm -rf {} + 2>/dev/null || true
+        rmdir "$OPT_DIR" 2>/dev/null || true
+    fi
 }
 
 purge_user_data() {
@@ -118,8 +222,7 @@ purge_user_data() {
     for p in "${paths[@]}"; do
         [ -e "$p" ] && { say "Removing $p"; rm -rf "$p"; }
     done
-    # The loop's last test ([ -e ] on an absent path) leaves $?=1; under set -e
-    # that would fail the caller's `[ "$PURGE" = 1 ] && purge_user_data`.
+    # Explicit return 0: the loop's last [ -e ] test can leave $?=1 under set -e.
     return 0
 }
 
@@ -141,4 +244,8 @@ main() {
     say "Done."
 }
 
-main "$@"
+# Lets tests `source` this file without running main. BASH_SOURCE is empty (not unset)
+# when piped (curl|bash); a naive `:-` default would then wrongly skip main entirely.
+if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary

- Detect the shell and offer to add `~/.local/bin` to `PATH` when it's missing, instead of only printing instructions: bash, zsh, fish, and — independent of `$SHELL`, since they're rarely the login shell — Nushell and PowerShell on Linux when installed.
- Prompted with a default of yes, silent under `-y`; a decline, an unreachable prompt, or the new `--no-modify-path` falls back to the existing printed instructions.
- `uninstall.sh` reverses the edit using the files `install.sh` recorded in its state file, not shell re-detection (`$SHELL` may differ by then).
- Wire `shellcheck` into pre-commit, scoped to `scripts/install/*.sh` (the repo's other shell scripts have pre-existing findings, one a real bug, that are out of scope here).
- Add a bats functional test suite (9 cases) that sources the scripts and drives fish/nu/pwsh with fake stub binaries — no real shell install needed beyond bats — wired into a new path-filtered GitHub Actions job (ubuntu + macos).

Refs: END-653

## Test plan

- [x] `shellcheck` clean on `scripts/install/install.sh` and `uninstall.sh`
- [x] `bats scripts/install/tests/` passes locally (9/9)
- [x] Manually verified: bash/zsh rc-file edits, idempotency on rerun, `--no-modify-path`, fish `fish_add_path`, nu/pwsh opportunistic config, pwsh gated to Linux only, decline-falls-back-to-print, empty-Enter defaults to yes (via a real pty), install→uninstall round trip leaves unrelated rc-file lines untouched
- [x] CI green on the new `install-scripts.yml` workflow