### PR TITLE
fix(ai-hooks): use native osascript for macOS secret notifications

### DIFF
--- a/changelog.d/20260722_000000_achille.mascia_fix_ai_hook_macos_notification.md
+++ b/changelog.d/20260722_000000_achille.mascia_fix_ai_hook_macos_notification.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- AI hook desktop notifications no longer crash the hook on macOS. The
+  notification is now delivered through native `osascript` on macOS, so it
+  works on Homebrew installs (which strip notifypy's bundled notifier) and on
+  Apple Silicon (notifypy's bundled applet is Intel-only and Apple-deprecated).
+  The whole notification step is also fully guarded, so a notifier failure can
+  never prevent the `PostToolUse` block decision from being emitted.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -1,6 +1,8 @@
 import hashlib
 import json
 import re
+import subprocess
+import sys
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Sequence, Set
 
@@ -298,6 +300,47 @@ def _parse_command(
     return payloads
 
 
+def _send_desktop_notification(title: str, message: str) -> None:
+    """Deliver a desktop notification, dispatching to the right backend per OS.
+
+    On macOS we shell out to the native ``osascript``: it ships with every
+    macOS (so it works on Homebrew installs, which strip notifypy's bundled
+    Notificator.app), is arm64-native (notifypy's applet is Intel-only and
+    Apple-deprecated) and produces a normal Notification Center banner. The
+    strings are passed as run-handler arguments rather than interpolated into
+    the AppleScript source: this is injection-safe (the message embeds
+    attacker-influenced command text) and correctness-safe, as an AppleScript
+    string literal can't represent non-ASCII or control characters (accented
+    paths, emoji, tabs...). ``stdin`` is detached and a timeout enforced so a
+    misbehaving notifier can't stall the hook. Other platforms use notifypy.
+    """
+    if sys.platform == "darwin":
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                "on run argv",
+                "-e",
+                "display notification (item 1 of argv) with title (item 2 of argv)",
+                "-e",
+                "end run",
+                "--",
+                message,
+                title,
+            ],
+            check=False,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=10,
+        )
+    else:
+        notification = Notify()
+        notification.title = title
+        notification.message = message
+        notification.application_name = "ggshield"
+        notification.send()
+
+
 class AIHookScanner:
     """AI hook scanner.
 
@@ -450,32 +493,36 @@ class AIHookScanner:
         result: HookResult,
     ) -> None:
         """
-        Send desktop notification when secrets are detected.
+        Send a best-effort desktop notification when secrets are detected.
+
+        This runs on the security-critical PostToolUse path (the secret has
+        already leaked to the agent), so it must NEVER crash the hook: the
+        whole body is guarded and any failure is swallowed, letting the block
+        decision still be emitted.
 
         Args:
-            nbr_secrets: Number of detected secrets
-            tool: Tool used to detect the secrets
-            agent_name: Name of the agent that detected the secrets
+            result: The blocking scan result.
         """
-        tool = result.payload.tool
-        source = "using a tool"
-        if tool == Tool.READ:
-            source = "reading a file"
-        elif tool == Tool.BASH:
-            # This should always be present, unless agents changed their payload in an update.
-            command = result.payload.raw.get("tool_input", {}).get("command", "")
-            source = (
-                f"running the command `{command}`" if command else "running a command"
-            )
-        notification = Notify()
-        notification.title = "ggshield - Secrets Detected"
-        notification.message = (
-            f"{result.payload.agent.display_name} got access to {result.nbr_secrets}"
-            f" {pluralize('secret', result.nbr_secrets)} by {source}"
-        )
-        notification.application_name = "ggshield"
         try:
-            notification.send()
+            tool = result.payload.tool
+            source = "using a tool"
+            if tool == Tool.READ:
+                source = "reading a file"
+            elif tool == Tool.BASH:
+                # This should always be present, unless agents changed their
+                # payload in an update.
+                command = result.payload.raw.get("tool_input", {}).get("command", "")
+                source = (
+                    f"running the command `{command}`"
+                    if command
+                    else "running a command"
+                )
+            title = "ggshield - Secrets Detected"
+            message = (
+                f"{result.payload.agent.display_name} got access to {result.nbr_secrets}"
+                f" {pluralize('secret', result.nbr_secrets)} by {source}"
+            )
+            _send_desktop_notification(title, message)
         except Exception:
             # This is best effort, we don't want to propagate an error
             # if the notification fails.

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from collections import Counter
 from pathlib import Path
 from typing import List, Set
@@ -200,6 +201,29 @@ class TestAIHookScannerScan:
         result = mock_notify.call_args[0][0]
         assert result.nbr_secrets == 1  # nbr_secrets
         assert result.payload.tool == Tool.BASH  # tool
+
+    @patch("ggshield.verticals.ai.hooks._send_desktop_notification")
+    def test_scan_post_tool_use_notifier_failure_still_emits_block(
+        self, mock_send: MagicMock
+    ):
+        """GIVEN a PostToolUse leak whose desktop notifier backend crashes
+        (e.g. BinaryNotFound on a Homebrew install)
+        WHEN scan() runs
+        THEN the notifier failure is swallowed and scan() still returns the
+        normal block exit code instead of crashing the hook (NHI-1681)."""
+        mock_send.side_effect = Exception("BinaryNotFound")
+        scanner = AIHookScanner(_mock_scanner(["sk-xxx"]))
+        data = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo sk-xxx"},
+            "tool_response": {"stdout": "sk-xxx\n"},
+            "transcript_path": "/home/user/.claude/projects/foo/session.jsonl",
+            "session_id": "427ae0c5-0862-4e14-aa2c-12fad909c323",
+        }
+        # Must not raise, and must still reach output_result() (exit 0 for Claude).
+        assert scanner.scan(json.dumps(data)) == 0
+        mock_send.assert_called_once()
 
     def test_scan_pre_tool_use_with_secrets_blocks(self):
         """scan() on PRE_TOOL_USE with secrets returns block result."""
@@ -421,33 +445,100 @@ class TestSendSecretNotification:
             ),
         )
 
-    @patch("ggshield.verticals.ai.hooks.Notify")
-    def test_notification_for_bash_tool(self, mock_notify_cls: MagicMock):
-        """Notification for BASH tool says 'running the command'
-        and contains the command run."""
+    @patch("ggshield.verticals.ai.hooks._send_desktop_notification")
+    def test_notification_for_bash_tool(self, mock_send: MagicMock):
+        """GIVEN a BASH-tool result
+        WHEN a notification is sent
+        THEN the message says 'running the command' with the command run."""
         AIHookScanner._send_secret_notification(
             self._result(1, Tool.BASH, Claude(), input_command="ls -la")
         )
-        instance = mock_notify_cls.return_value
-        assert "running the command `ls -la`" in instance.message
-        assert "Claude Code" in instance.message
-        instance.send.assert_called_once()
+        title, message = mock_send.call_args.args
+        assert title == "ggshield - Secrets Detected"
+        assert "running the command `ls -la`" in message
+        assert "Claude Code" in message
 
-    @patch("ggshield.verticals.ai.hooks.Notify")
-    def test_notification_for_read_tool(self, mock_notify_cls: MagicMock):
-        """Notification for READ tool says 'reading a file'."""
+    @patch("ggshield.verticals.ai.hooks._send_desktop_notification")
+    def test_notification_for_read_tool(self, mock_send: MagicMock):
+        """GIVEN a READ-tool result
+        WHEN a notification is sent
+        THEN the message says 'reading a file'."""
         AIHookScanner._send_secret_notification(self._result(2, Tool.READ, Cursor()))
-        instance = mock_notify_cls.return_value
-        assert "reading a file" in instance.message
-        assert "2" in instance.message
-        instance.send.assert_called_once()
+        _, message = mock_send.call_args.args
+        assert "reading a file" in message
+        assert "2" in message
+
+    @patch("ggshield.verticals.ai.hooks._send_desktop_notification")
+    def test_notification_for_other_tool(self, mock_send: MagicMock):
+        """GIVEN an OTHER-tool result
+        WHEN a notification is sent
+        THEN the message says 'using a tool'."""
+        AIHookScanner._send_secret_notification(self._result(1, Tool.OTHER, Copilot()))
+        _, message = mock_send.call_args.args
+        assert "using a tool" in message
+
+    @patch("ggshield.verticals.ai.hooks._send_desktop_notification")
+    def test_notification_failure_never_propagates(self, mock_send: MagicMock):
+        """GIVEN a notifier backend that raises (e.g. missing binary on brew)
+        WHEN a notification is sent
+        THEN the exception is swallowed so the hook can still emit its block."""
+        mock_send.side_effect = Exception("BinaryNotFound")
+        # Must not raise.
+        AIHookScanner._send_secret_notification(self._result(1, Tool.BASH, Claude()))
+
+
+class TestSendDesktopNotification:
+    """Unit tests for the per-OS desktop notification backends."""
+
+    @patch("ggshield.verticals.ai.hooks.subprocess.run")
+    @patch("ggshield.verticals.ai.hooks.sys")
+    def test_macos_uses_native_osascript(
+        self, mock_sys: MagicMock, mock_run: MagicMock
+    ):
+        """GIVEN a macOS host
+        WHEN a desktop notification is sent
+        THEN it invokes osascript, passing the (attacker-influenced) message
+        and title as run-handler arguments rather than interpolating them into
+        the AppleScript source (injection- and unicode-safe)."""
+        mock_sys.platform = "darwin"
+        from ggshield.verticals.ai.hooks import _send_desktop_notification
+
+        # Message with a quote, an accent, an emoji and a tab: none of these
+        # can be represented in an AppleScript string literal, so they must be
+        # passed as arguments, not baked into the script.
+        message = 'ran `café` ❤\ttell app "Finder"'
+        _send_desktop_notification("ggshield - Secrets Detected", message)
+
+        args = mock_run.call_args.args[0]
+        assert args[0] == "osascript"
+        # Uses a run handler reading from argv; the raw strings are the trailing
+        # argv items, never embedded in any "-e" script fragment.
+        assert "on run argv" in args
+        assert message == args[-2]
+        assert "ggshield - Secrets Detected" == args[-1]
+        script_fragments = [args[i + 1] for i, a in enumerate(args) if a == "-e"]
+        assert not any(message in frag for frag in script_fragments)
+        # A hook must never hang or read stdin from a notifier subprocess.
+        assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+        assert mock_run.call_args.kwargs["timeout"] == 10
 
     @patch("ggshield.verticals.ai.hooks.Notify")
-    def test_notification_for_other_tool(self, mock_notify_cls: MagicMock):
-        """Notification for OTHER tool says 'using a tool'."""
-        AIHookScanner._send_secret_notification(self._result(1, Tool.OTHER, Copilot()))
+    @patch("ggshield.verticals.ai.hooks.sys")
+    def test_non_macos_uses_notifypy(
+        self, mock_sys: MagicMock, mock_notify_cls: MagicMock
+    ):
+        """GIVEN a non-macOS host
+        WHEN a desktop notification is sent
+        THEN it uses the notifypy backend."""
+        mock_sys.platform = "linux"
+        from ggshield.verticals.ai.hooks import _send_desktop_notification
+
+        _send_desktop_notification("title", "message")
+
         instance = mock_notify_cls.return_value
-        assert "using a tool" in instance.message
+        assert instance.title == "title"
+        assert instance.message == "message"
+        assert instance.application_name == "ggshield"
         instance.send.assert_called_once()
 
 


### PR DESCRIPTION
Fixes [NHI-1681](https://linear.app/gitguardian/issue/NHI-1681).

On macOS the AI hook's PostToolUse notification crashed the **whole hook**, so the "Secrets detected" block was never emitted. notifypy's bundled notifier is stripped on Homebrew and Intel-only on Apple Silicon, and the `Notify()` constructor wasn't guarded.

**Changes:**
- Guard the entire notification step so a notifier failure can never crash the hook.
- Deliver via native `osascript` on macOS (no bundled binary, arm64-native, injection/unicode-safe argv, timeout-bounded). Keep notifypy for Linux/Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)