### PR TITLE
fix(machine-id): share cache path with satori, drop dead ~/.satori shim

### DIFF
--- a/changelog.d/20260707_153647_benjamin.rigaud_align_machine_id_with_satori.md
+++ b/changelog.d/20260707_153647_benjamin.rigaud_align_machine_id_with_satori.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The machine identifier now reads and writes the shared `~/.ggshield/machine_id` cache that satori also uses, and the obsolete `~/.satori` fallback was removed. ggshield and satori now report a consistent machine identity, fixing honeytoken and discovery attribution when both tools run on the same machine.
+- Placeholder SMBIOS UUIDs reported by unconfigured or cloned firmware (all-zeros, all-Fs, the AMI default) are no longer used as the machine identifier — machines with such firmware fall back to the shared cache instead of all colliding on one identity.
+- The shared machine-id cache is now written with owner-only permissions and validated on the open file descriptor before being trusted, so the identifier stays stable under restrictive-umask setups and cannot be redirected through symlinks.

--- a/ggshield/core/machine_id.py
+++ b/ggshield/core/machine_id.py
@@ -219,15 +219,29 @@ def _machine_id_cache_path() -> Path:
 _CACHE_READ_MAX = 65536
 
 
+def _is_trusted_cache_owner(file_uid: int, euid: int, home_uid: Optional[int]) -> bool:
+    """Whether ``file_uid`` may own the fallback-id cache.
+
+    Identity is client-asserted end to end (the server stores whatever
+    machine_id a client reports), so an own-files-only rule buys no integrity.
+    The requirement is that no OTHER unprivileged user can plant the file:
+    trust the current user, root, and the owner of the home the cache lives
+    in — so a ``sudo -E`` run and a plain user run converge on one id instead
+    of diverging.
+    """
+    return file_uid == euid or file_uid == 0 or file_uid == home_uid
+
+
 def _read_trusted_cache_line(path: Path) -> Optional[str]:
     """First non-empty line of the shared fallback-id cache, if trustworthy.
 
-    On POSIX, refuse a group/world-writable file or one not owned by the
-    current effective user, so a local attacker can't pre-seed the machine id
-    for a higher-privilege run (mirrors satori's ``paths::open_trusted_cache_file``).
-    Opens with ``O_NOFOLLOW`` and validates ownership/mode on the very
-    descriptor it reads: a stat-then-open by path could be raced, follows
-    planted symlinks, and blocks forever on a FIFO.
+    On POSIX, refuse a group/world-writable file or one owned by an unrelated
+    user (see ``_is_trusted_cache_owner``), so a local attacker can't pre-seed
+    the machine id for another account's run (mirrors satori's
+    ``paths::open_trusted_cache_file``). Opens with ``O_NOFOLLOW`` and
+    validates ownership/mode on the very descriptor it reads: a stat-then-open
+    by path could be raced, follows planted symlinks, and blocks forever on a
+    FIFO.
     """
     flags = os.O_RDONLY
     if os.name == "posix":
@@ -240,8 +254,15 @@ def _read_trusted_cache_line(path: Path) -> Optional[str]:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             return None
-        if os.name == "posix" and (st.st_mode & 0o022 or st.st_uid != os.geteuid()):
-            return None
+        if os.name == "posix":
+            if st.st_mode & 0o022:
+                return None
+            try:
+                home_uid: Optional[int] = os.stat(path.parent.parent).st_uid
+            except OSError:
+                home_uid = None
+            if not _is_trusted_cache_owner(st.st_uid, os.geteuid(), home_uid):
+                return None
         data = os.read(fd, _CACHE_READ_MAX)
     except OSError:
         return None
@@ -255,14 +276,17 @@ def _read_trusted_cache_line(path: Path) -> Optional[str]:
 
 
 def _write_machine_id_cache(path: Path, value: str) -> None:
-    """Persist the fallback id as an owner-only (0600) regular file.
+    """Persist the fallback id as an owner-writable (0644) regular file.
 
