### PR TITLE
[AI] Improve server format support

### DIFF
--- a/changelog.d/20260717_160000_paul.beslin.ext_mcp_server_format_support.md
+++ b/changelog.d/20260717_160000_paul.beslin.ext_mcp_server_format_support.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `ggshield ai discover` now finds MCP servers that Cursor, Claude Code and Codex plugins declare through a `mcpServers` manifest field holding an inline block, a path to a config file, or a list of either (e.g. the Datadog Cursor plugin), instead of silently skipping them.
+- `ggshield ai discover` now reports the SSE transport for MCP servers declared with the `"type": "sse"` spelling used by Cursor, instead of HTTP.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -228,13 +228,16 @@ class Claude(Agent):
             yield from self._parse_servers_block(mcp_data, scope, project)
             return
 
-        # Fallback: inline mcpServers in the plugin manifest.
+        # Fallback: mcpServers in the plugin manifest (inline block, path to a
+        # config file, or a list of either).
         manifest = self._load_file(install_dir / ".claude-plugin" / "plugin.json")
         if not manifest:
             return
         inline = manifest.get("mcpServers")
-        if isinstance(inline, dict):
-            yield from self._parse_servers_block({"mcpServers": inline}, scope, project)
+        if inline is not None:
+            yield from self._parse_servers_block(
+                {"mcpServers": inline}, scope, project, base_dir=install_dir
+            )
 
     def _get_claudeai_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         """Yield MCP servers connected through the user's claude.ai account.

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -123,12 +123,15 @@ class Codex(Agent):
             display_name = None
             mcp_location = ".mcp.json"
 
-        # Try to read the mcp.json file
-        if not (data := self._load_file(plugin_dir / mcp_location)):
-            return
-
+        # mcp_location may be a path relative to the plugin dir, an inline
+        # servers block, or a list mixing both; _parse_servers_block handles
+        # all of them (including bare {name: entry} referenced files).
         yield from self._parse_servers_block(
-            data, scope, None if scope == Scope.USER else plugin_dir, display_name
+            {"mcpServers": mcp_location},
+            scope,
+            None if scope == Scope.USER else plugin_dir,
+            display_name,
+            base_dir=plugin_dir,
         )
 
     def parse_mcp_activity(

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -184,14 +184,15 @@ class Cursor(Agent):
                 yield from self._parse_servers_block(mcp_data, Scope.USER, None)
                 return
 
-        # Fallback: inline mcpServers in the plugin manifest.
+        # Fallback: mcpServers in the plugin manifest (inline block, path to a
+        # config file, or a list of either).
         manifest = self._load_file(install_dir / ".cursor-plugin" / "plugin.json")
         if not manifest:
             return
         inline = manifest.get("mcpServers")
-        if isinstance(inline, dict):
+        if inline is not None:
             yield from self._parse_servers_block(
-                {"mcpServers": inline}, Scope.USER, None
+                {"mcpServers": inline}, Scope.USER, None, base_dir=install_dir
             )
 
     def _get_extension_mcp_configurations(self) -> Iterator[MCPConfiguration]:

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -249,7 +249,7 @@ class Agent(ABC):
 
     def _parse_servers_block(
         self,
-        data: Dict[str, Dict[str, Any]],
+        data: Dict[str, Any],
         scope: Scope,
         project: Optional[Path],
         display_name: Optional[str] = None,
@@ -262,6 +262,17 @@ class Agent(ABC):
         servers = data.get(
             "mcpServers", data.get("servers", data.get("mcp_servers", {}))
         )
+        # Theoretically, servers can also be a string (path to another file), or a list.
+        if isinstance(servers, str):
+            servers = self._load_file(Path(servers))
+            if servers is None:
+                return
+        elif isinstance(servers, list):
+            for server in servers:
+                yield from self._parse_servers_block(
+                    {"mcpServers": server}, scope, project, display_name
+                )
+            return
         for name, entry in servers.items():
             if "url" in entry:
                 if entry.get("transport") == "sse":

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -302,7 +302,9 @@ class Agent(ABC):
             if not isinstance(entry, dict):
                 continue
             if "url" in entry:
-                if entry.get("transport") == "sse":
+                # The transport key is spelled "transport" or "type" depending
+                # on the assistant.
+                if entry.get("transport", entry.get("type")) == "sse":
                     transport = Transport.SSE
                 else:
                     transport = Transport.HTTP

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -253,6 +253,8 @@ class Agent(ABC):
         scope: Scope,
         project: Optional[Path],
         display_name: Optional[str] = None,
+        base_dir: Optional[Path] = None,
+        _in_list: bool = False,
     ) -> Iterator[MCPConfiguration]:
         """Utility function to parse a "mcpServer" block and return the MCP server entries.
 
