### PR TITLE
feat(ai): add Mistral Vibe hooks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ To catch errors earlier, use `ggshield` as a [pre-commit, pre-push or pre-receiv
 
 You can install the hooks with the `ggshield install` command.
 
-Supported tools: **Cursor**, **Claude Code**, **Copilot Chat**, and **Codex**.
+Supported tools: **Cursor**, **Claude Code**, **Copilot Chat**, **Codex**, and
+**Mistral Vibe 2.21+**.
 
 # Learn more
 

--- a/changelog.d/20260729_000000_nathan.riviere_vibe_hooks.md
+++ b/changelog.d/20260729_000000_nathan.riviere_vibe_hooks.md
@@ -1,0 +1,5 @@
+### Added
+
+- Add secret-scanning hook support for Mistral Vibe 2.21 and later. Global and
+  project installation preserves existing `hooks.toml` content and configures
+  Vibe's `pre_tool` and `post_tool` events.

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -9,9 +9,11 @@ from .vibe import Vibe
 from .vscode import VSCode
 
 
+# Order matters: _detect_agent takes the first agent whose is_caller matches, so
+# exact matchers come before Claude's "claude" in transcript_path substring check.
 AGENTS: Dict[str, Agent] = {
     agent.name: agent
-    for agent in [Claude(), Codex(), Copilot(), Cursor(), Vibe(), VSCode()]
+    for agent in [Vibe(), Claude(), Codex(), Copilot(), Cursor(), VSCode()]
 }
 
 

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -5,12 +5,14 @@ from .claude_code import Claude
 from .codex import Codex
 from .copilot import Copilot
 from .cursor import Cursor
+from .vibe import Vibe
 from .vscode import VSCode
 
 
 AGENTS: Dict[str, Agent] = {
-    agent.name: agent for agent in [Claude(), Codex(), Copilot(), Cursor(), VSCode()]
+    agent.name: agent
+    for agent in [Claude(), Codex(), Copilot(), Cursor(), Vibe(), VSCode()]
 }
 
 
-__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "VSCode"]
+__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "Vibe", "VSCode"]

