### PR TITLE
perf(ai-hook): cut MCP PreToolUse latency from ~1.2s to ~0.4s

### DIFF
--- a/changelog.d/20260804_120000_achille.mascia_ai_hook_mcp_latency.md
+++ b/changelog.d/20260804_120000_achille.mascia_ai_hook_mcp_latency.md
@@ -1,0 +1,9 @@
+### Changed
+
+- `ggshield secret scan ai-hook` is now much faster on MCP tool calls: the local
+  discovery walk is cached for an hour instead of running on every call, and the
+  secret scan and the MCP activity call now run concurrently instead of one after
+  the other. Measured against a mock API at the production p50 latency, an MCP
+  `PreToolUse` event goes from 1183 ms to 387 ms (p50). Other events are
+  unaffected. As a consequence, an MCP tool call is now reported to GitGuardian
+  even when the secret scan blocks it.

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -23,12 +23,21 @@ VERDICT_CACHE_FILENAME = "ai_hook_verdicts.json"
 VERDICT_CACHE_TTL_SECONDS = 15 * 60
 VERDICT_CACHE_MAX_ENTRIES = 500
 
+# The walk inventories assistant configuration files, which change on the order of
+# days, but it runs on *every* MCP tool call. One hour keeps staleness well under a
+# coding session while making the walk negligible.
+DISCOVERY_CACHE_TTL_SECONDS = 3600
+
+
+def _discovery_cache_path() -> Path:
+    return get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
+
 
 def save_discovery_cache(config: AIDiscovery) -> None:
     """
     Save probe results to cache.
     """
-    cache_path = get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
+    cache_path = _discovery_cache_path()
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(config.to_dict(), indent=4))
@@ -41,7 +50,7 @@ def load_discovery_cache() -> Optional[AIDiscovery]:
 
     Returns None if the cache does not exist.
     """
-    cache_path = get_cache_dir() / AI_DISCOVERY_CACHE_FILENAME
+    cache_path = _discovery_cache_path()
     if not cache_path.exists():
         return None
     try:
@@ -177,6 +186,23 @@ def store_clean_verdict(key: str) -> None:
             if hasattr(os, "fchmod"):
                 os.fchmod(file.fileno(), 0o600)
             json.dump(dict(kept), file)
+    except OSError:
+        pass
+
+
+def is_discovery_cache_fresh() -> bool:
+    """Tell whether the cached discovery was refreshed less than the TTL ago."""
+    try:
+        age = time.time() - _discovery_cache_path().stat().st_mtime
+    except OSError:
+        return False
+    return 0 <= age < DISCOVERY_CACHE_TTL_SECONDS
+
+
+def touch_discovery_cache() -> None:
+    """Reset the TTL of the cache, without rewriting its unchanged content."""
+    try:
+        _discovery_cache_path().touch()
     except OSError:
         pass
 

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -13,21 +13,34 @@ from pygitguardian.models import AgentInfo, AIDiscovery, Detail, MCPServer
 from ggshield.core.errors import UnexpectedError
 
 from .agents import AGENTS
-from .cache import has_changed_from, load_discovery_cache, save_discovery_cache
+from .cache import (
+    has_changed_from,
+    is_discovery_cache_fresh,
+    load_discovery_cache,
+    save_discovery_cache,
+    touch_discovery_cache,
+)
 from .installation import are_hooks_installed_globally
 from .models import MCPConfiguration
 from .user import get_user_info
 
 
 def refresh_and_maybe_submit_discovery(client: GGClient) -> AIDiscovery:
-    """Always run discovery, compare with cache, submit only if changed."""
+    """Run discovery unless the cache is still fresh, compare with cache, submit only
+    if changed."""
     cached = load_discovery_cache()
+
+    # This runs on every MCP tool call: trust a recent walk rather than redo it.
+    if cached is not None and is_discovery_cache_fresh():
+        return cached
+
     # If we already have a machine id, reuse it.
     machine_id = cached.user.machine_id if cached is not None else None
     discovery = discover_ai_configuration(machine_id=machine_id)
 
     # Nothing changed,
     if cached is not None and not has_changed_from(discovery, cached):
+        touch_discovery_cache()
         return cached
 
     try:

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -3,6 +3,7 @@ import json
 import re
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Set
 
@@ -18,7 +19,7 @@ from ggshield.core.scan import ScannerProtocol
 from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
-from ggshield.verticals.ai.mcp import send_mcp_activity
+from ggshield.verticals.ai.mcp import is_mcp_activity_payload, send_mcp_activity
 
 from .agents import AGENTS
 from .cache import has_clean_verdict, store_clean_verdict, verdict_key
@@ -566,14 +567,29 @@ class AIHookScanner:
         if not payloads:
             raise ValueError("Error: no payloads to scan")
         for payload in payloads:
-            # Scan for secrets first
-            result = self._scan_content(payload)
-            if result.block:
-                return result
-            # We only send the MCP activity if the payload wasn't already blocked.
-            result = self._send_mcp_activity(payload)
-            if result.block:
-                return result
+            if not is_mcp_activity_payload(payload):
+                # No activity to send: keep the plain, single-threaded path.
+                result = self._scan_content(payload)
+                if result.block:
+                    return result
+                continue
+
+            # Both are blocking HTTP round trips against the same API, so overlap them
+            # instead of paying for them one after the other. The activity is now logged
+            # even when the scan blocks, which the MCP feature owner wants.
+            with ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="mcp_activity"
+            ) as executor:
+                activity = executor.submit(self._send_mcp_activity, payload)
+                scan_result = self._scan_content(payload)
+                mcp_result = activity.result()
+
+            # The scan verdict keeps precedence, as it did when it short-circuited
+            # the activity call.
+            if scan_result.block:
+                return scan_result
+            if mcp_result.block:
+                return mcp_result
         return HookResult.allow(payloads[0])
 
     def _send_mcp_activity(self, payload: HookPayload) -> HookResult:

--- a/ggshield/verticals/ai/mcp.py
+++ b/ggshield/verticals/ai/mcp.py
@@ -10,6 +10,11 @@ def _mcp_activity_fail_open() -> MCPActivityResponse:
     return MCPActivityResponse(allowed=True, reason="")
 
 
+def is_mcp_activity_payload(payload: HookPayload) -> bool:
+    """Tell whether `send_mcp_activity` would do any actual work for this payload."""
+    return payload.event_type == EventType.PRE_TOOL_USE and payload.tool == Tool.MCP
+
+
 def send_mcp_activity(client: GGClient, payload: HookPayload) -> MCPActivityResponse:
     """Build the MCP activity request and send it to the GitGuardian API.
 
