### PR TITLE
fix(ai-hooks): recognize Codex when transcript_path is null

### DIFF
--- a/changelog.d/20260717_150233_achille.mascia_fix_codex_hook_null_transcript.md
+++ b/changelog.d/20260717_150233_achille.mascia_fix_codex_hook_null_transcript.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- AI hooks no longer crash under Codex. Codex sends `transcript_path` as a
+  present-but-null field, which made agent detection raise a `TypeError` before
+  Codex could be recognized, so every `PreToolUse`/`PostToolUse` hook exited 1.
+  The detectors now treat a null `transcript_path` as absent, and the fail-open
+  safety net catches any detection error so a hook can never break the agent.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -131,8 +131,10 @@ class Claude(Agent):
         return 0
 
     def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
-        return "session_id" in hook_payload and "claude" in hook_payload.get(
-            "transcript_path", ""
+        # transcript_path may be present but null (Codex sends it as a nullable
+        # required field), so `or ""` guards against a None slipping through.
+        return "session_id" in hook_payload and "claude" in (
+            hook_payload.get("transcript_path") or ""
         )
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -76,7 +76,7 @@ class Codex(Agent):
     def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
         return (
             "turn_id" in hook_payload
-            or ".codex" in hook_payload.get("transcript_path", "").lower()
+            or ".codex" in (hook_payload.get("transcript_path") or "").lower()
         )
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -94,7 +94,9 @@ class VSCode(Agent):
         return 0
 
     def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
-        return "github.copilot-chat" in hook_payload.get("transcript_path", "").lower()
+        return (
+            "github.copilot-chat" in (hook_payload.get("transcript_path") or "").lower()
+        )
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return (

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -199,7 +199,7 @@ def emit_fail_open_response(stdin_content: str, error: Exception) -> int:
     ui.display_warning(warning)
     try:
         payload = parse_hook_input(stdin_content)[-1]
-    except ValueError:
+    except Exception:
         # We can't even tell which agent is calling us, so we can't emit a
         # well-formed response. Agents treat exit 1 as a non-blocking error.
         return 1

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -938,6 +938,25 @@ class TestAIHookScannerParseInput:
         assert payload.content == "whoami"
         assert isinstance(payload.agent, Codex)
 
+    def test_codex_pre_tool_use_null_transcript_path(self):
+        """Codex sends transcript_path as a present-but-null field; detection
+        must fall back to turn_id instead of crashing on the None."""
+        data = {
+            "session_id": "273ad859-3608-4799-9971-fa15ecb1a65c",
+            "transcript_path": None,
+            "cwd": "/home/user/project",
+            "hook_event_name": "PreToolUse",
+            "turn_id": "turn_123",
+            "model": "gpt-5.4",
+            "tool_name": "Bash",
+            "tool_input": {"command": "whoami"},
+            "tool_use_id": "call_123",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.BASH
+        assert isinstance(payload.agent, Codex)
+
     def test_pre_tool_use_read_with_missing_file(self):
         """PRE_TOOL_USE with tool_name 'read' and non-existing file yields empty content."""
         content = json.dumps(


### PR DESCRIPTION
## Context

`ggshield machine setup` installs the AI secret-scanning hooks into Codex, but every `PreToolUse`/`PostToolUse` hook failed under Codex with `hook exited with code 1`, while the same hooks worked in Claude Code.

## Root cause

Codex 0.144.x sends `transcript_path` as a **present-but-null** required field in its hook JSON payload. The agent detectors read it with `.get("transcript_path", "")`, which returns `None` (not the `""` default) when the key exists with a null value, so `"claude" in None` raised a `TypeError`.

`Claude` is probed first in the detection loop, so it crashed on every Codex payload before Codex's own `turn_id`-based detector could claim it. The `TypeError` also bypassed the fail-open safety net (which only caught `ValueError`), surfacing as exit 1 with a traceback instead of failing open. Claude Code was unaffected because it always sends a real `transcript_path` string.

This is pure-Python `None` handling with no OS dependency: it reproduces identically on Linux, macOS and Windows whenever Codex sends a null `transcript_path`.

## Fix

- Guard the null in the `Claude`, `Codex` and `VSCode` `is_caller` detectors (`hook_payload.get("transcript_path") or ""`).
- Broaden `emit_fail_open_response` to catch `Exception` instead of only `ValueError`, so any detection-time error fails open rather than breaking the agent.

## Tests

- New `test_codex_pre_tool_use_null_transcript_path` asserts a null-`transcript_path` Codex payload is detected as `Codex` without crashing. Verified it fails with the exact `TypeError` before the fix and passes after.
- Full `tests/unit/verticals/ai/` suite: 396 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)