### PR TITLE
ci: add explicit GITHUB_TOKEN permission scopes to workflows

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -17,6 +17,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.10'
@@ -24,6 +26,8 @@ env:
 jobs:
   build_wheel_sdist:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +52,8 @@ jobs:
   build_os_packages:
     name: Build packages
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,6 +13,8 @@ on:
       - 'labeled'
       - 'unlabeled'
 
+permissions: {}
+
 jobs:
   check-changelog:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
       - 'doc/**'
       - 'README.md'
 
+permissions: {}
+
 env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.9'
@@ -25,6 +27,8 @@ jobs:
   lint:
     name: Lint package
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,6 +79,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -139,6 +145,8 @@ jobs:
     # See note about steps requiring the GITGUARDIAN_API at the top of this file
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -169,6 +177,8 @@ jobs:
           TEST_UNKNOWN_SECRET: ${{ secrets.TEST_UNKNOWN_SECRET }}
 
   build_os_packages:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build_release_assets.yml
     secrets: inherit
 
@@ -177,6 +187,8 @@ jobs:
     # See note about steps requiring the GITGUARDIAN_API at the top of this file
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,6 +207,9 @@ jobs:
     name: Push Docker image to Docker Hub and GitHub Packages
     runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
     needs:
       - lint
       - build

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -16,10 +16,14 @@ on:
       - 'scripts/install/**'
       - '.github/workflows/install-scripts.yml'
 
+permissions: {}
+
 jobs:
   bats:
     name: bats (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -10,6 +10,8 @@ on:
         description: 'Python version to use (use https://github.com/actions/setup-python#supported-version-syntax)'
         default: '3.10'
 
+permissions: {}
+
 env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.10'
@@ -19,6 +21,8 @@ jobs:
     name: Run performance benchmark
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       PYTHONUNBUFFERED: 1
       # How many times to repeat each run

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -5,8 +5,12 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   build_release_assets:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build_release_assets.yml
     secrets: inherit
     with:
@@ -16,6 +20,8 @@ jobs:
     needs: build_release_assets
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -113,6 +119,9 @@ jobs:
     name: Push Docker image to Docker Hub and GitHub Packages
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Docker meta
         id: meta
@@ -157,6 +166,8 @@ jobs:
     needs: build_release_assets
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -182,6 +193,8 @@ jobs:
     name: Push to Chocolatey
     runs-on: windows-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -14,6 +14,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   update-ggshield-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1350.

No workflow declared a `permissions:` block, so every job ran with the repository's default `GITHUB_TOKEN` scopes. Depending on repository and organisation settings, those defaults can include write access to contents, packages and pull requests — considerably more than any of these jobs needs.

I went through every workflow under `.github/workflows/`, not just the two named in the issue. Each one now denies everything at the top level (`permissions: {}`) and grants the minimum back per job.

### What each job got, and why

| Workflow | Job | Scopes | Reason |
|---|---|---|---|
| `build_release_assets.yml` | `build_wheel_sdist`, `build_os_packages` | `contents: read` | checkout |
| | `linux_package_smoke_tests` | none | only consumes artifacts from its own run |
| `changelog-check.yml` | `check-changelog` | none | the action takes no token input and works anonymously on public repos |
| `ci.yml` | `lint`, `build`, `functest_api`, `test_github_secret_scan_action` | `contents: read` | checkout; Codecov and GitGuardian use their own credentials |
| | `build_os_packages` | `contents: read` | passed through to the reusable workflow |
| | `push_docker_images-unstable` | `contents: read`, `packages: write` | GHCR publishing; Docker Hub uses separate credentials |
| `install-scripts.yml` | `bats` | `contents: read` | checkout, plus authenticated public release API reads |
| `perfbench.yml` | `benchmark` | `contents: read` | checkout with full history |
| `tag.yml` | `release` | `contents: write`, `id-token: write`, `attestations: write` | **unchanged** — creates the release, uploads assets, writes provenance |
| | `push_to_pypi`, `push_to_cloudsmith`, `push_to_chocolatey` | `contents: read` | checkout; each publishes with its own API key |
| | `push_docker_images` | `contents: read`, `packages: write` | GHCR publishing |
| `update-downstream.yml` | `update-ggshield-version` | none | checkout, push and PR creation all use `PAT_GITHUB` |

### Two things worth flagging

- `tag.yml` references `./.github/workflows/update_vscode_extension.yml`, but that file isn't present in the repository. I left that job's permissions untouched (it inherits the empty default) since I can't see what it needs — happy to adjust if you can tell me.
- Workflow changes in a fork PR aren't executed by CI (`pull_request` runs use the base branch's workflow files), so this can't be validated by the checks on this PR. I verified statically that all seven files parse and that the resulting permission tree is what's described above. You may want to confirm on a branch in the main repo before merging.

If you'd rather have a single workflow-level `contents: read` instead of `permissions: {}` plus per-job grants, say the word and I'll rework it.

---
Prepared with AI assistance; I reviewed every line and verified the YAML parses and resolves to the permission tree documented above.