### PR TITLE
Add login guidance to expired auth error message

### DIFF
--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -121,7 +121,7 @@ class AuthExpiredError(AuthError):
     def __init__(self, instance: str):
         super().__init__(
             instance,
-            f"Instance '{instance}' authentication expired, please authenticate again.",
+            f"Instance '{instance}' authentication expired, please authenticate again (ggshield auth login).",
         )
 
 


### PR DESCRIPTION
# Summary
Users hitting an expired API key only saw "please authenticate again," with no indication of the command needed to fix it, leading to avoidable support requests.

Refs: **[END-759](https://linear.app/gitguardian/issue/END-759/improve-invalid-api-key-error-message-with-auth-login-guidance)**

# Changes
The `AuthExpiredError` message now points directly to `ggshield auth login` as the remediation step.