@@ -262,18 +264,43 @@ class Agent(ABC):
         servers = data.get(
             "mcpServers", data.get("servers", data.get("mcp_servers", {}))
         )
-        # Theoretically, servers can also be a string (path to another file), or a list.
+        # Handle path to a config file
         if isinstance(servers, str):
-            servers = self._load_file(Path(servers))
-            if servers is None:
+            path = Path(servers)
+            if not path.is_absolute():
+                if base_dir is None:
+                    # Without an anchor a relative location would resolve
+                    # against the process cwd; drop it instead.
+                    return
+                path = base_dir / path
+            if (loaded := self._load_file(path)) is None:
                 return
+            # The official shape is {"mcpServers": {...}}, but non-wrapped configs are sometimes leniently supported.
+            # Also we expect only the dict shape for referenced config files.
+            # This also prevents a potential infinite loop if the referenced file points back to the original file.
+            servers = loaded.get(
+                "mcpServers", loaded.get("servers", loaded.get("mcp_servers", loaded))
+            )
+        # Handle list of servers. Nested lists are undocumented, so we don't support them.
         elif isinstance(servers, list):
+            if _in_list:
+                return
             for server in servers:
+                # An element may itself be a wrapped block: don't double-wrap.
+                if not (
+                    isinstance(server, dict)
+                    and server.keys() & {"mcpServers", "servers", "mcp_servers"}
+                ):
+                    server = {"mcpServers": server}
                 yield from self._parse_servers_block(
-                    {"mcpServers": server}, scope, project, display_name
+                    server, scope, project, display_name, base_dir, _in_list=True
                 )
             return
+        if not isinstance(servers, dict):
+            return
         for name, entry in servers.items():
+            if not isinstance(entry, dict):
+                continue
             if "url" in entry:
                 if entry.get("transport") == "sse":
                     transport = Transport.SSE
@@ -391,9 +418,9 @@ class Agent(ABC):
 
     def _load_file(self, path: Path) -> Optional[Dict[str, Any]]:
         """Load a file and return the data, or None if the file doesn't exist."""
-        if not path.is_file():
-            return None
         try:
+            if not path.is_file():
+                return None
             raw = path.read_text()
             # Fallback to JSON
             if path.suffix == ".toml":

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -270,6 +270,55 @@ class TestCursorGetPluginMcpConfigurations:
         assert configs[0].transport == Transport.SSE
         assert configs[0].url == "https://example.com/mcp"
 