@@ -22,7 +27,7 @@ def send_mcp_activity(client: GGClient, payload: HookPayload) -> MCPActivityResp
     """
 
     # if the payload is not an MCP pre-tool use, early return
-    if payload.event_type != EventType.PRE_TOOL_USE or payload.tool != Tool.MCP:
+    if not is_mcp_activity_payload(payload):
         return _mcp_activity_fail_open()
 
     ai_config = refresh_and_maybe_submit_discovery(client)

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -1,4 +1,5 @@
 import json
+import os
 import stat
 import time
 from pathlib import Path
@@ -19,15 +20,18 @@ from pygitguardian.models import (
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.verticals.ai.cache import (
+    DISCOVERY_CACHE_TTL_SECONDS,
     VERDICT_CACHE_MAX_ENTRIES,
     VERDICT_CACHE_TTL_SECONDS,
     _server_has_capabilities_unknown_to,
     _verdict_cache_path,
     has_changed_from,
     has_clean_verdict,
+    is_discovery_cache_fresh,
     load_discovery_cache,
     save_discovery_cache,
     store_clean_verdict,
+    touch_discovery_cache,
     verdict_key,
 )
 from ggshield.verticals.ai.discovery import _merge_mcp_configurations
@@ -602,3 +606,40 @@ class TestVerdictCache:
         # Keep the file trustworthy so these tests exercise the content checks
         # and not the permission check.
         path.chmod(0o600)
+
+
+class TestDiscoveryCacheTTL:
+    def _age(self, tmp_path: Path, seconds: float) -> Path:
+        cache_file = tmp_path / "ai_discovery.json"
+        cache_file.write_text("{}")
+        mtime = time.time() - seconds
+        os.utime(cache_file, (mtime, mtime))
+        return cache_file
+
+    def test_not_fresh_when_missing(self, tmp_path: Path):
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert is_discovery_cache_fresh() is False
+
+    def test_fresh_within_ttl(self, tmp_path: Path):
+        self._age(tmp_path, DISCOVERY_CACHE_TTL_SECONDS / 2)
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert is_discovery_cache_fresh() is True
+
+    def test_stale_past_ttl(self, tmp_path: Path):
+        self._age(tmp_path, DISCOVERY_CACHE_TTL_SECONDS + 1)
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert is_discovery_cache_fresh() is False
+
+    def test_stale_when_mtime_is_in_the_future(self, tmp_path: Path):
+        """A clock jump must not pin the cache as fresh forever."""
+        self._age(tmp_path, -DISCOVERY_CACHE_TTL_SECONDS)
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            assert is_discovery_cache_fresh() is False
+
+    def test_touch_makes_a_stale_cache_fresh_again(self, tmp_path: Path):
+        cache_file = self._age(tmp_path, DISCOVERY_CACHE_TTL_SECONDS + 1)
+        content = cache_file.read_text()
+        with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+            touch_discovery_cache()
+            assert is_discovery_cache_fresh() is True
+        assert cache_file.read_text() == content

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -199,6 +199,23 @@ class TestSubmitAIDiscovery:
 
 
 class TestRefreshAndMaybeSubmitDiscovery:
+    @pytest.fixture(autouse=True)
+    def cache_ttl(self):
+        """Expired TTL by default, so tests exercise the filesystem discovery path.
+
+        Yields the two TTL mocks so a test can make the cache fresh instead.
+        """
+        with (
+            patch(
+                "ggshield.verticals.ai.discovery.is_discovery_cache_fresh",
+                return_value=False,
+            ) as m_fresh,
+            patch(
+                "ggshield.verticals.ai.discovery.touch_discovery_cache",
+            ) as m_touch,
+        ):
+            yield m_fresh, m_touch
+
     def _patch_all(self):
         return (
             patch(
@@ -289,6 +306,94 @@ class TestRefreshAndMaybeSubmitDiscovery:
 
             assert result == new_disc
             m_save.assert_not_called()
+
+    def test_fresh_cache_skips_the_filesystem_walk(self, cache_ttl):
+        """Within the TTL, the cached discovery is returned without re-walking."""
+        m_fresh, _ = cache_ttl
+        m_fresh.return_value = True
+        cached = _discovery()
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = cached
+
+            result = refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_discover.assert_not_called()
+            m_submit.assert_not_called()
+            m_save.assert_not_called()
+            assert result == cached
+
+    def test_fresh_but_unreadable_cache_still_walks(self, cache_ttl):
+        """A recent but corrupt cache file must not short-circuit discovery."""
+        m_fresh, _ = cache_ttl
+        m_fresh.return_value = True
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = None  # unparseable cache
+            m_discover.return_value = _discovery()
+            m_submit.return_value = _discovery()
+
+            refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_discover.assert_called_once()
+            m_submit.assert_called_once()
+            m_save.assert_called_once()
+
+    def test_expired_ttl_walks_again_and_resets_the_ttl(self, cache_ttl):
+        """Past the TTL we re-walk; if nothing changed we reset the TTL instead of
+        re-walking on every subsequent call."""
+        _, m_touch = cache_ttl
+        cached = _discovery()
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = cached
+            m_discover.return_value = cached
+
+            result = refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_discover.assert_called_once()
+            m_touch.assert_called_once()
+            m_submit.assert_not_called()
+            m_save.assert_not_called()
+            assert result == cached
+
+    def test_expired_ttl_with_changed_configuration_still_submits(self, cache_ttl):
+        """The TTL must not swallow a real configuration change."""
+        _, m_touch = cache_ttl
+        cached = _discovery(user=_user(hostname="old"))
+        new_disc = _discovery(user=_user(hostname="new"))
+        p_load, p_discover, p_submit, p_save = self._patch_all()
+        with (
+            p_load as m_load,
+            p_discover as m_discover,
+            p_submit as m_submit,
+            p_save as m_save,
+        ):
+            m_load.return_value = cached
+            m_discover.return_value = new_disc
+            m_submit.return_value = new_disc
+
+            refresh_and_maybe_submit_discovery(MagicMock())
+
+            m_submit.assert_called_once()
+            m_save.assert_called_once()
+            # save_discovery_cache already refreshes the file mtime.
+            m_touch.assert_not_called()
 
     def test_reuses_machine_id_from_cache(self):
         cached = _discovery(user=_user(machine_id="cached-id"))

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1,6 +1,7 @@
 import errno
 import json
 import subprocess
+import time
 from collections import Counter
 from pathlib import Path
 from typing import List, Optional, Set
@@ -520,6 +521,131 @@ class TestMCPActivity:
         call_payload = mock_send_mcp.call_args[0][1]
         assert call_payload.event_type == EventType.PRE_TOOL_USE
         assert call_payload.tool == Tool.MCP
+
+
+class TestMCPActivityOverlap:
+    """The secret scan and the MCP activity call are two blocking round trips against
+    the same API: for an MCP PreToolUse they must run concurrently."""
+
+    def _payload(
+        self,
+        event_type: EventType = EventType.PRE_TOOL_USE,
+        tool: Optional[Tool] = Tool.MCP,
+    ) -> HookPayload:
+        return HookPayload(
+            event_type=event_type,
+            tool=tool,
+            content="some tool input",
+            identifier="mcp__some_server__some_tool",
+            agent=MagicMock(),
+            raw={},
+        )
+
+    @staticmethod
+    def _timed(intervals: dict, name: str, duration: float, result: object):
+        """Return a callable that sleeps and records the interval it ran over."""
+
+        def _run(*args, **kwargs):
+            start = time.monotonic()
+            time.sleep(duration)
+            intervals[name] = (start, time.monotonic())
+            return result
+
+        return _run
+
+    def test_scan_and_activity_run_concurrently(self):
+        """Their execution intervals must intersect: if a refactor serialises them
+        again, this fails."""
+        intervals: dict = {}
+        scanner = _mock_scanner([])
+        scanner.scan.side_effect = self._timed(
+            intervals, "scan", 0.2, scanner.scan.return_value
+        )
+
+        with patch(
+            "ggshield.verticals.ai.hooks.send_mcp_activity",
+            side_effect=self._timed(
+                intervals, "mcp", 0.2, MCPActivityResponse(allowed=True, reason="")
+            ),
+        ):
+            result = AIHookScanner(scanner)._scan_payloads([self._payload()])
+
+        assert not result.block
+        scan_start, scan_end = intervals["scan"]
+        mcp_start, mcp_end = intervals["mcp"]
+        assert scan_start < mcp_end and mcp_start < scan_end
+
+    def test_scan_block_wins_over_the_mcp_verdict(self):
+        """Same verdict as when the scan short-circuited the activity call."""
+        scanner = _mock_scanner(["sk-secret"])
+        with patch(
+            "ggshield.verticals.ai.hooks.send_mcp_activity",
+            return_value=MCPActivityResponse(allowed=False, reason="blocked by policy"),
+        ) as mock_send:
+            result = AIHookScanner(scanner)._scan_payloads([self._payload()])
+
+        assert result.block
+        assert result.nbr_secrets == 1
+        assert "blocked by policy" not in result.message
+        # Approved behaviour change: the activity is logged even when we block.
+        mock_send.assert_called_once()
+
+    def test_mcp_block_returned_when_the_scan_allows(self):
+        scanner = _mock_scanner([])
+        with patch(
+            "ggshield.verticals.ai.hooks.send_mcp_activity",
+            return_value=MCPActivityResponse(allowed=False, reason="blocked by policy"),
+        ):
+            result = AIHookScanner(scanner)._scan_payloads([self._payload()])
+
+        assert result.block
+        assert result.message == "blocked by policy"
+
+    def test_api_failure_on_the_worker_thread_fails_open(self):
+        """An exception raised while logging the activity must not escape the thread
+        and kill the hook."""
+        scanner = _mock_scanner([])
+        scanner.client.log_mcp_activity.side_effect = RuntimeError("network")
+        with patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery"):
+            result = AIHookScanner(scanner)._scan_payloads([self._payload()])
+
+        assert not result.block
+
+    @pytest.mark.parametrize(
+        ("event_type", "tool"),
+        [
+            (EventType.PRE_TOOL_USE, Tool.BASH),
+            (EventType.PRE_TOOL_USE, None),
+            (EventType.POST_TOOL_USE, Tool.MCP),
+            (EventType.USER_PROMPT, None),
+        ],
+    )
+    def test_non_mcp_payloads_stay_on_the_serial_path(
+        self, event_type: EventType, tool: Optional[Tool]
+    ):
+        """send_mcp_activity would no-op for these, so they must not pay for a thread."""
+        scanner = _mock_scanner([])
+        with patch("ggshield.verticals.ai.hooks.send_mcp_activity") as mock_send:
+            result = AIHookScanner(scanner)._scan_payloads(
+                [self._payload(event_type=event_type, tool=tool)]
+            )
+
+        assert not result.block
+        mock_send.assert_not_called()
+
+    def test_first_blocking_payload_wins_across_payloads(self):
+        """_parse_command can yield several payloads: the first block still wins."""
+        allowed = self._payload(event_type=EventType.PRE_TOOL_USE, tool=Tool.BASH)
+        blocked = self._payload()
+        scanner = _mock_scanner([])
+        with patch(
+            "ggshield.verticals.ai.hooks.send_mcp_activity",
+            return_value=MCPActivityResponse(allowed=False, reason="blocked by policy"),
+        ):
+            result = AIHookScanner(scanner)._scan_payloads([allowed, blocked])
+
+        assert result.block
+        assert result.payload is blocked
 
 
 class TestMessageFromSecrets:


### PR DESCRIPTION
## Context

An MCP `PreToolUse` event is the slowest thing the AI hook does: it pays the
secret scan, plus a filesystem walk, plus up to two more API round trips, all
strictly serially. **p50 goes from 1183 ms to 387 ms** (p90 1210 -> 388 ms).
Other events are untouched.

## What has been done

- **Discovery walk cached for an hour.** It inventories assistant config files,
  which change on the order of days, but it ran on every MCP tool call. The
  existing cache file's mtime is the TTL marker; when the discovery is unchanged
  we `touch()` it rather than rewrite it. The "submit only if changed" logic is
  unchanged, it just runs at most once an hour.
- **Scan and `log_mcp_activity` now overlap** on a worker thread instead of
  running one after the other. Non-MCP payloads are detected before any thread is
  spawned and keep the plain serial path. The scan verdict still wins over the
  MCP policy verdict, so the decision the user sees is identical.

**Approved behaviour change** (agreed with the MCP feature owner): an MCP tool
call is now logged even when the secret scan blocks it. Before, a block skipped
the activity entirely.

Two things found on the way, **not changed here**:
- `has_changed_from` never converges, so discovery is re-submitted on *every*
  MCP call, not just when it changed: `discover_ai_configuration` builds
  `ggshield...MCPConfiguration` while the cache round trip yields
  `pygitguardian.models.MCPConfiguration`, and dataclass `__eq__` compares
  classes. Identical `to_dict()`, still `!=`. That third round trip is why the
  before-number is 1183 ms and not ~800 ms. The TTL hides it for an hour; it is
  worth fixing properly.
- `mcp.py` fails open on every exception. Left as is.

## Validation

Benchmarked in-process against a localhost mock API (fixed delay, identical on
both arms), measuring `AIHookScanner._scan_payloads` on the Claude MCP
`PreToolUse` fixture from `tests/unit/verticals/ai/test_hooks.py`. n=25 per arm,
arms alternated.

| arm (mock delay 380 ms = prod p50) | p50 | p90 |
| --- | --- | --- |
| MCP PreToolUse, before | 1183 ms | 1210 ms |
| MCP PreToolUse, TTL only | 773 ms | 775 ms |
| MCP PreToolUse, after | **387 ms** | **388 ms** |
| non-MCP, before | 385 ms | 388 ms |
| non-MCP, after | 386 ms | 387 ms |

With the mock at ~0 ms, to isolate local cost: MCP 26 -> 2 ms, non-MCP 1 -> 1 ms.

`pytest tests/unit` : 2520 passed, 4 skipped. `black --check`, `flake8`,
`isort --check-only` clean on touched files. The new tests were run against the
pre-change code and fail there (including the one asserting the two calls
actually overlap).

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
