### PR TITLE
fix(ai-hook): scan the range an agent reads, not the whole file

### DIFF
--- a/changelog.d/20260804_120000_achille.mascia_ai_hook_read_range.md
+++ b/changelog.d/20260804_120000_achille.mascia_ai_hook_read_range.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `ggshield secret scan ai-hook` now scans only the lines an agent actually reads, instead of
+  the whole file. A file over the API's 1 MiB document limit was skipped outright — allowed
+  without being scanned at all — even when the agent only read a few hundred lines of it;
+  that slice now scans normally. Ranges are read from Claude Code (`offset`/`limit`) and
+  VS Code (`startLine`/`endLine`); a read without a range still scans the whole file.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -16,6 +16,7 @@ from ..models import (
     HookPayload,
     HookResult,
     MCPConfiguration,
+    ReadRange,
     Scope,
     Transport,
 )
@@ -136,6 +137,22 @@ class Claude(Agent):
         return "session_id" in hook_payload and "claude" in (
             hook_payload.get("transcript_path") or ""
         )
+
+    def read_range(self, tool_input: Dict[str, Any]) -> Optional[ReadRange]:
+        """Claude Code's Read takes `offset`, the first line, and `limit`, a
+        number of lines. Either can be absent: no `offset` reads from the top,
+        no `limit` reads to the end.
+
+        Read does cap an open-ended read at a default number of lines, but that
+        cap is an implementation detail we are not told about, so we do not
+        subtract it from what we scan.
+        """
+        offset = tool_input.get("offset")
+        limit = tool_input.get("limit")
+        first = offset if isinstance(offset, int) and offset > 0 else 1
+        if isinstance(limit, int) and limit > 0:
+            return first, first + limit - 1
+        return None if first == 1 else (first, None)
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".claude") / "settings.json"

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -11,7 +11,14 @@ from pygitguardian.models import AIDiscovery, MCPActivityRequest
 from ggshield.core.dirs import get_editor_user_data_dir, get_user_home_dir
 
 from ..agent_activity.sources import JSONLActivitySource
-from ..models import Agent, EventType, HookPayload, HookResult, MCPConfiguration
+from ..models import (
+    Agent,
+    EventType,
+    HookPayload,
+    HookResult,
+    MCPConfiguration,
+    ReadRange,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -97,6 +104,21 @@ class VSCode(Agent):
         return (
             "github.copilot-chat" in (hook_payload.get("transcript_path") or "").lower()
         )
+
+    def read_range(self, tool_input: Dict[str, Any]) -> Optional[ReadRange]:
+        """VS Code's read_file takes `startLine` and `endLine`, 1-based and
+        inclusive.
+
+        Copilot CLI inherits this, and its `view` tool likely has a range of its
+        own, but every `view` payload we have carries only `path`. Until one
+        turns up it falls through to the whole file: guessing a parameter name
+        would under-scan without ever saying so.
+        """
+        start = tool_input.get("startLine")
+        end = tool_input.get("endLine")
+        first = start if isinstance(start, int) and start > 0 else 1
+        last = end if isinstance(end, int) and end > 0 else None
+        return None if first == 1 and last is None else (first, last)
 
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return (

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -141,6 +141,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
     identifier = ""
     content = ""
     tool = None
+    read_range = None
 
     # Extract the identifier and content based on the event type
     if event_type == EventType.USER_PROMPT:
@@ -163,6 +164,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         elif tool == Tool.READ:
             # We only need to deal with the identifier, the content will be read by the Scannable
             identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
+            read_range = agent.read_range(tool_input)
         elif tool_input:
             # MCP and unrecognized tool arguments can carry secrets bound for
             # potentially external servers. Scan them, like tool_output below.
@@ -177,9 +179,12 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         if isinstance(content, (dict, list)):
             content = json.dumps(content)
         if tool == Tool.READ:
-            identifier = lookup(
-                data.get("tool_input", {}), ["file_path", "filePath", "path"], ""
-            )
+            # Same tool_input as PreToolUse, hence the same range: both events
+            # scan the exact same bytes for one read, which the verdict cache
+            # (keyed on the document) relies on.
+            tool_input = data.get("tool_input", {})
+            identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
+            read_range = agent.read_range(tool_input)
 
     # If identifier was not set, hash the content
     if not identifier:
@@ -194,6 +199,7 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             agent=agent,
             raw=data,
             timestamp=timestamp,
+            read_range=read_range,
         )
     )
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -5,8 +5,9 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum, auto
+from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 
 if TYPE_CHECKING:
@@ -57,6 +58,26 @@ class Tool(Enum):
     OTHER = auto()
 
 
+# (first, last), 1-based and inclusive, `last` being None for "to the end".
+ReadRange = Tuple[int, Optional[int]]
+
+
+def line_slice(content: str, first: int, last: Optional[int]) -> str:
+    """Return lines `first` to `last` of `content`, 1-based and inclusive.
+
+    Split on "\\n" only, the way agents number lines: str.splitlines() also
+    breaks on \\v, \\f and U+2028, which would shift every line number past the
+    first such character and move the window off what the agent reads.
+
+    One line of slack on each side, hence the -2/+1: we cannot check every
+    agent's convention against a real agent, and being one line out must not
+    leave content unscanned. An extra line costs nothing, a missing one is a
+    miss.
+    """
+    lines = content.split("\n")
+    return "\n".join(lines[max(0, first - 2) : None if last is None else last + 1])
+
+
 def markdown_hard_breaks(text: str) -> str:
     """Turn single newlines into markdown hard breaks (two trailing spaces)."""
     lines = text.split("\n")
@@ -98,10 +119,16 @@ class HookPayload:
     agent: "Agent"
     raw: Dict[str, Any]
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    # Lines a Tool.READ is about to expose; None means the whole file.
+    read_range: Optional[ReadRange] = None
 
-    @property
+    @cached_property
     def scannable(self) -> Scannable:
-        """Return the appropriate Scannable for the payload."""
+        """Return the appropriate Scannable for the payload.
+
+        Cached: a ranged read builds the slice by reading the file, and callers
+        ask for the scannable more than once (`empty`, then the scan itself).
+        """
         if self.tool == Tool.READ:
             # The identifier is not always a real path: it can be a whole shell
             # command (a heredoc, a pipeline...) that a caller guessed was a
@@ -111,7 +138,23 @@ class HookPayload:
             try:
                 path = Path(self.identifier)
                 if path.is_file() and not is_path_binary(path):
-                    return File(path=self.identifier)
+                    file = File(path=self.identifier)
+                    if self.read_range is not None:
+                        try:
+                            # Scanning the slice rather than the file is also
+                            # the difference between scanning and not scanning
+                            # at all: SecretScanner silently skips any document
+                            # over maximum_document_size, so over-scanning a
+                            # large file ends up allowing an unscanned read.
+                            return StringScannable(
+                                url=self.identifier,
+                                content=line_slice(file.content, *self.read_range),
+                            )
+                        except Exception:
+                            # Unreadable or undecodable: let the scanner skip it
+                            # and say why, rather than deciding here.
+                            pass
+                    return file
             except (OSError, ValueError):
                 pass
         return StringScannable(url=self.identifier, content=self.content)
@@ -168,6 +211,16 @@ class Agent(ABC):
         By default, this is in PostToolUse hooks, but it can depend on the agent.
         """
         return payload.event_type == EventType.POST_TOOL_USE
+
+    def read_range(self, tool_input: Dict[str, Any]) -> Optional[ReadRange]:
+        """The lines a read tool call is about to expose, 1-based and inclusive.
+
+        None — the default — means the whole file, and stays the answer for
+        every agent whose range parameters we have not established from a real
+        payload: over-scanning is a scope problem, under-scanning lets content
+        reach the model unscanned. Absent parameters mean everything too.
+        """
+        return None
 
     def post_process_payload(self, payload: HookPayload):
         """Post-process the payload.

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pygitguardian import GGClient
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MAXIMUM_PAYLOAD_SIZE
 from pygitguardian.models import MCPActivityResponse
 
 from ggshield.core.config.user_config import SecretConfig
@@ -1907,3 +1908,308 @@ class TestFlavorOutputResult:
 def test_find_filepaths(prompt: str, filepaths: Set[str]):
     """Test filepath regex."""
     assert find_filepaths(prompt) == filepaths, prompt
