### PR TITLE
ci: bump release build Python from 3.10 to 3.12

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -72,12 +72,12 @@ jobs:
           - os: macos-15-intel
             arch: x86_64
             sha256sum:
-              python: e654c21d0ba53e2c671868d4112fac5874deca4c35226d36c5cfe53bc5c9cd71
+              python: 21ea90aa55057e5f1d177f1f5fb2d730704f68124ca8ff40d872a81ffdf0543e
               rcodesign: bca6e648afaddd48f1c3d5dd25aa516659992cbbd2ba7131ba6add739aa895d3
           - os: macos-14
             arch: aarch64
             sha256sum:
-              python: 2f18cdef4125ca1440dd1ba00ebcb267526efb532138c0860438f755ea4eebac
+              python: 12d6700f7e8f222639f0ee5bbd173082c3041aeb65af8f9828e4216bc8047de6
               rcodesign: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   UV_VERSION: 0.10.8
-  DEFAULT_PYTHON_VERSION: '3.10'
+  DEFAULT_PYTHON_VERSION: '3.12'
 
 jobs:
   build_wheel_sdist:
@@ -59,25 +59,25 @@ jobs:
             arch: x86_64
             nfpm_arch: x86_64
             sha256sum:
-              python: e8d7ed8c6f8c6f85cd083d5051cafd8c6c01d09eca340d1da74d0c00ff1cb897
+              python: 7ceaf4360f4b4ab44f31d8217cfdc70df8e12b61d9561b4900ee7af87176e50d
               nfpm: 9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
           - os: ubuntu-24.04-arm
             container: rockylinux/rockylinux:8
             arch: aarch64
             nfpm_arch: arm64
             sha256sum:
-              python: 5dcd0486c403d07e27a1f2c256810122ac5d153f921433d77116df5c7d09b4c9
+              python: e125d3e75034fe75d49ae8577b53758b0bb7d7817fadde2c020ad2cf7afe64c4
               nfpm: ccfc3a154dec318100c6b6e28deddef0a1ffddf5e258364d74b647a129c72a0e
           - os: windows-2022
           - os: macos-15-intel
             arch: x86_64
             sha256sum:
-              python: 6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a
+              python: e654c21d0ba53e2c671868d4112fac5874deca4c35226d36c5cfe53bc5c9cd71
               rcodesign: bca6e648afaddd48f1c3d5dd25aa516659992cbbd2ba7131ba6add739aa895d3
           - os: macos-14
             arch: aarch64
             sha256sum:
-              python: 5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a
+              python: 2f18cdef4125ca1440dd1ba00ebcb267526efb532138c0860438f755ea4eebac
               rcodesign: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
     steps:
       - uses: actions/checkout@v4
@@ -85,13 +85,13 @@ jobs:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
-      - name: Set up Python 3.10 (Windows 1/2)
+      - name: Set up Python 3.12 (Windows 1/2)
         if: matrix.os == 'windows-2022'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
-      - name: Set up Python 3.10 (Windows 2/2)
+      - name: Set up Python 3.12 (Windows 2/2)
         if: matrix.os == 'windows-2022'
         shell: bash
         run: |
@@ -108,9 +108,9 @@ jobs:
             git-core \
             findutils
 
-          # Install Python 3.10 (we can't use the one from setup-python@v5: it requires a more recent version of libc)
-          PYTHON_VERSION=3.10.16
-          PYTHON_BUILD=20250317
+          # Install Python 3.12 (we can't use the one from setup-python@v5: it requires a more recent version of libc)
+          PYTHON_VERSION=3.12.13
+          PYTHON_BUILD=20260728
           scripts/download \
             https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${{ matrix.arch }}-unknown-linux-gnu-install_only_stripped.tar.gz \
             python.tar.gz \
@@ -143,8 +143,8 @@ jobs:
           # macs it installs the Framework version of Python, and the binaries
           # produced with that version do not pass Apple notarization step.
           # (tested with actions/setup-python@v4 and @v5)
-          PYTHON_VERSION=3.10.13
-          PYTHON_BUILD=20240224
+          PYTHON_VERSION=3.12.13
+          PYTHON_BUILD=20260728
 
           scripts/download \
             https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${{ matrix.arch }}-apple-darwin-install_only.tar.gz \

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -97,6 +97,27 @@ jobs:
         run: |
           echo PYTHON_CMD=python >> $GITHUB_ENV
 
