### PR TITLE
fix(ai): submit AI discovery only when it actually changed

### DIFF
--- a/changelog.d/20260804_150000_achille.mascia_ai_discovery_change_detection.md
+++ b/changelog.d/20260804_150000_achille.mascia_ai_discovery_change_detection.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The AI discovery is now submitted to GitGuardian only when the local AI/MCP
+  configuration actually changed, as it was always meant to be. A type mismatch
+  between a freshly discovered MCP configuration and one read back from the local
+  cache made the comparison always report a change, so every MCP tool call
+  uploaded a full discovery payload.

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -2,7 +2,7 @@ import json
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from enum import Enum, auto
 from pathlib import Path
@@ -29,6 +29,24 @@ class MCPConfiguration(BaseMCPConfiguration):
     """MCP configuration that can store a human-readable name for its server."""
 
     display_name: Optional[str] = None
+
+    def __eq__(self, other: object) -> bool:
+        """Compare on the base fields, across both classes.
+
+        A freshly walked discovery holds these instances, one read back from the
+        cache or the API holds plain `BaseMCPConfiguration`, and the generated
+        __eq__ refuses to compare across classes — which made change detection
+        always answer "changed".
+
+        `display_name` is excluded: it is local, not part of the wire schema, so
+        it can never survive a round trip.
+        """
+        if not isinstance(other, BaseMCPConfiguration):
+            return NotImplemented
+        return all(
+            getattr(self, f.name) == getattr(other, f.name)
+            for f in fields(BaseMCPConfiguration)
+        )
 
 
 # Small re-exports arount Py-gitguardian models to make our life easier.

--- a/tests/unit/verticals/ai/test_cache.py
+++ b/tests/unit/verticals/ai/test_cache.py
@@ -30,6 +30,8 @@ from ggshield.verticals.ai.cache import (
     store_clean_verdict,
     verdict_key,
 )
+from ggshield.verticals.ai.discovery import _merge_mcp_configurations
+from ggshield.verticals.ai.models import MCPConfiguration as LocalMCPConfiguration
 from ggshield.verticals.ai.models import MCPServer, Scope, Transport
 from tests.conftest import skipwindows
 
@@ -243,6 +245,114 @@ class TestAIDiscoveryHasChangedFrom:
             discovery_duration=0.2,
         )
         assert has_changed_from(a, b) is False
