### PR TITLE
fix(auth): probe keyring availability with a read instead of a write

### DIFF
--- a/changelog.d/20260803_120000_achille.mascia_fix_keyring_write_probe.md
+++ b/changelog.d/20260803_120000_achille.mascia_fix_keyring_write_probe.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- On macOS, `ggshield` no longer pops a "Keychain Not Found" dialog when checking
+  whether the keyring is usable. The check now only reads from the credential
+  store instead of writing a probe entry, which also stops it from silently
+  falling back to file-based token storage on machines where the keychain can be
+  read but not written.

--- a/ggshield/core/config/token_store.py
+++ b/ggshield/core/config/token_store.py
@@ -93,24 +93,28 @@ class KeyringTokenStore(TokenStore):
                 logger.debug("No keyring entry to delete for instance %s", instance_url)
 
     def is_available(self) -> bool:
-        """Check if keyring is usable by probing with a test key."""
+        """Check if keyring is usable, by probing it with a read.
+
+        The probe must never write: on macOS, set_password() pops a blocking
+        modal ("A keychain cannot be found to store ...") when the Security
+        framework can't resolve a writable keychain, which froze hooks and
+        flooded users with dialogs. Reading a key that was never stored
+        returns None on a working backend and raises on a broken one (e.g. a
+        ChainerBackend that passes the isinstance check above), which is all
+        the signal we need. This also matches what the hot path does: reading
+        a token. Writes are only done by the interactive `auth login`, where a
+        dialog is acceptable and a failure already falls back to the config
+        file.
+        """
         try:
             kr = keyring.get_keyring()
             if isinstance(kr, keyring.backends.fail.Keyring):
                 return False
-            # Probe the backend to verify it actually works (e.g. a
-            # ChainerBackend may pass the isinstance check but still fail).
-            # Hold the lock across the whole probe so it doesn't race the
-            # token reads of concurrent processes.
-            probe_key = "__ggshield_probe__"
+            # Hold the lock across the probe so it doesn't race the token
+            # reads of concurrent processes.
             with _keyring_lock():
-                keyring.set_password(KEYRING_SERVICE, probe_key, "test")
-                val = keyring.get_password(KEYRING_SERVICE, probe_key)
-                try:
-                    keyring.delete_password(KEYRING_SERVICE, probe_key)
-                except Exception:
-                    logger.debug("Failed to clean up keyring probe key")
-            return val == "test"
+                keyring.get_password(KEYRING_SERVICE, "__ggshield_probe__")
+            return True
         except Exception:
             return False
 

--- a/tests/unit/core/config/test_token_store.py
+++ b/tests/unit/core/config/test_token_store.py
@@ -56,19 +56,32 @@ class TestKeyringTokenStore:
             store.delete_token(INSTANCE_URL)
 
     def test_is_available_true(self):
+        """GIVEN a working backend WHEN probing THEN a read of an unknown key
+        returning None means available"""
         store = KeyringTokenStore()
-        mock_keyring = MagicMock()
         with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", return_value=None) as mock_get,
+        ):
+            assert store.is_available() is True
+            mock_get.assert_called_once()
+
+    def test_is_available_never_writes(self):
+        """GIVEN a working backend WHEN probing THEN it must not write.
+
+        Regression guard: probing with set_password pops a blocking modal on
+        macOS when no writable keychain can be resolved.
+        """
+        store = KeyringTokenStore()
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", return_value=None),
             patch("keyring.set_password") as mock_set,
-            patch("keyring.get_password", return_value="test") as mock_get,
             patch("keyring.delete_password") as mock_delete,
         ):
             assert store.is_available() is True
-            # Verify the probe cycle ran
-            mock_set.assert_called_once()
-            mock_get.assert_called_once()
-            mock_delete.assert_called_once()
+            mock_set.assert_not_called()
+            mock_delete.assert_not_called()
 
     def test_is_available_false_fail_backend(self):
         import keyring.backends.fail
@@ -79,15 +92,25 @@ class TestKeyringTokenStore:
             assert store.is_available() is False
 
     def test_is_available_false_probe_fails(self):
+        """GIVEN a backend whose get_password raises THEN it is not available"""
         store = KeyringTokenStore()
-        mock_keyring = MagicMock()
         with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
-            patch("keyring.set_password"),
-            patch("keyring.get_password", return_value="wrong"),
-            patch("keyring.delete_password"),
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", side_effect=RuntimeError("no keychain")),
         ):
             assert store.is_available() is False