--- a/ggshield/verticals/ai/agents/vibe.py
+++ b/ggshield/verticals/ai/agents/vibe.py
@@ -1,0 +1,234 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterator, Literal, Optional, Tuple
+
+import click
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
+
+from ggshield.core.dirs import get_user_home_dir
+
+from ..models import (
+    Agent,
+    HookPayload,
+    HookResult,
+    MCPConfiguration,
+    Scope,
+    Tool,
+    Transport,
+)
+
+
+class Vibe(Agent):
+    """Behavior specific to the Mistral Vibe CLI."""
+
+    @property
+    def name(self) -> str:
+        return "vibe"
+
+    @property
+    def display_name(self) -> str:
+        return "Mistral Vibe"
+
+    @property
+    def config_folder(self) -> Path:
+        if custom_home := os.getenv("VIBE_HOME"):
+            return Path(custom_home).expanduser()
+        return get_user_home_dir() / ".vibe"
+
+    def output_result(self, result: HookResult) -> int:
+        response: Dict[str, Any] = {}
+        if result.block:
+            response["decision"] = "deny"
+            response["reason"] = result.message
+        elif result.warning:
+            response["system_message"] = result.warning
+
+        # Vibe's documented passthrough response is empty stdout.
+        if response:
+            click.echo(json.dumps(response))
+        return 0
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        return hook_payload.get("hook_event_name") in {
+            "pre_tool",
+            "post_tool",
+            "post_agent",
+        }
+
+    def settings_path(self, mode: Literal["local", "global"]) -> Path:
+        if mode == "global":
+            return self.config_folder / "hooks.toml"
+        return Path(".vibe") / "hooks.toml"
+
+    @property
+    def settings_format(self) -> Literal["json", "toml"]:
+        return "toml"
+
+    @property
+    def settings_template(self) -> Dict[str, Any]:
+        command = "<COMMAND>"
+        return {
+            "hooks": [
+                {
+                    "name": "ggshield-pre-tool",
+                    "type": "pre_tool",
+                    "match": "*",
+                    "command": command,
+                    "strict": False,
+                    "description": "Scan tool inputs for secrets before execution.",
+                },
+                {
+                    "name": "ggshield-post-tool",
+                    "type": "post_tool",
+                    "match": "*",
+                    "command": command,
+                    "strict": False,
+                    "description": "Scan tool outputs for secrets after execution.",
+                },
+            ]
+        }
+
+    def settings_locate(
+        self, candidates: list[Dict[str, Any]], template: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        name = template.get("name")
+        return next(
+            (candidate for candidate in candidates if candidate.get("name") == name),
+            None,
+        )
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".vibe" / "config.toml"
+
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "config.toml"
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        data = self._load_file(self.config_folder / "trusted_folders.toml")
+        if not data:
+            return
+        for folder in data.get("trusted", []):
+            if isinstance(folder, str):
+                path = Path(folder).expanduser()
+                if path.is_dir():
+                    yield path.resolve()
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        data = self._load_file(self.user_mcp_file)
+        if data:
+            yield from self._parse_vibe_mcp_servers(data, Scope.USER, None)
+
+    def _get_project_mcp_configurations(
+        self, directory: Path
+    ) -> Iterator[MCPConfiguration]:
+        data = self._load_file(self.project_mcp_file(directory))
+        if data:
+            yield from self._parse_vibe_mcp_servers(data, Scope.PROJECT, directory)
+
+    def _parse_vibe_mcp_servers(
+        self, data: Dict[str, Any], scope: Scope, project: Optional[Path]
+    ) -> Iterator[MCPConfiguration]:
+        servers = data.get("mcp_servers", [])
+        if not isinstance(servers, list):
+            return
+        for entry in servers:
+            if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+                continue
+
+            transport_name = entry.get("transport", "stdio")
+            if transport_name == "sse":
+                transport = Transport.SSE
+            elif "url" in entry:
+                transport = Transport.HTTP
+            else:
+                transport = Transport.STDIO
+
+            auth = entry.get("auth", {})
+            auth_headers = auth.get("headers", {}) if isinstance(auth, dict) else {}
+            headers = entry.get("headers", auth_headers)
+            if not isinstance(headers, dict):
+                headers = {}
+
+            yield MCPConfiguration(
+                name=entry["name"],
+                agent=self.name,
+                scope=scope,
+                transport=transport,
+                project=str(project) if project else None,
+                command=entry.get("command"),
+                args=entry.get("args", []),
+                env=entry.get("env", {}),
+                url=entry.get("url"),
+                headers=headers,
+            )
+
+    def post_process_payload(self, payload: HookPayload):
+        if payload.tool not in {Tool.MCP, Tool.OTHER}:
+            return
+        raw_tool_name = payload.raw.get("tool_name", "")
+        cwd = payload.raw.get("cwd", "")
+        if self._match_mcp_tool_name(raw_tool_name, cwd) is not None:
+            payload.tool = Tool.MCP
+        else:
+            # Vibe MCP tools use "{server}_{tool}", not an "mcp" prefix.
+            # Undo the generic prefix heuristic unless a configured server
+            # actually matches, so custom tools named "mcp_*" are not
+            # misreported as MCP activity.
+            payload.tool = Tool.OTHER
+
+    def _match_mcp_tool_name(
+        self, raw_tool_name: str, cwd: str
+    ) -> Optional[Tuple[str, str]]:
+        configurations = list(self._get_user_mcp_configurations())
+        if cwd:
+            configurations.extend(self._get_project_mcp_configurations(Path(cwd)))
+        names = sorted(
+            {configuration.name for configuration in configurations},
+            key=len,
+            reverse=True,
+        )
+        for name in names:
+            prefix = f"{name}_"
+            if raw_tool_name.startswith(prefix):
+                return name, raw_tool_name.removeprefix(prefix)
+        return None
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        raw_tool_name = payload.raw.get("tool_name", "")
+        configuration_name = ""
+        tool_name = raw_tool_name
+        server_name = ""
+
+        candidates = []
+        for server in ai_config.servers:
+            for configuration in server.configurations:
+                if configuration.agent != self.name:
+                    continue
+                prefix = f"{configuration.name}_"
+                if raw_tool_name.startswith(prefix):
+                    candidates.append(
+                        (len(configuration.name), configuration.name, server.name)
+                    )
+        if candidates:
+            _, configuration_name, server_name = max(candidates)
+            tool_name = raw_tool_name.removeprefix(f"{configuration_name}_")
+        elif matched := self._match_mcp_tool_name(
+            raw_tool_name, payload.raw.get("cwd", "")
+        ):
+            configuration_name, tool_name = matched
+            server_name = configuration_name
+
+        return MCPActivityRequest(
+            user=ai_config.user,
+            tool=tool_name,
+            server=server_name or configuration_name,
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
+        )

--- a/ggshield/verticals/ai/agents/vibe.py
+++ b/ggshield/verticals/ai/agents/vibe.py
@@ -65,6 +65,26 @@ class Vibe(Agent):
     def settings_format(self) -> Literal["json", "toml"]:
         return "toml"
 
+    def post_install_warning(self, mode: Literal["local", "global"]) -> Optional[str]:
+        # Vibe only loads a project's .vibe/hooks.toml once the folder is
+        # trusted, so a local install alone silently protects nothing.
+        if mode == "global":
+            return None
+        cwd = Path.cwd().resolve()
+        if any(cwd == trusted or trusted in cwd.parents for trusted in self._trusted()):
+            return None
+        return (
+            f"{self.display_name} only loads project hooks from trusted folders. "
+            f"Run 'vibe' once in {cwd} and accept the trust prompt, otherwise "
+            "these hooks will be ignored."
+        )
+
+    def _trusted(self) -> Iterator[Path]:
+        data = self._load_file(self.config_folder / "trusted_folders.toml") or {}
+        for folder in data.get("trusted", []):
+            if isinstance(folder, str):
+                yield Path(folder).expanduser().resolve()
+
     @property
     def settings_template(self) -> Dict[str, Any]:
         command = "<COMMAND>"
@@ -106,14 +126,9 @@ class Vibe(Agent):
         return self.config_folder / "config.toml"
 
     def discover_project_directories(self) -> Iterator[Path]:
-        data = self._load_file(self.config_folder / "trusted_folders.toml")
-        if not data:
-            return
-        for folder in data.get("trusted", []):
-            if isinstance(folder, str):
-                path = Path(folder).expanduser()
-                if path.is_dir():
-                    yield path.resolve()
+        for path in self._trusted():
+            if path.is_dir():
+                yield path
 
     def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
         data = self._load_file(self.user_mcp_file)
@@ -137,10 +152,9 @@ class Vibe(Agent):
             if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
                 continue
 
+            # Vibe has no SSE transport: stdio, http and streamable-http only.
             transport_name = entry.get("transport", "stdio")
-            if transport_name == "sse":
-                transport = Transport.SSE
-            elif "url" in entry:
+            if transport_name in {"http", "streamable-http"} or "url" in entry:
                 transport = Transport.HTTP
             else:
                 transport = Transport.STDIO
@@ -151,14 +165,23 @@ class Vibe(Agent):
             if not isinstance(headers, dict):
                 headers = {}
 
+            # Vibe accepts `command` as either a string or a full argv list.
+            command = entry.get("command")
+            args = entry.get("args", [])
+            if isinstance(command, list):
+                command, args = (command[0] if command else None), [
+                    *command[1:],
+                    *args,
+                ]
+
             yield MCPConfiguration(
                 name=entry["name"],
                 agent=self.name,
                 scope=scope,
                 transport=transport,
                 project=str(project) if project else None,
-                command=entry.get("command"),
-                args=entry.get("args", []),
+                command=command,
+                args=args,
                 env=entry.get("env", {}),
                 url=entry.get("url"),
                 headers=headers,

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -46,7 +46,9 @@ HOOK_NAME_TO_EVENT_TYPE = {
 
 TOOL_NAME_TO_TOOL = {
     "shell": Tool.BASH,  # Cursor
-    "bash": Tool.BASH,  # Claude Code
+    "bash": Tool.BASH,  # Claude Code, Mistral Vibe
+    "git_bash": Tool.BASH,  # Mistral Vibe
+    "powershell": Tool.BASH,  # Mistral Vibe, on Windows
     "run_in_terminal": Tool.BASH,  # Copilot
     "read": Tool.READ,  # Claude/Cursor
     "read_file": Tool.READ,  # Copilot

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -39,7 +39,9 @@ HOOK_NAME_TO_EVENT_TYPE = {
     "userpromptsubmitted": EventType.USER_PROMPT,  # Copilot CLI's native event name
     "beforesubmitprompt": EventType.USER_PROMPT,
     "pretooluse": EventType.PRE_TOOL_USE,
+    "pre_tool": EventType.PRE_TOOL_USE,
     "posttooluse": EventType.POST_TOOL_USE,
+    "post_tool": EventType.POST_TOOL_USE,
 }
 
 TOOL_NAME_TO_TOOL = {
@@ -205,6 +207,10 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
     elif event_type == EventType.POST_TOOL_USE:
         tool = _parse_tool(data)
         content = lookup(data, ["tool_output", "tool_response", "tool_result"], {})
+        if content is None:
+            # Vibe reports a null structured output on tool failure, while the
+            # text shown to the model remains available in tool_output_text.
+            content = data.get("tool_output_text", "")
         # Some agents return a dict for the tool output. Also support lists just in case.
         if isinstance(content, (dict, list)):
             content = json.dumps(content)

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 import click
 import tomlkit
 from pygitguardian.models import HealthCheckResponse
-from tomlkit.exceptions import ParseError as TOMLParseError
+from tomlkit.exceptions import TOMLKitError
 
 
 if sys.version_info >= (3, 11):
@@ -129,6 +129,9 @@ def install_hooks(
     else:
         click.echo(f"{display_name} hooks successfully added in {styled_path}")
 
+    if warning := result.agent.post_install_warning(mode):
+        ui.display_warning(warning)
+
     return 0
 
 
@@ -164,15 +167,21 @@ def build_hook_config(
             with settings_path.open("r", encoding="utf-8") as f:
                 if agent.settings_format == "toml":
                     raw_config = f.read()
-                    # tomlkit preserves formatting and comments when writing,
-                    # but its parser intentionally accepts a few malformed
-                    # constructs. Validate strictly before building its editable
-                    # document representation.
+                    # Two parsers on purpose, don't drop either one:
+                    # - tomllib validates. tomlkit silently *repairs* some
+                    #   malformed input ("[[hooks]" becomes "[[hooks]]"), so on
+                    #   its own it would rewrite a broken file into a different
+                    #   one instead of telling the user to fix it.
+                    # - tomlkit then builds the editable document, because it is
+                    #   the only one of the two that can write back, and it keeps
+                    #   the comments and formatting of a file the user hand-edits.
                     tomllib.loads(raw_config)
                     existing_config = tomlkit.parse(raw_config)
                 else:
                     existing_config = json.load(f)
-        except (json.JSONDecodeError, tomllib.TOMLDecodeError, TOMLParseError) as e:
+        # TOMLKitError, not just its ParseError subclass: a duplicate key in an
+        # inline table raises KeyAlreadyPresent, which is not a ParseError.
+        except (json.JSONDecodeError, tomllib.TOMLDecodeError, TOMLKitError) as e:
             raise UnexpectedError(
                 f"Failed to parse {settings_path}: {e}. "
                 "Please fix or remove the file before installing hooks."
@@ -185,14 +194,21 @@ def build_hook_config(
         command="",
     )
 
-    stats = _fill_dict(
-        config=existing_config,
-        template=agent.settings_template,
-        command=command,
-        overwrite=force,
-        stats=stats,
-        locator=agent.settings_locate,
-    )
+    try:
+        stats = _fill_dict(
+            config=existing_config,
+            template=agent.settings_template,
+            command=command,
+            overwrite=force,
+            stats=stats,
+            locator=agent.settings_locate,
+        )
+    except ValueError as e:
+        # The file parsed but does not have the shape we can merge into.
+        raise UnexpectedError(
+            f"Failed to update {settings_path}: {e}. "
+            "Please fix or remove the file before installing hooks."
+        )
 
     return BuildConfigResult(
         agent=agent,
@@ -213,9 +229,9 @@ def _fill_dict(
     """
     Recursively fill a dictionary with the template, leaving other keys untouched.
 
-    Inside lists, will look for a match by searching "ggshield" anywhere in the object, otherwise add a new element.
-    This means that the template cannot have multiple hooks in the same list.
-    In case the need arises, the algorithm will need to be adapted.
+    Inside lists, `locator` finds the object to update, otherwise a new element is
+    added. A template list may hold several objects: each is located independently,
+    so an agent can declare more than one hook in the same list.
 
     Args:
         config: The dictionary to fill
@@ -232,10 +248,15 @@ def _fill_dict(
         # List: locate the correct object
         elif isinstance(value, list):
             config_list = config.setdefault(key, [])
+            if not isinstance(config_list, list):
+                raise ValueError(f"expected a list of objects at '{key}'")
+            # Ignore anything that isn't an object: the file is hand-editable and a
+            # stray scalar must not crash the install.
+            candidates = [item for item in config_list if isinstance(item, dict)]
             for template_item in value:
                 if not isinstance(template_item, dict):
                     raise ValueError(f"Expected objects in template list for {key}")
-                existing_value = locator(config_list, template_item)
+                existing_value = locator(candidates, template_item)
                 if existing_value is not None:
                     # Found it. Continue with this object.
                     _fill_dict(
@@ -262,9 +283,11 @@ def _fill_dict(
         else:
             if key not in config:
                 config[key] = value
-            # for stats
+            # For stats: only the command slot tells us whether ggshield is already
+            # installed. Other scalars may legitimately contain "ggshield" — a hook
+            # name, for instance — and must not be counted as an existing install.
             cmd = config.get(key, "")
-            if isinstance(cmd, str) and "ggshield" in cmd:
+            if value == "<COMMAND>" and isinstance(cmd, str) and "ggshield" in cmd:
                 stats.already_present += 1
                 stats.command = cmd
             # Update if needed

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -3,13 +3,22 @@ import os
 import shlex
 import shutil
 import sys
+from collections.abc import MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 import click
+import tomlkit
 from pygitguardian.models import HealthCheckResponse
+from tomlkit.exceptions import ParseError as TOMLParseError
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from ggshield.core import ui
 from ggshield.core.client import create_client_from_config
@@ -32,7 +41,7 @@ class InstallationStats:
 class BuildConfigResult:
     agent: Agent
     settings_path: Path
-    new_config: Dict[str, Any]
+    new_config: MutableMapping[str, Any]
     stats: InstallationStats
 
 
@@ -103,10 +112,13 @@ def install_hooks(
     # Ensure parent directory exists
     settings_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write the updated config
+    # Write the updated config in the assistant's native format.
     with settings_path.open("w", encoding="utf-8") as f:
-        json.dump(new_config, f, indent=2)
-        f.write("\n")
+        if result.agent.settings_format == "toml":
+            f.write(tomlkit.dumps(new_config))
+        else:
+            json.dump(new_config, f, indent=2)
+            f.write("\n")
 
     # Report what happened
     styled_path = click.style(settings_path, fg="yellow", bold=True)
@@ -143,13 +155,24 @@ def build_hook_config(
     command = build_hook_command()
 
     # Load existing config or create new one
-    existing_config: dict = {}
+    existing_config: MutableMapping[str, Any] = (
+        tomlkit.document() if agent.settings_format == "toml" else {}
+    )
 
     if settings_path.exists():
         try:
             with settings_path.open("r", encoding="utf-8") as f:
-                existing_config = json.load(f)
-        except json.JSONDecodeError as e:
+                if agent.settings_format == "toml":
+                    raw_config = f.read()
+                    # tomlkit preserves formatting and comments when writing,
+                    # but its parser intentionally accepts a few malformed
+                    # constructs. Validate strictly before building its editable
+                    # document representation.
+                    tomllib.loads(raw_config)
+                    existing_config = tomlkit.parse(raw_config)
+                else:
+                    existing_config = json.load(f)
+        except (json.JSONDecodeError, tomllib.TOMLDecodeError, TOMLParseError) as e:
             raise UnexpectedError(
                 f"Failed to parse {settings_path}: {e}. "
                 "Please fix or remove the file before installing hooks."
@@ -180,7 +203,7 @@ def build_hook_config(
 
 
 def _fill_dict(
-    config: Dict[str, Any],
+    config: MutableMapping[str, Any],
     template: Dict[str, Any],
     command: str,
     overwrite: bool,
@@ -208,21 +231,32 @@ def _fill_dict(
             _fill_dict(new_config, value, command, overwrite, stats, locator)
         # List: locate the correct object
         elif isinstance(value, list):
-            # but first, make sure we only have one object in the template
-            if len(value) != 1:
-                raise ValueError(f"Expected only one object in template for {key}")
-
             config_list = config.setdefault(key, [])
-            existing_value = locator(config_list, value[0])
-            if existing_value is not None:
-                # Found it. Continue with this object.
-                _fill_dict(existing_value, value[0], command, overwrite, stats, locator)
-            else:
-                # Not found. Add new object.
-                config_list.append(deepcopy(value[0]))
-                _fill_dict(
-                    config_list[-1], value[0], command, overwrite, stats, locator
-                )
+            for template_item in value:
+                if not isinstance(template_item, dict):
+                    raise ValueError(f"Expected objects in template list for {key}")
+                existing_value = locator(config_list, template_item)
+                if existing_value is not None:
+                    # Found it. Continue with this object.
+                    _fill_dict(
+                        existing_value,
+                        template_item,
+                        command,
+                        overwrite,
+                        stats,
+                        locator,
+                    )
+                else:
+                    # Not found. Add a new object.
+                    config_list.append(deepcopy(template_item))
+                    _fill_dict(
+                        config_list[-1],
+                        template_item,
+                        command,
+                        overwrite,
+                        stats,
+                        locator,
+                    )
 
         # Scalar value: if template is the string "<COMMAND>", replace it with the command.
         else:

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -264,6 +264,11 @@ class Agent(ABC):
         """Path to the settings file for this AI coding tool."""
 
     @property
+    def settings_format(self) -> Literal["json", "toml"]:
+        """Serialization format used by the assistant's hook settings file."""
+        return "json"
+
+    @property
     def settings_template(self) -> Dict[str, Any]:
         """
         Template for the settings file for this AI coding tool.

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -268,6 +268,11 @@ class Agent(ABC):
         """Serialization format used by the assistant's hook settings file."""
         return "json"
 
+    def post_install_warning(self, mode: Literal["local", "global"]) -> Optional[str]:
+        """Warning to show after a successful install, if the assistant needs
+        one more step before it will actually load the hooks."""
+        return None
+
     @property
     def settings_template(self) -> Dict[str, Any]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "notify-py>=0.3.43",
     "keyring>=24.0.0,<26",
     "tomli>=2.4.0; python_version < \"3.11\"",
+    "tomlkit>=0.13.3,<0.14",
     "filelock>=3.19.1",
     "unearth>=0.18.2",
 ]

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -11,6 +11,7 @@ from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.codex import Codex
 from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
+from ggshield.verticals.ai.agents.vibe import Vibe
 from ggshield.verticals.ai.agents.vscode import VSCode
 from ggshield.verticals.ai.models import (
     Agent,
@@ -1042,6 +1043,107 @@ class TestCodex:
         assert req.model == "gpt-5.4"
         assert req.cwd == "/tmp/project"
         assert req.input == {"query": "hello"}
+
+
+# ===========================================================================
+# Vibe
+# ===========================================================================
+
+
+class TestVibe:
+    def test_config_folder_defaults_to_dot_vibe(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None
+        ), patch(
+            "ggshield.verticals.ai.agents.vibe.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            assert Vibe().config_folder == tmp_path / ".vibe"
+
+    def test_config_folder_honors_vibe_home(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv",
+            return_value=str(tmp_path / "custom-vibe"),
+        ):
+            assert Vibe().config_folder == tmp_path / "custom-vibe"
+
+    def test_parse_mcp_activity(self):
+        vibe = Vibe()
+        cfg = _cfg(name="my_server", agent="vibe")
+        server = MCPServer(
+            name="My Server",
+            configurations=[cfg],
+            tools=[MCPToolInfo(name="run_query")],
+        )
+        discovery = _ai_discovery(servers=[server])
+        payload = _payload(
+            vibe,
+            raw={
+                "tool_name": "my_server_run_query",
+                "cwd": "/tmp/project",
+                "tool_input": {"query": "hello"},
+            },
+        )
+
+        req = vibe.parse_mcp_activity(payload, discovery)
+
+        assert req.user == discovery.user
+        assert req.tool == "run_query"
+        assert req.server == "My Server"
+        assert req.agent == "vibe"
+        assert req.model == ""
+        assert req.cwd == "/tmp/project"
+        assert req.input == {"query": "hello"}
+
+    def test_post_process_payload_recognizes_configured_mcp_tool(self, tmp_path: Path):
+        vibe_home = tmp_path / ".vibe"
+        vibe_home.mkdir()
+        (vibe_home / "config.toml").write_text(
+            "[[mcp_servers]]\n"
+            'name = "my_server"\n'
+            'transport = "stdio"\n'
+            'command = "server"\n'
+        )
+        payload = _payload(
+            Vibe(),
+            raw={
+                "tool_name": "my_server_run_query",
+                "cwd": str(tmp_path / "project"),
+                "tool_input": {"query": "hello"},
+            },
+            tool=Tool.OTHER,
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None
+        ), patch(
+            "ggshield.verticals.ai.agents.vibe.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            payload.agent.post_process_payload(payload)
+
+        assert payload.tool == Tool.MCP
+
+    def test_post_process_payload_rejects_unconfigured_mcp_prefix(self, tmp_path: Path):
+        payload = _payload(
+            Vibe(),
+            raw={
+                "tool_name": "mcp_custom_tool",
+                "cwd": str(tmp_path),
+                "tool_input": {},
+            },
+            tool=Tool.MCP,
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None
+        ), patch(
+            "ggshield.verticals.ai.agents.vibe.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            payload.agent.post_process_payload(payload)
+
+        assert payload.tool == Tool.OTHER
 
 
 class TestCodexDiscoverProjectDirectories:

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1124,6 +1124,44 @@ class TestVibe:
 
         assert payload.tool == Tool.MCP
 
+    def test_parse_mcp_servers_transports_and_argv_command(self, tmp_path: Path):
+        """Vibe has no SSE transport, and `command` may be a full argv list."""
+        vibe_home = tmp_path / ".vibe"
+        vibe_home.mkdir()
+        (vibe_home / "config.toml").write_text(
+            "[[mcp_servers]]\n"
+            'name = "argv"\n'
+            'transport = "stdio"\n'
+            'command = ["npx", "-y", "some-mcp"]\n'
+            'args = ["--flag"]\n'
+            "\n"
+            "[[mcp_servers]]\n"
+            'name = "streamy"\n'
+            'transport = "streamable-http"\n'
+            'url = "https://example.com/mcp"\n'
+            'auth = { headers = { Authorization = "Bearer abc" } }\n'
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None
+        ), patch(
+            "ggshield.verticals.ai.agents.vibe.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            configurations = {
+                configuration.name: configuration
+                for configuration in Vibe()._get_user_mcp_configurations()
+            }
+
+        argv = configurations["argv"]
+        assert argv.transport == Transport.STDIO
+        assert argv.command == "npx"
+        assert argv.args == ["-y", "some-mcp", "--flag"]
+
+        streamy = configurations["streamy"]
+        assert streamy.transport == Transport.HTTP
+        assert streamy.headers == {"Authorization": "Bearer abc"}
+
     def test_post_process_payload_rejects_unconfigured_mcp_prefix(self, tmp_path: Path):
         payload = _payload(
             Vibe(),

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1939,6 +1939,44 @@ class TestAIHookScannerParseInput:
         assert payload.content == "failure output"
         assert isinstance(payload.agent, Vibe)
 
+    @pytest.mark.parametrize("tool_name", ["bash", "git_bash", "powershell"])
+    def test_vibe_shell_tools_are_bash(self, tool_name: str):
+        """Every Vibe shell tool is treated as BASH, so the command is parsed for
+        file reads instead of being scanned as an opaque tool input."""
+        data = {
+            "session_id": "session-123",
+            "transcript_path": "/home/user/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "pre_tool",
+            "tool_name": tool_name,
+            "tool_call_id": "call-123",
+            "tool_input": {"command": "cat /tmp/secret.txt"},
+        }
+
+        payloads = parse_hook_input(json.dumps(data))
+
+        assert payloads[-1].tool == Tool.BASH
+        assert payloads[-1].identifier == "cat /tmp/secret.txt"
+        # The command references a file, so it is also scanned as a read.
+        assert Tool.READ in {payload.tool for payload in payloads}
+
+    def test_vibe_wins_over_claude_when_path_contains_claude(self):
+        """Vibe's event names are unambiguous, so they take precedence over
+        Claude's transcript_path substring heuristic."""
+        data = {
+            "session_id": "session-123",
+            "transcript_path": "/home/claude/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "pre_tool",
+            "tool_name": "bash",
+            "tool_call_id": "call-123",
+            "tool_input": {"command": "whoami"},
+        }
+
+        payload = parse_hook_input(json.dumps(data))[0]
+
+        assert isinstance(payload.agent, Vibe)
+
     def test_pre_tool_use_read_with_missing_file(self):
         """PRE_TOOL_USE with tool_name 'read' and non-existing file yields empty content."""
         content = json.dumps(

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -17,7 +17,15 @@ from pygitguardian.models import ScanResult as ApiScanResult
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import File, ScanContext, ScanMode, StringScannable
 from ggshield.utils.git_shell import Filemode
-from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
+from ggshield.verticals.ai.agents import (
+    Agent,
+    Claude,
+    Codex,
+    Copilot,
+    Cursor,
+    Vibe,
+    VSCode,
+)
 from ggshield.verticals.ai.cache import (
     _verdict_cache_path,
     has_clean_verdict,
@@ -1863,6 +1871,74 @@ class TestAIHookScannerParseInput:
         assert payload.tool == Tool.BASH
         assert isinstance(payload.agent, Codex)
 
+    def test_vibe_pre_tool_bash(self):
+        data = {
+            "session_id": "session-123",
+            "parent_session_id": None,
+            "transcript_path": "/home/user/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "pre_tool",
+            "tool_name": "bash",
+            "tool_call_id": "call-123",
+            "tool_input": {"command": "whoami"},
+        }
+
+        payload = parse_hook_input(json.dumps(data))[0]
+
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        assert payload.tool == Tool.BASH
+        assert payload.content == "whoami"
+        assert isinstance(payload.agent, Vibe)
+
+    def test_vibe_post_tool_read(self):
+        data = {
+            "session_id": "session-123",
+            "parent_session_id": None,
+            "transcript_path": "/home/user/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "post_tool",
+            "tool_name": "read_file",
+            "tool_call_id": "call-123",
+            "tool_input": {"path": "/tmp/secret.txt"},
+            "tool_status": "success",
+            "tool_output": {"content": "file content"},
+            "tool_output_text": "file content",
+            "tool_error": None,
+            "duration_ms": 42.5,
+        }
+
+        payload = parse_hook_input(json.dumps(data))[0]
+
+        assert payload.event_type == EventType.POST_TOOL_USE
+        assert payload.tool == Tool.READ
+        # Canonicalized against the event's cwd (see _abs_read_path).
+        assert payload.identifier == os.path.abspath("/tmp/secret.txt")
+        assert payload.content == '{"content": "file content"}'
+        assert isinstance(payload.agent, Vibe)
+
+    def test_vibe_failed_post_tool_scans_output_text(self):
+        data = {
+            "session_id": "session-123",
+            "parent_session_id": None,
+            "transcript_path": "/home/user/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "post_tool",
+            "tool_name": "bash",
+            "tool_call_id": "call-123",
+            "tool_input": {"command": "failing-command"},
+            "tool_status": "failure",
+            "tool_output": None,
+            "tool_output_text": "failure output",
+            "tool_error": "failed",
+            "duration_ms": 42.5,
+        }
+
+        payload = parse_hook_input(json.dumps(data))[0]
+
+        assert payload.event_type == EventType.POST_TOOL_USE
+        assert payload.content == "failure output"
+        assert isinstance(payload.agent, Vibe)
+
     def test_pre_tool_use_read_with_missing_file(self):
         """PRE_TOOL_USE with tool_name 'read' and non-existing file yields empty content."""
         content = json.dumps(
@@ -2321,6 +2397,45 @@ class TestFlavorOutputResult:
         assert code == 0
         out = json.loads(mock_echo.call_args[0][0])
         assert out == {"systemMessage": "could not scan"}
+
+    @patch("ggshield.verticals.ai.agents.vibe.click.echo")
+    def test_vibe_output_result_allow(self, mock_echo: MagicMock):
+        result = HookResult.allow(_dummy_payload(EventType.PRE_TOOL_USE))
+
+        code = Vibe().output_result(result)
+
+        assert code == 0
+        mock_echo.assert_not_called()
+
+    @patch("ggshield.verticals.ai.agents.vibe.click.echo")
+    def test_vibe_output_result_block(self, mock_echo: MagicMock):
+        result = HookResult(
+            block=True,
+            message="Secrets detected in command",
+            nbr_secrets=1,
+            payload=_dummy_payload(EventType.PRE_TOOL_USE),
+        )
+
+        code = Vibe().output_result(result)
+
+        assert code == 0
+        out = json.loads(mock_echo.call_args[0][0])
+        assert out == {
+            "decision": "deny",
+            "reason": "Secrets detected in command",
+        }
+
+    @patch("ggshield.verticals.ai.agents.vibe.click.echo")
+    def test_vibe_output_result_allow_with_warning(self, mock_echo: MagicMock):
+        result = HookResult.allow_with_warning(
+            _dummy_payload(EventType.PRE_TOOL_USE), "could not scan"
+        )
+
+        code = Vibe().output_result(result)
+
+        assert code == 0
+        out = json.loads(mock_echo.call_args[0][0])
+        assert out == {"system_message": "could not scan"}
 
     @patch("ggshield.verticals.ai.agents.cursor.click.echo")
     def test_cursor_output_result_allow_with_warning(self, mock_echo: MagicMock):

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -9,8 +9,14 @@ from unittest.mock import patch
 
 import pytest
 
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 from ggshield.core.errors import UnexpectedError
-from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor
+from ggshield.verticals.ai.agents import Claude, Codex, Copilot, Cursor, Vibe
 from ggshield.verticals.ai.installation import (
     AgentHookStatus,
     InstallationStats,
@@ -335,6 +341,22 @@ class TestFlavorSettingsProperties:
     def test_codex_settings_template(self):
         assert isinstance(Codex().settings_template, dict)
 
+    def test_vibe_settings_path_and_format(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv",
+            return_value=str(tmp_path / "vibe-home"),
+        ):
+            assert (
+                Vibe().settings_path("global") == tmp_path / "vibe-home" / "hooks.toml"
+            )
+            assert Vibe().settings_path("local") == Path(".vibe") / "hooks.toml"
+            assert Vibe().settings_format == "toml"
+
+    def test_vibe_settings_template(self):
+        hooks = Vibe().settings_template["hooks"]
+        assert [hook["type"] for hook in hooks] == ["pre_tool", "post_tool"]
+        assert all(hook["match"] == "*" for hook in hooks)
+
 
 class TestInstallHooks:
     """Unit tests for the install_hooks function."""
@@ -397,6 +419,100 @@ class TestInstallHooks:
 
         codex_config = tmp_path / ".codex" / "config.toml"
         assert not codex_config.exists()
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None)
+    def test_install_vibe_global(
+        self,
+        mock_getenv: Any,
+        mock_vibe_home: Any,
+        mock_home: Any,
+        tmp_path: Path,
+    ):
+        mock_home.return_value = tmp_path
+        mock_vibe_home.return_value = tmp_path
+
+        code = install_hooks("vibe", mode="global")
+
+        assert code == 0
+        settings_path = tmp_path / ".vibe" / "hooks.toml"
+        config = tomllib.loads(settings_path.read_text())
+        assert [hook["name"] for hook in config["hooks"]] == [
+            "ggshield-pre-tool",
+            "ggshield-post-tool",
+        ]
+        assert all("ggshield" in hook["command"] for hook in config["hooks"])
+        assert all(hook["strict"] is False for hook in config["hooks"])
+
+        install_hooks("vibe", mode="global")
+        config = tomllib.loads(settings_path.read_text())
+        assert [hook["name"] for hook in config["hooks"]] == [
+            "ggshield-pre-tool",
+            "ggshield-post-tool",
+        ]
+
+        updated_command = "/opt/ggshield/bin/ggshield secret scan ai-hook"
+        with patch(
+            "ggshield.verticals.ai.installation.build_hook_command",
+            return_value=updated_command,
+        ):
+            install_hooks("vibe", mode="global", force=True)
+        config = tomllib.loads(settings_path.read_text())
+        assert all(hook["command"] == updated_command for hook in config["hooks"])
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None)
+    def test_install_vibe_preserves_existing_toml(
+        self,
+        mock_getenv: Any,
+        mock_vibe_home: Any,
+        mock_home: Any,
+        tmp_path: Path,
+    ):
+        mock_home.return_value = tmp_path
+        mock_vibe_home.return_value = tmp_path
+        settings_path = tmp_path / ".vibe" / "hooks.toml"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(
+            "# Keep this comment\n"
+            "[[hooks]]\n"
+            'name = "existing"\n'
+            'type = "pre_tool"\n'
+            'match = "bash"\n'
+            'command = "other-tool"\n'
+        )
+
+        install_hooks("vibe", mode="global")
+
+        text = settings_path.read_text()
+        config = tomllib.loads(text)
+        assert "# Keep this comment" in text
+        assert [hook["name"] for hook in config["hooks"]] == [
+            "existing",
+            "ggshield-pre-tool",
+            "ggshield-post-tool",
+        ]
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None)
+    def test_install_vibe_with_corrupt_toml_raises(
+        self,
+        mock_getenv: Any,
+        mock_vibe_home: Any,
+        mock_home: Any,
+        tmp_path: Path,
+    ):
+        mock_home.return_value = tmp_path
+        mock_vibe_home.return_value = tmp_path
+        settings_path = tmp_path / ".vibe" / "hooks.toml"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text("[[hooks]\n")
+
+        with pytest.raises(UnexpectedError, match="Failed to parse"):
+            install_hooks("vibe", mode="global")
 
     def test_install_unsupported_agent_raises(self):
         """install_hooks raises ValueError for unsupported agent."""

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -199,6 +199,53 @@ class TestFillDict:
             added=2, already_present=1, command="ggshield already"
         )
 
+    def test_non_command_scalar_is_not_an_existing_install(self):
+        """A template scalar other than the command may contain "ggshield" (a hook
+        name, say). It must not be mistaken for an existing installation."""
+        config: Dict[str, Any] = {}
+        template = {"hooks": [{"name": "ggshield-pre-tool", "command": "<COMMAND>"}]}
+        stats = _fill_dict(
+            config,
+            template,
+            COMMAND,
+            overwrite=False,
+            stats=InstallationStats(added=0, already_present=0),
+            locator=_locator,
+        )
+
+        assert config == {"hooks": [{"name": "ggshield-pre-tool", "command": COMMAND}]}
+        assert stats == InstallationStats(added=1, already_present=0)
+
+    def test_non_object_entries_are_ignored(self):
+        """Settings files are hand-editable: a stray scalar in a hook list must not
+        crash the merge."""
+        config: Dict[str, Any] = {"hooks": ["stray", {"command": "other"}]}
+        template = {"hooks": [{"command": "<COMMAND>"}]}
+        stats = _fill_dict(
+            config,
+            template,
+            COMMAND,
+            overwrite=False,
+            stats=InstallationStats(added=0, already_present=0),
+            locator=_locator,
+        )
+
+        assert config["hooks"][0] == "stray"
+        assert {"command": COMMAND} in config["hooks"]
+        assert stats.added == 1
+
+    def test_unmergeable_shape_raises_value_error(self):
+        """A list key holding something other than a list cannot be merged into."""
+        with pytest.raises(ValueError, match="expected a list of objects"):
+            _fill_dict(
+                {"hooks": "not-a-list"},
+                {"hooks": [{"command": "<COMMAND>"}]},
+                COMMAND,
+                overwrite=False,
+                stats=InstallationStats(added=0, already_present=0),
+                locator=_locator,
+            )
+
     def test_template_list_supports_multiple_elements(self):
         config: Dict[str, Any] = {}
         template = {
@@ -357,6 +404,31 @@ class TestFlavorSettingsProperties:
         assert [hook["type"] for hook in hooks] == ["pre_tool", "post_tool"]
         assert all(hook["match"] == "*" for hook in hooks)
 
+    def test_vibe_post_install_warning_on_untrusted_folder(self, tmp_path: Path):
+        """Vibe ignores project hooks in untrusted folders, so a local install
+        there must say so instead of reporting plain success."""
+        vibe_home = tmp_path / ".vibe"
+        vibe_home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        with patch(
+            "ggshield.verticals.ai.agents.vibe.os.getenv",
+            return_value=str(vibe_home),
+        ), patch("ggshield.verticals.ai.agents.vibe.Path.cwd", return_value=project):
+            vibe = Vibe()
+            # No trusted_folders.toml at all: the folder is not trusted.
+            assert "trusted folders" in (vibe.post_install_warning("local") or "")
+            # A global install is unaffected by folder trust.
+            assert vibe.post_install_warning("global") is None
+
+            # A TOML literal string: a Windows path's backslashes must not be
+            # read as escape sequences.
+            (vibe_home / "trusted_folders.toml").write_text(
+                f"trusted = ['{project}']\n"
+            )
+            assert vibe.post_install_warning("local") is None
+
 
 class TestInstallHooks:
     """Unit tests for the install_hooks function."""
@@ -512,6 +584,52 @@ class TestInstallHooks:
         settings_path.write_text("[[hooks]\n")
 
         with pytest.raises(UnexpectedError, match="Failed to parse"):
+            install_hooks("vibe", mode="global")
+
+        # The file is reported, never repaired: tomlkit alone parses "[[hooks]"
+        # as "[[hooks]]" and would write that back over the user's file.
+        assert settings_path.read_text() == "[[hooks]\n"
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None)
+    def test_install_vibe_with_duplicate_inline_key_raises(
+        self,
+        mock_getenv: Any,
+        mock_vibe_home: Any,
+        mock_home: Any,
+        tmp_path: Path,
+    ):
+        """A duplicate key in an inline table raises tomlkit's KeyAlreadyPresent,
+        which is a TOMLKitError but not a ParseError."""
+        mock_home.return_value = tmp_path
+        mock_vibe_home.return_value = tmp_path
+        settings_path = tmp_path / ".vibe" / "hooks.toml"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text("a = { x = 1, x = 2 }\n")
+
+        with pytest.raises(UnexpectedError, match="Failed to parse"):
+            install_hooks("vibe", mode="global")
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.get_user_home_dir")
+    @patch("ggshield.verticals.ai.agents.vibe.os.getenv", return_value=None)
+    def test_install_vibe_with_unmergeable_toml_raises(
+        self,
+        mock_getenv: Any,
+        mock_vibe_home: Any,
+        mock_home: Any,
+        tmp_path: Path,
+    ):
+        """Valid TOML of the wrong shape reports the same actionable error as a
+        syntax error, instead of an unhandled traceback."""
+        mock_home.return_value = tmp_path
+        mock_vibe_home.return_value = tmp_path
+        settings_path = tmp_path / ".vibe" / "hooks.toml"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text('hooks = "not-a-list"\n')
+
+        with pytest.raises(UnexpectedError, match="Failed to update"):
             install_hooks("vibe", mode="global")
 
     def test_install_unsupported_agent_raises(self):

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -193,21 +193,37 @@ class TestFillDict:
             added=2, already_present=1, command="ggshield already"
         )
 
-    def test_template_list_must_have_exactly_one_element(self):
-        """Template list value must have exactly one element (raises ValueError otherwise)."""
+    def test_template_list_supports_multiple_elements(self):
         config: Dict[str, Any] = {}
-        template = {"hooks": [{"a": 1}, {"b": 2}]}
+        template = {
+            "hooks": [
+                {"name": "pre", "command": "<COMMAND>"},
+                {"name": "post", "command": "<COMMAND>"},
+            ]
+        }
         stats = InstallationStats(added=0, already_present=0)
-        with pytest.raises(ValueError, match="Expected only one object in template"):
-            stats = _fill_dict(
-                config,
-                template,
-                COMMAND,
-                overwrite=False,
-                stats=stats,
-                locator=_locator,
-            )
-        assert stats == InstallationStats(added=0, already_present=0)
+        stats = _fill_dict(
+            config,
+            template,
+            COMMAND,
+            overwrite=False,
+            stats=stats,
+            locator=lambda candidates, item: next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate.get("name") == item["name"]
+                ),
+                None,
+            ),
+        )
+        assert config == {
+            "hooks": [
+                {"name": "pre", "command": COMMAND},
+                {"name": "post", "command": COMMAND},
+            ]
+        }
+        assert stats == InstallationStats(added=2, already_present=0)
 
 
 class TestFlavorSettingsProperties:

--- a/uv.lock
+++ b/uv.lock
@@ -1092,6 +1092,7 @@ dependencies = [
     { name = "sigstore", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sigstore", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
     { name = "truststore", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions" },
     { name = "unearth" },
@@ -1167,6 +1168,7 @@ requires-dist = [
     { name = "rich", specifier = "~=13.0" },
     { name = "sigstore", specifier = ">=4.0.0,<5" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.0" },
+    { name = "tomlkit", specifier = ">=0.13.3,<0.14" },
     { name = "truststore", marker = "python_full_version >= '3.10'", specifier = ">=0.10.1" },
     { name = "typing-extensions", specifier = "~=4.14" },
     { name = "unearth", specifier = ">=0.18.2" },
@@ -4013,6 +4015,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Mistral Vibe 2.21+ exposes lifecycle hooks for tool inputs and outputs, but
ggshield cannot currently install or process them. This leaves autonomous file,
shell, and MCP activity unprotected when using Vibe.

Vibe does not expose an equivalent to `UserPromptSubmit`, so this integration
intentionally covers tool boundaries only.

## What has been done

- Add reusable TOML hook-settings support while preserving existing formatting
  and comments.
- Register Mistral Vibe as a supported AI coding assistant.
- Install `pre_tool` and `post_tool` hooks in Vibe's local or global
  `hooks.toml`.
- Scan Vibe tool inputs before execution and tool outputs before they are
  returned to the model, including failure output.
- Discover Vibe MCP configurations and report MCP activity using Vibe's tool
  naming convention.
- Add unit tests, documentation, and a changelog entry.

## Validation

- `uv run pytest -q tests/unit/verticals/ai/test_agents.py tests/unit/verticals/ai/test_hooks.py tests/unit/verticals/ai/test_installation.py`
  - 285 passed
- Black, isort, and Flake8 pass on the changed Python files.
- `ggshield secret scan commit-range origin/main..HEAD --json`
  - No secrets found.
- Manually tested with Vibe 2.21+:
  - local hook installation and authentication;
  - `pre_tool` blocking a dummy secret before a Bash command executed;
  - `post_tool` preventing a dummy secret in command output from reaching the
    model.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
