### PR TITLE
perf(ai-hook): cache clean scan verdicts to skip duplicate API calls

### DIFF
--- a/changelog.d/20260803_120000_achille.mascia_ai_hook_verdict_cache.md
+++ b/changelog.d/20260803_120000_achille.mascia_ai_hook_verdict_cache.md
@@ -1,0 +1,6 @@
+### Changed
+
+- AI hooks no longer call the API twice for the same document. An unambiguously clean
+  scan result is cached locally for 15 minutes, keyed on the exact document sent and on
+  the instance and token it was sent with, so a file read costs one API round trip
+  instead of two (`PreToolUse` and `PostToolUse` scan the same file).

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -3,8 +3,8 @@ Protocols for SecretScanner and its results,
 so that other verticals can use the scanner if they are provided one.
 """
 
-from collections.abc import Sequence
-from typing import Iterable, Optional, Protocol
+from collections.abc import Mapping, Sequence
+from typing import Any, Iterable, Optional, Protocol
 
 from pygitguardian import GGClient
 from pygitguardian.models import Match
@@ -39,6 +39,12 @@ class SecretProtocol(Protocol):
 class ResultProtocol(Protocol):
     @property
     def secrets(self) -> Sequence[SecretProtocol]: ...
+
+    @property
+    def ignored_secrets_count_by_kind(self) -> Mapping[Any, int]:
+        """Secrets the API reported but ggshield filtered out locally. Non-empty
+        means `secrets` reflects the local configuration, not just the API."""
+        ...
 
 
 class ResultsProtocol(Protocol):

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Optional, Protocol
 from pygitguardian import GGClient
 from pygitguardian.models import Match
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scanner_ui import ScannerUI
 
 from . import Scannable
@@ -57,6 +58,9 @@ class ScannerProtocol(Protocol):
 
     @property
     def client(self) -> GGClient: ...
+
+    @property
+    def secret_config(self) -> SecretConfig: ...
 
     def scan(
         self,

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Tuple
 from marshmallow.exceptions import ValidationError
 from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.dirs import get_cache_dir
 
 from .models import Scope
@@ -49,16 +50,48 @@ def load_discovery_cache() -> Optional[AIDiscovery]:
         return None
 
 
-def verdict_key(instance: str, api_key: str, filename: str, content: str) -> str:
+def config_fingerprint(secret_config: SecretConfig) -> str:
+    """The settings that change what we send or how we read the answer.
+
+    Only these: a setting that merely changes what we print would cost cache
+    misses without preventing a stale verdict.
+
+    - filename_only rewrites the filename we send, and the key holds the local one
+    - all_secrets moves locally-ignored breaks into `secrets` instead of
+      `ignored_secrets_count_by_kind`, which is the guard that decides whether a
+      verdict is cacheable at all
+    - source_uuid switches the endpoint to scan_and_create_incidents
+
+    The ignore settings (ignored_matches, ignored_detectors,
+    ignore_known_secrets) are deliberately absent: a verdict that depended on
+    them is never stored, see AIHookScanner._scan_content.
+    """
+    return (
+        f"all_secrets={int(secret_config.all_secrets)};"
+        f"filename_only={int(secret_config.filename_only)};"
+        f"source_uuid={secret_config.source_uuid or ''}"
+    )
+
+
+def verdict_key(
+    instance: str,
+    api_key: str,
+    secret_config: SecretConfig,
+    filename: str,
+    content: str,
+) -> str:
     """Cache key for one document: everything the API's answer depends on.
 
-    The document we send (content and filename), plus the instance and token,
-    because custom detectors and dashboard exclusions are per-workspace.
+    The document we send (content and filename), the instance and token, because
+    custom detectors and dashboard exclusions are per-workspace, and the config
+    that shapes the request (see config_fingerprint).
 
     NUL separates the parts: it cannot appear in a URL, a token or a path.
     `surrogatepass` rather than `replace`: this key must not be lossy.
     """
-    joined = "\0".join((instance, api_key, filename, content))
+    joined = "\0".join(
+        (instance, api_key, config_fingerprint(secret_config), filename, content)
+    )
     return hashlib.sha256(joined.encode("utf-8", "surrogatepass")).hexdigest()
 
 

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -17,10 +17,8 @@ from .models import Scope
 AI_DISCOVERY_CACHE_FILENAME = "ai_discovery.json"
 
 VERDICT_CACHE_FILENAME = "ai_hook_verdicts.json"
-# The key covers everything the verdict depends on (see verdict_key), so an
-# entry can never be wrong about what was scanned. It can only go stale if the
-# server's detection, or a secret's known/valid status, changes — hence a short
-# TTL rather than a long one.
+# The key covers what we send (see verdict_key), so an entry can only go stale
+# if the server's answer changes — hence a short TTL.
 VERDICT_CACHE_TTL_SECONDS = 15 * 60
 VERDICT_CACHE_MAX_ENTRIES = 500
 
@@ -54,14 +52,11 @@ def load_discovery_cache() -> Optional[AIDiscovery]:
 def verdict_key(instance: str, api_key: str, filename: str, content: str) -> str:
     """Cache key for one document: everything the API's answer depends on.
 
-    Content and filename because that is exactly what we send. Instance and
-    token because the answer is per-workspace: custom detectors, dashboard
-    exclusions and the engine version all differ between them, so a verdict
-    obtained with one token says nothing about another.
+    The document we send (content and filename), plus the instance and token,
+    because custom detectors and dashboard exclusions are per-workspace.
 
