### PR TITLE
test(scan-pypi): expect leaks in tensorflow func test

### DIFF
--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -16,11 +16,6 @@ pytestmark = pytest.mark.uses_gitguardian_api
         # tensorflow 2.5.0 requires Python <3.9, which no supported interpreter
         # satisfies. It must still download and scan: this guards #458, where
         # `pip download` refused packages incompatible with the running interpreter.
-        # It also ships a secret the backend flags (a CFTOKEN in
-        # python/training/ftrl.py), so a successful scan returns 1 (leaks found).
-        # A download/resolution failure would instead raise UnexpectedError with a
-        # different exit code, so `1` here proves the package was downloaded and
-        # scanned end-to-end.
         ("tensorflow==2.5.0", 1),
     ),
 )

--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -14,9 +14,14 @@ pytestmark = pytest.mark.uses_gitguardian_api
         ("ggshield==1.14.2", 1),  # ggshield 1.14.2 contains some test secrets
         ("marshmallow", 0),
         # tensorflow 2.5.0 requires Python <3.9, which no supported interpreter
-        # satisfies. It must still download and scan clean: this guards #458, where
+        # satisfies. It must still download and scan: this guards #458, where
         # `pip download` refused packages incompatible with the running interpreter.
-        ("tensorflow==2.5.0", 0),
+        # It also ships a secret the backend flags (a CFTOKEN in
+        # python/training/ftrl.py), so a successful scan returns 1 (leaks found).
+        # A download/resolution failure would instead raise UnexpectedError with a
+        # different exit code, so `1` here proves the package was downloaded and
+        # scanned end-to-end.
+        ("tensorflow==2.5.0", 1),
     ),
 )
 def test_scan_pypi(tmp_path: Path, package: str, expected_code: int) -> None:


### PR DESCRIPTION
Follow-up of #1346: tensorflow 2.5.0 ships a backend-flagged secret, so the pypi func test must expect exit 1 (leaks found), not 0. Still guards #458 — a download failure returns a different exit code.

Fixes the red run: https://github.com/GitGuardian/ggshield/actions/runs/30261888530/job/89963470856

🤖 Generated with [Claude Code](https://claude.com/claude-code)