### PR TITLE
test(api-status): stop pinning workspace id and scopes to recorded values

### DIFF
--- a/tests/unit/cmd/test_status.py
+++ b/tests/unit/cmd/test_status.py
@@ -1,4 +1,5 @@
 import json
+import re
 from unittest import mock
 
 import jsonschema
@@ -6,7 +7,7 @@ import pytest
 import requests.exceptions
 from pygitguardian.models import APITokensResponse, Detail, HealthCheckResponse
 from pytest_voluptuous import S
-from voluptuous.validators import All, In, Match
+from voluptuous.validators import All, Contains, In, Match
 
 from ggshield.__main__ import cli
 from ggshield.core.config.config import ConfigSource
@@ -49,8 +50,12 @@ def test_api_status(cli_fs_runner, api_status_json_schema):
                     "secrets_engine_version": Match(r"\d\.\d{1,3}\.\d"),
                     "instance_source": In(x.name for x in ConfigSource),
                     "api_key_source": In(x.name for x in ConfigSource),
-                    "token_scopes": ["scan"],
-                    "workspace_id": 1,
+                    # Neither is pinned to the recorded value: the release
+                    # process re-records the cassettes, so both depend on the
+                    # releaser's token. Its scopes are a superset of "scan":
+                    # the honeytoken tests need `honeytokens:write` to record.
+                    "token_scopes": All([str], Contains("scan")),
+                    "workspace_id": int,
                 }
             )
         )
@@ -210,7 +215,7 @@ def test_api_status_shows_workspace_id(cli_fs_runner):
     with my_vcr.use_cassette("test_health_check"):
         result = cli_fs_runner.invoke(cli, ["api-status"], color=False)
     assert_invoke_ok(result)
-    assert "Workspace ID: 1" in result.output
+    assert re.search(r"^Workspace ID: \d+$", result.output, re.MULTILINE)
 
     lines = result.output.splitlines()
     api_url_index = next(


### PR DESCRIPTION
## Problem

`scripts/release run-tests` deletes every cassette and re-records it against production, so `workspace_id` and `token_scopes` in `api-status` output hold the values of the releaser's own token. Two assertions in `test_status.py` pinned them to the values in the committed cassette, which no real token can reproduce:

- `workspace_id == 1` — workspace 1 only exists in a hand-written cassette entry (added in 331dd3ba, with `"name":"test-token"` and `created_at` 2023-01-01, and none of the fields the live API actually returns). The repo's genuine recordings are from workspace 8.
- `token_scopes == ["scan"]` exactly — impossible in a re-record run, because the honeytoken tests need a token carrying `honeytokens:write`. The two requirements are mutually exclusive, so **no single token could make `run-tests` pass**.

The tests never failed in CI because CI replays the committed cassette; they only break in the release flow, which is the one place they were meant to check reality.

## Fix

Assert the shape instead of the recorded value: `workspace_id` is an int, `token_scopes` is a list of strings containing `scan`, and the text output matches `Workspace ID: \d+`. Any releaser's token now works.

## Test plan

- `pytest tests/unit/cmd/test_status.py` on the committed cassette: 13 passed.
- Replaying a cassette carrying a real workspace-8 / 9-scope `api_tokens/self` response: fails on `main` with exactly the two assertions above, passes with this change.