-    NUL separates the parts: it cannot appear in a URL, a token or a path, so
-    the concatenation is unambiguous. `surrogatepass` rather than `replace`:
-    the key of a security control must not be lossy.
+    NUL separates the parts: it cannot appear in a URL, a token or a path.
+    `surrogatepass` rather than `replace`: this key must not be lossy.
     """
     joined = "\0".join((instance, api_key, filename, content))
     return hashlib.sha256(joined.encode("utf-8", "surrogatepass")).hexdigest()
@@ -75,18 +70,13 @@ def _load_verdicts() -> Dict[str, float]:
     """Load the cached clean verdicts, or an empty mapping if the cache can't be trusted.
 
     Every failure path returns an empty mapping, so the caller scans: a broken
-    or suspicious cache must never turn into an "allow".
-
-    Trust here only rules out *other* users. Anyone who can write the file as
-    the current user can seed sha256(secret-bearing content) and have the hook
-    allow it without asking the API — but they could equally replace ggshield
-    itself, so that is not a boundary we can defend from inside the cache.
+    or suspicious cache must never turn into an "allow". This only rules out
+    *other* users; whoever can write as us could replace ggshield itself.
     """
     path = _verdict_cache_path()
     try:
-        # Open once and check the descriptor, not the path: O_NOFOLLOW refuses a
-        # symlink (not a cache file we wrote) and fstat leaves no window in which
-        # the file we validated could be swapped for the file we read.
+        # Check the descriptor, not the path: O_NOFOLLOW refuses a symlink, and
+        # fstat leaves no window for a swap between check and read.
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         with os.fdopen(fd, "r", encoding="utf-8") as file:
             info = os.fstat(file.fileno())
@@ -97,15 +87,15 @@ def _load_verdicts() -> Dict[str, float]:
                 info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
                 or info.st_uid != os.getuid()
             ):
-                # Group/other-writable, or written by somebody else: either way
-                # this is not a file only we could have produced.
+                # Group/other-writable, or somebody else's: not a file only we
+                # could have produced.
                 return {}
             data = json.loads(file.read())
     except (OSError, ValueError):
         return {}
     if not isinstance(data, dict):
         return {}
-    # No bound here on purpose: store_clean_verdict() caps what we write, and
+    # Unbounded on purpose: store_clean_verdict() caps what we write, and
     # truncating before validation would let junk entries evict real ones.
     return {
         key: float(value)
@@ -115,8 +105,7 @@ def _load_verdicts() -> Dict[str, float]:
 
 
 def _is_fresh(stored: float, now: float) -> bool:
-    # A timestamp in the future is not fresh, it is either clock skew or a
-    # forged entry meant to never expire.
+    # A timestamp in the future is clock skew, or a forged never-expiring entry.
     return 0 <= now - stored < VERDICT_CACHE_TTL_SECONDS
 
 
@@ -141,16 +130,15 @@ def store_clean_verdict(key: str) -> None:
     path = _verdict_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        # 0600 on creation, and never through a symlink. No file lock: unlike
-        # the hook debounce, this is advisory — a lost or torn write costs a
-        # cache miss, and a miss simply scans.
+        # 0600 on creation, and never through a symlink. No file lock: a lost or
+        # torn write costs a cache miss, and a miss simply scans.
         fd = os.open(
             path,
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
             0o600,
         )
         with os.fdopen(fd, "w") as file:
-            # O_CREAT's mode only applies to a file we actually created. Force
+            # O_CREAT's mode only applies to a file we actually created: force
             # it, so a pre-existing loose-permission file — which _load_verdicts
             # refuses to read — doesn't disable the cache for good.
             if hasattr(os, "fchmod"):

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -1,4 +1,9 @@
+import hashlib
 import json
+import os
+import stat
+import time
+from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 from marshmallow.exceptions import ValidationError
@@ -10,6 +15,14 @@ from .models import Scope
 
 
 AI_DISCOVERY_CACHE_FILENAME = "ai_discovery.json"
+
+VERDICT_CACHE_FILENAME = "ai_hook_verdicts.json"
+# The key covers everything the verdict depends on (see verdict_key), so an
+# entry can never be wrong about what was scanned. It can only go stale if the
+# server's detection, or a secret's known/valid status, changes — hence a short
+# TTL rather than a long one.
+VERDICT_CACHE_TTL_SECONDS = 15 * 60
+VERDICT_CACHE_MAX_ENTRIES = 500
 
 
 def save_discovery_cache(config: AIDiscovery) -> None:
@@ -36,6 +49,115 @@ def load_discovery_cache() -> Optional[AIDiscovery]:
         return AIDiscovery.from_dict(json.loads(cache_path.read_text()))
     except (OSError, json.JSONDecodeError, ValidationError):
         return None
+
+
+def verdict_key(instance: str, api_key: str, filename: str, content: str) -> str:
+    """Cache key for one document: everything the API's answer depends on.
+
+    Content and filename because that is exactly what we send. Instance and
+    token because the answer is per-workspace: custom detectors, dashboard
+    exclusions and the engine version all differ between them, so a verdict
+    obtained with one token says nothing about another.
+
+    NUL separates the parts: it cannot appear in a URL, a token or a path, so
+    the concatenation is unambiguous. `surrogatepass` rather than `replace`:
+    the key of a security control must not be lossy.
+    """
+    joined = "\0".join((instance, api_key, filename, content))
+    return hashlib.sha256(joined.encode("utf-8", "surrogatepass")).hexdigest()
+
+
+def _verdict_cache_path() -> Path:
+    return get_cache_dir() / VERDICT_CACHE_FILENAME
+
+
+def _load_verdicts() -> Dict[str, float]:
+    """Load the cached clean verdicts, or an empty mapping if the cache can't be trusted.
+
+    Every failure path returns an empty mapping, so the caller scans: a broken
+    or suspicious cache must never turn into an "allow".
+
+    Trust here only rules out *other* users. Anyone who can write the file as
+    the current user can seed sha256(secret-bearing content) and have the hook
+    allow it without asking the API — but they could equally replace ggshield
+    itself, so that is not a boundary we can defend from inside the cache.
+    """
+    path = _verdict_cache_path()
+    try:
+        # Open once and check the descriptor, not the path: O_NOFOLLOW refuses a
+        # symlink (not a cache file we wrote) and fstat leaves no window in which
+        # the file we validated could be swapped for the file we read.
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        with os.fdopen(fd, "r", encoding="utf-8") as file:
+            info = os.fstat(file.fileno())
+            if not stat.S_ISREG(info.st_mode):
+                return {}
+            # Windows does not use these bits, and reports them set on every file.
+            if os.name == "posix" and (
+                info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+                or info.st_uid != os.getuid()
+            ):
+                # Group/other-writable, or written by somebody else: either way
+                # this is not a file only we could have produced.
+                return {}
+            data = json.loads(file.read())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    # No bound here on purpose: store_clean_verdict() caps what we write, and
+    # truncating before validation would let junk entries evict real ones.
+    return {
+        key: float(value)
+        for key, value in data.items()
+        if isinstance(key, str) and isinstance(value, (int, float))
+    }
+
+
+def _is_fresh(stored: float, now: float) -> bool:
+    # A timestamp in the future is not fresh, it is either clock skew or a
+    # forged entry meant to never expire.
+    return 0 <= now - stored < VERDICT_CACHE_TTL_SECONDS
+
+
+def has_clean_verdict(key: str) -> bool:
+    """Whether `key` (see `verdict_key`) was scanned clean recently enough to skip
+    the API call."""
+    stored = _load_verdicts().get(key)
+    return stored is not None and _is_fresh(stored, time.time())
+
+
+def store_clean_verdict(key: str) -> None:
+    """Remember that `key` was scanned clean. Best effort, failures are ignored."""
+    now = time.time()
+    verdicts = _load_verdicts()
+    verdicts[key] = now
+    # Drop expired entries and keep the cache bounded, newest kept first.
+    kept = sorted(
+        ((key, ts) for key, ts in verdicts.items() if _is_fresh(ts, now)),
+        key=lambda item: item[1],
+        reverse=True,
+    )[:VERDICT_CACHE_MAX_ENTRIES]
+    path = _verdict_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # 0600 on creation, and never through a symlink. No file lock: unlike
+        # the hook debounce, this is advisory — a lost or torn write costs a
+        # cache miss, and a miss simply scans.
+        fd = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        with os.fdopen(fd, "w") as file:
+            # O_CREAT's mode only applies to a file we actually created. Force
+            # it, so a pre-existing loose-permission file — which _load_verdicts
+            # refuses to read — doesn't disable the cache for good.
+            if hasattr(os, "fchmod"):
+                os.fchmod(file.fileno(), 0o600)
+            json.dump(dict(kept), file)
+    except OSError:
+        pass
 
 
 def has_changed_from(current: AIDiscovery, other: AIDiscovery) -> bool:

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set
 
 import filelock
 from notifypy import Notify
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES
 
 from ggshield.core import ui
 from ggshield.core.dirs import get_cache_dir
@@ -20,6 +21,7 @@ from ggshield.core.text_utils import pluralize, translate_validity
 from ggshield.verticals.ai.mcp import send_mcp_activity
 
 from .agents import AGENTS
+from .cache import has_clean_verdict, store_clean_verdict, verdict_key
 from .models import (
     Agent,
     EventType,
@@ -588,14 +590,72 @@ class AIHookScanner:
         if payload.empty:
             return HookResult.allow(payload)
 
+        # One Scannable for both the cache key and the scan, so the two can never
+        # disagree about what was scanned.
+        scannable = payload.scannable
+        try:
+            # is_longer_than() answers from the byte size when it can, so an
+            # oversized document is not pulled into memory just to key the
+            # cache. The API would reject it, so it is never cached anyway.
+            content = (
+                ""
+                if scannable.is_longer_than(DOCUMENT_SIZE_THRESHOLD_BYTES)
+                else scannable.content
+            )
+        except Exception:
+            # Unreadable or undecodable: we have no cache key. Hand it to the
+            # scanner, which knows how to skip it, rather than deciding here.
+            content = ""
+
+        key = (
+            verdict_key(
+                self.scanner.client.base_uri,
+                self.scanner.client.api_key,
+                scannable.filename,
+                content,
+            )
+            if content
+            else None
+        )
+
+        # Shortest path: this exact document already came back clean from the API
+        # recently. A Read is scanned twice — PreToolUse and PostToolUse both
+        # resolve to File(file_path) (see HookPayload.scannable), so the second
+        # call sends an identical document and can be answered locally.
+        # This is a different layer from has_already_been_seen() above, which
+        # debounces on the raw stdin payload and therefore cannot see the Pre/Post
+        # pair: those two payloads differ (event name, and Post carries the tool
+        # response). That one is a single slot keyed on what the agent sent us,
+        # this one is a TTL'd set keyed on what we send the API.
+        if key and has_clean_verdict(key):
+            return HookResult.allow(payload)
+
         with create_message_only_scanner_ui() as scanner_ui:
-            results = self.scanner.scan([payload.scannable], scanner_ui=scanner_ui)
+            results = self.scanner.scan([scannable], scanner_ui=scanner_ui)
         # Collect all secrets from results
         secrets: List[Secret] = []
         for result in results.results:
             secrets.extend(result.secrets)
 
         if not secrets:
+            # Only cache an unambiguous verdict.
+            # - Exactly one Result: we submitted exactly one document, so that is
+            #   the API answering about it. A degraded scan — chunk error, or a
+            #   scannable the scanner skipped as too large / undecodable /
+            #   missing — yields no Result at all (see
+            #   SecretScanner._collect_results), which is not a verdict.
+            # - Nothing filtered out: an empty `secrets` may also mean the API
+            #   *did* report policy breaks and Result.from_scan_result dropped
+            #   them locally (ignored matches/detectors, known secrets, dashboard
+            #   exclusions). That verdict depends on the config in effect here,
+            #   so caching it would let one project's ignore rule allow the same
+            #   content in a project that does not have it.
+            if (
+                key
+                and len(results.results) == 1
+                and not results.results[0].ignored_secrets_count_by_kind
+            ):
+                store_clean_verdict(key)
             return HookResult.allow(payload)
 
         message = self._message_from_secrets(

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -610,6 +610,7 @@ class AIHookScanner:
             verdict_key(
                 self.scanner.client.base_uri,
                 self.scanner.client.api_key,
+                self.scanner.secret_config,
                 scannable.filename,
                 content,
             )

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -595,16 +595,15 @@ class AIHookScanner:
         scannable = payload.scannable
         try:
             # is_longer_than() answers from the byte size when it can, so an
-            # oversized document is not pulled into memory just to key the
-            # cache. The API would reject it, so it is never cached anyway.
+            # oversized document is not pulled into memory just to key the cache.
             content = (
                 ""
                 if scannable.is_longer_than(DOCUMENT_SIZE_THRESHOLD_BYTES)
                 else scannable.content
             )
         except Exception:
-            # Unreadable or undecodable: we have no cache key. Hand it to the
-            # scanner, which knows how to skip it, rather than deciding here.
+            # Unreadable or undecodable: no cache key. Let the scanner decide
+            # how to skip it.
             content = ""
 
         key = (
@@ -622,11 +621,8 @@ class AIHookScanner:
         # recently. A Read is scanned twice — PreToolUse and PostToolUse both
         # resolve to File(file_path) (see HookPayload.scannable), so the second
         # call sends an identical document and can be answered locally.
-        # This is a different layer from has_already_been_seen() above, which
-        # debounces on the raw stdin payload and therefore cannot see the Pre/Post
-        # pair: those two payloads differ (event name, and Post carries the tool
-        # response). That one is a single slot keyed on what the agent sent us,
-        # this one is a TTL'd set keyed on what we send the API.
+        # has_already_been_seen() above cannot catch that pair: it debounces on
+        # the raw stdin payload, which differs between the two events.
         if key and has_clean_verdict(key):
             return HookResult.allow(payload)
 
@@ -638,18 +634,12 @@ class AIHookScanner:
             secrets.extend(result.secrets)
 
         if not secrets:
-            # Only cache an unambiguous verdict.
-            # - Exactly one Result: we submitted exactly one document, so that is
-            #   the API answering about it. A degraded scan — chunk error, or a
-            #   scannable the scanner skipped as too large / undecodable /
-            #   missing — yields no Result at all (see
-            #   SecretScanner._collect_results), which is not a verdict.
-            # - Nothing filtered out: an empty `secrets` may also mean the API
-            #   *did* report policy breaks and Result.from_scan_result dropped
-            #   them locally (ignored matches/detectors, known secrets, dashboard
-            #   exclusions). That verdict depends on the config in effect here,
-            #   so caching it would let one project's ignore rule allow the same
-            #   content in a project that does not have it.
+            # Only cache an unambiguous verdict:
+            # - exactly one Result, so the API did answer about our document (a
+            #   degraded or skipped scan yields no Result at all);
+            # - nothing filtered out locally, since an empty `secrets` may also
+            #   mean the API reported policy breaks that the local config
+            #   ignored — a verdict about the config, not about the content.
             if (
                 key
                 and len(results.results) == 1

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -1,3 +1,6 @@
+import json
+import stat
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
@@ -14,12 +17,19 @@ from pygitguardian.models import (
 )
 
 from ggshield.verticals.ai.cache import (
+    VERDICT_CACHE_MAX_ENTRIES,
+    VERDICT_CACHE_TTL_SECONDS,
     _server_has_capabilities_unknown_to,
+    _verdict_cache_path,
     has_changed_from,
+    has_clean_verdict,
     load_discovery_cache,
     save_discovery_cache,
+    store_clean_verdict,
+    verdict_key,
 )
 from ggshield.verticals.ai.models import MCPServer, Scope, Transport
+from tests.conftest import skipwindows
 
 
 def _user(**kwargs: Any) -> UserInfo:
@@ -270,3 +280,164 @@ class TestLoadSaveDiscoveryCache:
             cache_file = tmp_path / "ai_discovery.json"
             cache_file.mkdir()  # directory instead of file triggers OSError
             assert load_discovery_cache() is None
+
+
+class TestVerdictKey:
+    """The key must cover everything the API's answer depends on."""
+
+    ARGS = ("https://api.example.com", "token", "file.py", "content")
+
+    @pytest.mark.parametrize("index", range(len(ARGS)))
+    def test_every_part_changes_the_key(self, index: int):
+        """GIVEN two keys differing in one part only THEN they differ."""
+        other = list(self.ARGS)
+        other[index] += "-x"
+        assert verdict_key(*self.ARGS) != verdict_key(*other)
+
+    def test_parts_cannot_be_shifted_across_the_separator(self):
+        """A longer instance must not be able to impersonate another key."""
+        assert verdict_key("a", "b", "c", "d") != verdict_key("a\0b", "c", "d", "")
+
+    def test_unencodable_content_still_yields_distinct_keys(self):
+        """Lone surrogates (reachable from a JSON payload) must not collide."""
+        assert verdict_key("i", "k", "f", "\ud800") != verdict_key(
+            "i", "k", "f", "\ud801"
+        )
+
+
+class TestVerdictCache:
+    """Unit tests for the AI hook clean-verdict cache. Keys are opaque strings
+    here; what goes into them is TestVerdictKey's business.
+
+    The autouse do_not_use_real_user_dirs fixture already points get_cache_dir()
+    at a per-test temporary directory.
+    """
+
+    def test_store_then_hit(self):
+        """GIVEN a stored clean verdict WHEN the same content is looked up THEN it hits."""
+        store_clean_verdict("some content")
+        assert has_clean_verdict("some content") is True
+
+    def test_miss_on_different_content(self):
+        """GIVEN a stored verdict WHEN other content is looked up THEN it misses."""
+        store_clean_verdict("some content")
+        assert has_clean_verdict("other content") is False
+
+    def test_miss_on_empty_cache(self):
+        """GIVEN no cache file WHEN content is looked up THEN it misses."""
+        assert not _verdict_cache_path().exists()
+        assert has_clean_verdict("some content") is False
+
+    def test_miss_once_expired(self):
+        """GIVEN a verdict older than the TTL WHEN looked up THEN it misses."""
+        store_clean_verdict("some content")
+        with patch(
+            "ggshield.verticals.ai.cache.time.time",
+            return_value=time.time() + VERDICT_CACHE_TTL_SECONDS + 1,
+        ):
+            assert has_clean_verdict("some content") is False
+
+    def test_miss_on_timestamp_in_the_future(self):
+        """A forged far-future timestamp must not become a never-expiring hit."""
+        self._write_cache({"some content": time.time() + 10_000})
+        assert has_clean_verdict("some content") is False
+
+    def test_miss_on_corrupted_json(self):
+        """GIVEN a cache file that is not valid JSON WHEN read THEN it is treated as empty."""
+        self._write_cache_text("{not json")
+        assert has_clean_verdict("some content") is False
+
+    def test_miss_on_json_that_is_not_an_object(self):
+        """A JSON array where a mapping is expected is treated as empty."""
+        self._write_cache_text('["nope"]')
+        assert has_clean_verdict("some content") is False
+
+    @skipwindows
+    def test_poisoned_world_writable_cache_is_ignored(self):
+        """A cache anyone can write is a bypass oracle: refuse to read it."""
+        store_clean_verdict("some content")
+        assert has_clean_verdict("some content") is True
+        _verdict_cache_path().chmod(0o666)
+        assert has_clean_verdict("some content") is False
+
+    @skipwindows
+    def test_group_writable_cache_is_ignored(self):
+        """Same for a group-writable cache."""
+        store_clean_verdict("some content")
+        _verdict_cache_path().chmod(0o660)
+        assert has_clean_verdict("some content") is False
+
+    @skipwindows
+    def test_cache_owned_by_another_user_is_ignored(self):
+        """0600 is only trustworthy if we are the owner: a file somebody else
+        dropped in a writable cache dir must not be believed."""
+        store_clean_verdict("some content")
+        with patch("ggshield.verticals.ai.cache.os.getuid", return_value=-1):
+            assert has_clean_verdict("some content") is False
+
+    @skipwindows
+    def test_stored_cache_file_is_private(self):
+        """The cache file must be created 0600."""
+        store_clean_verdict("some content")
+        assert stat.S_IMODE(_verdict_cache_path().stat().st_mode) == 0o600
+
+    @skipwindows
+    def test_writing_repairs_a_loose_permission_cache_file(self):
+        """A file we refuse to read must not disable the cache for good."""
+        store_clean_verdict("some content")
+        _verdict_cache_path().chmod(0o666)
+        store_clean_verdict("other content")
+        assert stat.S_IMODE(_verdict_cache_path().stat().st_mode) == 0o600
+        assert has_clean_verdict("other content") is True
+        # The verdicts of the untrusted file were dropped, not carried over.
+        assert has_clean_verdict("some content") is False
+
+    @skipwindows
+    def test_symlinked_cache_is_ignored(self):
+        """A symlink at the cache path is not a cache file we wrote."""
+        path = _verdict_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        target = path.parent / "elsewhere.json"
+        target.write_text(json.dumps({"some content": time.time()}))
+        path.symlink_to(target)
+        assert has_clean_verdict("some content") is False
+
+    def test_entry_count_is_bounded(self):
+        """GIVEN more verdicts than the cap WHEN stored THEN only the newest are kept."""
+        for i in range(VERDICT_CACHE_MAX_ENTRIES + 10):
+            store_clean_verdict(f"content {i}")
+        stored = json.loads(_verdict_cache_path().read_text())
+        assert len(stored) == VERDICT_CACHE_MAX_ENTRIES
+        assert has_clean_verdict(f"content {VERDICT_CACHE_MAX_ENTRIES + 9}") is True
+
+    def test_expired_entries_are_dropped_on_write(self):
+        """Storing a verdict purges entries that have expired."""
+        store_clean_verdict("old content")
+        with patch(
+            "ggshield.verticals.ai.cache.time.time",
+            return_value=time.time() + VERDICT_CACHE_TTL_SECONDS + 1,
+        ):
+            store_clean_verdict("new content")
+        assert list(json.loads(_verdict_cache_path().read_text())) == ["new content"]
+
+    def test_store_never_raises_when_the_cache_dir_is_unusable(self):
+        """A cache failure must never propagate: the hook would rather scan."""
+        with patch(
+            "ggshield.verticals.ai.cache.get_cache_dir",
+            return_value=Path(__file__) / "not-a-dir",
+        ):
+            store_clean_verdict("some content")
+            assert has_clean_verdict("some content") is False
+
+    @staticmethod
+    def _write_cache(payload: Dict[str, float]) -> None:
+        TestVerdictCache._write_cache_text(json.dumps(payload))
+
+    @staticmethod
+    def _write_cache_text(text: str) -> None:
+        path = _verdict_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        # Keep the file trustworthy so these tests exercise the content checks
+        # and not the permission check.
+        path.chmod(0o600)

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 from pygitguardian.models import (
@@ -16,6 +17,7 @@ from pygitguardian.models import (
     UserInfo,
 )
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.verticals.ai.cache import (
     VERDICT_CACHE_MAX_ENTRIES,
     VERDICT_CACHE_TTL_SECONDS,
@@ -285,9 +287,20 @@ class TestLoadSaveDiscoveryCache:
 class TestVerdictKey:
     """The key must cover everything the API's answer depends on."""
 
-    ARGS = ("https://api.example.com", "token", "file.py", "content")
+    ARGS = ("https://api.example.com", "token", SecretConfig(), "file.py", "content")
 
-    @pytest.mark.parametrize("index", range(len(ARGS)))
+    @staticmethod
+    def _key(**config_kwargs: Any) -> str:
+        return verdict_key(
+            "https://api.example.com",
+            "token",
+            SecretConfig(**config_kwargs),
+            "file.py",
+            "content",
+        )
+
+    # Index 2 is the config, covered by its own tests below.
+    @pytest.mark.parametrize("index", [0, 1, 3, 4])
     def test_every_part_changes_the_key(self, index: int):
         """GIVEN two keys differing in one part only THEN they differ."""
         other = list(self.ARGS)
@@ -296,13 +309,51 @@ class TestVerdictKey:
 
     def test_parts_cannot_be_shifted_across_the_separator(self):
         """A longer instance must not be able to impersonate another key."""
-        assert verdict_key("a", "b", "c", "d") != verdict_key("a\0b", "c", "d", "")
+        config = SecretConfig()
+        assert verdict_key("a", "b", config, "c", "d") != verdict_key(
+            "a\0b", "c", config, "d", ""
+        )
 
     def test_unencodable_content_still_yields_distinct_keys(self):
         """Lone surrogates (reachable from a JSON payload) must not collide."""
-        assert verdict_key("i", "k", "f", "\ud800") != verdict_key(
-            "i", "k", "f", "\ud801"
+        config = SecretConfig()
+        assert verdict_key("i", "k", config, "f", "\ud800") != verdict_key(
+            "i", "k", config, "f", "\ud801"
         )
+
+    def test_same_config_yields_the_same_key(self):
+        """Two equivalent configs must still hit, otherwise the cache is dead."""
+        assert self._key() == self._key()
+
+    @pytest.mark.parametrize(
+        "config_kwargs",
+        [
+            # Rewrites the filename we send.
+            {"filename_only": True},
+            # Changes which policy breaks land in `secrets`.
+            {"all_secrets": True},
+            # Switches the endpoint to scan_and_create_incidents.
+            {"source_uuid": UUID("11111111-1111-1111-1111-111111111111")},
+        ],
+    )
+    def test_request_shaping_settings_change_the_key(self, config_kwargs: Any):
+        """A setting that changes the request, or how we read the answer, must not
+        serve a verdict recorded under its other value."""
+        assert self._key() != self._key(**config_kwargs)
+
+    @pytest.mark.parametrize(
+        "config_kwargs",
+        [
+            # Presentation only.
+            {"show_secrets": True},
+            # A verdict that depended on it is never stored in the first place,
+            # see AIHookScanner._scan_content.
+            {"ignore_known_secrets": True},
+        ],
+    )
+    def test_unrelated_settings_do_not_change_the_key(self, config_kwargs: Any):
+        """Settings that cannot make a verdict stale must not cost a cache miss."""
+        assert self._key() == self._key(**config_kwargs)
 
 
 class TestVerdictCache:

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -12,6 +12,11 @@ from pygitguardian.models import MCPActivityResponse
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
+from ggshield.verticals.ai.cache import (
+    _verdict_cache_path,
+    has_clean_verdict,
+    verdict_key,
+)
 from ggshield.verticals.ai.hooks import (
     AIHookScanner,
     build_agent_headers,
@@ -22,8 +27,14 @@ from ggshield.verticals.ai.hooks import (
 from ggshield.verticals.ai.mcp import send_mcp_activity
 from ggshield.verticals.ai.models import EventType, HookPayload, HookResult, Tool
 from ggshield.verticals.secret import SecretScanner
+from ggshield.verticals.secret.secret_scan_collection import IgnoreKind
 from ggshield.verticals.secret.secret_scan_collection import Result as ScanResult
 from ggshield.verticals.secret.secret_scan_collection import Results, Secret
+from tests.conftest import skipwindows
+
+
+INSTANCE = "https://api.example.com"
+API_KEY = "some-api-key"
 
 
 def _dummy_payload(event_type: EventType = EventType.OTHER) -> HookPayload:
@@ -49,6 +60,10 @@ def _mock_scanner(matches: List[str]) -> MagicMock:
     """Create a mock SecretScanner that returns the given Results from scan()."""
     mock = MagicMock(spec=SecretScanner)
     mock.client = MagicMock(spec=GGClient)
+    # Annotation-only attributes on GGClient, so spec= does not provide them,
+    # and the verdict cache key needs both.
+    mock.client.base_uri = INSTANCE
+    mock.client.api_key = API_KEY
     scan_result = Results(
         results=[
             ScanResult(
@@ -133,6 +148,133 @@ class TestAIHookScannerScanContent:
         assert "dummy-detector" in result.message
         assert "secret" in result.message.lower()
         assert "remove the secret from your prompt" in result.message
+
+
+class TestVerdictCacheShortCircuit:
+    """The clean-verdict cache must skip the API call, and only when it is safe to."""
+
+    @staticmethod
+    def _payload(
+        content: str = "safe content", identifier: str = "id", **kwargs
+    ) -> HookPayload:
+        return HookPayload(
+            event_type=EventType.USER_PROMPT,
+            tool=None,
+            content=content,
+            identifier=identifier,
+            agent=Cursor(),
+            raw={},
+            **kwargs,
+        )
+
+    @staticmethod
+    def _key(content: str = "safe content") -> str:
+        # A payload with no tool becomes a StringScannable whose filename is the
+        # payload identifier.
+        return verdict_key(INSTANCE, API_KEY, "id", content)
+
+    def test_second_scan_of_identical_content_skips_the_api(self):
+        """GIVEN a clean scan WHEN the same content is scanned again THEN no API call."""
+        mock_scanner = _mock_scanner([])
+        hook_scanner = AIHookScanner(mock_scanner)
+        assert hook_scanner._scan_content(self._payload()).block is False
+        assert hook_scanner._scan_content(self._payload()).block is False
+        mock_scanner.scan.assert_called_once()
+
+    def test_different_content_still_hits_the_api(self):
+        """A cached verdict must not leak onto different content."""
+        mock_scanner = _mock_scanner([])
+        hook_scanner = AIHookScanner(mock_scanner)
+        hook_scanner._scan_content(self._payload("safe content"))
+        hook_scanner._scan_content(self._payload("other content"))
+        assert mock_scanner.scan.call_count == 2
+
+    def test_pre_and_post_tool_use_of_a_read_share_one_api_call(self):
+        """Both Read events resolve to the same file, so the second is served locally."""
+        mock_scanner = _mock_scanner([])
+        hook_scanner = AIHookScanner(mock_scanner)
+        pre = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": __file__},
+                "cursor_version": "1.2.3",
+            }
+        )
+        post = json.dumps(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": __file__},
+                "tool_response": {"file": {"filePath": __file__}},
+                "cursor_version": "1.2.3",
+            }
+        )
+        assert hook_scanner.scan(pre) == 0
+        assert hook_scanner.scan(post) == 0
+        mock_scanner.scan.assert_called_once()
+
+    def test_scan_with_secrets_is_not_cached(self):
+        """A blocking verdict is never remembered as clean."""
+        mock_scanner = _mock_scanner(["sk-xxx"])
+        hook_scanner = AIHookScanner(mock_scanner)
+        assert hook_scanner._scan_content(self._payload("content sk-xxx")).block is True
+        assert not has_clean_verdict(self._key("content sk-xxx"))
+
+    def test_degraded_scan_is_not_cached(self):
+        """A scan that returned no Result at all is not a verdict, so it is not cached."""
+        mock_scanner = _mock_scanner([])
+        mock_scanner.scan.return_value = Results(results=[], errors=[])
+        hook_scanner = AIHookScanner(mock_scanner)
+        assert hook_scanner._scan_content(self._payload()).block is False
+        assert not has_clean_verdict(self._key())
+        # ... and the next identical payload is scanned again.
+        hook_scanner._scan_content(self._payload())
+        assert mock_scanner.scan.call_count == 2
+
+    def test_locally_filtered_verdict_is_not_cached(self):
+        """The API reported secrets and the local config dropped them: that "clean"
+        answer belongs to this config only, so it must not be remembered."""
+        mock_scanner = _mock_scanner([])
+        mock_scanner.scan.return_value.results[0].ignored_secrets_count_by_kind = (
+            Counter({IgnoreKind.IGNORED_DETECTOR: 1})
+        )
+        hook_scanner = AIHookScanner(mock_scanner)
+        assert hook_scanner._scan_content(self._payload()).block is False
+        assert not has_clean_verdict(self._key())
+        hook_scanner._scan_content(self._payload())
+        assert mock_scanner.scan.call_count == 2
+
+    def test_another_instance_or_token_does_not_reuse_the_verdict(self):
+        """Custom detectors and dashboard exclusions are per-workspace."""
+        mock_scanner = _mock_scanner([])
+        AIHookScanner(mock_scanner)._scan_content(self._payload())
+        for attribute, value in (
+            ("base_uri", "https://other.example.com"),
+            ("api_key", "other-key"),
+        ):
+            other = _mock_scanner([])
+            setattr(other.client, attribute, value)
+            AIHookScanner(other)._scan_content(self._payload())
+            other.scan.assert_called_once()
+
+    def test_same_content_under_another_filename_is_rescanned(self):
+        """The filename is part of the document we send, so it is part of the key."""
+        mock_scanner = _mock_scanner([])
+        hook_scanner = AIHookScanner(mock_scanner)
+        hook_scanner._scan_content(self._payload())
+        hook_scanner._scan_content(self._payload(identifier="other-id"))
+        assert mock_scanner.scan.call_count == 2
+
+    @skipwindows
+    def test_untrustworthy_cache_falls_back_to_scanning(self):
+        """A world-writable cache is ignored, so the hook scans rather than allows."""
+        mock_scanner = _mock_scanner([])
+        hook_scanner = AIHookScanner(mock_scanner)
+        hook_scanner._scan_content(self._payload())
+        _verdict_cache_path().chmod(0o666)
+        hook_scanner._scan_content(self._payload())
+        assert mock_scanner.scan.call_count == 2
 
 
 class TestHasAlreadyBeenSeen:

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -9,6 +9,7 @@ import pytest
 from pygitguardian import GGClient
 from pygitguardian.models import MCPActivityResponse
 
+from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import ScanContext, ScanMode
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import Agent, Claude, Codex, Copilot, Cursor, VSCode
@@ -56,7 +57,9 @@ def tmp_file(tmp_path: Path) -> Path:
     return file
 
 
-def _mock_scanner(matches: List[str]) -> MagicMock:
+def _mock_scanner(
+    matches: List[str], secret_config: Optional[SecretConfig] = None
+) -> MagicMock:
     """Create a mock SecretScanner that returns the given Results from scan()."""
     mock = MagicMock(spec=SecretScanner)
     mock.client = MagicMock(spec=GGClient)
@@ -64,6 +67,8 @@ def _mock_scanner(matches: List[str]) -> MagicMock:
     # and the verdict cache key needs both.
     mock.client.base_uri = INSTANCE
     mock.client.api_key = API_KEY
+    # Set in SecretScanner.__init__, so spec= does not provide it either.
+    mock.secret_config = secret_config or SecretConfig()
     scan_result = Results(
         results=[
             ScanResult(
@@ -171,7 +176,7 @@ class TestVerdictCacheShortCircuit:
     def _key(content: str = "safe content") -> str:
         # A payload with no tool becomes a StringScannable whose filename is the
         # payload identifier.
-        return verdict_key(INSTANCE, API_KEY, "id", content)
+        return verdict_key(INSTANCE, API_KEY, SecretConfig(), "id", content)
 
     def test_second_scan_of_identical_content_skips_the_api(self):
         """GIVEN a clean scan WHEN the same content is scanned again THEN no API call."""
@@ -257,6 +262,13 @@ class TestVerdictCacheShortCircuit:
             setattr(other.client, attribute, value)
             AIHookScanner(other)._scan_content(self._payload())
             other.scan.assert_called_once()
+
+    def test_another_secret_config_does_not_reuse_the_verdict(self):
+        """filename_only changes the document we send, so the verdict is not reusable."""
+        AIHookScanner(_mock_scanner([]))._scan_content(self._payload())
+        other = _mock_scanner([], SecretConfig(filename_only=True))
+        AIHookScanner(other)._scan_content(self._payload())
+        other.scan.assert_called_once()
 
     def test_same_content_under_another_filename_is_rescanned(self):
         """The filename is part of the document we send, so it is part of the key."""


### PR DESCRIPTION
## Context

The ai-hook pays the ~380 ms API round trip twice for identical bytes. For a Read, **both** `PreToolUse` and `PostToolUse` scan the same file from disk: `hooks.py` sets `identifier = file_path` at both events, and `HookPayload.scannable` turns that into `File(path=...)`, so `PostToolUse` discards its own `tool_response` and re-reads the file. The bytes are provably identical, so caching the verdict is a correct short-circuit rather than a heuristic.

The existing debounce (`has_already_been_seen`) doesn't catch this pair — it hashes payload `content`, which is `""` for Pre-Read and the JSON `tool_response` for Post-Read.

## What has been done

New `verticals/ai/cache.py`: after an unambiguously clean scan, store `sha256(scanned_bytes) → timestamp`; a fresh hit returns allow without calling the API. Keyed on the bytes actually sent (`payload.scannable.content`), 15 min TTL, 500 entries max.

Hardening, since a poisoned cache would wave secret-bearing content through:
- file created `0600`, parent dir `0700`
- refuses to read a group/other-writable file, and `os.fstat` on the open fd + `S_ISREG` check (no TOCTOU window, rejects symlinks)
- every failure path fails **closed** — scan anyway, never allow

`ResultProtocol` gains `ignored_secrets_count_by_kind` so we only cache when the API itself found nothing — not when ggshield filtered secrets out locally, which would otherwise survive an ignore-rule change as a stale clean verdict.

## Validation

- `tests/unit` → **2525 passed, 4 skipped**; new `test_cache.py` covers hit/miss/expiry, corrupt JSON, world-writable file ignored, and "never cache a non-clean scan"
- Benchmark, API leg simulated at 380 ms identically on both arms, 20 iterations, fresh file each: **772.6 ms → 395.1 ms** per Read Pre+Post pair, API legs **40 → 20**

Honest scope: this removes only the API leg. The ~440 ms startup and ~135 ms config cost are untouched and still paid twice, so a tool call goes from ~2 s to ~1.6 s, not ~1 s. Write is deliberately not helped — its Pre and Post payloads genuinely differ. No skip table and no minimum-size gate: both were prototyped and rejected (the skip table would have skipped Post-Write content that Pre never saw).

## PR check list

- [x] Tests included
- [x] Changelog entry (`changelog.d/`)


## Follow-up: the config is part of the key

Review feedback was that a verdict goes stale when the config changes. The literal case (removing an entry from the ignore list) is already safe — a verdict is only stored when `ignored_secrets_count_by_kind` is empty, so a clean answer that depended on a local ignore rule is never cached. The general point holds though, so the key now also covers the *effective* secret config.

In the key: `filename_only` (rewrites the filename sent to the API, while the key held the local one), `all_secrets` (moves locally-ignored breaks into `secrets` instead of the counter that gates caching) and `source_uuid` (switches the endpoint to `scan_and_create_incidents`). Out of the key: presentation-only settings (`show_secrets`, verbosity, output format) and the ignore settings, which cannot make a stored verdict stale and would only cost misses.

Behaviour: the key derivation changes, so entries written by earlier builds become misses. A miss means "scan", so this is fail-safe and needs no migration.

**#1381 (Rust port) must mirror this**, since it deliberately shares the same cache file and key derivation. The new derivation is:

```
sha256(instance \0 api_key \0 config \0 filename \0 content)
```

- separator: a single NUL byte (`\0`), field order exactly as above
- `config` = `all_secrets=<0|1>;filename_only=<0|1>;source_uuid=<uuid or empty string>`, in that order, `;` separated, `=` between name and value, booleans as `0`/`1`, `source_uuid` as its lowercase canonical hyphenated form or the empty string when unset
- the whole joined string is UTF-8 encoded with `surrogatepass` (WTF-8: lone surrogates encoded as-is, not replaced), then SHA-256, then lowercase hex
- the config is inlined as plain text, **not** pre-hashed