+
+
+# ---------------------------------------------------------------------------
+# Change detection against a discovery that really went through the cache
+# ---------------------------------------------------------------------------
+
+
+def _local_cfg(
+    name: str = "srv",
+    agent: str = "cursor",
+    scope: Scope = Scope.USER,
+    project: Optional[str] = None,
+    command: Optional[str] = "run",
+    args: Optional[List[str]] = None,
+    display_name: Optional[str] = "Pretty Server",
+) -> LocalMCPConfiguration:
+    """A configuration exactly as `discover_ai_configuration` builds it."""
+    return LocalMCPConfiguration(
+        name=name,
+        agent=agent,
+        scope=scope,
+        transport=Transport.STDIO,
+        project=project,
+        command=command,
+        args=args or [],
+        display_name=display_name,
+    )
+
+
+def _local_discovery(
+    configurations: List[LocalMCPConfiguration],
+    user: Optional[UserInfo] = None,
+    agents: Optional[List[AgentInfo]] = None,
+) -> AIDiscovery:
+    return AIDiscovery(
+        user=user or _user(),
+        servers=_merge_mcp_configurations(configurations),
+        agents=(
+            agents
+            if agents is not None
+            else [AgentInfo(name="cursor", hooks_installed=True)]
+        ),
+        discovery_duration=0.1,
+    )
+
+
+def _through_cache(discovery: AIDiscovery, tmp_path: Path) -> AIDiscovery:
+    with patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path):
+        save_discovery_cache(discovery)
+        loaded = load_discovery_cache()
+    assert loaded is not None
+    return loaded
+
+
+class TestHasChangedFromThroughCache:
+    """A freshly walked discovery holds `ggshield` MCPConfiguration instances, a
+    cached one holds `pygitguardian` ones. Change detection must see through that."""
+
+    def test_same_configuration_is_not_a_change(self, tmp_path: Path):
+        discovery = _local_discovery([_local_cfg()])
+        assert has_changed_from(discovery, _through_cache(discovery, tmp_path)) is False
+
+    def test_added_server_is_a_change(self, tmp_path: Path):
+        cached = _through_cache(_local_discovery([_local_cfg(name="a")]), tmp_path)
+        current = _local_discovery([_local_cfg(name="a"), _local_cfg(name="b")])
+        assert has_changed_from(current, cached) is True
+
+    def test_removed_server_is_a_change(self, tmp_path: Path):
+        cached = _through_cache(
+            _local_discovery([_local_cfg(name="a"), _local_cfg(name="b")]), tmp_path
+        )
+        current = _local_discovery([_local_cfg(name="a")])
+        assert has_changed_from(current, cached) is True
+
+    def test_changed_configuration_content_is_a_change(self, tmp_path: Path):
+        cached = _through_cache(
+            _local_discovery([_local_cfg(command="old", args=["--x"])]), tmp_path
+        )
+        current = _local_discovery([_local_cfg(command="new", args=["--x"])])
+        assert has_changed_from(current, cached) is True
+
+    def test_changed_user_is_a_change(self, tmp_path: Path):
+        cached = _through_cache(
+            _local_discovery([_local_cfg()], user=_user(hostname="old")), tmp_path
+        )
+        current = _local_discovery([_local_cfg()], user=_user(hostname="new"))
+        assert has_changed_from(current, cached) is True
+
+    def test_changed_agents_is_a_change(self, tmp_path: Path):
+        cached = _through_cache(
+            _local_discovery(
+                [_local_cfg()],
+                agents=[AgentInfo(name="cursor", hooks_installed=False)],
+            ),
+            tmp_path,
+        )
+        current = _local_discovery(
+            [_local_cfg()], agents=[AgentInfo(name="cursor", hooks_installed=True)]
+        )
+        assert has_changed_from(current, cached) is True
+
+    def test_display_name_only_change_is_not_a_change(self, tmp_path: Path):
+        """`display_name` is local, so it cannot round trip and must not submit."""
+        cached = _through_cache(
+            _local_discovery([_local_cfg(display_name="Old")]), tmp_path
+        )
+        current = _local_discovery([_local_cfg(display_name="New")])
+        assert has_changed_from(current, cached) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -1,3 +1,5 @@
+import os
+import time
 from pathlib import Path
 from typing import Any, List
 from unittest.mock import MagicMock, patch
@@ -302,3 +304,58 @@ class TestRefreshAndMaybeSubmitDiscovery:
 
             _, kwargs = m_discover.call_args
             assert kwargs.get("machine_id") == "cached-id"
+
+
+# ---------------------------------------------------------------------------
+# refresh_and_maybe_submit_discovery, against the real on-disk cache
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAgainstRealCache:
+    """The tests above mock the cache away, so they cannot see whether a
+    discovery that really went through it still compares equal."""
+
+    @staticmethod
+    def _age_cache(tmp_path: Path) -> None:
+        """Backdate the cache file, so that a freshness short-circuit around the
+        walk cannot be what keeps the submission from happening."""
+        cache_file = tmp_path / "ai_discovery.json"
+        mtime = time.time() - 24 * 3600
+        os.utime(cache_file, (mtime, mtime))
+
+    def test_submits_once_then_stays_quiet(self, tmp_path: Path):
+        discovery = AIDiscovery(
+            user=_user(),
+            servers=_merge_mcp_configurations(
+                [
+                    MCPConfiguration(
+                        name="srv",
+                        agent="cursor",
+                        scope=Scope.USER,
+                        transport=Transport.STDIO,
+                        command="run",
+                        display_name="Pretty Server",
+                    )
+                ]
+            ),
+            discovery_duration=0.1,
+        )
+        with (
+            patch("ggshield.verticals.ai.cache.get_cache_dir", return_value=tmp_path),
+            patch(
+                "ggshield.verticals.ai.discovery.discover_ai_configuration",
+                return_value=discovery,
+            ),
+            patch(
+                "ggshield.verticals.ai.discovery.submit_ai_discovery",
+                # The API answers with its own, plain pygitguardian objects.
+                side_effect=lambda client, sent: AIDiscovery.from_dict(sent.to_dict()),
+            ) as m_submit,
+        ):
+            refresh_and_maybe_submit_discovery(MagicMock())
+            assert m_submit.call_count == 1, "cold cache must submit"
+
+            for _ in range(2):
+                self._age_cache(tmp_path)
+                refresh_and_maybe_submit_discovery(MagicMock())
+            assert m_submit.call_count == 1, "unchanged configuration must not submit"


