### PR TITLE
ci: point tag workflow at the renamed downstream workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -102,9 +102,9 @@ jobs:
             dist/ggshield-*.gz \
             dist/ggshield-*.msi
 
-  update_vscode_extension:
+  update_downstream:
     needs: release
-    uses: ./.github/workflows/update_vscode_extension.yml
+    uses: ./.github/workflows/update-downstream.yml
     secrets: inherit
     with:
       version: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
## Problem

Pushing `v1.53.0` failed with:

```
Invalid workflow file: .github/workflows/tag.yml#L107
error parsing called workflow ".github/workflows/tag.yml"
  -> "./.github/workflows/update_vscode_extension.yml" : failed to fetch workflow: workflow was not found.
```

#1362 renamed `update_vscode_extension.yml` to `update-downstream.yml` in a single-file commit and did not update its caller in `tag.yml:107`.

GitHub rejects the **entire** workflow file when a reusable-workflow reference cannot be resolved, so the tag push ran **no jobs at all** — no release assets were built and no draft release was created. This blocks the 1.53.0 release.

## Fix

Point the caller at the renamed file. The renamed workflow keeps the same `workflow_call` input (`version`, required string), so only the path changed; the job is renamed from `update_vscode_extension` to `update_downstream` to match, since it now also updates the Azure DevOps extension.

`build_release_assets.yml` is the only other local reusable-workflow reference in `tag.yml` and it resolves correctly.

## Note for the releaser

The `v1.53.0` tag currently points at `b5831731`, which still contains the broken reference. Re-running the release requires moving the tag onto a commit that includes this fix.