+    def test_manifest_string_path_with_custom_filename(self, tmp_path: Path):
+        # Real-world case (datadog-labs/cursor-plugin): the manifest points to
+        # a custom-named config file at the plugin root.
+        config_folder = tmp_path / ".cursor"
+        install_dir = config_folder / "plugins" / "cache" / "owner" / "dd" / "v1"
+        install_dir.mkdir(parents=True)
+        (install_dir / ".cursor-plugin").mkdir()
+        (install_dir / ".cursor-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "dd", "mcpServers": "./.dd_cursor_mcp.json"})
+        )
+        (install_dir / ".dd_cursor_mcp.json").write_text(
+            json.dumps({"mcpServers": {"datadog": {"command": "npx"}}})
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "datadog"
+        assert configs[0].command == "npx"
+
+    def test_manifest_array_of_path_and_inline(self, tmp_path: Path):
+        config_folder = tmp_path / ".cursor"
+        install_dir = config_folder / "plugins" / "local" / "mixed"
+        install_dir.mkdir(parents=True)
+        (install_dir / ".cursor-plugin").mkdir()
+        (install_dir / ".cursor-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "mixed",
+                    "mcpServers": [
+                        "./mcp/remote.json",
+                        {"inline-srv": {"command": "npx"}},
+                    ],
+                }
+            )
+        )
+        (install_dir / "mcp").mkdir()
+        (install_dir / "mcp" / "remote.json").write_text(
+            json.dumps({"mcpServers": {"from-file": {"url": "https://e.com/mcp"}}})
+        )
+
+        cursor = Cursor()
+        with self._patch(cursor, config_folder):
+            configs = list(cursor._get_plugin_mcp_configurations())
+
+        assert sorted(c.name for c in configs) == ["from-file", "inline-srv"]
+
     def test_plugin_without_mcp_servers_yields_nothing(self, tmp_path: Path):
         config_folder = tmp_path / ".cursor"
         install_dir = (
@@ -691,6 +740,35 @@ class TestClaudeGetPluginMcpConfigurations:
         assert configs[0].name == "inline-srv"
         assert configs[0].transport == Transport.SSE
         assert configs[0].url == "https://example.com/mcp"
+
+    def test_manifest_string_path_resolved_against_install_dir(self, tmp_path: Path):
+        config_folder = self._setup(tmp_path)
+        install_dir = self._make_plugin(config_folder, "pathy@official")
+        (install_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "pathy", "mcpServers": "./custom-mcp.json"})
+        )
+        (install_dir / "custom-mcp.json").write_text(
+            json.dumps({"mcpServers": {"pathy-srv": {"command": "node"}}})
+        )
+        (config_folder / "plugins" / "installed_plugins.json").write_text(
+            json.dumps(
+                {
+                    "plugins": {
+                        "pathy@official": [
+                            {"scope": "user", "installPath": str(install_dir)}
+                        ]
+                    }
+                }
+            )
+        )
+
+        claude = Claude()
+        with self._patch(claude, config_folder):
+            configs = list(claude._get_plugin_mcp_configurations())
+
+        assert len(configs) == 1
+        assert configs[0].name == "pathy-srv"
+        assert configs[0].command == "node"
 
     def test_missing_install_dir_skipped(self, tmp_path: Path):
         config_folder = self._setup(tmp_path)
@@ -1204,6 +1282,140 @@ class TestCodexGetCodexPluginMcpConfigurations:
         assert len(configs) == 1
         assert configs[0].transport == Transport.HTTP
         assert configs[0].url == "https://example.com/mcp"