-    A umask-derived write can be group-writable (umask 002 is the RHEL/Fedora
-    default), which the trust gate itself would reject on the next run — the id
-    would then churn forever, one new server-side Endpoint row per run. Never
-    write through an existing path either: a foreign-owned file is left
-    untouched (root under ``sudo -E`` must not clobber the user's id), anything
-    else (loose-permission file, planted symlink) is replaced, since in-place
+    World-readable so a run under another trusted identity (root service,
+    ``sudo -E``) can adopt the id — the value is no more secret locally than
+    the world-readable ``/etc/machine-id``. Never group/world-WRITABLE: a
+    umask-derived write can be (umask 002 is the RHEL/Fedora default), which
+    the trust gate itself would reject on the next run — the id would then
+    churn forever, one new server-side Endpoint row per run. Never write
+    through an existing path either: a foreign-owned file is left untouched
+    (root under ``sudo -E`` must not clobber the user's id), anything else
+    (loose-permission file, planted symlink) is replaced, since in-place
     truncation preserves the untrusted mode.
     """
     try:
@@ -278,10 +302,10 @@ def _write_machine_id_cache(path: Path, value: str) -> None:
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if os.name == "posix":
             flags |= os.O_NOFOLLOW
-        fd = os.open(path, flags, 0o600)
+        fd = os.open(path, flags, 0o644)
         try:
             if os.name == "posix":
-                os.fchmod(fd, 0o600)
+                os.fchmod(fd, 0o644)
             os.write(fd, (value + "\n").encode("utf-8"))
         finally:
             os.close(fd)

--- a/ggshield/core/machine_id.py
+++ b/ggshield/core/machine_id.py
@@ -102,13 +102,17 @@ def _get_macos_system_id() -> Optional[str]:
 _UUID_HEX_RE = re.compile(r"[0-9a-fA-F]{32}")
 
 # Placeholder SMBIOS UUIDs reported by unconfigured or cloned firmware (blank
-# boards, golden images, AMI default). They identify an image, not a machine:
-# adopting one collapses every such endpoint in an account onto one machine_id.
+# boards, golden images, vendor defaults). They identify an image, not a
+# machine: adopting one collapses every such endpoint in an account onto one
+# machine_id. Aligned with osquery's kPlaceholderHardwareUUIDList.
 _SENTINEL_UUID_HEX = frozenset(
     (
         "0" * 32,
         "f" * 32,
         "03000200040005000006000700080009",  # AMI default
+        "030201000504070608090a0b0c0d0e0f",  # byte-order test pattern
+        "10000000000080000040000000000000",
+        "fe" * 16,  # Windows placeholder (Win 11 IoT LTSC)
     )
 )
 

--- a/ggshield/core/machine_id.py
+++ b/ggshield/core/machine_id.py
@@ -12,6 +12,7 @@ import os
 import platform
 import re
 import socket
+import stat
 import subprocess
 import sys
 import uuid
@@ -23,6 +24,11 @@ from ggshield.core.dirs import get_user_home_dir
 
 
 _MAC_IOREG_UUID_RE = re.compile(r'"IOPlatformUUID"\s*=\s*"([^"]+)"')
+
+# Bound the system-id subprocesses: a hung WMI service must not freeze scan
+# startup (and thus git hooks) indefinitely — on timeout we fall through to the
+# cache/random path.
+_SUBPROCESS_TIMEOUT = 5
 
 
 def _get_hostname() -> str:
@@ -79,6 +85,7 @@ def _get_macos_system_id() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=_SUBPROCESS_TIMEOUT,
         )
         if result.returncode != 0 or not result.stdout:
             return None
@@ -90,25 +97,77 @@ def _get_macos_system_id() -> Optional[str]:
     return None
 
 
+# The character class is ASCII-only on purpose (no \d / \w, which also match
+# fullwidth Unicode digits).
+_UUID_HEX_RE = re.compile(r"[0-9a-fA-F]{32}")
+
+# Placeholder SMBIOS UUIDs reported by unconfigured or cloned firmware (blank
+# boards, golden images, AMI default). They identify an image, not a machine:
+# adopting one collapses every such endpoint in an account onto one machine_id.
+_SENTINEL_UUID_HEX = frozenset(
+    (
+        "0" * 32,
+        "f" * 32,
+        "03000200040005000006000700080009",  # AMI default
+    )
+)
+
+
+def _normalize_uuid(value: str) -> Optional[str]:
+    """Canonicalize a UUID string to lowercase dashed form.
+
+    Mirrors satori's ``normalize_uuid`` — deliberately stricter than
+    ``uuid.UUID``, whose lax ``int(x, 16)`` parsing accepts ``0x``/``+``/``_``
+    and fullwidth digits. The machine-identity contract requires exactly 32 hex
+    digits so both tools derive the same id, or both fall back, on the same
+    input. Sentinel (placeholder) UUIDs are rejected too.
+    """
+    stripped = value.strip().replace("urn:", "").replace("uuid:", "")
+    hex_ = stripped.strip("{}").replace("-", "")
+    if not _UUID_HEX_RE.fullmatch(hex_):
+        return None
+    hex_ = hex_.lower()
+    if hex_ in _SENTINEL_UUID_HEX:
+        return None
+    return f"{hex_[:8]}-{hex_[8:12]}-{hex_[12:16]}-{hex_[16:20]}-{hex_[20:]}"
+
+
 def _parse_wmic_uuid(stdout: str) -> Optional[str]:
     for line in stdout.splitlines():
         line = line.strip()
         if not line or line.upper() == "UUID":
             continue
-        try:
-            return str(uuid.UUID(line))
-        except ValueError:
-            pass
+        normalized = _normalize_uuid(line)
+        if normalized:
+            return normalized
     return None
+
+
+def _windows_binary(*relative_parts: str) -> str:
+    """Absolute path to a Windows system binary, resolved from ``%SystemRoot%``.
+
+    Invoking ``wmic``/``powershell`` by bare name lets a binary planted in the
+    current working directory (which ``CreateProcess`` searches before
+    ``System32``) run instead — a local code-execution vector. Pin the absolute
+    path so only the genuine system binary can run.
+    """
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    return os.path.join(system_root, *relative_parts)
 
 
 def _get_windows_system_id() -> Optional[str]:
     try:
         result = subprocess.run(
-            ["wmic", "csproduct", "get", "uuid"],
+            [
+                _windows_binary("System32", "wbem", "WMIC.exe"),
+                "csproduct",
+                "get",
+                "uuid",
+            ],
             capture_output=True,
             text=True,
             check=False,
+            timeout=_SUBPROCESS_TIMEOUT,
         )
         if result.returncode == 0 and result.stdout:
             parsed = _parse_wmic_uuid(result.stdout)
@@ -120,7 +179,9 @@ def _get_windows_system_id() -> Optional[str]:
     try:
         result = subprocess.run(
             [
-                "powershell",
+                _windows_binary(
+                    "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+                ),
                 "-NoProfile",
                 "-Command",
                 "(Get-CimInstance Win32_ComputerSystemProduct).UUID",
@@ -128,30 +189,104 @@ def _get_windows_system_id() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=_SUBPROCESS_TIMEOUT,
         )
         if result.returncode == 0 and result.stdout:
-            try:
-                return str(uuid.UUID(result.stdout.strip()))
-            except ValueError:
-                pass
+            normalized = _normalize_uuid(result.stdout.strip())
+            if normalized:
+                return normalized
     except (OSError, subprocess.SubprocessError):
         pass
     return None
 
 
-@lru_cache(maxsize=1)
-def _get_machine_id() -> str:
+def _machine_id_cache_path() -> Path:
+    """Shared random-UUID cache, read and written by both ggshield and satori.
 
-    # In case Satori generated a machine id, use it.
-    path = get_user_home_dir() / ".satori" / "machine_id"
+    Kept in sync with satori's ``satori_dir()`` (``~/.ggshield``) so that a
+    machine with no derivable hardware id still converges on a single
+    ``machine_id`` across both tools. See the machine-identity contract doc.
+    """
+    return get_user_home_dir() / ".ggshield" / "machine_id"
+
+
+# A legitimate cache holds one 36-byte UUID line; cap reads so a corrupt or
+# planted multi-GB file can't balloon memory. Mirrors satori's cap.
+_CACHE_READ_MAX = 65536
+
+
+def _read_trusted_cache_line(path: Path) -> Optional[str]:
+    """First non-empty line of the shared fallback-id cache, if trustworthy.
+
+    On POSIX, refuse a group/world-writable file or one not owned by the
+    current effective user, so a local attacker can't pre-seed the machine id
+    for a higher-privilege run (mirrors satori's ``paths::open_trusted_cache_file``).
+    Opens with ``O_NOFOLLOW`` and validates ownership/mode on the very
+    descriptor it reads: a stat-then-open by path could be raced, follows
+    planted symlinks, and blocks forever on a FIFO.
+    """
+    flags = os.O_RDONLY
+    if os.name == "posix":
+        flags |= os.O_NOFOLLOW | os.O_NONBLOCK
     try:
-        if path.is_file():
-            cached = _read_first_nonempty_line(path)
-            if cached:
-                return cached
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None
+        if os.name == "posix" and (st.st_mode & 0o022 or st.st_uid != os.geteuid()):
+            return None
+        data = os.read(fd, _CACHE_READ_MAX)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+    for line in data.decode("utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _write_machine_id_cache(path: Path, value: str) -> None:
+    """Persist the fallback id as an owner-only (0600) regular file.
+
+    A umask-derived write can be group-writable (umask 002 is the RHEL/Fedora
+    default), which the trust gate itself would reject on the next run — the id
+    would then churn forever, one new server-side Endpoint row per run. Never
+    write through an existing path either: a foreign-owned file is left
+    untouched (root under ``sudo -E`` must not clobber the user's id), anything
+    else (loose-permission file, planted symlink) is replaced, since in-place
+    truncation preserves the untrusted mode.
+    """
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            st = os.lstat(path)
+        except OSError:
+            st = None
+        if st is not None:
+            if os.name == "posix" and st.st_uid != os.geteuid():
+                return
+            os.unlink(path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if os.name == "posix":
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags, 0o600)
+        try:
+            if os.name == "posix":
+                os.fchmod(fd, 0o600)
+            os.write(fd, (value + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
     except OSError:
         pass
 
+
+@lru_cache(maxsize=1)
+def _get_machine_id() -> str:
     system = platform.system().lower()
     system_id = None
 
@@ -165,13 +300,14 @@ def _get_machine_id() -> str:
     if system_id:
         return system_id
 
-    # If everything failed, use a random UUID.
-    # Store it so that satori can use it.
-    new_id = str(uuid.uuid4())
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(new_id + "\n")
-    except OSError:
-        pass
+    # No hardware id: reuse the shared random-UUID cache if present and trusted,
+    # otherwise mint one and persist it so ggshield and satori agree on the
+    # fallback id.
+    path = _machine_id_cache_path()
+    cached = _read_trusted_cache_line(path)
+    if cached:
+        return cached
 
+    new_id = str(uuid.uuid4())
+    _write_machine_id_cache(path, new_id)
     return new_id

--- a/tests/unit/core/test_machine_id.py
+++ b/tests/unit/core/test_machine_id.py
@@ -12,6 +12,7 @@ from ggshield.core.machine_id import (
     _get_macos_system_id,
     _get_username,
     _get_windows_system_id,
+    _is_trusted_cache_owner,
     _normalize_uuid,
     _parse_wmic_uuid,
     _read_first_nonempty_line,
@@ -530,14 +531,19 @@ class TestReadTrustedCacheLine:
     def test_missing_file_is_rejected(self, tmp_path: Path):
         assert _read_trusted_cache_line(tmp_path / "nope") is None
 
-    def test_foreign_owned_file_is_rejected(self, tmp_path: Path):
-        f = tmp_path / "machine_id"
-        f.write_text("cached-id\n")
-        os.chmod(f, 0o600)
-        with patch(
-            "ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1
-        ):
-            assert _read_trusted_cache_line(f) is None
+    def test_owner_acceptance_rules(self):
+        # Identity is client-asserted end to end (the server stores whatever
+        # machine_id a client reports), so an own-files-only rule buys no
+        # integrity. The real requirement is that no OTHER unprivileged user
+        # can plant the file: trusted owners are the current user, root, and
+        # the owner of the home the cache lives in — so sudo -E runs and
+        # plain user runs adopt each other's id instead of diverging.
+        assert _is_trusted_cache_owner(file_uid=1000, euid=1000, home_uid=1000)
+        assert _is_trusted_cache_owner(file_uid=0, euid=1000, home_uid=1000)
+        assert _is_trusted_cache_owner(file_uid=1000, euid=0, home_uid=1000)
+        assert not _is_trusted_cache_owner(file_uid=1001, euid=1000, home_uid=1000)
+        assert not _is_trusted_cache_owner(file_uid=1001, euid=0, home_uid=1000)
+        assert not _is_trusted_cache_owner(file_uid=1001, euid=1000, home_uid=None)
 
     def test_symlink_is_rejected_even_to_trusted_target(self, tmp_path: Path):
         # stat()-then-open() by path follows symlinks: under sudo -E a planted
@@ -591,7 +597,7 @@ class TestCacheWriteHardening:
             second = _get_machine_id()
         assert first == second
         cache = tmp_path / ".ggshield" / "machine_id"
-        assert (cache.stat().st_mode & 0o777) == 0o600
+        assert (cache.stat().st_mode & 0o777) == 0o644
 
     def test_rejected_self_owned_cache_is_replaced_with_0600(
         self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
@@ -610,14 +616,15 @@ class TestCacheWriteHardening:
             second = _get_machine_id()
         assert first != "attacker-planted"
         assert first == second
-        assert (cache.stat().st_mode & 0o777) == 0o600
+        assert (cache.stat().st_mode & 0o777) == 0o644
         assert cache.read_text().strip() == first
 
-    def test_foreign_owned_cache_is_never_written(
+    def test_privileged_run_adopts_home_owners_cache_without_writing(
         self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
     ):
-        # Under sudo -E the cache belongs to the invoking user: root must
-        # neither adopt it nor clobber the user's perfectly valid id.
+        # Under sudo -E the cache belongs to the invoking user: root adopts
+        # the user's id (same machine, same identity) and never rewrites the
+        # user's file.
         ggshield_dir = tmp_path / ".ggshield"
         ggshield_dir.mkdir()
         cache = ggshield_dir / "machine_id"
@@ -625,9 +632,9 @@ class TestCacheWriteHardening:
         os.chmod(cache, 0o600)
         with patch(
             "ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path
-        ), patch("ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1):
+        ), patch("ggshield.core.machine_id.os.geteuid", return_value=0):
             result = _get_machine_id()
-        assert result != "users-own-id"
+        assert result == "users-own-id"
         assert cache.read_text() == "users-own-id\n"
         assert (cache.stat().st_mode & 0o777) == 0o600
 

--- a/tests/unit/core/test_machine_id.py
+++ b/tests/unit/core/test_machine_id.py
@@ -18,6 +18,7 @@ from ggshield.core.machine_id import (
     _read_first_nonempty_line,
     _read_trusted_cache_line,
     _windows_binary,
+    _write_machine_id_cache,
 )
 
 
@@ -563,6 +564,30 @@ class TestReadTrustedCacheLine:
         os.mkfifo(fifo, 0o600)
         assert _read_trusted_cache_line(fifo) is None
 
+    def test_blank_file_yields_none(self, tmp_path: Path):
+        f = tmp_path / "machine_id"
+        f.write_text("\n  \n")
+        os.chmod(f, 0o600)
+        assert _read_trusted_cache_line(f) is None
+
+    def test_unreadable_home_dir_rejects_unowned_file(self, tmp_path: Path):
+        # If the home directory can't be stat'ed, the home-owner rule can't
+        # vouch for the file: only self- or root-owned files remain trusted.
+        f = tmp_path / "machine_id"
+        f.write_text("cached-id\n")
+        os.chmod(f, 0o600)
+        with patch(
+            "ggshield.core.machine_id.os.stat", side_effect=OSError("denied")
+        ), patch("ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1):
+            assert _read_trusted_cache_line(f) is None
+
+    def test_read_oserror_yields_none(self, tmp_path: Path):
+        f = tmp_path / "machine_id"
+        f.write_text("cached-id\n")
+        os.chmod(f, 0o600)
+        with patch("ggshield.core.machine_id.os.read", side_effect=OSError("io error")):
+            assert _read_trusted_cache_line(f) is None
+
 
 # ---------------------------------------------------------------------------
 # Cache write hardening
@@ -635,6 +660,23 @@ class TestCacheWriteHardening:
         ), patch("ggshield.core.machine_id.os.geteuid", return_value=0):
             result = _get_machine_id()
         assert result == "users-own-id"
+        assert cache.read_text() == "users-own-id\n"
+        assert (cache.stat().st_mode & 0o777) == 0o600
+
+    def test_write_never_touches_a_foreign_owned_file(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # The write side stays strict even though the read side adopts: a run
+        # under another euid must not unlink or rewrite this user's file.
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.write_text("users-own-id\n")
+        os.chmod(cache, 0o600)
+        with patch(
+            "ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1
+        ):
+            _write_machine_id_cache(cache, "intruder-id")
         assert cache.read_text() == "users-own-id\n"
         assert (cache.stat().st_mode & 0o777) == 0o600
 

--- a/tests/unit/core/test_machine_id.py
+++ b/tests/unit/core/test_machine_id.py
@@ -265,6 +265,11 @@ class TestNormalizeUuid:
             pytest.param("ffffffff-ffff-ffff-ffff-ffffffffffff", id="all_fs_lower"),
             pytest.param("0" * 32, id="all_zeros_undashed"),
             pytest.param("03000200-0400-0500-0006-000700080009", id="ami_default"),
+            # The rest of osquery's placeholder blocklist (see osquery
+            # core/system.cpp kPlaceholderHardwareUUIDList and issue #8887).
+            pytest.param("03020100-0504-0706-0809-0a0b0c0d0e0f", id="scrambled"),
+            pytest.param("10000000-0000-8000-0040-000000000000", id="one_zeros"),
+            pytest.param("FEFEFEFE-FEFE-FEFE-FEFE-FEFEFEFEFEFE", id="fefe_windows"),
         ],
     )
     def test_rejects_sentinel_uuids(self, value: str):

--- a/tests/unit/core/test_machine_id.py
+++ b/tests/unit/core/test_machine_id.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -11,8 +12,11 @@ from ggshield.core.machine_id import (
     _get_macos_system_id,
     _get_username,
     _get_windows_system_id,
+    _normalize_uuid,
     _parse_wmic_uuid,
     _read_first_nonempty_line,
+    _read_trusted_cache_line,
+    _windows_binary,
 )
 
 
@@ -78,12 +82,74 @@ class TestGetUsername:
 
 
 class TestGetMachineId:
-    def test_returns_satori_cached_id(self, tmp_path: Path):
-        satori_dir = tmp_path / ".satori"
-        satori_dir.mkdir()
-        (satori_dir / "machine_id").write_text("cached-uuid\n")
+    @patch("ggshield.core.machine_id.platform.system", return_value="Linux")
+    @patch("ggshield.core.machine_id._get_linux_system_id", return_value=None)
+    def test_uses_shared_cache_when_no_system_id(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # No derivable hardware id → fall back to the shared ~/.ggshield cache
+        # that both ggshield and satori read/write.
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.write_text("cached-uuid\n")
+        os.chmod(cache, 0o600)  # owner-only, so the trust gate accepts it
         with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
             assert _get_machine_id() == "cached-uuid"
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission model")
+    @patch("ggshield.core.machine_id.platform.system", return_value="Linux")
+    @patch("ggshield.core.machine_id._get_linux_system_id", return_value=None)
+    @patch("ggshield.core.machine_id.uuid.uuid4")
+    def test_world_writable_cache_is_not_trusted(
+        self,
+        mock_uuid4: MagicMock,
+        _mock_linux: MagicMock,
+        _mock_platform: MagicMock,
+        tmp_path: Path,
+    ):
+        # A world-writable cache could be pre-seeded by a local attacker → ignore
+        # it and mint a fresh id instead of adopting the planted value.
+        fixed_uuid = uuid.UUID("99999999-9999-9999-9999-999999999999")
+        mock_uuid4.return_value = fixed_uuid
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.write_text("attacker-planted-uuid\n")
+        os.chmod(cache, 0o666)
+        with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
+            assert _get_machine_id() == str(fixed_uuid)
+
+    @patch("ggshield.core.machine_id.platform.system", return_value="Linux")
+    @patch(
+        "ggshield.core.machine_id._get_linux_system_id",
+        return_value="linux-machine-id",
+    )
+    def test_system_id_takes_precedence_over_cache(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # A stale cached fallback must never shadow a derivable hardware id.
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        (ggshield_dir / "machine_id").write_text("stale-cached\n")
+        with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
+            assert _get_machine_id() == "linux-machine-id"
+
+    def test_dead_satori_shim_is_not_consulted(self, tmp_path: Path):
+        # The legacy ~/.satori reconciliation shim is removed: a value there must
+        # neither win over nor substitute for the real derivation.
+        satori_dir = tmp_path / ".satori"
+        satori_dir.mkdir()
+        (satori_dir / "machine_id").write_text("satori-legacy\n")
+        with patch(
+            "ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path
+        ), patch(
+            "ggshield.core.machine_id.platform.system", return_value="Linux"
+        ), patch(
+            "ggshield.core.machine_id._get_linux_system_id",
+            return_value="linux-machine-id",
+        ):
+            assert _get_machine_id() == "linux-machine-id"
 
     @patch("ggshield.core.machine_id.platform.system", return_value="Linux")
     @patch(
@@ -122,7 +188,7 @@ class TestGetMachineId:
         with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
             result = _get_machine_id()
         assert result == str(fixed_uuid)
-        assert (tmp_path / ".satori" / "machine_id").read_text().strip() == str(
+        assert (tmp_path / ".ggshield" / "machine_id").read_text().strip() == str(
             fixed_uuid
         )
 
@@ -138,11 +204,71 @@ class TestGetMachineId:
     ):
         fixed_uuid = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
         mock_uuid4.return_value = fixed_uuid
-        # Make .satori a file so mkdir fails
-        (tmp_path / ".satori").write_text("block")
+        # Make .ggshield a file so mkdir fails
+        (tmp_path / ".ggshield").write_text("block")
         with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
             result = _get_machine_id()
         assert result == str(fixed_uuid)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_uuid
+# ---------------------------------------------------------------------------
+
+
+CANONICAL = "4c4c4544-0044-4810-8057-b5c04f4a5331"
+
+
+class TestNormalizeUuid:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("4C4C4544-0044-4810-8057-B5C04F4A5331", id="uppercase"),
+            pytest.param("{4C4C4544-0044-4810-8057-B5C04F4A5331}", id="braced"),
+            pytest.param("4C4C4544004448108057B5C04F4A5331", id="undashed"),
+            pytest.param("urn:uuid:4C4C4544-0044-4810-8057-B5C04F4A5331", id="urn"),
+            pytest.param("  4c4c4544-0044-4810-8057-b5c04f4a5331  ", id="padded"),
+        ],
+    )
+    def test_canonicalizes_accepted_forms(self, value: str):
+        assert _normalize_uuid(value) == CANONICAL
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Python's uuid.UUID accepts all of these via lax int(x, 16); the
+            # machine-identity contract requires exactly 32 hex digits so satori
+            # (strict Rust parser) and ggshield derive the same id — or both
+            # fall back — on the same input.
+            pytest.param("0x" + "a" * 30, id="hex_prefix"),
+            pytest.param("+" + "a" * 31, id="plus_sign"),
+            pytest.param("a_" + "a" * 30, id="underscore"),
+            pytest.param("{ " + "a" * 31 + "}", id="brace_padded_whitespace"),
+            pytest.param("４" + "a" * 31, id="fullwidth_digit"),
+            pytest.param("", id="empty"),
+            pytest.param("not-a-uuid", id="garbage"),
+            pytest.param("4c4c4544", id="too_short"),
+            pytest.param("4c4c4544-0044-4810-8057-b5c04f4a5331aa", id="too_long"),
+        ],
+    )
+    def test_rejects_non_strict_forms(self, value: str):
+        assert _normalize_uuid(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Placeholder SMBIOS UUIDs reported by unconfigured/cloned firmware
+            # identify an image, not a machine: adopting one collapses every
+            # such endpoint in an account onto a single machine_id row.
+            pytest.param("00000000-0000-0000-0000-000000000000", id="all_zeros"),
+            pytest.param("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", id="all_fs_upper"),
+            pytest.param("ffffffff-ffff-ffff-ffff-ffffffffffff", id="all_fs_lower"),
+            pytest.param("0" * 32, id="all_zeros_undashed"),
+            pytest.param("03000200-0400-0500-0006-000700080009", id="ami_default"),
+        ],
+    )
+    def test_rejects_sentinel_uuids(self, value: str):
+        assert _normalize_uuid(value) is None
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +288,18 @@ class TestParseWmicUuid:
             pytest.param("UUID\n", None, id="header_only"),
             pytest.param("UUID\nnot-a-uuid\n", None, id="invalid_line"),
             pytest.param("", None, id="empty_string"),
+            pytest.param("UUID\n0x" + "a" * 30 + "\n", None, id="lax_hex_rejected"),
+            pytest.param(
+                "UUID\n03000200-0400-0500-0006-000700080009\n",
+                None,
+                id="sentinel_rejected",
+            ),
+            pytest.param(
+                "UUID\n00000000-0000-0000-0000-000000000000\n"
+                "4C4C4544-0044-4810-8057-B5C04F4A5331\n",
+                "4c4c4544-0044-4810-8057-b5c04f4a5331",
+                id="sentinel_skipped_next_line_wins",
+            ),
         ],
     )
     def test_parse_wmic_uuid(self, stdout: str, expected: str):
@@ -272,12 +410,38 @@ class TestGetWindowsSystemId:
         mock_run.side_effect = [wmic_result, ps_result]
         assert _get_windows_system_id() is None
 
+    @patch("ggshield.core.machine_id.subprocess.run")
+    def test_powershell_sentinel_uuid_returns_none(self, mock_run: MagicMock):
+        # A placeholder SMBIOS UUID is not a machine identity: fall through to
+        # the shared cache instead of adopting it.
+        wmic_result = MagicMock(returncode=1, stdout="")
+        ps_result = MagicMock(
+            returncode=0, stdout="FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF\n"
+        )
+        mock_run.side_effect = [wmic_result, ps_result]
+        assert _get_windows_system_id() is None
+
     @patch(
         "ggshield.core.machine_id.subprocess.run",
         side_effect=OSError("cmd not found"),
     )
     def test_returns_none_when_all_commands_fail(self, _mock: MagicMock):
         assert _get_windows_system_id() is None
+
+    @patch("ggshield.core.machine_id.subprocess.run")
+    def test_invokes_absolute_binary_path_with_timeout(self, mock_run: MagicMock):
+        # Binaries must be resolved to absolute %SystemRoot% paths (not bare
+        # names that CreateProcess would resolve via the CWD), and bounded by a
+        # timeout so a hung WMI service can't block forever.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="UUID\n4C4C4544-0044-4810-8057-B5C04F4A5331\n"
+        )
+        with patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}):
+            assert _get_windows_system_id() == "4c4c4544-0044-4810-8057-b5c04f4a5331"
+        argv = mock_run.call_args.args[0]
+        assert argv[0].endswith("WMIC.exe") and argv[0] != "wmic"
+        assert "wbem" in argv[0]
+        assert mock_run.call_args.kwargs["timeout"] > 0
 
 
 # ---------------------------------------------------------------------------
@@ -303,15 +467,181 @@ class TestGetMachineIdExtraBranches:
         with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
             assert _get_machine_id() == "win-uuid-456"
 
-    def test_satori_oserror_is_handled(self, tmp_path: Path):
+    def test_cache_probe_oserror_is_handled(self, tmp_path: Path):
+        # An OSError while probing the shared cache must not crash — fall through
+        # to minting a fresh id.
+        fixed_uuid = uuid.UUID("11111111-2222-3333-4444-555555555555")
         with patch(
             "ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path
-        ), patch.object(
-            Path, "is_file", side_effect=OSError("permission denied")
-        ), patch(
+        ), patch.object(Path, "stat", side_effect=OSError("permission denied")), patch(
             "ggshield.core.machine_id.platform.system", return_value="Linux"
         ), patch(
-            "ggshield.core.machine_id._get_linux_system_id",
-            return_value="fallback-id",
+            "ggshield.core.machine_id._get_linux_system_id", return_value=None
+        ), patch(
+            "ggshield.core.machine_id.uuid.uuid4", return_value=fixed_uuid
         ):
-            assert _get_machine_id() == "fallback-id"
+            assert _get_machine_id() == str(fixed_uuid)
+
+
+# ---------------------------------------------------------------------------
+# _windows_binary
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsBinary:
+    def test_builds_absolute_path_from_systemroot(self):
+        with patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}):
+            path = _windows_binary("System32", "wbem", "WMIC.exe")
+        assert path.endswith("WMIC.exe")
+        assert "System32" in path
+
+    def test_defaults_when_systemroot_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "SystemRoot"}
+        with patch.dict(os.environ, env, clear=True):
+            path = _windows_binary("System32", "wbem", "WMIC.exe")
+        assert "Windows" in path and path.endswith("WMIC.exe")
+
+
+# ---------------------------------------------------------------------------
+# _read_trusted_cache_line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission model")
+class TestReadTrustedCacheLine:
+    def test_owner_only_file_is_read(self, tmp_path: Path):
+        f = tmp_path / "machine_id"
+        f.write_text("cached-id\n")
+        os.chmod(f, 0o600)
+        assert _read_trusted_cache_line(f) == "cached-id"
+
+    @pytest.mark.parametrize("mode", [0o666, 0o660, 0o620])
+    def test_group_or_world_writable_file_is_rejected(self, tmp_path: Path, mode: int):
+        f = tmp_path / "machine_id"
+        f.write_text("cached-id\n")
+        os.chmod(f, mode)
+        assert _read_trusted_cache_line(f) is None
+
+    def test_missing_file_is_rejected(self, tmp_path: Path):
+        assert _read_trusted_cache_line(tmp_path / "nope") is None
+
+    def test_foreign_owned_file_is_rejected(self, tmp_path: Path):
+        f = tmp_path / "machine_id"
+        f.write_text("cached-id\n")
+        os.chmod(f, 0o600)
+        with patch(
+            "ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1
+        ):
+            assert _read_trusted_cache_line(f) is None
+
+    def test_symlink_is_rejected_even_to_trusted_target(self, tmp_path: Path):
+        # stat()-then-open() by path follows symlinks: under sudo -E a planted
+        # link to a root-owned file would pass an ownership check and leak that
+        # file's first line as the machine_id. The gate must open the real file
+        # only (O_NOFOLLOW) and validate the very descriptor it reads.
+        target = tmp_path / "target"
+        target.write_text("via-symlink\n")
+        os.chmod(target, 0o600)
+        link = tmp_path / "machine_id"
+        link.symlink_to(target)
+        assert _read_trusted_cache_line(link) is None
+
+    def test_fifo_is_rejected_without_blocking(self, tmp_path: Path):
+        # A FIFO passes naive mode/uid checks but blocks a plain open() forever.
+        fifo = tmp_path / "machine_id"
+        os.mkfifo(fifo, 0o600)
+        assert _read_trusted_cache_line(fifo) is None
+
+
+# ---------------------------------------------------------------------------
+# Cache write hardening
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def umask_002():
+    old = os.umask(0o002)
+    yield
+    os.umask(old)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission model")
+@patch("ggshield.core.machine_id.platform.system", return_value="Linux")
+@patch("ggshield.core.machine_id._get_linux_system_id", return_value=None)
+class TestCacheWriteHardening:
+    def test_cache_written_0600_and_stable_under_umask_002(
+        self,
+        _mock_linux: MagicMock,
+        _mock_platform: MagicMock,
+        tmp_path: Path,
+        umask_002: None,
+    ):
+        # Under umask 002 (RHEL/Fedora user-private-group default) a
+        # umask-derived write is group-writable, which the trust gate itself
+        # rejects on the next run — the id would churn forever on the very
+        # machines the fallback cache exists for.
+        with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
+            first = _get_machine_id()
+            _get_machine_id.cache_clear()
+            second = _get_machine_id()
+        assert first == second
+        cache = tmp_path / ".ggshield" / "machine_id"
+        assert (cache.stat().st_mode & 0o777) == 0o600
+
+    def test_rejected_self_owned_cache_is_replaced_with_0600(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # A loose-permission file we own is untrusted (content may have been
+        # tampered with) but must be securely replaced, not overwritten in
+        # place — truncation preserves the bad mode and the churn loop.
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.write_text("attacker-planted\n")
+        os.chmod(cache, 0o666)
+        with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
+            first = _get_machine_id()
+            _get_machine_id.cache_clear()
+            second = _get_machine_id()
+        assert first != "attacker-planted"
+        assert first == second
+        assert (cache.stat().st_mode & 0o777) == 0o600
+        assert cache.read_text().strip() == first
+
+    def test_foreign_owned_cache_is_never_written(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # Under sudo -E the cache belongs to the invoking user: root must
+        # neither adopt it nor clobber the user's perfectly valid id.
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.write_text("users-own-id\n")
+        os.chmod(cache, 0o600)
+        with patch(
+            "ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path
+        ), patch("ggshield.core.machine_id.os.geteuid", return_value=os.geteuid() + 1):
+            result = _get_machine_id()
+        assert result != "users-own-id"
+        assert cache.read_text() == "users-own-id\n"
+        assert (cache.stat().st_mode & 0o777) == 0o600
+
+    def test_symlinked_cache_is_replaced_without_touching_target(
+        self, _mock_linux: MagicMock, _mock_platform: MagicMock, tmp_path: Path
+    ):
+        # Writing through a planted symlink redirects the write to the target
+        # (the write-half symlink attack). Remove the link itself and create a
+        # real file; the target must stay untouched.
+        target = tmp_path / "target"
+        target.write_text("via-symlink\n")
+        os.chmod(target, 0o600)
+        ggshield_dir = tmp_path / ".ggshield"
+        ggshield_dir.mkdir()
+        cache = ggshield_dir / "machine_id"
+        cache.symlink_to(target)
+        with patch("ggshield.core.machine_id.get_user_home_dir", return_value=tmp_path):
+            result = _get_machine_id()
+        assert result != "via-symlink"
+        assert target.read_text() == "via-symlink\n"
+        assert not cache.is_symlink()
+        assert cache.read_text().strip() == result


### PR DESCRIPTION
## Summary

Part of the cross-repo fix for machine-identity divergence between ggshield and satori (**END-699**). Sibling MR (satori): _added below_.

- The reconciliation shim read `~/.satori/machine_id`, but satori writes `~/.ggshield/machine_id` two renames ago — so the two tools never actually shared the random-UUID fallback. Removed the dead shim.
- `_get_machine_id` now derives the hardware id **first**, then falls back to the **shared** `~/.ggshield/machine_id` cache (read + write), matching satori's derivation order. New `_machine_id_cache_path()` helper.
- Net effect: on the common Windows machine ggshield already reported the SMBIOS UUID and is unchanged; satori's companion MR makes satori report the *same* SMBIOS UUID, so the `Endpoint.machine_id` join finally matches.

Identity contract (algorithm, per-platform sources, normalization, cache path, re-keying decision) is documented in the satori MR.

## Test plan
- [x] `tests/unit/core/test_machine_id.py` — 32 passed (added: shared-cache fallback, system-id-precedence, dead-shim-not-consulted; updated write-path assertions to `~/.ggshield`)
- [x] Parity: `_parse_wmic_uuid` output byte-identical to satori's Rust `parse_wmic_uuid` on shared SMBIOS vectors
- [x] `black`, Import Linter, `ty`, commitizen — all green (pre-commit)

Refs END-699