### PR TITLE
fix(ai-hook): do not abandon the scan when a "cat" argument is not a path

### DIFF
--- a/changelog.d/20260803_120000_fix_ai_hook_unstatable_path.md
+++ b/changelog.d/20260803_120000_fix_ai_hook_unstatable_path.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `ggshield secret scan ai-hook` no longer skips the scan when a Bash command starting with
+  `cat` or `Get-Content` is not a plain file read (a heredoc, a redirection...).
+  Such commands are now always scanned as text.

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -103,9 +103,17 @@ class HookPayload:
     def scannable(self) -> Scannable:
         """Return the appropriate Scannable for the payload."""
         if self.tool == Tool.READ:
-            path = Path(self.identifier)
-            if path.is_file() and not is_path_binary(path):
-                return File(path=self.identifier)
+            # The identifier is not always a real path: it can be a whole shell
+            # command (a heredoc, a pipeline...) that a caller guessed was a
+            # file name. Path.is_file() only swallows "not found" errors, so it
+            # still raises on such identifiers (ENAMETOOLONG, embedded NULs...).
+            # Never let that abort the scan: fall back to scanning the content.
+            try:
+                path = Path(self.identifier)
+                if path.is_file() and not is_path_binary(path):
+                    return File(path=self.identifier)
+            except (OSError, ValueError):
+                pass
         return StringScannable(url=self.identifier, content=self.content)
 
     @property

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import subprocess
 from collections import Counter
@@ -9,7 +10,7 @@ import pytest
 from pygitguardian import GGClient
 from pygitguardian.models import MCPActivityResponse
 
-from ggshield.core.scan import ScanContext, ScanMode
+from ggshield.core.scan import File, ScanContext, ScanMode, StringScannable
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
 from ggshield.verticals.ai.hooks import (
@@ -1318,6 +1319,55 @@ class TestAIHookScannerParseInput:
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
         assert payload.identifier == "README.md"
+
+    @staticmethod
+    def _bash_hook_input(command: str) -> str:
+        return json.dumps(
+            {
+                "session_id": "273ad859-3608-4799-9971-fa15ecb1a65c",
+                "transcript_path": "/home/user/.codex/sessions/2026/04/30/session.jsonl",
+                "cwd": "/home/user/project",
+                "hook_event_name": "PreToolUse",
+                "turn_id": "turn_123",
+                "model": "gpt-5.4",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_use_id": "call_123",
+            }
+        )
+
+    def test_cat_command_yields_file_scannable(self, tmp_path: Path):
+        """`cat <existing file>` is still parsed as a file read."""
+        target = tmp_path / "code.py"
+        target.write_text("secret = 'abc'")
+        payloads = parse_hook_input(self._bash_hook_input(f"cat {target}"))
+        read = next(p for p in payloads if p.tool == Tool.READ)
+        assert read.identifier == str(target)
+        assert isinstance(read.scannable, File)
+
+    def test_cat_heredoc_command_is_still_scanned_as_string(self):
+        """A `cat > file <<EOF` heredoc must not abort the scan.
+
+        Everything after "cat " used to be treated as a file name, and
+        Path.is_file() raised OSError (ENAMETOOLONG) on it, so the command --
+        which is precisely a secret being written to a file -- was never
+        scanned. Python < 3.13 raises for real here; force the error so the
+        regression is covered on every supported version.
+        """
+        command = "cat > /tmp/script.py <<'EOF'\n" + "x = 1\n" * 2000 + "EOF"
+        error = OSError(errno.ENAMETOOLONG, "File name too long")
+        with patch.object(Path, "is_file", side_effect=error):
+            payloads = parse_hook_input(self._bash_hook_input(command))
+            # The bogus "file" payload must not raise, and must be dropped
+            # before any API call.
+            read = next(p for p in payloads if p.tool == Tool.READ)
+            assert isinstance(read.scannable, StringScannable)
+            assert read.empty
+        bash = payloads[-1]
+        assert bash.tool == Tool.BASH
+        assert isinstance(bash.scannable, StringScannable)
+        assert not bash.empty
+        assert bash.scannable.content == command
 
 
 class TestFlavorOutputResult:

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -1,3 +1,4 @@
+import errno
 import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional
@@ -61,6 +62,31 @@ class TestHookPayloadScannable:
             raw={},
         )
         assert isinstance(payload.scannable, StringScannable)
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # Python < 3.13 lets ENAMETOOLONG through Path.is_file().
+            pytest.param(
+                OSError(errno.ENAMETOOLONG, "File name too long"), id="name-too-long"
+            ),
+            pytest.param(ValueError("embedded null byte"), id="embedded-nul"),
+        ],
+    )
+    def test_read_tool_unstatable_identifier_returns_string_scannable(
+        self, error: Exception
+    ):
+        """An identifier we cannot even stat must fall back to the content, not raise."""
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="some content",
+            identifier="not-really-a-path",
+            agent=Cursor(),
+            raw={},
+        )
+        with patch.object(Path, "is_file", side_effect=error):
+            assert isinstance(payload.scannable, StringScannable)
 
     def test_non_read_tool_returns_string_scannable(self):
         payload = HookPayload(


### PR DESCRIPTION
## Context

`ggshield secret scan ai-hook` fails open with `OSError: [Errno 63] File name too long` — 5 of 2021 hook runs in a local production sample were **never scanned**.

`_parse_command` (`verticals/ai/hooks.py:302`) treats everything after `cat ` / `Get-Content ` as a filename and builds a `Tool.READ` payload. For a heredoc (`cat > script.py <<'EOF' …`) that "filename" is the whole multi-KB command, and `Path.is_file()` raises instead of returning `False` — pathlib's `_ignore_error()` only swallows ENOENT/ENOTDIR/EBADF/ELOOP, not ENAMETOOLONG. The exception escapes to the fail-open handler, so the command being scanned — typically a secret being written to a file — is skipped entirely.

## What has been done

One `try/except (OSError, ValueError)` around the stat in `HookPayload.scannable` (`models.py`), falling back to `StringScannable`. A single guard at the shared choke point: all payload shapes route through this property, so no per-caller guards.

`_parse_command` is deliberately unchanged — with the guard, its derived READ payload becomes an empty `StringScannable` that `payload.empty` drops before any API call, while the sibling BASH payload (same invocation, carries the full command) is scanned normally. That's the coverage that was being lost.

## Validation

- `tests/unit` → **2499 passed, 4 skipped**
- 3 new tests (heredoc end-to-end + parametrized ENAMETOOLONG / embedded-NUL); all 3 fail with the guard reverted
- Note: the crash does not reproduce on Python 3.13+ (`is_file()` there swallows all `OSError`), so the tests patch `Path.is_file` to raise — a test using a genuinely over-long path would pass on 3.14 and prove nothing

## PR check list

- [x] Tests included
- [x] Changelog entry (`changelog.d/`)