+
+
+def _numbered_file(
+    directory: Path, nb_lines: int, name: str = "numbered.txt", newline: str = "\n"
+) -> Path:
+    """A file whose content is `nb_lines` distinguishable lines, "line 1" first.
+
+    Bytes with an explicit terminator, because `write_text` translates "\\n" to
+    os.linesep: the fixture would be CRLF on Windows and LF elsewhere, and the
+    tests would only ever exercise the host's convention.
+    """
+    file = directory / name
+    file.write_bytes(newline.join(f"line {i}" for i in range(1, nb_lines + 1)).encode())
+    return file
+
+
+def _assert_scanned_lines(payload: HookPayload, file: Path, expected: range) -> None:
+    """The scannable holds exactly lines `expected` of `file`, byte for byte.
+
+    Asserted separately so neither can paper over the other: it is a verbatim
+    extract (no newline rewriting, no stripped "\\r" — we scan what the agent
+    reads, not a normalised lookalike), and it is the right window.
+    `splitlines()` here — never in `line_slice`, which must not guess at line
+    boundaries — only makes the second check terminator agnostic.
+    """
+    content = payload.scannable.content
+    assert content in file.read_bytes().decode()
+    assert content.splitlines() == [f"line {i}" for i in expected]
+
+
+def _claude_read(file_path: str, event: str = "PreToolUse", **tool_input: int) -> str:
+    """A Claude Code Read hook payload, optionally carrying a range."""
+    data: dict = {
+        "session_id": "3b7ae0c5",
+        "transcript_path": "/home/user1/.claude/projects/foo/3b7ae0c5.jsonl",
+        "cwd": "/home/user1/foo",
+        "hook_event_name": event,
+        "tool_name": "Read",
+        "tool_input": {"file_path": file_path, **tool_input},
+    }
+    if event == "PostToolUse":
+        # The tool response is not what we scan for a Read: the file on disk is,
+        # so that Pre and Post produce the same document.
+        data["tool_response"] = {"content": "whatever the agent got back"}
+    return json.dumps(data)
+
+
+def _scanner_finding(needle: str) -> MagicMock:
+    """A scanner that reports a secret only if `needle` is in what it is handed."""
+    mock = MagicMock(spec=SecretScanner)
+    mock.client = MagicMock(spec=GGClient)
+    # spec= only provides what the class declares, and the verdict cache key
+    # reads all three: base_uri and api_key are annotation-only on GGClient,
+    # secret_config is set in SecretScanner.__init__.
+    mock.client.base_uri = "https://api.example.com"
+    mock.client.api_key = "some-api-key"
+    mock.secret_config = SecretConfig()
+
+    def scan(scannables, scanner_ui=None, **kwargs):
+        leaked = any(needle in scannable.content for scannable in scannables)
+        return Results(
+            results=[
+                ScanResult(
+                    filename="url",
+                    filemode=Filemode.FILE,
+                    path=Path("."),
+                    url="url",
+                    secrets=[_make_secret(needle)] if leaked else [],
+                    ignored_secrets_count_by_kind=Counter(),
+                )
+            ],
+            errors=[],
+        )
+
+    mock.scan.side_effect = scan
+    return mock
+
+
+def _real_secret_scanner() -> SecretScanner:
+    """A real SecretScanner with a stubbed client, to exercise the size limits."""
+    client = MagicMock()
+    client.maximum_payload_size = MAXIMUM_PAYLOAD_SIZE
+    client.secret_scan_preferences.maximum_document_size = DOCUMENT_SIZE_THRESHOLD_BYTES
+    client.secret_scan_preferences.maximum_documents_per_scan = 20
+    return SecretScanner(
+        client=client,
+        cache=MagicMock(),
+        scan_context=ScanContext(
+            scan_mode=ScanMode.AI_HOOK, command_path="ggshield secret scan ai-hook"
+        ),
+        secret_config=SecretConfig(),
+        check_api_key=False,
+    )
+
+
+class TestReadRange:
+    """A `Tool.READ` must scan the lines the agent is actually reading.
+
+    The part that bites: `SecretScanner._start_scans` silently skips any
+    document over `maximum_document_size` (1 MiB), so over-scanning a large
+    file ends up scanning nothing and allowing the read, where the slice would
+    have scanned fine.
+
+    `line_slice` takes one line of slack on each side, hence the ranges
+    asserted below.
+
+    Tests that assert on sliced bytes run against LF and CRLF on every
+    platform: line numbering must not depend on the terminator, and a CRLF file
+    really does carry "\\r", which the agent's context contains and we must not
+    normalise away.
+    """
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_claude_offset_and_limit_scans_only_that_window(
+        self, tmp_path: Path, newline: str
+    ):
+        """GIVEN a Claude Read of lines 10-14 THEN only that window is scanned."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        payload = parse_hook_input(_claude_read(file.as_posix(), offset=10, limit=5))[0]
+        assert payload.read_range == (10, 14)
+        _assert_scanned_lines(payload, file, range(9, 16))
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_claude_offset_only_reads_to_the_end(self, tmp_path: Path, newline: str):
+        """An open-ended read must scan to the end, not stop at some assumed cap."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        payload = parse_hook_input(_claude_read(file.as_posix(), offset=500))[0]
+        assert payload.read_range == (500, None)
+        _assert_scanned_lines(payload, file, range(499, 1001))
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_claude_limit_only_starts_at_the_top(self, tmp_path: Path, newline: str):
+        """No offset means "from the first line", not "from nowhere"."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        payload = parse_hook_input(_claude_read(file.as_posix(), limit=5))[0]
+        assert payload.read_range == (1, 5)
+        _assert_scanned_lines(payload, file, range(1, 7))
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_no_range_still_scans_the_whole_file(self, tmp_path: Path, newline: str):
+        """Absent range parameters mean everything: the previous behaviour."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        payload = parse_hook_input(_claude_read(file.as_posix()))[0]
+        assert payload.read_range is None
+        assert isinstance(payload.scannable, File)
+        assert payload.scannable.content == file.read_bytes().decode()
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_secret_inside_the_range_still_blocks_at_pre(
+        self, tmp_path: Path, newline: str
+    ):
+        """The whole point of the Pre hook: a secret about to be read is blocked."""
+        file = tmp_path / "conf.txt"
+        file.write_bytes(
+            newline.join(
+                ["padding"] * 20 + ["token=SECRET_IN_RANGE"] + ["padding"] * 500
+            ).encode()
+        )
+        # The secret sits on line 21, the agent reads lines 15 to 25.
+        payload = parse_hook_input(_claude_read(file.as_posix(), offset=15, limit=11))[
+            0
+        ]
+        assert payload.event_type == EventType.PRE_TOOL_USE
+        result = AIHookScanner(_scanner_finding("SECRET_IN_RANGE"))._scan_content(
+            payload
+        )
+        assert result.block is True
+        assert result.nbr_secrets == 1
+        # The PreToolUse wording: nothing has reached the agent yet.
+        assert "was not shown to the agent" in result.message
+
+    def test_secret_outside_the_range_is_not_reported(self, tmp_path: Path):
+        """A secret on a line the agent never reads never enters its context."""
+        file = tmp_path / "conf.txt"
+        file.write_bytes(
+            "\n".join(
+                ["padding"] * 400 + ["token=SECRET_OUT_OF_RANGE"] + ["padding"]
+            ).encode()
+        )
+        payload = parse_hook_input(_claude_read(file.as_posix(), offset=1, limit=10))[0]
+        scanner = _scanner_finding("SECRET_OUT_OF_RANGE")
+        result = AIHookScanner(scanner)._scan_content(payload)
+        assert result.block is False
+        scanned = scanner.scan.call_args[0][0][0].content
+        assert "SECRET_OUT_OF_RANGE" not in scanned
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_pre_and_post_scan_the_same_bytes(self, tmp_path: Path, newline: str):
+        """One read must yield one identical document at both events: the
+        verdict cache is keyed on (filename, content), and Pre is the only event
+        that can block. CRLF included — a terminator handled differently between
+        the two would miss every cache hit, or hide a Pre block behind a Post
+        entry."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        pre = parse_hook_input(_claude_read(file.as_posix(), offset=10, limit=5))[0]
+        post = parse_hook_input(
+            _claude_read(file.as_posix(), "PostToolUse", offset=10, limit=5)
+        )[0]
+        assert pre.event_type == EventType.PRE_TOOL_USE
+        assert post.event_type == EventType.POST_TOOL_USE
+        assert pre.read_range == post.read_range == (10, 14)
+        assert pre.scannable.content == post.scannable.content
+        assert pre.scannable.filename == post.scannable.filename
+
+    def test_the_sliced_scannable_is_built_once(self, tmp_path: Path):
+        """Slicing reads the file, and `_scan_content` asks twice (`empty`, then
+        the scan itself): the second must not re-read it."""
+        file = _numbered_file(tmp_path, 1000)
+        payload = parse_hook_input(_claude_read(file.as_posix(), offset=10, limit=5))[0]
+        assert payload.scannable is payload.scannable
+
+    def test_oversized_file_scans_once_only_a_slice_is_read(self, tmp_path: Path):
+        """The headline case: a file too big to be scanned at all is skipped
+        outright, while the slice the agent actually reads scans fine."""
+        file = _numbered_file(tmp_path, 120_000)
+        assert file.stat().st_size > DOCUMENT_SIZE_THRESHOLD_BYTES
+
+        whole = parse_hook_input(_claude_read(file.as_posix()))[0]
+        sliced = parse_hook_input(_claude_read(file.as_posix(), offset=1, limit=500))[0]
+
+        scanner = _real_secret_scanner()
+
+        whole_ui = MagicMock()
+        assert scanner._start_scans(MagicMock(), [whole.scannable], whole_ui) == {}
+        assert whole_ui.on_skipped.called  # nothing was sent to the API at all
+
+        sliced_ui = MagicMock()
+        assert scanner._start_scans(MagicMock(), [sliced.scannable], sliced_ui) != {}
+        assert not sliced_ui.on_skipped.called
+
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"], ids=["lf", "crlf"])
+    def test_vscode_start_and_end_line(self, tmp_path: Path, newline: str):
+        """VS Code's read_file sends startLine/endLine, 1-based and inclusive."""
+        file = _numbered_file(tmp_path, 1000, newline=newline)
+        data = {
+            "session_id": "69cc6a03",
+            "transcript_path": (
+                "/home/user1/.config/Code/User/workspaceStorage/"
+                "abc123/GitHub.copilot-chat/transcripts/69cc6a03.jsonl"
+            ),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "read_file",
+            "tool_input": {
+                "filePath": file.as_posix(),
+                "startLine": 20,
+                "endLine": 24,
+            },
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert isinstance(payload.agent, VSCode)
+        assert payload.read_range == (20, 24)
+        _assert_scanned_lines(payload, file, range(19, 26))
+
+    def test_cursor_falls_back_to_the_whole_file(self, tmp_path: Path):
+        """Cursor's Read payload mimics Claude's and may carry a range of its
+        own, but we have never seen one: reading Claude's `offset`/`limit` here
+        would be a guess, and a wrong guess under-scans. Whole file, as before.
+        """
+        file = _numbered_file(tmp_path, 1000)
+        data = {
+            "cursor_version": "2.5.25",
+            "hook_event_name": "preToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": file.as_posix(), "offset": 10, "limit": 5},
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert isinstance(payload.agent, Cursor)
+        assert payload.read_range is None
+        assert payload.scannable.content == file.read_bytes().decode()
+
+    def test_copilot_view_falls_back_to_the_whole_file(self, tmp_path: Path):
+        """Every Copilot CLI `view` payload we have carries only `path`, with no
+        range parameter to read: whole file, exactly as before."""
+        file = _numbered_file(tmp_path, 1000)
+        data = {
+            "timestamp": "2026-02-26T11:53:49.593Z",
+            "hook_event_name": "PreToolUse",
+            "session_id": "69cc6a03",
+            "tool_name": "view",
+            "tool_input": {"path": file.as_posix()},
+            "cwd": "/home/user1/foo",
+        }
+        payload = parse_hook_input(json.dumps(data))[0]
+        assert isinstance(payload.agent, Copilot)
+        assert payload.read_range is None
+        assert payload.scannable.content == file.read_bytes().decode()
+
+    def test_codex_command_read_falls_back_to_the_whole_file(self, tmp_path: Path):
+        """The only Codex commands we treat as a read are `cat` and
+        `Get-Content`, which read the whole file. A partial read (`sed -n`,
+        `head`) stays a Bash payload, never a Tool.READ, so there is no range to
+        apply here."""
+        file = _numbered_file(tmp_path, 1000)
+        data = {
+            "turn_id": "t1",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "shell",
+            "tool_input": {"command": f"cat {file.as_posix()}"},
+        }
+        payloads = parse_hook_input(json.dumps(data))
+        read_payload = next(p for p in payloads if p.tool == Tool.READ)
+        assert isinstance(read_payload.agent, Codex)
+        assert read_payload.read_range is None
+        assert read_payload.scannable.content == file.read_bytes().decode()


### PR DESCRIPTION
## Context

`ggshield secret scan ai-hook` scanned the whole file on a `Read`, even when the agent only read a slice of it. `parse_hook_input` pulled `file_path` out of `tool_input` and dropped everything else.

The reason that matters most is not scope or latency, it is that **over-scanning can mean scanning nothing**. `SecretScanner._start_scans` does:

```python
if scannable.is_longer_than(maximum_document_size):
    scanner_ui.on_skipped(scannable, f"content is over {maximum_document_size:,} bytes")
    continue
```

`maximum_document_size` defaults to `DOCUMENT_SIZE_THRESHOLD_BYTES` (1 MiB). It is not a truncation and not an error: the document is dropped before any API call, no `Result` comes back, `_scan_content` sees no secrets and returns `allow`. So a `Read` of 300 lines from a 2 MB file was allowed having been scanned zero times, where those 300 lines would have scanned fine.

## What has been done

- New `Agent.read_range(tool_input)` returning `(first, last)`, 1-based and inclusive. Default: `None` — the whole file.
- `HookPayload.read_range` + `HookPayload.scannable` slices the file when a range is known.
- Both `PreToolUse` and `PostToolUse` read the range from the same `tool_input`, so one read produces one identical document at both events.

**Ranges implemented:**

| Agent | Parameters | Basis |
|---|---|---|
| Claude Code | `offset` / `limit` | `Read`'s documented parameters: `offset` is the line to start from, `limit` a line count |
| VS Code | `startLine` / `endLine` | The `read_file` PreToolUse fixture already in `test_hooks.py` (`startLine: 1, endLine: 200`), 1-based inclusive |

**Whole file — and the three are not the same case:**

- **Codex** genuinely only reads whole files, by construction. The only Codex read path ggshield recognises is `_parse_command`, which fires on a command starting with `cat ` or `Get-Content ` — both read the entire file. A partial read (`sed -n '10,20p'`, `head -50`) is not classified as a `Tool.READ` at all: it stays a Bash payload whose command string is scanned, and the file is never opened. There is nothing to slice here.
- **Cursor** and **Copilot CLI** almost certainly *do* support ranged reads — Cursor's `Read` mirrors Claude's, and Copilot's `view` is a text-editor-style tool of the kind that usually takes a view range. I have no payload showing the parameter names or their convention (0- vs 1-based, count vs end index), and the fixtures in `test_hooks.py` carry none. So they keep scanning the whole file: **unchanged from today, no regression, but no improvement either.** Guessing the names would silently under-scan if wrong, which is the one outcome worth avoiding.

Adding either is a small follow-up once someone captures one ranged `preToolUse` payload from each — a fixture and a `read_range` override, nothing more.

The same rule applies inside an implemented agent: a missing `offset` means "from the top", a missing `limit` means "to the end", never "nothing". `line_slice` also takes one line of slack on each side, so being one off on an agent's 0/1-based convention can never turn into unscanned content.

**Interaction with #1376:** its verdict cache is keyed on `(instance, token, filename, content)` and depends on Pre and Post hashing identically for a `Read`. They still do — both build the same `File` from the same `file_path` and apply the same range — and `filename` is unchanged (`url=self.identifier`). Test `test_pre_and_post_scan_the_same_bytes` pins exactly that property. No conflict with the diff; the two merge in either order.

## Validation

`tests/unit/verticals/ai/test_hooks.py::TestReadRange`, notably:

- `test_oversized_file_scans_once_only_a_slice_is_read` — a 1.4 MB file driven through the real `SecretScanner._start_scans`: whole file → `on_skipped`, nothing sent; 500-line slice → chunk sent, not skipped.
- `test_secret_inside_the_range_still_blocks_at_pre` / `test_secret_outside_the_range_is_not_reported` — asserting on the bytes handed to the scanner.
- `test_no_range_still_scans_the_whole_file` — previous behaviour preserved exactly.
- One test per agent, including the three that fall back.

`pytest tests/unit`: 2514 passed, 4 skipped. `black`, `flake8`, `isort` clean.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
