### PR TITLE
perf(plugin): defer sigstore imports off the startup path

### DIFF
--- a/ggshield/core/plugin/signature.py
+++ b/ggshield/core/plugin/signature.py
@@ -18,20 +18,25 @@ Verification modes (these decide how a result is handled, not how it is computed
 - DISABLED: skip verification entirely
 """
 
+from __future__ import annotations
+
 import enum
 import functools
 import logging
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
-
-from sigstore.errors import VerificationError
-from sigstore.models import Bundle, TrustedRoot
-from sigstore.verify import Verifier
-from sigstore.verify.policy import AllOf, GitHubWorkflowRepository, OIDCIssuer
+from typing import TYPE_CHECKING, List, Optional
 
 from ggshield.core.plugin._sigstore_trusted_root import TRUSTED_ROOT_JSON
+
+
+if TYPE_CHECKING:
+    # Imported lazily at call time (see _bundled_verifier / verify_wheel_signature)
+    # so that merely importing this module -- e.g. for SignatureVerificationMode,
+    # used when constructing PluginLoader on every ggshield invocation -- does not
+    # drag in the whole sigstore/pydantic/rekor stack (~500ms of imports).
+    from sigstore.verify import Verifier
 
 
 logger = logging.getLogger(__name__)
@@ -127,6 +132,9 @@ def _bundled_verifier() -> Verifier:
     ``TrustedRoot.from_file`` is sigstore's only public constructor, so the
     embedded JSON is materialised to a temp file to load it.
     """
+    from sigstore.models import TrustedRoot
+    from sigstore.verify import Verifier
+
     with tempfile.TemporaryDirectory() as tmp_dir:
         trusted_root_path = Path(tmp_dir) / "trusted_root.json"
         trusted_root_path.write_text(TRUSTED_ROOT_JSON)
@@ -170,6 +178,10 @@ def verify_wheel_signature(
             raise SignatureVerificationError(SignatureStatus.MISSING, msg)
         logger.warning("%s", msg)
         return SignatureInfo(status=SignatureStatus.MISSING, message=msg)
+
+    from sigstore.errors import VerificationError
+    from sigstore.models import Bundle
+    from sigstore.verify.policy import AllOf, GitHubWorkflowRepository, OIDCIssuer
 
     bundle = Bundle.from_json(bundle_path.read_bytes())
     wheel_bytes = wheel_path.read_bytes()

--- a/tests/unit/core/plugin/test_signature.py
+++ b/tests/unit/core/plugin/test_signature.py
@@ -118,12 +118,12 @@ class TestVerifierIsPinnedToBundledRoot:
                 "ggshield.core.plugin.signature._bundled_verifier",
                 return_value=mock_verifier,
             ) as mock_bundled,
-            patch("ggshield.core.plugin.signature.Verifier", mock_verifier_cls),
-            patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
-            patch("ggshield.core.plugin.signature.AllOf", MagicMock()),
-            patch("ggshield.core.plugin.signature.OIDCIssuer", MagicMock()),
+            patch("sigstore.verify.Verifier", mock_verifier_cls),
+            patch("sigstore.models.Bundle", mock_bundle_cls),
+            patch("sigstore.verify.policy.AllOf", MagicMock()),
+            patch("sigstore.verify.policy.OIDCIssuer", MagicMock()),
             patch(
-                "ggshield.core.plugin.signature.GitHubWorkflowRepository",
+                "sigstore.verify.policy.GitHubWorkflowRepository",
                 MagicMock(),
             ),
         ):
@@ -165,18 +165,18 @@ class TestBundleVerification:
         """Patch the sigstore seams: the bundled/pinned verifier plus the
         bundle and policy helpers used by the signature module."""
         with (
-            patch("ggshield.core.plugin.signature.Bundle", mock_bundle_cls),
+            patch("sigstore.models.Bundle", mock_bundle_cls),
             patch(
                 "ggshield.core.plugin.signature._bundled_verifier",
                 return_value=mock_verifier,
             ),
-            patch("ggshield.core.plugin.signature.AllOf", mock_all_of_cls),
+            patch("sigstore.verify.policy.AllOf", mock_all_of_cls),
             patch(
-                "ggshield.core.plugin.signature.OIDCIssuer",
+                "sigstore.verify.policy.OIDCIssuer",
                 mock_oidc_issuer_cls,
             ),
             patch(
-                "ggshield.core.plugin.signature.GitHubWorkflowRepository",
+                "sigstore.verify.policy.GitHubWorkflowRepository",
                 mock_gh_repo_cls,
             ),
         ):
@@ -325,7 +325,7 @@ class TestBundledVerifier:
         _bundled_verifier.cache_clear()
         sentinel = MagicMock()
         try:
-            with patch("ggshield.core.plugin.signature.Verifier") as mock_verifier_cls:
+            with patch("sigstore.verify.Verifier") as mock_verifier_cls:
                 mock_verifier_cls.return_value = sentinel
                 result = _bundled_verifier()
         finally:


### PR DESCRIPTION
`plugin/signature.py` imported the whole sigstore/pydantic/rekor stack (~100ms or more) at module load. Because the plugin loader imports it and plugin registration runs on every invocation, every command paid that cost, though signature verification only runs when loading a local-wheel plugin.

This moves the sigstore imports into the two functions that use them (`_bundled_verifier`, `verify_wheel_signature`), so importing the module (for the signature enums used when constructing `PluginLoader`) no longer drags sigstore onto the startup path.

**Impact (frozen binary, on a test machine):**
- `ggshield --version`: ~800ms → ~560ms
- `secret scan ai-hook` (AI hooks path): ~875ms → ~630ms

Tests that patched the sigstore names on the signature module now patch them at their sigstore source, since the imports are function-local.