### PR TITLE
perf(cli): import only the invoked command at startup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/changelog.d/20260803_170000_achille.mascia_lazy_command_imports.md
+++ b/changelog.d/20260803_170000_achille.mascia_lazy_command_imports.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `ggshield` starts faster: each command now imports only the modules it needs, and
+  plugin discovery runs only when a plugin command is actually resolved. This speeds
+  up every invocation, in particular the ones that run automatically on every git
+  commit (`secret scan pre-commit`) and on every AI agent tool call
+  (`secret scan ai-hook`).

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -10,31 +10,15 @@ from typing import Any, List, Optional
 import click
 
 from ggshield import __version__
-from ggshield.cmd.ai import ai_group
-from ggshield.cmd.auth import auth_group
-from ggshield.cmd.config import config_group
-from ggshield.cmd.hmsl import hmsl_group
-from ggshield.cmd.honeytoken import honeytoken_group
-from ggshield.cmd.install import install_cmd
-from ggshield.cmd.machine import machine_group
-from ggshield.cmd.plugin import plugin_group
-from ggshield.cmd.quota import quota_cmd
-from ggshield.cmd.secret import secret_group
-from ggshield.cmd.secret.scan import scan_group
-from ggshield.cmd.status import status_cmd
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.debug import setup_debug_mode
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 from ggshield.core import check_updates, ui
 from ggshield.core.cache import Cache
 from ggshield.core.config import Config
-from ggshield.core.config.enterprise_config import EnterpriseConfig
 from ggshield.core.env_utils import load_dot_env
-from ggshield.core.errors import ExitCode
-from ggshield.core.plugin.loader import PluginLoader
-from ggshield.core.plugin.registry import PluginRegistry
 from ggshield.core.ui import ensure_level, log_utils
-from ggshield.core.ui.rich import RichGGShieldUI
 from ggshield.utils.click import RealPath
 from ggshield.utils.os import getenv_bool
 
@@ -42,66 +26,27 @@ from ggshield.utils.os import getenv_bool
 logger = logging.getLogger(__name__)
 
 
