### PR TITLE
fix: prevent install prompt on git availability check on macos

### DIFF
--- a/changelog.d/20260730_143000_6d7a_macos_clt_stub.md
+++ b/changelog.d/20260730_143000_6d7a_macos_clt_stub.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- On macOS, `ggshield` no longer triggers the Xcode Command Line Tools install prompt
+  when the tools are not installed.

--- a/ggshield/utils/git_shell.py
+++ b/ggshield/utils/git_shell.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
@@ -68,9 +69,65 @@ def is_git_available() -> bool:
         return False
 
 
+_MACOS_CLT_GIT = "/Library/Developer/CommandLineTools/usr/bin/git"
+
+
+def _macos_developer_git_exists() -> bool:
+    """Conservatively check whether a real git is installed behind the /usr/bin/git stub.
+
+    xcode-select is safe to run, unlike the stub, but a failure to answer
+    must not render a working git unusable. This means that in very unlikely edge cases
+    a user will be prompted to install git, even if not using git-based ggshield commands.
+    """
+    if Path(_MACOS_CLT_GIT).exists():
+        return True
+    try:
+        result = subprocess.run(
+            ["/usr/bin/xcode-select", "-p"], capture_output=True, timeout=1
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    if result.returncode != 0:
+        return False
+    developer_dir = result.stdout.decode("utf-8", errors="ignore").strip()
+    return bool(developer_dir) and Path(developer_dir, "usr", "bin", "git").exists()
+
+
+def _is_macos_clt_stub(git_path: str) -> bool:
+    """True if git_path is the xcrun stub and no Command Line Tools are behind it.
+
+    Running such a stub opens a GUI prompt asking to install them.
+    """
+    if sys.platform != "darwin" or _macos_developer_git_exists():
+        return False
+    try:
+        with open(git_path, "rb") as f:
+            # try to detect whether libxcselect is linked by searching for the path string in the header
+            return b"libxcselect" in f.read(256 * 1024)
+    except OSError:
+        return False
+
+
 @lru_cache(None)
 def _get_git_path() -> str:
     git_path = which("git")
+
+    if git_path is not None and _is_macos_clt_stub(git_path):
+        # The default git binary is a macOS stub prompting the user to install
+        # Xcode Command Line Tools. Before raising an error, check for other git
+        # binaries on the PATH.
+        stub_dir = os.path.dirname(os.path.abspath(git_path))
+        path = os.pathsep.join(
+            entry
+            for entry in os.environ.get("PATH", "").split(os.pathsep)
+            if entry and os.path.abspath(entry) != stub_dir
+        )
+        git_path = which("git", path=path) if path else None
+        if git_path is None:
+            raise GitExecutableNotFound(
+                "git is the Xcode Command Line Tools stub and the tools are not "
+                "installed. To use all features of ggshield, please install git."
+            )
 
     if git_path is None:
         raise GitExecutableNotFound("unable to find git executable in PATH/PATHEXT")

--- a/tests/unit/utils/test_git_shell.py
+++ b/tests/unit/utils/test_git_shell.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from ggshield.core.tar_utils import tar_from_ref_and_filepaths
+from ggshield.utils import git_shell
 from ggshield.utils.git_shell import (
     GitExecutableNotFound,
     InvalidGitRefError,
@@ -57,6 +58,89 @@ def _create_repository_with_remote(
 def test_is_git_available(_get_git_path_mock):
     _get_git_path_mock.side_effect = GitExecutableNotFound()
     assert not is_git_available()
+
+
+@pytest.mark.parametrize(
+    ("gits_on_path", "expected"),
+    (
+        (["stub"], None),
+        (["git"], 0),
+        (["stub", "git"], 1),
+        (["unreadable"], 0),
+    ),
+    ids=("stub only", "real git", "stub then real git", "unreadable git"),
+)
+def test_macos_clt_stub(monkeypatch, tmp_path, gits_on_path, expected):
+    """
+    GIVEN macOS with no Command Line Tools installed
+    WHEN resolving the git executable
+    THEN the xcrun stub is never returned, so it is never run and cannot open the
+    install prompt, but any real git on PATH still is
+    """
+    monkeypatch.setattr(git_shell.sys, "platform", "darwin")
+    monkeypatch.setattr(git_shell, "_macos_developer_git_exists", lambda: False)
+
+    gits = []
+    for index, kind in enumerate(gits_on_path):
+        directory = tmp_path / str(index)
+        directory.mkdir()
+        git_path = directory / "git"
+        git_path.write_bytes(b"\0" * 1000 + (b"libxcselect" if kind == "stub" else b""))
+        git_path.chmod(0o111 if kind == "unreadable" else 0o755)
+        gits.append(git_path)
+    monkeypatch.setenv("PATH", os.pathsep.join(str(g.parent) for g in gits))
+
+    if expected is None:
+        assert not is_git_available()
+    else:
+        assert git_shell._get_git_path() == str(gits[expected])
+
+
+@pytest.mark.parametrize(
+    ("clt_git_installed", "xcode_select", "expected"),
+    (
+        (True, None, True),
+        (False, (2, ""), False),
+        (False, (0, "DEVELOPER_DIR"), True),
+        (False, OSError("no xcode-select"), True),
+    ),
+    ids=(
+        "command line tools installed",
+        "no developer directory",
+        "developer directory holding git",
+        "xcode-select unusable",
+    ),
+)
+def test_macos_developer_git_exists(
+    monkeypatch, tmp_path, clt_git_installed, xcode_select, expected
+):
+    """
+    GIVEN a macOS machine whose developer tools may or may not be installed
+    WHEN checking whether a real git sits behind the /usr/bin/git stub
+    THEN it answers yes unless it can prove otherwise, so a working git is never
+    declared unusable
+    """
+    clt_git = tmp_path / "CommandLineTools" / "git"
+    if clt_git_installed:
+        clt_git.parent.mkdir()
+        clt_git.touch()
+    monkeypatch.setattr(git_shell, "_MACOS_CLT_GIT", str(clt_git))
+
+    developer_dir = tmp_path / "developer"
+    (developer_dir / "usr" / "bin").mkdir(parents=True)
+    (developer_dir / "usr" / "bin" / "git").touch()
+
+    def fake_run(*args, **kwargs):
+        if isinstance(xcode_select, Exception):
+            raise xcode_select
+        returncode, stdout = xcode_select
+        if stdout == "DEVELOPER_DIR":
+            stdout = str(developer_dir)
+        return subprocess.CompletedProcess(args, returncode, stdout.encode(), b"")
+
+    monkeypatch.setattr(git_shell.subprocess, "run", fake_run)
+
+    assert git_shell._macos_developer_git_exists() is expected
 
 
 def test_git_shell():


### PR DESCRIPTION
## Context

`ggshield` checks if git is available even when running commands that do not require git so that it can load environment variables from a .env file at a repository root. On MacOS, this check triggered a prompt to install Apple's Command Line Tools if git was not installed. This was because Apple inserts a shim in `/usr/bin/git`, that is linked to `libxcselect`, which will run the prompt if the respective tools aren't installed.

## What has been done

This commit adds a check for that shim on darwin systems. The check is conservative, so that in the worst case, a user without a git install will encounter the install prompt, but no user with a valid git install will be erroneously blocked.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
<!-- This can't be done for PR created from forks. In this case, uncomment the line below: -->

<!--
This PR comes from a fork and should have the skip-changelog label applied to it.
-->