+
+    def test_is_available_true_with_stale_probe_entry(self):
+        """GIVEN an old ggshield left a probe entry in the keychain THEN the
+        backend is still reported available (we never delete it: that's a write)"""
+        store = KeyringTokenStore()
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", return_value="test"),
+            patch("keyring.delete_password") as mock_delete,
+        ):
+            assert store.is_available() is True
+            mock_delete.assert_not_called()
 
     def test_is_available_false_on_exception(self):
         store = KeyringTokenStore()
@@ -122,12 +145,13 @@ class TestGetTokenStore:
 
     def test_returns_keyring_when_available(self, monkeypatch):
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
-        mock_keyring = MagicMock()
         with (
-            patch("keyring.get_keyring", return_value=mock_keyring),
-            patch("keyring.set_password"),
-            patch("keyring.get_password", return_value="test"),
-            patch("keyring.delete_password"),
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", return_value=None),
+            patch(
+                "keyring.set_password",
+                side_effect=AssertionError("selection must not write"),
+            ),
         ):
             store = get_token_store()
             assert isinstance(store, KeyringTokenStore)
@@ -138,6 +162,17 @@ class TestGetTokenStore:
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
         fail_keyring = keyring.backends.fail.Keyring()
         with patch("keyring.get_keyring", return_value=fail_keyring):
+            store = get_token_store()
+            assert isinstance(store, FileTokenStore)
+
+    def test_returns_file_store_when_probe_raises(self, monkeypatch):
+        """GIVEN a backend that can't be read WHEN selecting a store THEN we
+        degrade to the file store instead of crashing"""
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+        with (
+            patch("keyring.get_keyring", return_value=MagicMock()),
+            patch("keyring.get_password", side_effect=RuntimeError("no keychain")),
+        ):
             store = get_token_store()
             assert isinstance(store, FileTokenStore)
 


### PR DESCRIPTION
## Context

`KeyringTokenStore.is_available()` probed the backend by **writing** a `__ggshield_probe__` entry. On macOS, `set_password()` opens a blocking modal — *"A keychain cannot be found to store `__ggshield_probe__`"* — whenever the Security framework can't resolve a **writable** keychain, even on machines where reads work fine.

The probe runs once per process, and the AI hook spawns a fresh process twice per agent tool call, so the consequences compound:

- users get a flood of dialogs (reported by a Guardian dogfooding the hook)
- the hook blocks waiting for a click that never comes — longest recorded run in a local sample: **1,033,011 ms**
- a failed probe falls back to `FileTokenStore`, which returns no token, so the hook emits *"could not authenticate — this action was NOT scanned for secrets"* and **fails open**: 22 of 2021 runs in one sample

## What has been done

Replaced the write-probe with a read of a key that was never stored — `None` on a working backend, raises on a broken one. Same signal, no writable keychain required, no dialog. It also matches what the hot path actually does: the hook only ever *reads* a token.

Kept the `keyring.backends.fail.Keyring` short-circuit, the `_keyring_lock()`, and `except Exception: return False` so a broken backend still degrades to `FileTokenStore`.

Returns `True` on any non-raising read rather than checking the value: a machine that hit the old bug may have a leftover `__ggshield_probe__` entry, and gating on `None` would report the backend broken on exactly those machines. Stale entries are harmless and left alone — deleting one would be a write, i.e. the thing causing the dialog.

Writes remain in interactive `ggshield auth login`, where a prompt is actionable and `_persist_to_keyring` already falls back to the config file on failure.

## Validation

- `tests/unit` → **2498 passed, 4 skipped**
- New tests cover: working backend → `True`; raising backend → `False` **and** `get_token_store()` returns `FileTokenStore`; `fail.Keyring` → `False`; stale probe entry → `True`; and a regression guard asserting `is_available()` never calls `set_password`/`delete_password`, so the write can't be silently reintroduced
- `black` / `flake8` / `isort` clean
- Verified live on macOS: backend `keyring.backends.macOS.Keyring`, `is_available()` → `True`, no dialog. No `set_password`/`delete_password` was ever issued against a real keychain during testing.

Not verified: the absence of the modal on the *reporting* machine, which has a writable keychain and so never showed it. The fix rests on the reported evidence that reads succeed there while writes prompt.

## PR check list

- [x] Tests included
- [x] Changelog entry (`changelog.d/`)