### PR DESCRIPTION
## Context

`refresh_and_maybe_submit_discovery` is documented as *"Always run discovery, compare with cache, submit only if changed"*. The comparison never reported "unchanged", so it submitted on **every single call** — and that path runs on every MCP `PreToolUse`.

Reproduction, through the real `save_discovery_cache` / `load_discovery_cache`:

```
to_dict equal?                    True
user ==                           True
agents ==                         True
has_changed_from says changed?    True   <-- always
```

A freshly walked discovery holds `ggshield.verticals.ai.models.MCPConfiguration` (our dataclass subclass, which adds a local-only `display_name`), while a discovery read back from the cache — or returned by the API — holds `pygitguardian.models.MCPConfiguration`. The dataclass-generated `__eq__` returns `NotImplemented` when `other.__class__ is not self.__class__`, Python falls back to identity, and the two are never equal however identical their content.

`user` (`UserInfo`) and `agents` (`AgentInfo`) are the same type on both sides, so they were not affected — verified in the reproduction above.

## What has been done

Fixed at the source rather than with a canonical comparison in `has_changed_from`: our `MCPConfiguration` subclass now defines an `__eq__` that compares the base dataclass fields and accepts base instances. That repairs every comparison site, not just this one, and keeps a `to_dict()`-style workaround out of the cache code.

`display_name` stays out of the comparison on purpose: it is not part of the wire schema, so it can never survive a round trip, and the server may set `MCPServer.display_name` itself.

Nothing changes in *what* is submitted or in the fail-open `except Exception: pass` — only *when* a submission happens.

**Telemetry volume: this is the point of the PR.** AI-discovery submissions drop from one per MCP tool call to one per actual AI/MCP configuration change. Requested by the MCP governance feature owner.

Tests: the decisive case (save to cache, load back, assert `has_changed_from` is `False`) did not exist — the existing tests build both sides from `pygitguardian` types, or mock the cache away entirely, so neither could see the bug. Added a real-round-trip suite in `test_cache.py` (unchanged, added server, removed server, changed content, changed user, changed agents, `display_name`-only) and an end-to-end `refresh_and_maybe_submit_discovery` test against the real on-disk cache covering the cold-cache path.

Mutation-checked: with the `__eq__` reverted, exactly the three "must not report a change" tests fail; the "is a change" tests are regression guards and pass either way.

### Interaction with #1383

#1383 (`amascia/speed-up-ai-hook-mcp-path`) adds a 1-hour TTL around the same walk and deliberately left this bug in place. They are complementary and **merge cleanly in either order** — verified locally with a trial merge; the test blocks were placed at different anchors to avoid a pointless adjacency conflict.

- #1383 alone: the walk (and hence the submission) happens at most hourly instead of on every call.
- This PR alone: the walk still happens every call, but submits only on a real change.
- Both: the walk is hourly *and* submits only on a real change — `touch_discovery_cache()` in #1383's unchanged branch becomes the normal path.

The end-to-end test here backdates the cache file between calls, so #1383's freshness short-circuit cannot mask the change detection once both are merged. Confirmed on the merged tree: 486 tests pass, and the same three tests still fail if the fix is reverted.

## Validation

- `pytest tests/unit` — 2510 passed, 4 skipped.
- `black --check`, `flake8`, `isort --check-only`, `pyright` on touched files — clean.
- To see it by hand: run an MCP tool call twice with `ggshield` hooks installed; only the first one submits a discovery.
- `ggshield ai discover` calls `discover_ai_configuration()` directly and is unaffected.

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