-@scan_group.result_callback()
-@click.pass_context
-def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> int:
-    """
-    exit_code guarantees that the return value of a scan is 0
-    when exit_zero is enabled
-    """
-    ctx_obj = ContextObj.get(ctx)
-    if (
-        exit_code == ExitCode.SCAN_FOUND_PROBLEMS
-        and ctx_obj.config.user_config.exit_zero
-    ):
-        logger.debug("scan exit_code forced to 0")
-        sys.exit(ExitCode.SUCCESS)
-
-    logger.debug("scan exit_code=%d", exit_code)
-    return exit_code
-
-
-# Plugin registry, lazily initialized when _load_plugins() is called.
-_plugin_registry: Optional[PluginRegistry] = None
-
-# Warnings collected during plugin loading, before logging is configured.
-_deferred_warnings: List[str] = []
-
-
-def _load_plugins() -> PluginRegistry:
-    """Load plugins at module level so commands are available."""
-    global _plugin_registry
-    if _plugin_registry is None:
-        try:
-            enterprise_config = EnterpriseConfig.load_effective()
-            plugin_loader = PluginLoader(enterprise_config)
-            _plugin_registry = plugin_loader.load_enabled_plugins()
-        except Exception as e:
-            _deferred_warnings.append(f"Failed to load plugins: {e}")
-            _plugin_registry = PluginRegistry()
-
-        # Make registry available to hooks module
-        from ggshield.core.plugin.hooks import set_plugin_registry
-
-        set_plugin_registry(_plugin_registry)
-    return _plugin_registry
+# Imported only when Click resolves the name (see cmd/utils/lazy_group.py).
+# Every entry is checked by tests/unit/cmd/test_lazy_commands.py.
+_LAZY_COMMANDS = {
+    "ai": "ggshield.cmd.ai:ai_group",
+    "auth": "ggshield.cmd.auth:auth_group",
+    "config": "ggshield.cmd.config:config_group",
+    "plugin": "ggshield.cmd.plugin:plugin_group",
+    "secret": "ggshield.cmd.secret:secret_group",
+    "install": "ggshield.cmd.install:install_cmd",
+    "machine": "ggshield.cmd.machine:machine_group",
+    "quota": "ggshield.cmd.quota:quota_cmd",
+    "api-status": "ggshield.cmd.status:status_cmd",
+    "honeytoken": "ggshield.cmd.honeytoken:honeytoken_group",
+    "hmsl": "ggshield.cmd.hmsl:hmsl_group",
+}
 
 
 @click.group(
+    cls=PluginAwareLazyGroup,
+    lazy_commands=_LAZY_COMMANDS,
     context_settings={"help_option_names": ["-h", "--help"]},
-    commands={
-        "ai": ai_group,
-        "auth": auth_group,
-        "config": config_group,
-        "plugin": plugin_group,
-        "secret": secret_group,
-        "install": install_cmd,
-        "machine": machine_group,
-        "quota": quota_cmd,
-        "api-status": status_cmd,
-        "honeytoken": honeytoken_group,
-        "hmsl": hmsl_group,
-    },
 )
 @click.option(
     "-c",
@@ -157,78 +102,10 @@ def cli(
     if instance:
         ctx_obj.config.cmdline_instance_name = instance
 
-    # Use pre-loaded plugin registry
-    ctx_obj.plugin_registry = _load_plugins()
-
-    # Flush deferred plugin warnings now that logging is configured
-    for msg in _deferred_warnings:
-        logger.warning(msg)
-    _deferred_warnings.clear()
+    # Deliberately no plugin loading here: ContextObj.plugin_registry and
+    # PluginAwareLazyGroup each load on demand.
 
     _set_color(ctx)
-
-
-# Register plugin commands with the CLI group.
-# Called from main() to avoid import-time side effects.
-def _add_or_merge_plugin_command(
-    root: click.Group, command: click.Command, warnings: List[str]
-) -> None:
-    """Add a plugin command to the CLI, merging into a built-in group on conflict.
-
-    A plugin normally contributes a brand-new top-level command. When its name
-    collides with an existing built-in command we used to skip it entirely. But
-    some plugins (e.g. ``machine_scan``) contribute subcommands of a namespace
-    that ggshield now owns built-in (``machine``). In that case both the
-    existing command and the plugin command are groups, and we merge the
-    plugin's subcommands into the built-in group rather than dropping them.
-    Overlapping subcommand names are skipped so a plugin can never silently
-    override a built-in subcommand.
-    """
-    name = command.name
-    existing = root.commands.get(name) if name else None
-
-    if existing is None:
-        root.add_command(command)
-        return
-
-    if isinstance(existing, click.Group) and isinstance(command, click.Group):
-        for sub_name, sub_cmd in command.commands.items():
-            if sub_name in existing.commands:
-                warnings.append(
-                    f"Skipping plugin subcommand '{name} {sub_name}' because it "
-                    "conflicts with an existing command"
-                )
-                continue
-            existing.add_command(sub_cmd, sub_name)
-        return
-
-    warnings.append(
-        f"Skipping plugin command '{name}' because it conflicts with an "
-        "existing command"
-    )
-
-
-def _register_plugin_commands() -> None:
-    """Register plugin commands with the CLI."""
-    try:
-        registry = _load_plugins()
-        for cmd in registry.get_commands():
-            if not cmd.name:
-                _deferred_warnings.append("Skipping unnamed plugin command")
-                continue
-            _add_or_merge_plugin_command(cli, cmd, _deferred_warnings)
-    except Exception as e:
-        _deferred_warnings.append(f"Failed to register plugin commands: {e}")
-
-
-# Emitted before Click dispatches: a failed load leaves the command unregistered,
-# so Click rejects it as unknown and the group callback never runs to warn.
-def _warn_about_failed_plugins() -> None:
-    for name, reason in _load_plugins().get_load_failures().items():
-        ui.display_warning(
-            "Plugin '%s' is enabled but failed to load: %s. Its commands are "
-            "unavailable; run `ggshield plugin list` for status." % (name, reason)
-        )
 
 
 def _set_color(ctx: click.Context):
@@ -329,22 +206,19 @@ def main(args: Optional[List[str]] = None) -> Any:
     """
     log_utils.disable_logs()
 
-    _register_plugin_commands()
-
     # Required by pyinstaller when forking.
     # See https://pyinstaller.org/en/latest/common-issues-and-pitfalls.html#multi-processing
     multiprocessing.freeze_support()
 
     if not os.getenv("GG_PLAINTEXT_OUTPUT", False) and sys.stderr.isatty():
+        # Local import: rich is only needed for an interactive terminal, not for
+        # hooks and CI runs, whose output is piped.
+        from ggshield.core.ui.rich import RichGGShieldUI
+
         ui.set_ui(RichGGShieldUI())
 
     force_utf8_output()
     setup_truststore()
-
-    # cli.main() has not yet consumed _GGSHIELD_COMPLETE, so skip the warning
-    # during shell completion to avoid leaking it into completion output.
-    if "_GGSHIELD_COMPLETE" not in os.environ:
-        _warn_about_failed_plugins()
 
     show_crash_log = getenv_bool("GITGUARDIAN_CRASH_LOG")
     return cli.main(args, prog_name="ggshield", standalone_mode=not show_crash_log)

--- a/ggshield/cmd/ai/__init__.py
+++ b/ggshield/cmd/ai/__init__.py
@@ -4,9 +4,14 @@ import click
 
 from ggshield.cmd.ai.discover import discover_cmd
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 
-@click.group(commands={"discover": discover_cmd})
+@click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="ai",
+    commands={"discover": discover_cmd},
+)
 @add_common_options()
 def ai_group(**kwargs: Any) -> None:
     """Commands to work with AI assistants."""

--- a/ggshield/cmd/auth/__init__.py
+++ b/ggshield/cmd/auth/__init__.py
@@ -3,12 +3,17 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 from .login import login_cmd
 from .logout import logout_cmd
 
 
-@click.group(commands={"login": login_cmd, "logout": logout_cmd})
+@click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="auth",
+    commands={"login": login_cmd, "logout": logout_cmd},
+)
 @add_common_options()
 def auth_group(**kwargs: Any) -> None:
     """Commands to manage authentication."""

--- a/ggshield/cmd/config/__init__.py
+++ b/ggshield/cmd/config/__init__.py
@@ -3,6 +3,7 @@ from typing import Any
 import click
 
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 from .config_get import config_get_cmd
 from .config_list import config_list_cmd
@@ -12,13 +13,15 @@ from .config_unset import config_unset_cmd
 
 
 @click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="config",
     commands={
         "list": config_list_cmd,
         "set": config_set_cmd,
         "unset": config_unset_cmd,
         "get": config_get_cmd,
         "migrate": config_migrate_cmd,
-    }
+    },
 )
 @add_common_options()
 def config_group(**kwargs: Any) -> None:

--- a/ggshield/cmd/hmsl/__init__.py
+++ b/ggshield/cmd/hmsl/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 import click
 
@@ -10,11 +10,21 @@ from ggshield.cmd.hmsl.fingerprint import fingerprint_cmd
 from ggshield.cmd.hmsl.query import query_cmd
 from ggshield.cmd.hmsl.quota import quota_cmd
 from ggshield.cmd.utils.common_options import add_common_options
-from ggshield.utils.click import NaturalOrderGroup
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
+
+
+class _NaturalOrderPluginGroup(PluginAwareLazyGroup):
+    """Plugin-aware (see PluginAwareLazyGroup) but keeps the declaration order of
+    the commands in `--help`, like NaturalOrderGroup."""
+
+    def list_commands(self, ctx: click.Context) -> List[str]:
+        self._ensure_plugins()
+        return list(self.commands)
 
 
 @click.group(
-    cls=NaturalOrderGroup,
+    cls=_NaturalOrderPluginGroup,
+    plugin_scope="hmsl",
     commands={
         "check": check_cmd,
         "check-secret-manager": check_secret_manager_group,

--- a/ggshield/cmd/honeytoken/__init__.py
+++ b/ggshield/cmd/honeytoken/__init__.py
@@ -6,14 +6,17 @@ from ggshield.cmd.honeytoken.create import create_cmd
 from ggshield.cmd.honeytoken.create_with_context import create_with_context_cmd
 from ggshield.cmd.honeytoken.plant import plant_cmd
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 
 @click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="honeytoken",
     commands={
         "create": create_cmd,
         "create-with-context": create_with_context_cmd,
         "plant": plant_cmd,
-    }
+    },
 )
 @add_common_options()
 def honeytoken_group(**kwargs: Any) -> None:

--- a/ggshield/cmd/machine/__init__.py
+++ b/ggshield/cmd/machine/__init__.py
@@ -2,12 +2,18 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.machine.doctor import doctor_cmd
-from ggshield.cmd.machine.setup import setup_cmd
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 
-@click.group(commands={"setup": setup_cmd, "doctor": doctor_cmd})
+@click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="machine",
+    lazy_commands={
+        "setup": "ggshield.cmd.machine.setup:setup_cmd",
+        "doctor": "ggshield.cmd.machine.doctor:doctor_cmd",
+    },
+)
 @add_common_options()
 def machine_group(**kwargs: Any) -> None:
     """

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -16,7 +16,7 @@ from ggshield.cmd.install import (
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import create_client_from_config, safe_api_tokens
-from ggshield.core.plugin.hooks import get_plugin_registry
+from ggshield.core.plugin.hooks import load_plugin_registry
 from ggshield.verticals.ai.installation import ai_hook_posture
 
 
@@ -230,14 +230,14 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
 
 
 def _is_plugin_installed() -> bool:
-    registry = get_plugin_registry()
+    registry = load_plugin_registry()
     return registry is not None and registry.get_plugin(PLUGIN_NAME) is not None
 
 
 def _check_plugin_native() -> Check:
     """Prove the plugin's native scanner loads on this machine (signed, arch-specific
     wheel + compiled extension), without running a scan."""
-    registry = get_plugin_registry()
+    registry = load_plugin_registry()
     plugin = registry.get_plugin(PLUGIN_NAME) if registry else None
     version = ""
     if plugin is not None:

--- a/ggshield/cmd/plugin/__init__.py
+++ b/ggshield/cmd/plugin/__init__.py
@@ -12,9 +12,12 @@ from ggshield.cmd.plugin.plugin_list import list_cmd
 from ggshield.cmd.plugin.status import status_cmd
 from ggshield.cmd.plugin.update import update_cmd
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 
 @click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="plugin",
     commands={
         "install": install_cmd,
         "list": list_cmd,
@@ -23,7 +26,7 @@ from ggshield.cmd.utils.common_options import add_common_options
         "disable": disable_cmd,
         "uninstall": uninstall_cmd,
         "update": update_cmd,
-    }
+    },
 )
 @add_common_options()
 def plugin_group(**kwargs: Any) -> None:

--- a/ggshield/cmd/plugin/plugin_list.py
+++ b/ggshield/cmd/plugin/plugin_list.py
@@ -10,7 +10,7 @@ from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.core import ui
 from ggshield.core.config.enterprise_config import EnterpriseConfig
 from ggshield.core.plugin.downloader import PluginDownloader
-from ggshield.core.plugin.hooks import get_plugin_registry
+from ggshield.core.plugin.hooks import load_plugin_registry
 from ggshield.core.plugin.loader import PluginLoader
 
 
@@ -45,7 +45,7 @@ def list_cmd(ctx: click.Context, **kwargs: Any) -> None:
 
     ui.display_heading("Installed Plugins")
 
-    registry = get_plugin_registry()
+    registry = load_plugin_registry()
     load_failures = registry.get_load_failures() if registry else {}
 
     for plugin in discovered:

--- a/ggshield/cmd/secret/__init__.py
+++ b/ggshield/cmd/secret/__init__.py
@@ -2,12 +2,18 @@ from typing import Any
 
 import click
 
-from ggshield.cmd.secret.ignore import ignore_cmd
-from ggshield.cmd.secret.scan import scan_group
 from ggshield.cmd.utils.common_options import add_common_options
+from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
 
 
-@click.group(commands={"scan": scan_group, "ignore": ignore_cmd})
+@click.group(
+    cls=PluginAwareLazyGroup,
+    plugin_scope="secret",
+    lazy_commands={
+        "scan": "ggshield.cmd.secret.scan:scan_group",
+        "ignore": "ggshield.cmd.secret.ignore:ignore_cmd",
+    },
+)
 @add_common_options()
 def secret_group(**kwargs: Any) -> None:
     """Commands to work with secrets."""

--- a/ggshield/cmd/secret/scan/__init__.py
+++ b/ggshield/cmd/secret/scan/__init__.py
@@ -1,45 +1,39 @@
+import logging
 import os
+import sys
 from typing import Any, Optional
 
 import click
 
-from ggshield.cmd.secret.scan.ai_hook import ai_hook_cmd
-from ggshield.cmd.secret.scan.archive import archive_cmd
-from ggshield.cmd.secret.scan.changes import changes_cmd
-from ggshield.cmd.secret.scan.ci import ci_cmd
-from ggshield.cmd.secret.scan.docker import docker_name_cmd
-from ggshield.cmd.secret.scan.dockerarchive import docker_archive_cmd
-from ggshield.cmd.secret.scan.docset import docset_cmd
-from ggshield.cmd.secret.scan.path import path_cmd
-from ggshield.cmd.secret.scan.precommit import precommit_cmd
-from ggshield.cmd.secret.scan.prepush import prepush_cmd
-from ggshield.cmd.secret.scan.prereceive import prereceive_cmd
-from ggshield.cmd.secret.scan.pypi import pypi_cmd
-from ggshield.cmd.secret.scan.range import range_cmd
-from ggshield.cmd.secret.scan.repo import repo_cmd
 from ggshield.cmd.secret.scan.secret_scan_common_options import (
     add_secret_scan_common_options,
 )
 from ggshield.cmd.utils.context_obj import ContextObj
+from ggshield.cmd.utils.lazy_group import LazyGroup
 from ggshield.core import ui
+from ggshield.core.errors import ExitCode
+
+
+logger = logging.getLogger(__name__)
 
 
 @click.group(
-    commands={
-        "ai-hook": ai_hook_cmd,
-        "commit-range": range_cmd,
-        "changes": changes_cmd,
-        "pre-commit": precommit_cmd,
-        "pre-push": prepush_cmd,
-        "pre-receive": prereceive_cmd,
-        "ci": ci_cmd,
-        "path": path_cmd,
-        "repo": repo_cmd,
-        "docker": docker_name_cmd,
-        "docker-archive": docker_archive_cmd,
-        "pypi": pypi_cmd,
-        "archive": archive_cmd,
-        "docset": docset_cmd,
+    cls=LazyGroup,
+    lazy_commands={
+        "ai-hook": "ggshield.cmd.secret.scan.ai_hook:ai_hook_cmd",
+        "commit-range": "ggshield.cmd.secret.scan.range:range_cmd",
+        "changes": "ggshield.cmd.secret.scan.changes:changes_cmd",
+        "pre-commit": "ggshield.cmd.secret.scan.precommit:precommit_cmd",
+        "pre-push": "ggshield.cmd.secret.scan.prepush:prepush_cmd",
+        "pre-receive": "ggshield.cmd.secret.scan.prereceive:prereceive_cmd",
+        "ci": "ggshield.cmd.secret.scan.ci:ci_cmd",
+        "path": "ggshield.cmd.secret.scan.path:path_cmd",
+        "repo": "ggshield.cmd.secret.scan.repo:repo_cmd",
+        "docker": "ggshield.cmd.secret.scan.docker:docker_name_cmd",
+        "docker-archive": "ggshield.cmd.secret.scan.dockerarchive:docker_archive_cmd",
+        "pypi": "ggshield.cmd.secret.scan.pypi:pypi_cmd",
+        "archive": "ggshield.cmd.secret.scan.archive:archive_cmd",
+        "docset": "ggshield.cmd.secret.scan.docset:docset_cmd",
     },
 )
 # Deprecated options
@@ -65,6 +59,27 @@ def scan_group(
 ) -> int:
     """Commands to scan various contents."""
     return scan_group_impl(ctx)
+
+
+# Lives here rather than in __main__ so that registering it does not require
+# importing the scan group on every ggshield invocation.
+@scan_group.result_callback()
+@click.pass_context
+def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> int:
+    """
+    exit_code guarantees that the return value of a scan is 0
+    when exit_zero is enabled
+    """
+    ctx_obj = ContextObj.get(ctx)
+    if (
+        exit_code == ExitCode.SCAN_FOUND_PROBLEMS
+        and ctx_obj.config.user_config.exit_zero
+    ):
+        logger.debug("scan exit_code forced to 0")
+        sys.exit(ExitCode.SUCCESS)
+
+    logger.debug("scan exit_code=%d", exit_code)
+    return exit_code
 
 
 def scan_group_impl(ctx: click.Context) -> int:

--- a/ggshield/cmd/utils/context_obj.py
+++ b/ggshield/cmd/utils/context_obj.py
@@ -84,7 +84,13 @@ class ContextObj:
 
     @property
     def plugin_registry(self) -> "PluginRegistry":
-        assert self._plugin_registry
+        """The plugin registry, loaded on first access rather than on every
+        ggshield invocation (see load_plugin_registry for why that is expensive).
+        """
+        if self._plugin_registry is None:
+            from ggshield.core.plugin.hooks import load_plugin_registry
+
+            self._plugin_registry = load_plugin_registry()
         return self._plugin_registry
 
     @plugin_registry.setter
@@ -92,8 +98,11 @@ class ContextObj:
         self._plugin_registry = value
 
     def has_plugin_registry(self) -> bool:
-        """Check if plugin registry has been set."""
-        return self._plugin_registry is not None
+        """Deprecated, always true: `plugin_registry` loads on demand and falls back
+        to an empty registry, so there is nothing to guard against. Kept only so
+        external plugin code doing `if has_plugin_registry(): ...` does not start
+        skipping; will be removed."""
+        return True
 
     @staticmethod
     def get(ctx: click.Context) -> "ContextObj":

--- a/ggshield/cmd/utils/lazy_group.py
+++ b/ggshield/cmd/utils/lazy_group.py
@@ -1,0 +1,202 @@
+"""Lazy click groups: subcommands are imported only when actually resolved.
+
+Every ggshield invocation used to import all 12 top-level command groups (and
+run plugin discovery), so `ggshield secret scan pre-commit` paid for `hmsl`,
+`honeytoken`, `auth`, ... Declaring subcommands as "module:attr" strings defers
+each import to the moment Click resolves that name.
+
+The strings are invisible to PyInstaller's static analysis: the frozen binary
+relies on `--collect-submodules ggshield` plus the generated command-tree smoke
+check in scripts/build-os-packages/build-os-packages to guarantee every command
+still resolves from the bundle.
+"""
+
+import importlib
+import os
+from typing import Any, Dict, List, Optional
+
+import click
+
+from ggshield.core import ui
+
+
+class LazyGroup(click.Group):
+    """A click Group whose subcommands can be declared as "module:attr" strings
+    and are imported only when resolved (canonical click lazy-loading pattern).
+
+    `list_commands()` deliberately does not import anything, so listing names
+    (shell completion) is free. `--help` still shows the short help of every
+    subcommand, because Click's help formatter calls `get_command()` for each
+    listed name -- help is the one slow path, which is fine.
+
+    Use this class for *nested* groups (e.g. `secret scan`), and
+    PluginAwareLazyGroup for top-level ones. Plugins contribute top-level
+    commands only, so a nested group has nothing to merge; making it
+    plugin-aware would just pay for plugin discovery (including wheel signature
+    verification) on `--help` and on every unknown subcommand, and would let a
+    plugin group that happens to share a nested group's name leak its
+    subcommands in there.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        lazy_commands: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.lazy_commands: Dict[str, str] = lazy_commands or {}
+
+    def list_commands(self, ctx: click.Context) -> List[str]:
+        return sorted(set(self.lazy_commands) | set(self.commands))
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is None and cmd_name in self.lazy_commands:
+            cmd = self.load_lazy_command(cmd_name)
+        return cmd
+
+    def load_lazy_command(self, name: str) -> click.Command:
+        module_name, attr = self.lazy_commands[name].split(":")
+        cmd = getattr(importlib.import_module(module_name), attr)
+        # Cache it, so later lookups (and plugin merges) see it in self.commands
+        self.add_command(cmd, name)
+        return cmd
+
+
+def _merge_subcommands(
+    target: click.Group, source: click.Group, warnings: List[str]
+) -> None:
+    """Merge `source`'s subcommands into `target`, never overriding an existing
+    one (a plugin must not be able to silently replace a built-in command).
+    Lazy subcommands count as existing even though they are not imported yet.
+
+    Conflicts warn instead of raising: `source` comes from a third-party plugin
+    wheel resolved at runtime, so a conflict is not necessarily a ggshield bug
+    we would catch during dev, and an installed plugin must never be able to
+    make the whole CLI unusable."""
+    lazy: Dict[str, str] = getattr(target, "lazy_commands", {})
+    for sub_name, sub_cmd in source.commands.items():
+        if target.commands.get(sub_name) is sub_cmd:
+            # Already merged: the root group and `target` itself both merge the
+            # same plugin group, so the second pass must stay silent instead of
+            # reporting the command it just added as a conflict.
+            continue
+        if sub_name in target.commands or sub_name in lazy:
+            warnings.append(
+                f"Skipping plugin subcommand '{source.name} {sub_name}' because it "
+                "conflicts with an existing command"
+            )
+            continue
+        target.add_command(sub_cmd, sub_name)
+
+
+def add_or_merge_plugin_command(
+    root: click.Group, command: click.Command, warnings: List[str]
+) -> None:
+    """Add a plugin command to the CLI, merging into a built-in group on conflict.
+
+    A plugin contributes a top-level command. If its name is free it is added
+    as-is. If it collides with a built-in we used to skip it entirely, which
+    broke plugins (e.g. ``machine_scan``) that contribute subcommands of a
+    namespace ggshield also owns built-in (``machine``). So when both the
+    existing command and the plugin command are groups, we merge the plugin's
+    subcommands into the built-in group rather than dropping them. Overlapping
+    subcommand names are skipped so a plugin can never silently override a
+    built-in subcommand.
+    """
+    name = command.name
+    existing = root.commands.get(name) if name else None
+    if existing is None and isinstance(root, LazyGroup) and name in root.lazy_commands:
+        # Force-load the built-in, otherwise the plugin would shadow it.
+        existing = root.load_lazy_command(name)
+
+    if existing is None:
+        root.add_command(command)
+        return
+
+    if isinstance(existing, click.Group) and isinstance(command, click.Group):
+        _merge_subcommands(existing, command, warnings)
+        return
+
+    warnings.append(
+        f"Skipping plugin command '{name}' because it conflicts with an "
+        "existing command"
+    )
+
+
+class PluginAwareLazyGroup(LazyGroup):
+    """LazyGroup that loads plugins on demand instead of on every invocation.
+
+    Plugin discovery (which includes wheel signature verification) runs only
+    when it can change the outcome:
+    - a command name misses both the built-in and the lazy map, or
+    - list_commands() runs, i.e. `--help`, so help output is unchanged.
+
+    ``plugin_scope=None`` is the root CLI group: plugin commands are added at
+    top level (merging groups on name conflicts). ``plugin_scope="machine"``
+    merges the subcommands of the plugin's ``machine`` group into this group.
+
+    Every built-in top-level group uses this cls with ``plugin_scope`` set to
+    its own name: the root group resolves them from ``_LAZY_COMMANDS`` without
+    loading plugins, so a group that is a plain LazyGroup would silently drop
+    the subcommands of a same-named plugin group. New top-level groups must do
+    the same; tests/unit/cmd/test_lazy_commands.py enforces it.
+    """
+
+    def __init__(
+        self, *args: Any, plugin_scope: Optional[str] = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.plugin_scope = plugin_scope
+        self._plugins_merged = False
+
+    def _ensure_plugins(self) -> None:
+        if self._plugins_merged:
+            return
+        self._plugins_merged = True
+
+        # Function-local import: keeps the plugin loader (and the enterprise
+        # config it reads) off the fast path.
+        from ggshield.core.plugin.hooks import load_plugin_registry
+
+        registry = load_plugin_registry()
+        warnings: List[str] = []
+        for cmd in registry.get_commands():
+            if not cmd.name:
+                warnings.append("Skipping unnamed plugin command")
+            elif self.plugin_scope is None:
+                add_or_merge_plugin_command(self, cmd, warnings)
+            elif cmd.name == self.plugin_scope and isinstance(cmd, click.Group):
+                _merge_subcommands(self, cmd, warnings)
+
+        # _GGSHIELD_COMPLETE is Click's completion protocol variable
+        # (_<PROG_NAME>_COMPLETE). The publisher is the user's shell: the
+        # completion function Click generates -- installed with e.g.
+        # `eval "$(_GGSHIELD_COMPLETE=bash_source ggshield)"` -- re-invokes
+        # ggshield with it set to ask for candidates. cli.main() has not
+        # consumed it yet when completion triggers list_commands(), so check it
+        # here: these warnings would otherwise be parsed as completion
+        # candidates.
+        if "_GGSHIELD_COMPLETE" in os.environ:
+            return
+        # A failed load leaves the command unregistered, so Click rejects it as
+        # unknown; warn here or the user never learns why it is missing.
+        for name, reason in registry.get_load_failures().items():
+            ui.display_warning(
+                f"Plugin '{name}' is enabled but failed to load: {reason}. Its "
+                "commands are unavailable; run `ggshield plugin list` for status."
+            )
+        for msg in warnings:
+            ui.display_warning(msg)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is None:
+            self._ensure_plugins()
+            cmd = super().get_command(ctx, cmd_name)
+        return cmd
+
+    def list_commands(self, ctx: click.Context) -> List[str]:
+        self._ensure_plugins()
+        return super().list_commands(ctx)

--- a/ggshield/cmd/utils/lazy_group.py
+++ b/ggshield/cmd/utils/lazy_group.py
@@ -57,7 +57,12 @@ class LazyGroup(click.Group):
         return cmd
 
     def load_lazy_command(self, name: str) -> click.Command:
-        module_name, attr = self.lazy_commands[name].split(":")
+        spec = self.lazy_commands[name]
+        module_name, _, attr = spec.partition(":")
+        if not module_name or not attr:
+            raise ValueError(
+                f"Invalid lazy command spec for '{name}': {spec!r}, expected 'module:attr'"
+            )
         cmd = getattr(importlib.import_module(module_name), attr)
         # Cache it, so later lookups (and plugin merges) see it in self.commands
         self.add_command(cmd, name)
@@ -156,19 +161,39 @@ class PluginAwareLazyGroup(LazyGroup):
             return
         self._plugins_merged = True
 
-        # Function-local import: keeps the plugin loader (and the enterprise
-        # config it reads) off the fast path.
-        from ggshield.core.plugin.hooks import load_plugin_registry
-
-        registry = load_plugin_registry()
         warnings: List[str] = []
-        for cmd in registry.get_commands():
-            if not cmd.name:
-                warnings.append("Skipping unnamed plugin command")
-            elif self.plugin_scope is None:
-                add_or_merge_plugin_command(self, cmd, warnings)
-            elif cmd.name == self.plugin_scope and isinstance(cmd, click.Group):
-                _merge_subcommands(self, cmd, warnings)
+        load_failures: Dict[str, str] = {}
+        try:
+            # Function-local import: keeps the plugin loader (and the enterprise
+            # config it reads) off the fast path.
+            from ggshield.core.plugin.hooks import (
+                get_plugin_load_error,
+                load_plugin_registry,
+            )
+
+            registry = load_plugin_registry()
+            load_error = get_plugin_load_error()
+            if load_error:
+                warnings.append(
+                    f"Failed to load plugins: {load_error}. Plugin commands are "
+                    "unavailable; run `ggshield plugin list` for status."
+                )
+            for cmd in registry.get_commands():
+                if not cmd.name:
+                    warnings.append("Skipping unnamed plugin command")
+                elif self.plugin_scope is None:
+                    add_or_merge_plugin_command(self, cmd, warnings)
+                elif cmd.name == self.plugin_scope and isinstance(cmd, click.Group):
+                    _merge_subcommands(self, cmd, warnings)
+            load_failures = registry.get_load_failures()
+        except Exception as exc:
+            # Everything above runs third-party code resolved at runtime (plugin
+            # discovery, and importing the built-in a plugin group collides
+            # with). A plugin must never be able to break `--help` or the error
+            # for an unknown command, which is every path that lands here, so a
+            # failure degrades to a warning as it did before commands were
+            # resolved lazily.
+            warnings.append(f"Failed to register plugin commands: {exc}")
 
         # _GGSHIELD_COMPLETE is Click's completion protocol variable
         # (_<PROG_NAME>_COMPLETE). The publisher is the user's shell: the
@@ -182,7 +207,7 @@ class PluginAwareLazyGroup(LazyGroup):
             return
         # A failed load leaves the command unregistered, so Click rejects it as
         # unknown; warn here or the user never learns why it is missing.
-        for name, reason in registry.get_load_failures().items():
+        for name, reason in load_failures.items():
             ui.display_warning(
                 f"Plugin '{name}' is enabled but failed to load: {reason}. Its "
                 "commands are unavailable; run `ggshield plugin list` for status."

--- a/ggshield/core/plugin/hooks.py
+++ b/ggshield/core/plugin/hooks.py
@@ -11,6 +11,7 @@ from ggshield.core.plugin.registry import PluginRegistry
 logger = logging.getLogger(__name__)
 
 _global_registry: Optional[PluginRegistry] = None
+_load_error: Optional[str] = None
 
 
 def set_plugin_registry(registry: PluginRegistry) -> None:
@@ -52,6 +53,20 @@ def load_plugin_registry() -> PluginRegistry:
             enterprise_config = EnterpriseConfig.load_effective()
             _global_registry = PluginLoader(enterprise_config).load_enabled_plugins()
         except Exception as e:
+            global _load_error
+            _load_error = str(e)
             logger.warning("Failed to load plugins: %s", e)
             _global_registry = PluginRegistry()
     return _global_registry
+
+
+def get_plugin_load_error() -> Optional[str]:
+    """Why the last `load_plugin_registry()` gave up, if it did.
+
+    The failure is swallowed there so a broken plugin install cannot take the
+    CLI down, and logging is still disabled while commands are resolved, so
+    the log line alone never reaches the user. Callers that can display it
+    (and that know whether displaying it is safe -- shell completion parses
+    stdout) ask for it here.
+    """
+    return _load_error

--- a/ggshield/core/plugin/hooks.py
+++ b/ggshield/core/plugin/hooks.py
@@ -2,20 +2,56 @@
 Plugin hooks - utilities for integrating plugins into existing commands.
 """
 
+import logging
 from typing import Optional
 
 from ggshield.core.plugin.registry import PluginRegistry
 
 
+logger = logging.getLogger(__name__)
+
 _global_registry: Optional[PluginRegistry] = None
 
 
 def set_plugin_registry(registry: PluginRegistry) -> None:
-    """Set the global plugin registry."""
+    """Set the global plugin registry.
+
+    Injection point for plugin code and tests only: in-tree code goes through
+    `load_plugin_registry()`, which populates the global itself.
+    """
     global _global_registry
     _global_registry = registry
 
 
 def get_plugin_registry() -> Optional[PluginRegistry]:
-    """Get the global plugin registry."""
+    """Get the global plugin registry, without loading it.
+
+    Returns None until something loads it, so in-tree code uses
+    `load_plugin_registry()`; kept for plugin code that must not trigger a load.
+    """
+    return _global_registry
+
+
+def load_plugin_registry() -> PluginRegistry:
+    """Get the global plugin registry, loading enabled plugins if needed.
+
+    This is the expensive path (plugin discovery + wheel signature
+    verification), so it is called only when plugin commands or plugin status
+    are actually needed, never on every ggshield invocation. A failure to load
+    yields an empty registry rather than an error: individual load failures are
+    reported by the registry itself.
+    """
+    global _global_registry
+    if _global_registry is None:
+        # Function-local imports: keep the loader (and sigstore & co) off the
+        # import path of commands that never touch plugins.
+        from ggshield.core.config.enterprise_config import EnterpriseConfig
+        from ggshield.core.plugin.loader import PluginLoader
+
+        try:
+            enterprise_config = EnterpriseConfig.load_effective()
+            _global_registry = PluginLoader(enterprise_config).load_enabled_plugins()
+        except Exception as e:
+            logger.warning("Failed to load plugins: %s", e)
+            _global_registry = PluginRegistry()
     return _global_registry

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -28,6 +28,12 @@ VERDICT_CACHE_MAX_ENTRIES = 500
 # coding session while making the walk negligible.
 DISCOVERY_CACHE_TTL_SECONDS = 3600
 
+# time.time() and the filesystem mtime do not come from the same clock source, so a
+# just-touched file can read marginally in the future (the Windows system timer has a
+# ~16ms granularity). Tolerate that much skew, while still treating a real clock jump
+# as stale rather than pinning the cache fresh forever.
+MTIME_SKEW_TOLERANCE_SECONDS = 5
+
 
 def _discovery_cache_path() -> Path:
     return get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
@@ -196,7 +202,7 @@ def is_discovery_cache_fresh() -> bool:
         age = time.time() - _discovery_cache_path().stat().st_mtime
     except OSError:
         return False
-    return 0 <= age < DISCOVERY_CACHE_TTL_SECONDS
+    return -MTIME_SKEW_TOLERANCE_SECONDS <= age < DISCOVERY_CACHE_TTL_SECONDS
 
 
 def touch_discovery_cache() -> None:

--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -202,6 +202,13 @@ step_build() {
     local collect_args=(
         --collect-data sigstore
         --hidden-import sigstore._store
+        # ggshield's command groups are declared as "module:attr" strings and
+        # imported on lookup (see ggshield/cmd/utils/lazy_group.py), which
+        # PyInstaller's static analysis cannot follow. Bundle everything under
+        # the package; frozen imports are pay-per-use, so this costs nothing at
+        # runtime. smoke_check_bundle() walks the whole command tree to prove
+        # each one still resolves from the bundle.
+        --collect-submodules ggshield
     )
 
     pyinstaller ggshield/__main__.py --name ggshield --exclude-module pkg_resources --noupx \
@@ -217,14 +224,62 @@ step_build() {
     smoke_check_bundle
 }
 
+# Walk the built bundle's Click command tree, running `--help` on every node.
+# Resolving a name is what triggers its lazy "module:attr" import, so this is
+# what proves the bundle contains every command's module. The tree is read from
+# the binary's own `--help` output, so a command added later is covered without
+# anyone updating a list here. Blind spot: `hidden=True` commands (e.g.
+# `secret scan docker-archive`) are absent from --help, so they are not walked;
+# they are covered by --collect-submodules and by the functional test suite,
+# which runs against this same binary.
+#
+# Expects $bin and $smoke_env to be set by smoke_check_bundle (bash scoping) and
+# counts leaves into the global $SMOKE_LEAF_COUNT (global, not local, because
+# this function recurses). $1 is the command path, empty for the root. Command
+# names never contain spaces or globs, so leaving $1 unquoted is the intended
+# word-splitting.
+smoke_check_command_tree() {
+    local path="$1"
+    local out
+    # shellcheck disable=SC2086
+    if ! out=$(env "${smoke_env[@]}" "$bin" $path --help 2>&1) ; then
+        err "$out"
+        die "Bundle smoke check FAILED for: ggshield $path --help. \
+Likely a PyInstaller bundling gap — command groups are imported lazily from \
+\"module:attr\" strings, so a dropped module only fails when that command is \
+resolved. Check the --collect-submodules argument in step_build."
+    fi
+
+    # Sub-commands are the first word of each entry in the "Commands:" section.
+    local subs
+    subs=$(printf '%s\n' "$out" | awk '
+        /^Commands:/ { in_cmds = 1; next }
+        in_cmds && /^[^ ]/ { in_cmds = 0 }
+        in_cmds && /^  [a-zA-Z][a-zA-Z0-9_-]*([ ]|$)/ { print $1 }
+    ')
+
+    if [ -z "$subs" ] ; then
+        SMOKE_LEAF_COUNT=$((SMOKE_LEAF_COUNT + 1))
+        return
+    fi
+    local sub
+    for sub in $subs ; do
+        smoke_check_command_tree "${path:+$path }$sub"
+    done
+}
+
 # Sanity-check the freshly built bundle. Catches "PyInstaller missed a
 # dynamic import / data file" regressions before they ship to users.
 #
-# Two layers:
-#   1. Run a small set of `ggshield --help` invocations. Any import failure in
-#      the main CLI/plugin-signature path will surface here as a non-zero exit /
-#      ModuleNotFoundError.
-#   2. Structurally assert that known package-data files are present in the
+# Three layers:
+#   1. Resolve every command in the tree from the bundle (see
+#      smoke_check_command_tree). Any import failure surfaces as a non-zero
+#      exit / ModuleNotFoundError.
+#   2. Run the `secret scan ai-hook` command end to end on a canned hook
+#      payload. This is the one command whose failure is silent: agents read a
+#      non-zero exit as "allow", so a broken ai-hook would fail open on every
+#      tool call instead of erroring visibly.
+#   3. Structurally assert that known package-data files are present in the
 #      bundle. PyInstaller does not raise when it silently drops data files,
 #      so a `--help` run can succeed while a runtime code path
 #      (e.g. sigstore's Verifier.production() loading the TUF roots) fails.
@@ -235,13 +290,9 @@ smoke_check_bundle() {
         die "Bundle smoke check: '$bin' not found or not executable"
     fi
 
-    # Layer 1: import smoketest via a minimal set of commands. Keep this list
-    # small: `ggshield --help` exercises the main CLI import graph, while the
-    # plugin commands exercise the sigstore/plugin-signature import path this
-    # check was introduced for.
-    #
-    # Run in an isolated config/data/cache directory and disable keyring so the
-    # smoke test never touches a developer's or CI runner's credential store.
+    # Layers 1 and 2 run in an isolated config/data/cache directory, with
+    # keyring and API key disabled, so the smoke test never touches a
+    # developer's or CI runner's credential store and never hits the network.
     local smoke_env_dir
     smoke_env_dir=$(mktemp -d)
     mkdir -p "$smoke_env_dir/home"
@@ -260,30 +311,56 @@ smoke_check_bundle() {
         "GG_CACHE_DIR=$smoke_env_dir_for_python/cache"
         "GGSHIELD_NO_KEYRING=1"
         "GG_PLAINTEXT_OUTPUT=1"
+        # Empty (not unset): ignore any key in the build environment, so the
+        # ai-hook check below always takes the unauthenticated path.
+        "GITGUARDIAN_API_KEY="
     )
-    local smoke_cmds=(
-        "--version"
-        "--help"
-        "plugin --help"
-        "plugin install --help"
-    )
-    local cmd
-    local -a args
-    for cmd in "${smoke_cmds[@]}" ; do
-        read -r -a args <<< "$cmd"
-        if ! env "${smoke_env[@]}" "$bin" "${args[@]}" > /dev/null 2>&1 ; then
-            err "----- Bundle smoke check FAILED for: ggshield $cmd -----"
-            env "${smoke_env[@]}" "$bin" "${args[@]}" >&2 || true
-            rm -rf "$smoke_env_dir"
-            die "Bundle is broken: 'ggshield $cmd' exited non-zero. \
-Likely a PyInstaller bundling gap — a module or data file referenced via a \
-dynamic import is missing from the bundle. Add a matching collect/hidden-import \
-argument in step_build and re-run."
-        fi
-    done
+
+    if ! env "${smoke_env[@]}" "$bin" --version > /dev/null 2>&1 ; then
+        rm -rf "$smoke_env_dir"
+        die "Bundle is broken: 'ggshield --version' exited non-zero."
+    fi
+
+    SMOKE_LEAF_COUNT=0
+    smoke_check_command_tree ""
+    if [ "$SMOKE_LEAF_COUNT" -lt 20 ] ; then
+        rm -rf "$smoke_env_dir"
+        die "Bundle smoke check: only $SMOKE_LEAF_COUNT leaf commands found, \
+expected at least 20. The command tree walk is probably not parsing \
+'ggshield --help' output any more, so it is not checking anything."
+    fi
+    info "Resolved $SMOKE_LEAF_COUNT leaf commands from the bundle"
+
+    # Layer 2: run the ai-hook end to end. Unauthenticated, so it takes the
+    # fail-open path and emits a "could not authenticate" systemMessage; what
+    # matters is that it exits 0 with parseable JSON on stdout, which is the
+    # contract the coding agent relies on. This covers the unauthenticated
+    # verdict only: a module reachable solely after a successful auth (or
+    # imported inside a command body) is not exercised here.
+    local hook_payload='{"session_id": "smoke-check", '
+    hook_payload+='"transcript_path": "/tmp/claude/transcript.jsonl", '
+    hook_payload+='"hook_event_name": "PreToolUse", "tool_name": "Bash", '
+    hook_payload+='"tool_input": {"command": "echo smoke check"}}'
+    local hook_out
+    if ! hook_out=$(printf '%s' "$hook_payload" \
+            | env "${smoke_env[@]}" "$bin" secret scan ai-hook 2>/dev/null) ; then
+        err "$hook_out"
+        rm -rf "$smoke_env_dir"
+        die "Bundle smoke check: 'ggshield secret scan ai-hook' exited non-zero. \
+Coding agents read a non-zero exit as 'allow', so this would silently disable \
+secret scanning on every AI tool call."
+    fi
+    local py=python
+    command -v "$py" > /dev/null 2>&1 || py=python3
+    if ! printf '%s' "$hook_out" | "$py" -c "import json,sys; json.load(sys.stdin)" ; then
+        err "stdout was: $hook_out"
+        rm -rf "$smoke_env_dir"
+        die "Bundle smoke check: 'ggshield secret scan ai-hook' did not emit \
+valid JSON on stdout. Coding agents cannot parse the verdict."
+    fi
     rm -rf "$smoke_env_dir"
 
-    # Layer 2: structural assertions for known package-data files. Each
+    # Layer 3: structural assertions for known package-data files. Each
     # entry below was added because we caught (or want to prevent) a
     # silent-drop bug. Keep paths in sync with dependency package-data layouts.
     local required_paths=(

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -214,17 +214,17 @@ class TestPluginChecks:
     def test_is_plugin_installed_true(self):
         registry = MagicMock()
         registry.get_plugin.return_value = MagicMock()
-        with patch(f"{BASE}.get_plugin_registry", return_value=registry):
+        with patch(f"{BASE}.load_plugin_registry", return_value=registry):
             assert _is_plugin_installed() is True
 
     def test_is_plugin_installed_false_no_registry(self):
-        with patch(f"{BASE}.get_plugin_registry", return_value=None):
+        with patch(f"{BASE}.load_plugin_registry", return_value=None):
             assert _is_plugin_installed() is False
 
     def test_is_plugin_installed_false_not_registered(self):
         registry = MagicMock()
         registry.get_plugin.return_value = None
-        with patch(f"{BASE}.get_plugin_registry", return_value=registry):
+        with patch(f"{BASE}.load_plugin_registry", return_value=registry):
             assert _is_plugin_installed() is False
 
     def test_native_loads_ok(self):
@@ -233,7 +233,7 @@ class TestPluginChecks:
             metadata=MagicMock(version="1.2.3")
         )
         native = MagicMock()
-        with patch(f"{BASE}.get_plugin_registry", return_value=registry), patch(
+        with patch(f"{BASE}.load_plugin_registry", return_value=registry), patch(
             f"{BASE}.import_module", return_value=native
         ):
             check = _check_plugin_native()
@@ -246,7 +246,7 @@ class TestPluginChecks:
         registry.get_plugin.return_value = MagicMock(
             metadata=MagicMock(version="1.2.3")
         )
-        with patch(f"{BASE}.get_plugin_registry", return_value=registry), patch(
+        with patch(f"{BASE}.load_plugin_registry", return_value=registry), patch(
             f"{BASE}.import_module", side_effect=ImportError("bad arch")
         ):
             check = _check_plugin_native()

--- a/tests/unit/cmd/plugin/test_list.py
+++ b/tests/unit/cmd/plugin/test_list.py
@@ -79,7 +79,7 @@ class TestPluginList:
         )
 
         with mock.patch.object(
-            plugin_list_module, "get_plugin_registry", return_value=registry
+            plugin_list_module, "load_plugin_registry", return_value=registry
         ):
             result = _run_list(cli_fs_runner, plugins)
 

--- a/tests/unit/cmd/test_lazy_commands.py
+++ b/tests/unit/cmd/test_lazy_commands.py
@@ -1,0 +1,66 @@
+"""Every lazily-declared command must actually resolve.
+
+Lazy commands are declared as "module:attr" strings, so a typo or a moved
+symbol is invisible until a user runs that exact command (and in the frozen
+binary, until PyInstaller drops the module). This walks the whole command tree
+and resolves every lazy entry.
+"""
+
+import click
+
+from ggshield.__main__ import _LAZY_COMMANDS, cli
+from ggshield.cmd.utils.lazy_group import LazyGroup, PluginAwareLazyGroup
+
+
+def test_every_lazy_command_resolves() -> None:
+    """GIVEN the ggshield command tree
+    WHEN every lazy "module:attr" entry is resolved
+    THEN each yields a click command registered under its name
+    """
+    checked: set[str] = set()
+
+    def walk(group: click.Group, path: str) -> None:
+        if isinstance(group, LazyGroup):
+            for name in list(group.lazy_commands):
+                cmd = group.load_lazy_command(name)
+                assert isinstance(cmd, click.Command), f"{path} {name}"
+                assert group.commands[name] is cmd, f"{path} {name}"
+                checked.add(f"{path} {name}")
+        # Resolving a group reveals its own lazy subcommands, so recurse after.
+        for name, cmd in list(group.commands.items()):
+            if isinstance(cmd, click.Group):
+                walk(cmd, f"{path} {name}")
+
+    walk(cli, "ggshield")
+
+    # Guard against the walk silently checking nothing.
+    assert "ggshield secret" in checked
+    assert "ggshield secret scan ai-hook" in checked
+
+
+def test_top_level_groups_accept_plugin_merges() -> None:
+    """GIVEN the built-in top-level command groups
+    WHEN they are resolved from the root group (which does not load plugins)
+    THEN each is plugin-aware and scoped to its own name
+
+    A plain LazyGroup here would silently drop the subcommands of a plugin group
+    sharing its name, because the root only loads plugins on a name miss.
+    """
+    ctx = click.Context(cli)
+
+    for name in _LAZY_COMMANDS:
+        cmd = cli.get_command(ctx, name)
+        if not isinstance(cmd, click.Group):
+            continue  # a plain command cannot be a merge target
+        assert isinstance(cmd, PluginAwareLazyGroup), name
+        assert cmd.plugin_scope == name, name
+
+
+def test_list_commands_does_not_import_anything() -> None:
+    """GIVEN a lazy group whose target module does not exist
+    WHEN its commands are listed
+    THEN listing succeeds, proving list_commands() imports nothing
+    """
+    group = LazyGroup("cli", lazy_commands={"nope": "ggshield_no_such_module:cmd"})
+
+    assert group.list_commands(click.Context(group)) == ["nope"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -902,3 +902,35 @@ SECRET_INCIDENT_MOCK = SecretIncident.from_dict(
         "occurrences": [],
     }
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state():
+    """Undo plugin side effects that outlive a test.
+
+    The CLI groups are module-level singletons and `PluginAwareLazyGroup`
+    memoizes the merge, so a test that triggers plugin loading leaves every
+    later test with plugins already "merged" (and the loader globals warm).
+    That makes the suite order-dependent, which tests worked around by
+    resetting `_plugins_merged` by hand.
+    """
+    yield
+
+    from ggshield.cmd.utils.lazy_group import PluginAwareLazyGroup
+    from ggshield.core.plugin import hooks
+
+    hooks._global_registry = None
+    hooks._load_error = None
+
+    def reset(group, seen):
+        if id(group) in seen:
+            return
+        seen.add(id(group))
+        if isinstance(group, PluginAwareLazyGroup):
+            group._plugins_merged = False
+        for sub in getattr(group, "commands", {}).values():
+            reset(sub, seen)
+
+    from ggshield.__main__ import cli
+
+    reset(cli, set())

--- a/tests/unit/test_main_plugin_registration.py
+++ b/tests/unit/test_main_plugin_registration.py
@@ -213,6 +213,56 @@ def test_load_failures_silent_during_shell_completion(monkeypatch) -> None:
     assert warnings == []
 
 
+def test_broken_plugin_registry_degrades_to_a_warning(monkeypatch) -> None:
+    """A plugin blowing up must not take `--help` or an unknown command down.
+
+    Plugin code is third-party and resolved at runtime, and it now runs inside
+    command resolution, i.e. on every `--help` and every unknown command name.
+    """
+    from ggshield.core import ui
+
+    registry = mock.MagicMock()
+    registry.get_commands.side_effect = RuntimeError("plugin exploded")
+    _patch_registry(monkeypatch, registry)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(ui, "display_warning", warnings.append)
+
+    group = PluginAwareLazyGroup("cli", commands={"auth": click.Command("auth")})
+
+    # Both paths that load plugins keep working.
+    assert group.list_commands(click.Context(group)) == ["auth"]
+    group._plugins_merged = False
+    assert group.get_command(click.Context(group), "missing") is None
+
+    assert any("plugin exploded" in w for w in warnings)
+
+
+def test_plugin_load_error_is_reported(monkeypatch) -> None:
+    """A loader that gave up entirely is surfaced, not just logged.
+
+    load_plugin_registry() swallows the failure to keep the CLI alive, and
+    logging is still disabled while commands are resolved, so without this the
+    user is never told why every plugin command vanished.
+    """
+    from ggshield.core import ui
+    from ggshield.core.plugin.registry import PluginRegistry
+
+    _patch_registry(monkeypatch, PluginRegistry())
+    monkeypatch.setattr(
+        "ggshield.core.plugin.hooks.get_plugin_load_error",
+        lambda: "enterprise config is unreadable",
+    )
+
+    warnings: list[str] = []
+    monkeypatch.setattr(ui, "display_warning", warnings.append)
+
+    group = PluginAwareLazyGroup("cli")
+    group.list_commands(click.Context(group))
+
+    assert any("enterprise config is unreadable" in w for w in warnings)
+
+
 def test_no_warning_when_no_failures(monkeypatch) -> None:
     from ggshield.core import ui
     from ggshield.core.plugin.registry import PluginRegistry
@@ -240,12 +290,6 @@ def test_main_warns_then_click_rejects_unknown_plugin_command(
     _patch_registry(monkeypatch, registry)
     monkeypatch.setattr(main_module, "force_utf8_output", lambda: None)
     monkeypatch.setattr(main_module, "setup_truststore", lambda: None)
-    # The cli group is a module-level singleton: reset plugin-merge memoization
-    monkeypatch.setattr(main_module.cli, "_plugins_merged", False)
-    machine_group = main_module.cli.get_command(
-        click.Context(main_module.cli), "machine"
-    )
-    monkeypatch.setattr(machine_group, "_plugins_merged", False)
 
     with pytest.raises(SystemExit):
         main_module.main(["machine", "scan"])

--- a/tests/unit/test_main_plugin_registration.py
+++ b/tests/unit/test_main_plugin_registration.py
@@ -1,48 +1,65 @@
-"""Tests for plugin command registration in __main__.py."""
+"""Tests for lazy plugin command registration (PluginAwareLazyGroup)."""
 
+import sys
+import types
 from unittest import mock
 
 import click
 import pytest
 
+from ggshield.cmd.utils.lazy_group import (
+    PluginAwareLazyGroup,
+    add_or_merge_plugin_command,
+)
 
-def test_register_plugin_commands_skips_conflicts(monkeypatch) -> None:
-    """Plugin commands must not override built-in commands."""
-    import ggshield.__main__ as main_module
 
+def _registry_with_commands(*commands, load_failures=None):
+    registry = mock.MagicMock()
+    registry.get_commands.return_value = list(commands)
+    registry.get_load_failures.return_value = load_failures or {}
+    return registry
+
+
+def _patch_registry(monkeypatch, registry) -> None:
+    monkeypatch.setattr(
+        "ggshield.core.plugin.hooks.load_plugin_registry", lambda: registry
+    )
+
+
+def test_plugin_commands_merge_on_miss(monkeypatch) -> None:
+    """A plugin command is registered when an unknown command name is resolved."""
+    root = PluginAwareLazyGroup("cli", commands={"auth": click.Command("auth")})
     plugin_conflicting_cmd = click.Command("auth")
     plugin_new_cmd = click.Command("plugin-extra")
+    _patch_registry(
+        monkeypatch, _registry_with_commands(plugin_conflicting_cmd, plugin_new_cmd)
+    )
 
-    mock_registry = mock.MagicMock()
-    mock_registry.get_commands.return_value = [plugin_conflicting_cmd, plugin_new_cmd]
+    cmd = root.get_command(click.Context(root), "plugin-extra")
 
-    mock_cli = mock.MagicMock()
-    mock_cli.commands = {
-        "auth": click.Command("auth"),
-        "config": click.Command("config"),
-    }
+    assert cmd is plugin_new_cmd
+    # Built-in auth must not be overridden by the conflicting plugin command
+    assert root.commands["auth"] is not plugin_conflicting_cmd
 
-    deferred_warnings: list[str] = []
 
-    monkeypatch.setattr(main_module, "cli", mock_cli)
-    monkeypatch.setattr(main_module, "_deferred_warnings", deferred_warnings)
-    monkeypatch.setattr(main_module, "_load_plugins", lambda: mock_registry)
+def test_plugins_not_loaded_when_command_resolves(monkeypatch) -> None:
+    """The whole point: resolving a known command must not load plugins."""
+    root = PluginAwareLazyGroup("cli", commands={"auth": click.Command("auth")})
+    monkeypatch.setattr(
+        "ggshield.core.plugin.hooks.load_plugin_registry",
+        lambda: pytest.fail("plugins must not be loaded to resolve a built-in command"),
+    )
 
-    main_module._register_plugin_commands()
-
-    mock_cli.add_command.assert_called_once_with(plugin_new_cmd)
-    assert any("conflicts with an existing command" in msg for msg in deferred_warnings)
+    assert root.get_command(click.Context(root), "auth") is not None
 
 
 def test_add_or_merge_adds_new_top_level_command() -> None:
     """A plugin command with a fresh name is added as-is."""
-    import ggshield.__main__ as main_module
-
     root = click.Group("cli", commands={"auth": click.Command("auth")})
     plugin_cmd = click.Command("brand-new")
     warnings: list[str] = []
 
-    main_module._add_or_merge_plugin_command(root, plugin_cmd, warnings)
+    add_or_merge_plugin_command(root, plugin_cmd, warnings)
 
     assert root.commands["brand-new"] is plugin_cmd
     assert warnings == []
@@ -50,8 +67,6 @@ def test_add_or_merge_adds_new_top_level_command() -> None:
 
 def test_add_or_merge_merges_plugin_group_into_builtin_group() -> None:
     """A plugin group colliding with a built-in group merges its subcommands in."""
-    import ggshield.__main__ as main_module
-
     builtin_machine = click.Group("machine", commands={"setup": click.Command("setup")})
     root = click.Group("cli", commands={"machine": builtin_machine})
     plugin_machine = click.Group(
@@ -64,7 +79,7 @@ def test_add_or_merge_merges_plugin_group_into_builtin_group() -> None:
     )
     warnings: list[str] = []
 
-    main_module._add_or_merge_plugin_command(root, plugin_machine, warnings)
+    add_or_merge_plugin_command(root, plugin_machine, warnings)
 
     # Plugin subcommands are merged into the SAME built-in group object.
     assert root.commands["machine"] is builtin_machine
@@ -75,48 +90,140 @@ def test_add_or_merge_merges_plugin_group_into_builtin_group() -> None:
     assert any("machine setup" in msg for msg in warnings)
 
 
+def test_add_or_merge_loads_lazy_builtin_before_merging(monkeypatch) -> None:
+    """A plugin command must not shadow a built-in that is still lazy."""
+    # A fake lazy target module, so we don't mutate the real machine_group
+    # singleton (test pollution).
+    mod = types.ModuleType("fake_machine_mod")
+    mod.machine_group = click.Group(  # type: ignore[attr-defined]
+        "machine", commands={"setup": click.Command("setup")}
+    )
+    monkeypatch.setitem(sys.modules, "fake_machine_mod", mod)
+
+    root = PluginAwareLazyGroup(
+        "cli", lazy_commands={"machine": "fake_machine_mod:machine_group"}
+    )
+    plugin_machine = click.Group("machine", commands={"scan": click.Command("scan")})
+    warnings: list[str] = []
+
+    add_or_merge_plugin_command(root, plugin_machine, warnings)
+
+    # The built-in machine group was force-loaded, plugin subcommands merged in.
+    assert root.commands["machine"] is not plugin_machine
+    assert "setup" in root.commands["machine"].commands
+    assert "scan" in root.commands["machine"].commands
+
+
 def test_add_or_merge_skips_non_group_conflict() -> None:
     """A plain command colliding with a built-in command is skipped, not merged."""
-    import ggshield.__main__ as main_module
-
     root = click.Group("cli", commands={"auth": click.Command("auth")})
     plugin_cmd = click.Command("auth")
     warnings: list[str] = []
 
-    main_module._add_or_merge_plugin_command(root, plugin_cmd, warnings)
+    add_or_merge_plugin_command(root, plugin_cmd, warnings)
 
     assert root.commands["auth"] is not plugin_cmd
     assert any("conflicts with an existing command" in msg for msg in warnings)
 
 
-def test_warn_about_failed_plugins_emits_one_warning_per_failure(monkeypatch) -> None:
-    import ggshield.__main__ as main_module
+def test_plugin_scope_merges_subcommands_into_group(monkeypatch) -> None:
+    """plugin_scope='machine' merges the plugin's machine subcommands in."""
+    group = PluginAwareLazyGroup(
+        "machine",
+        plugin_scope="machine",
+        lazy_commands={"setup": "fake_setup_mod:setup_cmd"},
+    )
+    plugin_machine = click.Group(
+        "machine",
+        commands={"scan": click.Command("scan"), "setup": click.Command("setup")},
+    )
+    _patch_registry(monkeypatch, _registry_with_commands(plugin_machine))
+
+    cmd = group.get_command(click.Context(group), "scan")
+
+    assert cmd is plugin_machine.commands["scan"]
+    # The still-lazy built-in `setup` wins over the plugin's conflicting one.
+    assert "setup" not in group.commands
+
+
+def test_merging_twice_does_not_warn(monkeypatch) -> None:
+    """GIVEN a plugin group whose name matches a built-in group
+    WHEN both the root group and the built-in group itself merge it
+    THEN the second merge is silent
+
+    Both merge into the same object, so warning on the second pass would claim a
+    plugin subcommand was dropped when it is in fact registered.
+    """
+    machine = PluginAwareLazyGroup("machine", plugin_scope="machine")
+    mod = types.ModuleType("fake_machine_mod2")
+    mod.machine = machine  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fake_machine_mod2", mod)
+    root = PluginAwareLazyGroup(
+        "cli", lazy_commands={"machine": "fake_machine_mod2:machine"}
+    )
+    plugin_machine = click.Group("machine", commands={"scan": click.Command("scan")})
+    _patch_registry(monkeypatch, _registry_with_commands(plugin_machine))
+
+    warnings: list[str] = []
+    monkeypatch.setattr("ggshield.core.ui.display_warning", warnings.append)
+
+    root.list_commands(click.Context(root))  # root merges into `machine`
+    machine.list_commands(click.Context(machine))  # `machine` merges again
+
+    assert "scan" in machine.commands
+    assert warnings == []
+
+
+def test_load_failures_warn_on_command_miss(monkeypatch) -> None:
+    """A failed plugin load warns when an unknown command is resolved."""
+    from ggshield.core import ui
     from ggshield.core.plugin.registry import PluginRegistry
 
     registry = PluginRegistry()
     registry.record_load_failure("machine_scan", "error relocating libsatori.so")
-    monkeypatch.setattr(main_module, "_load_plugins", lambda: registry)
+    _patch_registry(monkeypatch, registry)
 
     warnings: list[str] = []
-    monkeypatch.setattr(main_module.ui, "display_warning", warnings.append)
+    monkeypatch.setattr(ui, "display_warning", warnings.append)
 
-    main_module._warn_about_failed_plugins()
+    group = PluginAwareLazyGroup("cli")
+    assert group.get_command(click.Context(group), "missing") is None
 
     assert len(warnings) == 1
     assert "machine_scan" in warnings[0]
     assert "failed to load" in warnings[0].lower()
 
 
-def test_warn_about_failed_plugins_silent_when_none(monkeypatch) -> None:
-    import ggshield.__main__ as main_module
+def test_load_failures_silent_during_shell_completion(monkeypatch) -> None:
+    """Warnings must not leak into shell completion output."""
+    from ggshield.core import ui
     from ggshield.core.plugin.registry import PluginRegistry
 
-    monkeypatch.setattr(main_module, "_load_plugins", lambda: PluginRegistry())
+    registry = PluginRegistry()
+    registry.record_load_failure("machine_scan", "error relocating libsatori.so")
+    _patch_registry(monkeypatch, registry)
+    monkeypatch.setenv("_GGSHIELD_COMPLETE", "zsh_complete")
 
     warnings: list[str] = []
-    monkeypatch.setattr(main_module.ui, "display_warning", warnings.append)
+    monkeypatch.setattr(ui, "display_warning", warnings.append)
 
-    main_module._warn_about_failed_plugins()
+    group = PluginAwareLazyGroup("cli")
+    group.list_commands(click.Context(group))
+
+    assert warnings == []
+
+
+def test_no_warning_when_no_failures(monkeypatch) -> None:
+    from ggshield.core import ui
+    from ggshield.core.plugin.registry import PluginRegistry
+
+    _patch_registry(monkeypatch, PluginRegistry())
+
+    warnings: list[str] = []
+    monkeypatch.setattr(ui, "display_warning", warnings.append)
+
+    group = PluginAwareLazyGroup("cli")
+    assert group.get_command(click.Context(group), "missing") is None
 
     assert warnings == []
 
@@ -130,10 +237,15 @@ def test_main_warns_then_click_rejects_unknown_plugin_command(
 
     registry = PluginRegistry()
     registry.record_load_failure("machine_scan", "error relocating libsatori.so")
-    monkeypatch.setattr(main_module, "_load_plugins", lambda: registry)
-    monkeypatch.setattr(main_module, "_register_plugin_commands", lambda: None)
+    _patch_registry(monkeypatch, registry)
     monkeypatch.setattr(main_module, "force_utf8_output", lambda: None)
     monkeypatch.setattr(main_module, "setup_truststore", lambda: None)
+    # The cli group is a module-level singleton: reset plugin-merge memoization
+    monkeypatch.setattr(main_module.cli, "_plugins_merged", False)
+    machine_group = main_module.cli.get_command(
+        click.Context(main_module.cli), "machine"
+    )
+    monkeypatch.setattr(machine_group, "_plugins_merged", False)
 
     with pytest.raises(SystemExit):
         main_module.main(["machine", "scan"])

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -636,6 +636,13 @@ class TestDiscoveryCacheTTL:
         with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
             assert is_discovery_cache_fresh() is False
 
+    def test_fresh_when_mtime_is_barely_in_the_future(self, tmp_path: Path):
+        """A just-touched file can read slightly ahead of time.time(): the two come
+        from different clock sources. Small skew is fresh, not a clock jump."""
+        self._age(tmp_path, -1)
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert is_discovery_cache_fresh() is True
+
     def test_touch_makes_a_stale_cache_fresh_again(self, tmp_path: Path):
         cache_file = self._age(tmp_path, DISCOVERY_CACHE_TTL_SECONDS + 1)
         content = cache_file.read_text()


### PR DESCRIPTION
## Context

Every `ggshield` invocation imports all 12 command groups (`__main__.py:13-24`) and runs plugin discovery, before doing any work. On the shipped PyInstaller binary that's ~440 ms of the ~954 ms the ai-hook takes — and the hook fires twice per agent tool call. It also costs every `secret scan pre-commit`, which runs on every `git commit`.

Complements #1354 (`perf(plugin): defer sigstore imports off the startup path`) — the sigstore stack is already deferred; this removes the command-group imports and the per-invocation plugin discovery that remain.

## What has been done

- `cmd/utils/lazy_group.py`: click's canonical `LazyGroup` — a `name → "module:attr"` map imported on lookup. `list_commands()` does not import.
- Plugin discovery deferred to when it's actually needed (command-name miss, or `--help`); `ContextObj.plugin_registry` stays populated lazily, and the `_GGSHIELD_COMPLETE` guard that keeps plugin warnings out of shell completion is retained.
- **`scripts/build-os-packages`**: lazy imports are strings, so PyInstaller's static analysis can't see them — and for the ai-hook a non-zero exit reads as *allow*, i.e. a silent fail-open. So the build gate is the load-bearing part of this PR:
  - `--collect-submodules ggshield`, so everything under the package is bundled regardless of how it's imported
  - `smoke_check_bundle()` no longer runs a hardcoded 4-command list — it **generates** a walk of the click tree and resolves every leaf command from the built bundle, so a command added later is covered without anyone updating a list
  - plus one real end-to-end check: a canned Claude-Code payload piped into `secret scan ai-hook` from the bundle, asserting exit 0 and parseable JSON

## Validation

- `tests/unit` → **2502 passed, 4 skipped**; new `test_lazy_commands.py` asserts every entry in the lazy map resolves to a click command (catches `"module:attr"` typos without needing a build)
- Startup, source venv, n=25/side alternated, isolated `GG_*` dirs, no network: **551 ms → 209 ms**
- The new gate logic was exercised verbatim against a shim (44 leaf commands resolved, ai-hook exit 0 with valid JSON) and correctly **failed** when a lazy target was deliberately corrupted

✅ **Verified on CI** ([run 30892251277](https://github.com/GitGuardian/ggshield/actions/runs/30892251277), head `76a3119`): `build_os_packages` green on all five targets — windows-2022, macos-15-intel, macos-14, ubuntu-22.04 (rockylinux, x86_64), ubuntu-24.04-arm — and every one logged `Resolved 44 leaf commands from the bundle` then `Bundle smoke check OK`. `--collect-submodules` costs no build time: the PyInstaller step matches `main` (ubuntu 27s vs 27s, windows 38s vs 38s, macos-14 27s vs 26s); the +15–35s in the `Build` step is the new 44-command smoke walk itself. Packaged artifacts grow **+21–46 KB (≤0.05%)** per target vs the three latest `main` runs.

Venv numbers are not frozen-binary numbers: on the binary, expect roughly 954 ms → ~730 ms per invocation (~460 ms per tool call), since the API and config legs are untouched.

## PR check list

- [x] Tests included
- [x] Changelog entry (`changelog.d/`)