+      - name: Patch bundled sqlite3.dll (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: bash
+        run: |
+          # CPython 3.12's official Windows build still ships sqlite3.dll
+          # 3.49.1, vulnerable to CVE-2025-6965 (fixed in 3.50.2) among
+          # others. SQLite's public C API is strictly backward-compatible
+          # (verified: every symbol exported by 3.49.1 is also exported by
+          # 3.53.4), so dropping in the official upstream DLL is a safe fix
+          # without needing a newer CPython/PyInstaller.
+          SQLITE_DLL_VERSION=3530400
+          scripts/download \
+            https://www.sqlite.org/2026/sqlite-dll-win-x64-${SQLITE_DLL_VERSION}.zip \
+            sqlite-dll.zip \
+            8b959b7eff4a81f6a62fc3468f9273e5cfe78d4a927e62215aed231b654fb104
+
+          7z x sqlite-dll.zip sqlite3.dll -y -osqlite-dll
+
+          python_dlls_dir="$(python -c 'import sys; print(sys.prefix)')/DLLs"
+          cp sqlite-dll/sqlite3.dll "$python_dlls_dir/sqlite3.dll"
+
       - name: Install Linux specific dependencies
         if: startsWith(matrix.os, 'ubuntu-')
         run: |

--- a/changelog.d/20260730_120000_henri.hubert_bump_release_python_312.md
+++ b/changelog.d/20260730_120000_henri.hubert_bump_release_python_312.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Release binaries are now built with Python 3.12 instead of 3.10, ahead of Python 3.10's upcoming end-of-life and to drop the outdated bundled SQLite it shipped with.

--- a/changelog.d/20260730_130000_henri.hubert_patch_windows_sqlite.md
+++ b/changelog.d/20260730_130000_henri.hubert_patch_windows_sqlite.md
@@ -1,0 +1,3 @@
+### Security
+
+- Windows release binaries now bundle an up-to-date `sqlite3.dll` (3.53.4) instead of the one shipped by CPython 3.12's official Windows build (3.49.1), which was vulnerable to `CVE-2025-6965` and other fixed SQLite issues.

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
 if TYPE_CHECKING:
     from ggshield.verticals.ai.agent_activity import ActivitySource, AgentActivityEvent
 
-import tomli
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from pygitguardian.models import MCPConfiguration as BaseMCPConfiguration
 from pygitguardian.models import MCPServer, UserInfo
@@ -435,7 +438,7 @@ class Agent(ABC):
             raw = path.read_text()
             # Fallback to JSON
             if path.suffix == ".toml":
-                data = tomli.loads(raw)
+                data = tomllib.loads(raw)
             else:
                 data = json.loads(raw)
             if not isinstance(data, dict):

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
@@ -11,9 +12,9 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
 if TYPE_CHECKING:
     from ggshield.verticals.ai.agent_activity import ActivitySource, AgentActivityEvent
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
+else:
     import tomli as tomllib
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from pygitguardian.models import MCPConfiguration as BaseMCPConfiguration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "truststore>=0.10.1; python_version >= \"3.10\"",
     "notify-py>=0.3.43",
     "keyring>=24.0.0,<26",
-    "tomli>=2.4.0",
+    "tomli>=2.4.0; python_version < \"3.11\"",
     "filelock>=3.19.1",
     "unearth>=0.18.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-25T12:35:00.080953Z"
+exclude-newer = "2026-07-26T19:31:51.506349077Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1091,7 +1091,7 @@ dependencies = [
     { name = "rich" },
     { name = "sigstore", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sigstore", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "truststore", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions" },
     { name = "unearth" },
@@ -1166,7 +1166,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0,<3" },
     { name = "rich", specifier = "~=13.0" },
     { name = "sigstore", specifier = ">=4.0.0,<5" },
-    { name = "tomli", specifier = ">=2.4.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.0" },
     { name = "truststore", marker = "python_full_version >= '3.10'", specifier = ">=0.10.1" },
     { name = "typing-extensions", specifier = "~=4.14" },
     { name = "unearth", specifier = ">=0.18.2" },


### PR DESCRIPTION
## Summary
- Bump the Python interpreter used to build ggshield release assets from 3.10 to 3.12 (wheel/sdist job, Windows `setup-python`, and the pinned `python-build-standalone` downloads for Linux + macOS).
- Fix a PyInstaller bundling bug this exposed: `tomli`'s compiled wheels on cp311+ crashed the standalone binary. Switched to stdlib `tomllib` on 3.11+.
- Patch the Windows binary's bundled `sqlite3.dll`: CPython 3.12's official Windows build still ships 3.49.1 (vulnerable to `CVE-2025-6965`, fixed in 3.50.2). Python 3.13 would fix this too, but PyInstaller 6.7.0 is pinned specifically because it can't run on 3.13 — so instead the workflow drops in the official upstream `sqlite3.dll` (3.53.4) before packaging. SQLite's public C API is strictly backward-compatible, and every symbol the old DLL exports is also exported by the new one, so this is a safe swap.

## Why
Python 3.10 reaches EOL in ~3 months, and its bundled SQLite has a known vulnerability already reported against ggshield.

## Test plan
- [x] Rebuilt the Linux release binary locally (matches CI) — smoke check, packaging, and install on all 5 `linux_package_smoke_tests` images pass.
- [x] Unit tests for the touched module pass under 3.12.
- [x] CI green on this branch.
- [x] Verified with Grype that the current release's Windows `sqlite3.dll` (3.40.1.0) is vulnerable; re-verifying the patched artifact from this commit once CI rebuilds it.

Refs: END-833