+
+    def test_bare_layout_in_mcp_json(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        # Bare layout (no "mcpServers" wrapper)
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps({"my-srv": {"command": "node", "args": ["index.js"]}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "my-srv"
+        assert configs[0].transport == Transport.STDIO
+        assert configs[0].command == "node"
+
+    def test_inline_mcp_servers_in_manifest(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        manifest_dir = plugin_dir / ".codex-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "package.json").write_text(
+            json.dumps(
+                {
+                    "interface": {"displayName": "Inline Plugin"},
+                    "mcpServers": {
+                        "inline-srv": {
+                            "url": "https://example.com/mcp",
+                            "transport": "sse",
+                        }
+                    },
+                }
+            )
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "inline-srv"
+        assert configs[0].transport == Transport.SSE
+        assert configs[0].url == "https://example.com/mcp"
+        assert configs[0].display_name == "Inline Plugin"
+
+    def test_manifest_string_path_with_custom_filename(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        manifest_dir = plugin_dir / ".codex-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "package.json").write_text(
+            json.dumps({"mcpServers": "./custom_mcp.json"})
+        )
+        (plugin_dir / "custom_mcp.json").write_text(
+            json.dumps({"mcpServers": {"custom": {"command": "npx"}}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "custom"
+        assert configs[0].command == "npx"
+
+    def test_manifest_string_path_to_bare_layout_file(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        manifest_dir = plugin_dir / ".codex-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "package.json").write_text(
+            json.dumps({"mcpServers": "./custom_mcp.json"})
+        )
+        # Bare layout (no "mcpServers" wrapper) in the referenced file
+        (plugin_dir / "custom_mcp.json").write_text(
+            json.dumps({"bare-srv": {"command": "python", "args": ["srv.py"]}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "bare-srv"
+        assert configs[0].command == "python"
+
+    def test_manifest_array_of_path_and_inline(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        manifest_dir = plugin_dir / ".codex-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "package.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": [
+                        "./mcp/remote.json",
+                        {"inline-srv": {"command": "npx"}},
+                    ],
+                }
+            )
+        )
+        (plugin_dir / "mcp").mkdir()
+        (plugin_dir / "mcp" / "remote.json").write_text(
+            json.dumps({"mcpServers": {"from-file": {"url": "https://e.com/mcp"}}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert sorted(c.name for c in configs) == ["from-file", "inline-srv"]
+
+    def test_manifest_without_mcp_servers_falls_back_to_mcp_json(self, tmp_path: Path):
+        plugin_dir = tmp_path / "plugin"
+        manifest_dir = plugin_dir / ".codex-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "package.json").write_text(
+            json.dumps({"interface": {"displayName": "Skills Plugin"}})
+        )
+        (plugin_dir / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"default-srv": {"command": "node"}}})
+        )
+
+        codex = Codex()
+        configs = list(
+            codex._get_codex_plugin_mcp_configurations(plugin_dir, Scope.USER)
+        )
+
+        assert len(configs) == 1
+        assert configs[0].name == "default-srv"
+        assert configs[0].display_name == "Skills Plugin"
 
 
 # ===========================================================================

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -178,6 +178,23 @@ class TestParseServersBlock:
         configs = self._parse(data)
         assert configs[0].transport == Transport.SSE
 
+    def test_url_entry_with_sse_type_key(self):
+        # Cursor spells the transport key "type" ("sse", "streamable-http").
+        data = {
+            "mcpServers": {"remote": {"url": "https://example.com/sse", "type": "sse"}}
+        }
+        configs = self._parse(data)
+        assert configs[0].transport == Transport.SSE
+
+    def test_url_entry_with_streamable_http_type_key(self):
+        data = {
+            "mcpServers": {
+                "remote": {"url": "https://example.com/mcp", "type": "streamable-http"}
+            }
+        }
+        configs = self._parse(data)
+        assert configs[0].transport == Transport.HTTP
+
     def test_empty_block_yields_nothing(self):
         assert self._parse({}) == []
         assert self._parse({"mcpServers": {}}) == []

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -132,8 +132,11 @@ class TestParseServersBlock:
         data: Dict[str, Any],
         scope: Scope = Scope.USER,
         project: Optional[Path] = None,
+        base_dir: Optional[Path] = None,
     ) -> List[MCPConfiguration]:
-        return list(Cursor()._parse_servers_block(data, scope, project))
+        return list(
+            Cursor()._parse_servers_block(data, scope, project, base_dir=base_dir)
+        )
 
     def test_mcp_servers_key_stdio(self):
         data = {
@@ -201,6 +204,101 @@ class TestParseServersBlock:
         assert configs[1].name == "s2"
         assert configs[1].command == "python"
 
+    def test_servers_as_relative_string_path_resolved_against_base_dir(
+        self, tmp_path: Path
+    ):
+        sub = tmp_path / "mcp"
+        sub.mkdir()
+        (sub / "servers.json").write_text(
+            json.dumps({"mcpServers": {"rel-srv": {"command": "node"}}})
+        )
+        configs = self._parse({"mcpServers": "./mcp/servers.json"}, base_dir=tmp_path)
+        assert len(configs) == 1
+        assert configs[0].name == "rel-srv"
+
+    def test_servers_as_string_path_with_wrapped_layout(self, tmp_path: Path):
+        external = tmp_path / "external.json"
+        external.write_text(
+            json.dumps({"mcpServers": {"wrapped-srv": {"command": "node"}}})
+        )
+        configs = self._parse({"mcpServers": str(external)})
+        assert len(configs) == 1
+        assert configs[0].name == "wrapped-srv"
+        assert configs[0].command == "node"
+
+    def test_servers_as_string_path_chaining_not_followed(self, tmp_path: Path):
+        # A referenced file must hold a server map; indirection to yet another
+        # file is not part of any known format and must not loop.
+        chained = tmp_path / "chained.json"
+        chained.write_text(json.dumps({"mcpServers": str(chained)}))
+        assert self._parse({"mcpServers": str(chained)}) == []
+
+    def test_servers_as_list_with_string_elements(self, tmp_path: Path):
+        external = tmp_path / "external.json"
+        external.write_text(
+            json.dumps({"mcpServers": {"from-file": {"command": "node"}}})
+        )
+        data = {
+            "mcpServers": [
+                "./external.json",
+                {"inline-srv": {"command": "python"}},
+            ]
+        }
+        configs = self._parse(data, base_dir=tmp_path)
+        assert [c.name for c in configs] == ["from-file", "inline-srv"]
+
+    def test_servers_as_list_with_wrapped_element(self):
+        data = {"mcpServers": [{"mcpServers": {"srv": {"command": "node"}}}]}
+        configs = self._parse(data)
+        assert [c.name for c in configs] == ["srv"]
+
+    def test_list_inside_referenced_file_not_followed(self, tmp_path: Path):
+        # A list in a referenced file could hold string elements, reopening
+        # file-to-file indirection; it is dropped like any non-map value.
+        external = tmp_path / "external.json"
+        external.write_text(json.dumps({"mcpServers": [{"srv": {"command": "node"}}]}))
+        assert self._parse({"mcpServers": str(external)}) == []
+
+    def test_relative_string_path_without_base_dir_yields_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        (tmp_path / "servers.json").write_text(
+            json.dumps({"mcpServers": {"srv": {"command": "node"}}})
+        )
+        monkeypatch.chdir(tmp_path)
+        assert self._parse({"mcpServers": "./servers.json"}) == []
+
+    def test_non_dict_entry_skipped(self):
+        data = {"mcpServers": {"weird": "oops", "ok": {"command": "node"}}}
+        configs = self._parse(data)
+        assert [c.name for c in configs] == ["ok"]
+
+    def test_servers_as_unexpected_type_yields_nothing(self):
+        assert self._parse({"mcpServers": 42}) == []
+
+    def test_servers_as_unstatable_string_path_yields_nothing(self):
+        # Drop a string path that is too long for the filesystem to stat
+        assert self._parse({"mcpServers": "/" + "x" * 5000}) == []
+
+    def test_list_of_lists_dropped(self):
+        # All documented formats keep the list flat.
+        data = {"mcpServers": [[{"srv": {"command": "node"}}]]}
+        assert self._parse(data) == []
+
+    def test_wrapped_list_inside_list_dropped(self):
+        # A wrapped element reopening a list is nesting too, whatever the
+        # wrapper.
+        data = {"mcpServers": [{"mcpServers": [{"srv": {"command": "node"}}]}]}
+        assert self._parse(data) == []
+
+    def test_deeply_nested_lists_dropped(self):
+        # Avoid crashing in case of a maliciously crafted config file with many levels of nesting.
+        # Already covered since we don't support nested lists, kept in case we change our minds.
+        servers: Any = {"srv": {"command": "node"}}
+        for _ in range(10_000):
+            servers = [servers]
+        assert self._parse({"mcpServers": servers}) == []
+
 
 # ---------------------------------------------------------------------------
 # Agent._load_file
@@ -225,6 +323,10 @@ class TestLoadFile:
         f = tmp_path / "list.json"
         f.write_text(json.dumps([1, 2, 3]))
         assert Cursor()._load_file(f) is None
+
+    def test_returns_none_when_stat_fails(self, tmp_path: Path):
+        # Avoid crashing on long file names
+        assert Cursor()._load_file(tmp_path / ("x" * 5000)) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -179,6 +179,28 @@ class TestParseServersBlock:
         assert self._parse({}) == []
         assert self._parse({"mcpServers": {}}) == []
 
+    def test_servers_as_string_path_loads_external_file(self, tmp_path: Path):
+        external = tmp_path / "external.json"
+        external.write_text(json.dumps({"ext-srv": {"command": "node", "args": []}}))
+        configs = self._parse({"mcpServers": str(external)})
+        assert len(configs) == 1
+        assert configs[0].name == "ext-srv"
+        assert configs[0].command == "node"
+
+    def test_servers_as_list_parses_each_block(self):
+        data = {
+            "mcpServers": [
+                {"s1": {"command": "node"}},
+                {"s2": {"command": "python"}},
+            ]
+        }
+        configs = self._parse(data)
+        assert len(configs) == 2
+        assert configs[0].name == "s1"
+        assert configs[0].command == "node"
+        assert configs[1].name == "s2"
+        assert configs[1].command == "python"
+
 
 # ---------------------------------------------------------------------------
 # Agent._load_file


### PR DESCRIPTION
## Context

In some cases, (see https://cursor.com/docs/reference/plugins#optional-fields), the `mcpServers` field can be a string or a list. Support these cases.
