### PR TITLE
perf(ai-hook): scan an event's payloads in one API call

### DIFF
--- a/changelog.d/20260804_140000_achille.mascia_ai_hook_batch_payloads.md
+++ b/changelog.d/20260804_140000_achille.mascia_ai_hook_batch_payloads.md
@@ -1,0 +1,6 @@
+### Changed
+
+- AI hooks now scan all the payloads of an event in a single API call instead of one
+  call each. A prompt mentioning three files used to cost four round trips; measured
+  against a mock API at the production p50 latency, such a `UserPromptSubmit` goes from
+  1561 ms to 395 ms (p50). Single-payload events are unchanged.

--- a/changelog.d/20260805_100000_achille.mascia_ai_hook_prompt_file_message.md
+++ b/changelog.d/20260805_100000_achille.mascia_ai_hook_prompt_file_message.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- When a secret is found in a file mentioned in a prompt (`@path`), AI hooks now name
+  that file in the block message instead of reporting it as a secret "in your prompt".
+  The previous wording pointed at the wrong content and asked the user to edit a prompt
+  that did not contain the secret.

--- a/changelog.d/20260806_100000_achille.mascia_ai_hook_canonical_read_path.md
+++ b/changelog.d/20260806_100000_achille.mascia_ai_hook_canonical_read_path.md
@@ -1,0 +1,7 @@
+### Changed
+
+- AI hooks now resolve the file paths of `Read` tool calls and prompt `@`-mentions to an
+  absolute path against the event's working directory. A file mentioned in a prompt and the
+  same file later read by a tool now share one verdict-cache key, so it is scanned once
+  instead of twice. As a result, the file path reported in block messages (and sent for
+  scanning) is now absolute for prompt-mentioned files.

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -40,9 +40,8 @@ class SecretProtocol(Protocol):
 class ResultProtocol(Protocol):
     @property
     def url(self) -> str:
-        """The url of the Scannable this result is about. A scan answers about
-        several documents at once, so this is what matches a result back to the
-        document it was produced for."""
+        """Url of the Scannable this result is about; matches a result back to its
+        document."""
         ...
 
     @property
@@ -60,11 +59,8 @@ class ResultsProtocol(Protocol):
     def results(self) -> Sequence[ResultProtocol]: ...
 
     def by_url(self) -> Mapping[str, ResultProtocol]:
-        """The results, keyed by the url of the document each one is about.
-
-        See `Results.by_url()`. A scan answers about several documents at once,
-        so a caller that sent more than one asks here which answer is about
-        which document."""
+        """Results keyed by the url of the document each is about. See
+        `Results.by_url()`."""
         ...
 
 

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -39,6 +39,13 @@ class SecretProtocol(Protocol):
 
 class ResultProtocol(Protocol):
     @property
+    def url(self) -> str:
+        """The url of the Scannable this result is about. A scan answers about
+        several documents at once, so this is what matches a result back to the
+        document it was produced for."""
+        ...
+
+    @property
     def secrets(self) -> Sequence[SecretProtocol]: ...
 
     @property
@@ -51,6 +58,14 @@ class ResultProtocol(Protocol):
 class ResultsProtocol(Protocol):
     @property
     def results(self) -> Sequence[ResultProtocol]: ...
+
+    def by_url(self) -> Mapping[str, ResultProtocol]:
+        """The results, keyed by the url of the document each one is about.
+
+        See `Results.by_url()`. A scan answers about several documents at once,
+        so a caller that sent more than one asks here which answer is about
+        which document."""
+        ...
 
 
 class ScannerProtocol(Protocol):

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -114,6 +114,12 @@ class Cursor(Agent):
     def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
         return "cursor_version" in hook_payload
 
+    def event_cwd(self, data: Dict[str, Any]) -> str:
+        # Cursor reports the working directory as a list of workspace roots
+        # rather than a "cwd" field.
+        roots = data.get("workspace_roots") or []
+        return roots[0] if roots else ""
+
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".cursor") / "hooks.json"
 

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -110,6 +111,27 @@ def find_filepaths(prompt: str) -> Set[str]:
     return paths
 
 
+def _abs_read_path(identifier: str, cwd: str) -> str:
+    """Resolve a READ file path to an absolute path against the event's cwd.
+
+    The verdict cache is keyed on the filename, so the same physical file must
+    yield the same identifier whether it came from an @-mention in a prompt
+    (usually relative) or a tool's file_path (usually absolute) -- otherwise the
+    file is scanned twice. os.path.join leaves an already-absolute path alone,
+    and abspath normalizes it; realpath is deliberately avoided so the key stays
+    deterministic and matches how the file is referenced.
+
+    Never break the scan: with no cwd, or if resolution fails, the identifier is
+    returned unchanged (today's behavior).
+    """
+    if not identifier or not cwd:
+        return identifier
+    try:
+        return os.path.abspath(os.path.join(cwd, identifier))
+    except Exception:
+        return identifier
+
+
 def parse_hook_input(raw_content: str) -> list[HookPayload]:
     """Parse the input content. Raises a ValueError if the input is not valid.
 
@@ -144,12 +166,17 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
     tool = None
     read_range = None
 
+    # The event's working directory, used to canonicalize READ file paths to
+    # absolute so a prompt @-mention and a tool read of the same file share one
+    # verdict-cache key (see _abs_read_path). Agent-specific; "" when unknown.
+    cwd = agent.event_cwd(data)
+
     # Extract the identifier and content based on the event type
     if event_type == EventType.USER_PROMPT:
         content = data.get("prompt", "")
         # Look for files mentioned in the prompt that could be read
         # without triggering a PRE_TOOL_USE event.
-        payloads.extend(_parse_user_prompt(content, event_type, agent, timestamp))
+        payloads.extend(_parse_user_prompt(content, event_type, agent, timestamp, cwd))
 
     elif event_type == EventType.PRE_TOOL_USE:
         tool = _parse_tool(data)
@@ -161,10 +188,12 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
             content = tool_input.get("command", "")
             identifier = content
             # Try to detect a command that could be used to read a file.
-            payloads.extend(_parse_command(content, event_type, agent, timestamp))
+            payloads.extend(_parse_command(content, event_type, agent, timestamp, cwd))
         elif tool == Tool.READ:
             # We only need to deal with the identifier, the content will be read by the Scannable
-            identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
+            identifier = _abs_read_path(
+                lookup(tool_input, ["file_path", "filePath", "path"], ""), cwd
+            )
             read_range = agent.read_range(tool_input)
         elif tool_input:
             # MCP and unrecognized tool arguments can carry secrets bound for
@@ -180,11 +209,13 @@ def parse_hook_input(raw_content: str) -> list[HookPayload]:
         if isinstance(content, (dict, list)):
             content = json.dumps(content)
         if tool == Tool.READ:
-            # Same tool_input as PreToolUse, hence the same range: both events
-            # scan the exact same bytes for one read, which the verdict cache
-            # (keyed on the document) relies on.
+            # Same tool_input as PreToolUse, hence the same range and the same
+            # canonicalized path: both events scan the exact same bytes for one
+            # read, which the verdict cache (keyed on the document) relies on.
             tool_input = data.get("tool_input", {})
-            identifier = lookup(tool_input, ["file_path", "filePath", "path"], "")
+            identifier = _abs_read_path(
+                lookup(tool_input, ["file_path", "filePath", "path"], ""), cwd
+            )
             read_range = agent.read_range(tool_input)
 
     # If identifier was not set, hash the content
@@ -277,7 +308,11 @@ def build_agent_headers(content: str) -> Dict[str, str]:
 
 
 def _parse_user_prompt(
-    content: str, event_type: EventType, agent: Agent, timestamp: datetime
+    content: str,
+    event_type: EventType,
+    agent: Agent,
+    timestamp: datetime,
+    cwd: str = "",
 ) -> List[HookPayload]:
     """Parse the user prompt for additional payloads that we may miss."""
     payloads = []
@@ -291,7 +326,9 @@ def _parse_user_prompt(
                 event_type=event_type,
                 tool=Tool.READ,
                 content="",
-                identifier=match,
+                # Canonicalize so this matches the PreToolUse Read of the same
+                # file and both share one verdict-cache key (see _abs_read_path).
+                identifier=_abs_read_path(match, cwd),
                 agent=agent,
                 raw={},
                 timestamp=timestamp,
@@ -301,7 +338,11 @@ def _parse_user_prompt(
 
 
 def _parse_command(
-    content: str, event_type: EventType, agent: Agent, timestamp: datetime
+    content: str,
+    event_type: EventType,
+    agent: Agent,
+    timestamp: datetime,
+    cwd: str = "",
 ) -> List[HookPayload]:
     """Parse the command for additional payloads that we may miss."""
     # In Windows, some agents (at least Codex) use the Get-Content command to read a file.
@@ -310,7 +351,7 @@ def _parse_command(
 
     if content.startswith(("Get-Content ", "cat ")):
         # Extract the filename (remove the command)
-        identifier = content.partition(" ")[2].strip()
+        identifier = _abs_read_path(content.partition(" ")[2].strip(), cwd)
         payloads.append(
             HookPayload(
                 event_type=event_type,
@@ -577,9 +618,8 @@ class AIHookScanner:
             # No activity to send: keep the plain, single-threaded path.
             scan_results = self._scan_contents(payloads)
         else:
-            # Both are blocking HTTP round trips against the same API, so overlap them
-            # instead of paying for them one after the other. The activity is now logged
-            # even when the scan blocks, which the MCP feature owner wants.
+            # Both are blocking round trips to the same API, so overlap them. The
+            # activity is logged even when the scan blocks.
             with ThreadPoolExecutor(
                 max_workers=1, thread_name_prefix="mcp_activity"
             ) as executor:
@@ -592,11 +632,9 @@ class AIHookScanner:
                     index: activity.result() for index, activity in activities.items()
                 }
 
-        # All the payloads of an event are scanned in one go, but the verdicts are
-        # still applied one payload at a time, in order: the blocking payload and the
-        # MCP activity calls are exactly the ones a per-payload loop produced. The
-        # scan verdict keeps precedence, as it did when it short-circuited the
-        # activity call.
+        # All of an event's payloads are scanned in one call; verdicts are applied
+        # one payload at a time, in order, and the scan verdict takes precedence over
+        # the MCP activity verdict.
         for index, scan_result in enumerate(scan_results):
             if scan_result.block:
                 return scan_result
@@ -621,14 +659,11 @@ class AIHookScanner:
         return self._scan_contents([payload])[0]
 
     def _scan_contents(self, payloads: List[HookPayload]) -> List[HookResult]:
-        """Scan the payloads for secrets, in as few API calls as possible.
+        """Scan the payloads for secrets in as few API calls as possible.
 
-        One event routinely carries several payloads (a prompt mentioning files, a
-        `cat` command...), and one API call costs a round trip. So everything that
-        actually needs scanning is handed to the SecretScanner in a single call,
-        which chunks it to the API's per-document and per-batch limits.
-
-        Returns one HookResult per payload, in the same order.
+        Everything that needs scanning is handed to the SecretScanner in one call,
+        which chunks it to the API's per-document and per-batch limits. Returns one
+        HookResult per payload, in order.
         """
         results = [HookResult.allow(payload) for payload in payloads]
 
@@ -666,12 +701,11 @@ class AIHookScanner:
                 else None
             )
 
-            # Shortest path: this exact document already came back clean from the
-            # API recently, so it does not even go in the batch. A Read is scanned
-            # twice — PreToolUse and PostToolUse both resolve to File(file_path)
-            # (see HookPayload.scannable), so the second call sends an identical
-            # document and can be answered locally. has_already_been_seen() cannot
-            # catch that pair: it debounces on the raw stdin payload, which differs
+            # Shortest path: this exact document already came back clean recently, so
+            # it never goes in the batch. A Read is scanned twice -- PreToolUse and
+            # PostToolUse both resolve to File(file_path) (see HookPayload.scannable),
+            # so both send an identical document. has_already_been_seen() does not
+            # catch that pair, as it debounces on the raw stdin payload, which differs
             # between the two events.
             if key and has_clean_verdict(key):
                 continue
@@ -681,14 +715,10 @@ class AIHookScanner:
         if not to_scan:
             return results
 
-        # A batch is looked up by url, which answers once per url: two entries
-        # sharing one would make a document silently inherit another's verdict, and
-        # a wrong verdict here either misses a secret or blocks on the wrong file.
-        # So a round sends at most one entry per url and any repeat waits for the
-        # next round. That holds by construction, without having to prove two
-        # documents are the same. Today's parsers never produce a repeat -- a BASH
-        # identifier is the command text, a READ one is the path, anything else a
-        # sha256 of its own content -- but nothing upstream enforces it.
+        # A batch is looked up by url, so each url must appear at most once per round;
+        # a repeat waits for the next round. Today's parsers never repeat a url (BASH:
+        # command text, READ: path, else a content sha256), but nothing upstream
+        # enforces it.
         remaining = to_scan
         while remaining:
             batch: List[Tuple[int, Scannable, Optional[str]]] = []
@@ -707,22 +737,19 @@ class AIHookScanner:
                     [scannable for _, scannable, _ in batch], scanner_ui=scanner_ui
                 )
 
-            # The scan answers about all of them at once, and not in the order they
-            # were sent, so each document is looked up by the url identifying it.
+            # The scan answers out of send order, so each document is looked up by url.
             answers = scan.by_url()
 
             for index, scannable, key in batch:
                 result = answers.get(scannable.url)
                 if result is None:
-                    # The scan said nothing about this document: it was skipped or
-                    # the scan was degraded. Not a verdict, so nothing to cache --
-                    # and nothing to block on, as before.
+                    # Scan said nothing about this document (skipped or degraded): not
+                    # a verdict, so nothing to cache and nothing to block on.
                     continue
                 secrets: List[Secret] = list(result.secrets)
                 if not secrets:
-                    # Cacheability stays a per-document decision: this document's own
-                    # result must say nothing was filtered out locally, otherwise "no
-                    # secret" is a verdict about the config, not about the content.
+                    # Per-document: cache only if nothing was filtered out locally,
+                    # else "no secret" is a verdict about the config, not the content.
                     if key and not result.ignored_secrets_count_by_kind:
                         store_clean_verdict(key)
                     continue
@@ -765,7 +792,10 @@ class AIHookScanner:
         # Dispatch event-first, then tool: what the message should say depends
         # first on *when* the secret was caught (before vs. after it reached
         # the agent), and only then on how the offending tool is named.
-        if payload.event_type == EventType.USER_PROMPT:
+        # Exception: a USER_PROMPT event also carries a Tool.READ payload per file
+        # mentioned in the prompt (see _parse_user_prompt). The secret is in that
+        # file, not the prompt, so it gets the file wording, not the prompt wording.
+        if payload.event_type == EventType.USER_PROMPT and payload.tool != Tool.READ:
             template = _USER_PROMPT_TEMPLATE
         elif payload.event_type == EventType.POST_TOOL_USE:
             template = _POST_TEMPLATES.get(payload.tool, _POST_OTHER_TEMPLATE)

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence, Set
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import filelock
 from notifypy import Notify
@@ -15,7 +15,7 @@ from ggshield.core import ui
 from ggshield.core.dirs import get_cache_dir
 from ggshield.core.errors import AuthError
 from ggshield.core.filter import censor_match
-from ggshield.core.scan import ScannerProtocol
+from ggshield.core.scan import Scannable, ScannerProtocol
 from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
@@ -566,29 +566,42 @@ class AIHookScanner:
         """
         if not payloads:
             raise ValueError("Error: no payloads to scan")
-        for payload in payloads:
-            if not is_mcp_activity_payload(payload):
-                # No activity to send: keep the plain, single-threaded path.
-                result = self._scan_content(payload)
-                if result.block:
-                    return result
-                continue
+        mcp_indices = [
+            index
+            for index, payload in enumerate(payloads)
+            if is_mcp_activity_payload(payload)
+        ]
+        mcp_results: Dict[int, HookResult] = {}
 
+        if not mcp_indices:
+            # No activity to send: keep the plain, single-threaded path.
+            scan_results = self._scan_contents(payloads)
+        else:
             # Both are blocking HTTP round trips against the same API, so overlap them
             # instead of paying for them one after the other. The activity is now logged
             # even when the scan blocks, which the MCP feature owner wants.
             with ThreadPoolExecutor(
                 max_workers=1, thread_name_prefix="mcp_activity"
             ) as executor:
-                activity = executor.submit(self._send_mcp_activity, payload)
-                scan_result = self._scan_content(payload)
-                mcp_result = activity.result()
+                activities = {
+                    index: executor.submit(self._send_mcp_activity, payloads[index])
+                    for index in mcp_indices
+                }
+                scan_results = self._scan_contents(payloads)
+                mcp_results = {
+                    index: activity.result() for index, activity in activities.items()
+                }
 
-            # The scan verdict keeps precedence, as it did when it short-circuited
-            # the activity call.
+        # All the payloads of an event are scanned in one go, but the verdicts are
+        # still applied one payload at a time, in order: the blocking payload and the
+        # MCP activity calls are exactly the ones a per-payload loop produced. The
+        # scan verdict keeps precedence, as it did when it short-circuited the
+        # activity call.
+        for index, scan_result in enumerate(scan_results):
             if scan_result.block:
                 return scan_result
-            if mcp_result.block:
+            mcp_result = mcp_results.get(index)
+            if mcp_result is not None and mcp_result.block:
                 return mcp_result
         return HookResult.allow(payloads[0])
 
@@ -603,85 +616,131 @@ class AIHookScanner:
             payload=payload,
         )
 
-    def _scan_content(
-        self,
-        payload: HookPayload,
-    ) -> HookResult:
-        """Scan content for secrets using the SecretScanner."""
-        # Short path: if there is no content, no need to do an API call
-        if payload.empty:
-            return HookResult.allow(payload)
+    def _scan_content(self, payload: HookPayload) -> HookResult:
+        """Scan a single payload for secrets."""
+        return self._scan_contents([payload])[0]
 
-        # One Scannable for both the cache key and the scan, so the two can never
-        # disagree about what was scanned.
-        scannable = payload.scannable
-        try:
-            # is_longer_than() answers from the byte size when it can, so an
-            # oversized document is not pulled into memory just to key the cache.
-            content = (
-                ""
-                if scannable.is_longer_than(DOCUMENT_SIZE_THRESHOLD_BYTES)
-                else scannable.content
+    def _scan_contents(self, payloads: List[HookPayload]) -> List[HookResult]:
+        """Scan the payloads for secrets, in as few API calls as possible.
+
+        One event routinely carries several payloads (a prompt mentioning files, a
+        `cat` command...), and one API call costs a round trip. So everything that
+        actually needs scanning is handed to the SecretScanner in a single call,
+        which chunks it to the API's per-document and per-batch limits.
+
+        Returns one HookResult per payload, in the same order.
+        """
+        results = [HookResult.allow(payload) for payload in payloads]
+
+        # (index in `payloads`, document to scan, verdict cache key).
+        to_scan: List[Tuple[int, Scannable, Optional[str]]] = []
+        for index, payload in enumerate(payloads):
+            # One Scannable for both the cache key and the scan, so the two can
+            # never disagree about what was scanned.
+            scannable = payload.scannable
+            try:
+                # Short path: if there is no content, no need to do an API call.
+                if payload.empty:
+                    continue
+                # is_longer_than() answers from the byte size when it can, so an
+                # oversized document is not pulled into memory just to key the cache.
+                content = (
+                    ""
+                    if scannable.is_longer_than(DOCUMENT_SIZE_THRESHOLD_BYTES)
+                    else scannable.content
+                )
+            except Exception:
+                # Unreadable or undecodable: no cache key, and it still goes to the
+                # scanner, which decides how to skip it and says so.
+                content = ""
+
+            key = (
+                verdict_key(
+                    self.scanner.client.base_uri,
+                    self.scanner.client.api_key,
+                    self.scanner.secret_config,
+                    scannable.filename,
+                    content,
+                )
+                if content
+                else None
             )
-        except Exception:
-            # Unreadable or undecodable: no cache key. Let the scanner decide
-            # how to skip it.
-            content = ""
 
-        key = (
-            verdict_key(
-                self.scanner.client.base_uri,
-                self.scanner.client.api_key,
-                self.scanner.secret_config,
-                scannable.filename,
-                content,
-            )
-            if content
-            else None
-        )
+            # Shortest path: this exact document already came back clean from the
+            # API recently, so it does not even go in the batch. A Read is scanned
+            # twice — PreToolUse and PostToolUse both resolve to File(file_path)
+            # (see HookPayload.scannable), so the second call sends an identical
+            # document and can be answered locally. has_already_been_seen() cannot
+            # catch that pair: it debounces on the raw stdin payload, which differs
+            # between the two events.
+            if key and has_clean_verdict(key):
+                continue
 
-        # Shortest path: this exact document already came back clean from the API
-        # recently. A Read is scanned twice — PreToolUse and PostToolUse both
-        # resolve to File(file_path) (see HookPayload.scannable), so the second
-        # call sends an identical document and can be answered locally.
-        # has_already_been_seen() above cannot catch that pair: it debounces on
-        # the raw stdin payload, which differs between the two events.
-        if key and has_clean_verdict(key):
-            return HookResult.allow(payload)
+            to_scan.append((index, scannable, key))
 
-        with create_message_only_scanner_ui() as scanner_ui:
-            results = self.scanner.scan([scannable], scanner_ui=scanner_ui)
-        # Collect all secrets from results
-        secrets: List[Secret] = []
-        for result in results.results:
-            secrets.extend(result.secrets)
+        if not to_scan:
+            return results
 
-        if not secrets:
-            # Only cache an unambiguous verdict:
-            # - exactly one Result, so the API did answer about our document (a
-            #   degraded or skipped scan yields no Result at all);
-            # - nothing filtered out locally, since an empty `secrets` may also
-            #   mean the API reported policy breaks that the local config
-            #   ignored — a verdict about the config, not about the content.
-            if (
-                key
-                and len(results.results) == 1
-                and not results.results[0].ignored_secrets_count_by_kind
-            ):
-                store_clean_verdict(key)
-            return HookResult.allow(payload)
+        # A batch is looked up by url, which answers once per url: two entries
+        # sharing one would make a document silently inherit another's verdict, and
+        # a wrong verdict here either misses a secret or blocks on the wrong file.
+        # So a round sends at most one entry per url and any repeat waits for the
+        # next round. That holds by construction, without having to prove two
+        # documents are the same. Today's parsers never produce a repeat -- a BASH
+        # identifier is the command text, a READ one is the path, anything else a
+        # sha256 of its own content -- but nothing upstream enforces it.
+        remaining = to_scan
+        while remaining:
+            batch: List[Tuple[int, Scannable, Optional[str]]] = []
+            leftover: List[Tuple[int, Scannable, Optional[str]]] = []
+            batched_urls: Set[str] = set()
+            for entry in remaining:
+                url = entry[1].url
+                if url in batched_urls:
+                    leftover.append(entry)
+                else:
+                    batched_urls.add(url)
+                    batch.append(entry)
 
-        message = self._message_from_secrets(
-            secrets,
-            payload,
-            escape_markdown=True,
-        )
-        return HookResult(
-            block=True,
-            message=message,
-            nbr_secrets=len(secrets),
-            payload=payload,
-        )
+            with create_message_only_scanner_ui() as scanner_ui:
+                scan = self.scanner.scan(
+                    [scannable for _, scannable, _ in batch], scanner_ui=scanner_ui
+                )
+
+            # The scan answers about all of them at once, and not in the order they
+            # were sent, so each document is looked up by the url identifying it.
+            answers = scan.by_url()
+
+            for index, scannable, key in batch:
+                result = answers.get(scannable.url)
+                if result is None:
+                    # The scan said nothing about this document: it was skipped or
+                    # the scan was degraded. Not a verdict, so nothing to cache --
+                    # and nothing to block on, as before.
+                    continue
+                secrets: List[Secret] = list(result.secrets)
+                if not secrets:
+                    # Cacheability stays a per-document decision: this document's own
+                    # result must say nothing was filtered out locally, otherwise "no
+                    # secret" is a verdict about the config, not about the content.
+                    if key and not result.ignored_secrets_count_by_kind:
+                        store_clean_verdict(key)
+                    continue
+                payload = payloads[index]
+                results[index] = HookResult(
+                    block=True,
+                    message=self._message_from_secrets(
+                        secrets,
+                        payload,
+                        escape_markdown=True,
+                    ),
+                    nbr_secrets=len(secrets),
+                    payload=payload,
+                )
+
+            remaining = leftover
+
+        return results
 
     @staticmethod
     def _message_from_secrets(

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -230,6 +230,17 @@ class Agent(ABC):
         """
         return payload.event_type == EventType.POST_TOOL_USE
 
+    def event_cwd(self, data: Dict[str, Any]) -> str:
+        """The directory the event happened in, used to resolve relative file
+        paths to absolute ones so a file mentioned in a prompt and the same file
+        read by a tool share one verdict-cache key.
+
+        Most agents (Claude, Codex, Copilot CLI, VSCode) put it in "cwd"; Cursor
+        overrides this to read "workspace_roots". Returns "" when unknown, in
+        which case callers leave paths untouched rather than guess.
+        """
+        return data.get("cwd", "") or ""
+
     def read_range(self, tool_input: Dict[str, Any]) -> Optional[ReadRange]:
         """The lines a read tool call is about to expose, 1-based and inclusive.
 

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -242,19 +242,12 @@ class Results:
     errors: List[Error] = field(default_factory=list)
 
     def by_url(self) -> Dict[str, Result]:
-        """The results, keyed by the url of the document each one is about.
+        """Results keyed by the url of the document each is about.
 
-        One scan answers about several documents, and `results` is neither in the
-        order the documents were sent (chunks are collected as they complete) nor
-        one entry per document (a document the scan skipped has no result at
-        all). `Result.url` is what ties a result back to its document, so a
-        caller asking "what did the scan say about *this* document" asks here
-        instead of re-deriving the mapping -- getting that wrong means reporting
-        a secret against the wrong file.
-
-        Documents sharing a url collapse to one entry, and nothing here can tell
-        which of them the surviving result was about. A caller that needs an answer
-        per document therefore sends distinct urls in one scan.
+        `results` is neither in send order (chunks arrive as they complete) nor one
+        entry per document (a skipped document has no result), so `Result.url` is what
+        ties a result back to its document. Documents sharing a url collapse to one
+        entry, so a caller needing a per-document answer must send distinct urls.
         """
         return {result.url: result for result in self.results}
 

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -241,6 +241,23 @@ class Results:
     results: List[Result] = field(default_factory=list)
     errors: List[Error] = field(default_factory=list)
 
+    def by_url(self) -> Dict[str, Result]:
+        """The results, keyed by the url of the document each one is about.
+
+        One scan answers about several documents, and `results` is neither in the
+        order the documents were sent (chunks are collected as they complete) nor
+        one entry per document (a document the scan skipped has no result at
+        all). `Result.url` is what ties a result back to its document, so a
+        caller asking "what did the scan say about *this* document" asks here
+        instead of re-deriving the mapping -- getting that wrong means reporting
+        a secret against the wrong file.
+
+        Documents sharing a url collapse to one entry, and nothing here can tell
+        which of them the surviving result was about. A caller that needs an answer
+        per document therefore sends distinct urls in one scan.
+        """
+        return {result.url: result for result in self.results}
+
     @staticmethod
     def from_exception(exc: Exception) -> "Results":
         """Create a Results representing a failure"""

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -4,13 +4,14 @@ import subprocess
 import time
 from collections import Counter
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pygitguardian import GGClient
 from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MAXIMUM_PAYLOAD_SIZE
-from pygitguardian.models import MCPActivityResponse
+from pygitguardian.models import MCPActivityResponse, MultiScanResult
+from pygitguardian.models import ScanResult as ApiScanResult
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import File, ScanContext, ScanMode, StringScannable
@@ -61,7 +62,9 @@ def tmp_file(tmp_path: Path) -> Path:
 
 
 def _mock_scanner(
-    matches: List[str], secret_config: Optional[SecretConfig] = None
+    matches: List[str],
+    secret_config: Optional[SecretConfig] = None,
+    ignored_secrets_count_by_kind: Optional[Counter] = None,
 ) -> MagicMock:
     """Create a mock SecretScanner that returns the given Results from scan()."""
     mock = MagicMock(spec=SecretScanner)
@@ -72,20 +75,30 @@ def _mock_scanner(
     mock.client.api_key = API_KEY
     # Set in SecretScanner.__init__, so spec= does not provide it either.
     mock.secret_config = secret_config or SecretConfig()
-    scan_result = Results(
-        results=[
-            ScanResult(
-                filename="url",
-                filemode=Filemode.FILE,
-                path=Path("."),
-                url="url",
-                secrets=[_make_secret(match) for match in matches],
-                ignored_secrets_count_by_kind=Counter(),
-            )
-        ],
-        errors=[],
-    )
-    mock.scan.return_value = scan_result
+
+    def scan(scannables, scanner_ui=None, **kwargs):
+        # Like the real scanner, the answer is about the documents that were
+        # sent, so it carries their url -- that is what ties a result back to
+        # its document. This fixture answers about the first one, which is all
+        # a single-payload test sends.
+        first = list(scannables)[0]
+        return Results(
+            results=[
+                ScanResult(
+                    filename=first.filename,
+                    filemode=Filemode.FILE,
+                    path=Path("."),
+                    url=first.url,
+                    secrets=[_make_secret(match) for match in matches],
+                    ignored_secrets_count_by_kind=(
+                        ignored_secrets_count_by_kind or Counter()
+                    ),
+                )
+            ],
+            errors=[],
+        )
+
+    mock.scan.side_effect = scan
     return mock
 
 
@@ -232,7 +245,9 @@ class TestVerdictCacheShortCircuit:
     def test_degraded_scan_is_not_cached(self):
         """A scan that returned no Result at all is not a verdict, so it is not cached."""
         mock_scanner = _mock_scanner([])
-        mock_scanner.scan.return_value = Results(results=[], errors=[])
+        mock_scanner.scan.side_effect = lambda *args, **kwargs: Results(
+            results=[], errors=[]
+        )
         hook_scanner = AIHookScanner(mock_scanner)
         assert hook_scanner._scan_content(self._payload()).block is False
         assert not has_clean_verdict(self._key())
@@ -243,9 +258,9 @@ class TestVerdictCacheShortCircuit:
     def test_locally_filtered_verdict_is_not_cached(self):
         """The API reported secrets and the local config dropped them: that "clean"
         answer belongs to this config only, so it must not be remembered."""
-        mock_scanner = _mock_scanner([])
-        mock_scanner.scan.return_value.results[0].ignored_secrets_count_by_kind = (
-            Counter({IgnoreKind.IGNORED_DETECTOR: 1})
+        mock_scanner = _mock_scanner(
+            [],
+            ignored_secrets_count_by_kind=Counter({IgnoreKind.IGNORED_DETECTOR: 1}),
         )
         hook_scanner = AIHookScanner(mock_scanner)
         assert hook_scanner._scan_content(self._payload()).block is False
@@ -290,6 +305,280 @@ class TestVerdictCacheShortCircuit:
         _verdict_cache_path().chmod(0o666)
         hook_scanner._scan_content(self._payload())
         assert mock_scanner.scan.call_count == 2
+
+
+def _scanner_per_document(
+    secrets_by_url: Optional[Dict[str, List[str]]] = None,
+    skipped_urls: Set[str] = frozenset(),
+    ignored_urls: Set[str] = frozenset(),
+    reverse: bool = False,
+) -> MagicMock:
+    """A scanner answering per document, the way a multi-document scan does:
+    one result per document, identified by its url.
+
+    `skipped_urls` documents get no result at all (the scanner drops what it
+    could not scan) and `reverse` returns the results in another order than the
+    documents were sent (chunks are collected as they complete).
+    """
+    secrets_by_url = secrets_by_url or {}
+    mock = _mock_scanner([])
+
+    def scan(scannables, scanner_ui=None, **kwargs):
+        results = [
+            ScanResult(
+                filename=scannable.filename,
+                filemode=Filemode.FILE,
+                path=Path("."),
+                url=scannable.url,
+                secrets=[
+                    _make_secret(match)
+                    for match in secrets_by_url.get(scannable.url, [])
+                ],
+                ignored_secrets_count_by_kind=(
+                    Counter({IgnoreKind.IGNORED_DETECTOR: 1})
+                    if scannable.url in ignored_urls
+                    else Counter()
+                ),
+            )
+            for scannable in scannables
+            if scannable.url not in skipped_urls
+        ]
+        return Results(
+            results=list(reversed(results)) if reverse else results, errors=[]
+        )
+
+    mock.scan.side_effect = scan
+    return mock
+
+
+def _scanned_urls(mock_scanner: MagicMock, call: int = 0) -> List[str]:
+    """The urls of the documents sent to the API on the `call`-th scan."""
+    return [scannable.url for scannable in mock_scanner.scan.call_args_list[call][0][0]]
+
+
+class TestBatchedPayloadScan:
+    """One event carries several payloads (a prompt mentioning files, a `cat`
+    command...). They must cost one API call, not one each — while blocking on
+    exactly the payload a per-payload loop blocked on.
+    """
+
+    @staticmethod
+    def _payload(identifier: str, content: str = "some content") -> HookPayload:
+        return HookPayload(
+            event_type=EventType.USER_PROMPT,
+            tool=None,
+            content=content,
+            identifier=identifier,
+            agent=Cursor(),
+            raw={},
+        )
+
+    @staticmethod
+    def _read_payload(path: Path) -> HookPayload:
+        return HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="",
+            identifier=str(path),
+            agent=Cursor(),
+            raw={},
+        )
+
+    def test_documents_sharing_a_url_are_never_in_the_same_batch(self):
+        """GIVEN two payloads whose documents share a url
+        WHEN they are scanned
+        THEN every batch holds distinct urls, so no document can inherit another's
+        verdict from the by_url() lookup."""
+        payloads = [self._payload("same-url"), self._payload("same-url")]
+        mock_scanner = _scanner_per_document()
+
+        results = AIHookScanner(mock_scanner)._scan_contents(payloads)
+
+        assert len(results) == len(payloads)
+        assert mock_scanner.scan.call_count == 2
+        for call in mock_scanner.scan.call_args_list:
+            urls = [document.url for document in call.args[0]]
+            assert len(urls) == len(set(urls))
+
+    def test_a_prompt_mentioning_files_makes_a_single_api_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """GIVEN a UserPromptSubmit prompt mentioning three files
+        WHEN the hook scans it
+        THEN the four resulting payloads are sent in one call, all of them."""
+        # Mentioned by relative name, from inside tmp_path: an absolute Windows path
+        # (@C:/...) stops the @file regex at the drive-letter colon, and that gap in
+        # find_filepaths is not what this test is about.
+        monkeypatch.chdir(tmp_path)
+        files = []
+        for index in range(3):
+            file = tmp_path / f"file{index}.txt"
+            file.write_text(f"content {index}")
+            files.append(file)
+        mock_scanner = _scanner_per_document()
+        prompt = "look at " + " ".join(f"@{file.name}" for file in files)
+        data = {
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": prompt,
+            "cursor_version": "1.2.3",
+        }
+
+        assert AIHookScanner(mock_scanner).scan(json.dumps(data)) == 0
+
+        mock_scanner.scan.assert_called_once()
+        urls = _scanned_urls(mock_scanner)
+        assert len(urls) == 4  # the three files, plus the prompt itself
+        for file in files:
+            assert any(url.endswith(file.name) for url in urls)
+
+    def test_secret_in_the_second_payload_blocks_with_the_same_message(
+        self, tmp_path: Path
+    ):
+        """GIVEN three payloads, the second one holding a secret
+        WHEN they are scanned together
+        THEN that payload blocks, with the message the per-payload scan gives."""
+        files = []
+        for index in range(3):
+            file = tmp_path / f"file{index}.txt"
+            file.write_text(f"content {index}")
+            files.append(file)
+        payloads = [self._read_payload(file) for file in files]
+        secrets = {payloads[1].scannable.url: ["sk-xxx"]}
+
+        result = AIHookScanner(_scanner_per_document(secrets))._scan_payloads(payloads)
+
+        assert result.block is True
+        assert result.payload is payloads[1]
+        assert result.nbr_secrets == 1
+        # The exact wording of the PreToolUse/Read block, unchanged.
+        assert f"Detected 1 secret in {payloads[1].identifier}" in result.message
+        assert "The file content was not shown to the agent" in result.message
+        # ... and it is the very message a one-payload scan produces.
+        alone = AIHookScanner(_scanner_per_document(secrets))._scan_content(payloads[1])
+        assert result.message == alone.message
+
+    def test_the_secret_is_attributed_to_the_document_it_was_found_in(self):
+        """GIVEN three documents, only the last one holding a secret, and results
+        coming back in another order than they were sent
+        WHEN they are scanned together
+        THEN the block names that document, not one of its siblings."""
+        payloads = [self._payload(f"payload-{index}") for index in range(3)]
+        mock_scanner = _scanner_per_document({"payload-2": ["sk-xxx"]}, reverse=True)
+
+        results = AIHookScanner(mock_scanner)._scan_contents(payloads)
+
+        assert [result.block for result in results] == [False, False, True]
+        assert results[2].payload is payloads[2]
+
+    def test_a_skipped_document_does_not_shift_the_others(self):
+        """GIVEN a document the scanner skipped, so it gets no result at all
+        WHEN a sibling holds a secret
+        THEN the secret is still attributed to the sibling, not to the gap."""
+        payloads = [self._payload(f"payload-{index}") for index in range(3)]
+        mock_scanner = _scanner_per_document(
+            {"payload-2": ["sk-xxx"]}, skipped_urls={"payload-0"}
+        )
+
+        results = AIHookScanner(mock_scanner)._scan_contents(payloads)
+
+        assert [result.block for result in results] == [False, False, True]
+
+    def test_a_cached_document_is_left_out_of_the_batch(self):
+        """GIVEN a document with a clean verdict already cached
+        WHEN it is part of an event with other payloads
+        THEN it is not sent, and the others still are."""
+        mock_scanner = _scanner_per_document()
+        hook_scanner = AIHookScanner(mock_scanner)
+        cached = self._payload("cached")
+        hook_scanner._scan_content(cached)
+
+        hook_scanner._scan_contents([cached, self._payload("fresh")])
+
+        assert mock_scanner.scan.call_count == 2
+        assert _scanned_urls(mock_scanner, call=1) == ["fresh"]
+
+    def test_a_locally_filtered_document_is_not_cached_but_its_sibling_is(self):
+        """GIVEN two documents in one batch, one of them with secrets the local
+        config filtered out
+        WHEN they are scanned
+        THEN only the unambiguous one is remembered as clean."""
+        payloads = [self._payload("clean"), self._payload("filtered")]
+        hook_scanner = AIHookScanner(
+            _scanner_per_document(ignored_urls={"filtered"}, reverse=True)
+        )
+
+        results = hook_scanner._scan_contents(payloads)
+
+        assert [result.block for result in results] == [False, False]
+        key = verdict_key(INSTANCE, API_KEY, SecretConfig(), "clean", "some content")
+        assert has_clean_verdict(key)
+        filtered_key = verdict_key(
+            INSTANCE, API_KEY, SecretConfig(), "filtered", "some content"
+        )
+        assert not has_clean_verdict(filtered_key)
+
+    def test_a_skipped_document_is_not_cached(self):
+        """A document the scan said nothing about has no verdict to remember."""
+        payloads = [self._payload("answered"), self._payload("skipped")]
+        hook_scanner = AIHookScanner(_scanner_per_document(skipped_urls={"skipped"}))
+
+        hook_scanner._scan_contents(payloads)
+
+        assert has_clean_verdict(
+            verdict_key(INSTANCE, API_KEY, SecretConfig(), "answered", "some content")
+        )
+        assert not has_clean_verdict(
+            verdict_key(INSTANCE, API_KEY, SecretConfig(), "skipped", "some content")
+        )
+
+    def test_empty_payloads_never_reach_the_api(self):
+        """An empty payload costs no API call, batched or not."""
+        mock_scanner = _scanner_per_document()
+        payloads = [
+            self._payload("empty", content=""),
+            self._payload("full"),
+            self._payload("also-empty", content=""),
+        ]
+
+        results = AIHookScanner(mock_scanner)._scan_contents(payloads)
+
+        assert [result.block for result in results] == [False, False, False]
+        mock_scanner.scan.assert_called_once()
+        assert _scanned_urls(mock_scanner) == ["full"]
+
+    def test_no_payload_to_scan_makes_no_api_call(self):
+        """All payloads empty means nothing to send at all."""
+        mock_scanner = _scanner_per_document()
+        AIHookScanner(mock_scanner)._scan_contents([self._payload("empty", content="")])
+        mock_scanner.scan.assert_not_called()
+
+    def test_more_than_twenty_payloads_are_all_scanned(self):
+        """GIVEN more payloads than the API accepts in one call
+        WHEN they are scanned
+        THEN the scanner chunks them and not a single one is dropped."""
+        scanner = _real_secret_scanner()
+        scanner.client.base_uri = INSTANCE
+        scanner.client.api_key = API_KEY
+
+        def multi_content_scan(documents, *args, **kwargs):
+            result = MultiScanResult(
+                [
+                    ApiScanResult(policy_break_count=0, policy_breaks=[], policies=[])
+                    for _ in documents
+                ]
+            )
+            result.status_code = 200
+            return result
+
+        scanner.client.multi_content_scan.side_effect = multi_content_scan
+        payloads = [self._payload(f"payload-{index}") for index in range(25)]
+
+        assert AIHookScanner(scanner)._scan_payloads(payloads).block is False
+
+        calls = scanner.client.multi_content_scan.call_args_list
+        assert len(calls) == 2  # 20 + 5, the API's per-call document limit
+        sent = [document["filename"] for call in calls for document in call.args[0]]
+        assert sorted(sent) == sorted(payload.identifier for payload in payloads)
 
 
 class TestHasAlreadyBeenSeen:
@@ -2093,17 +2382,21 @@ def _scanner_finding(needle: str) -> MagicMock:
     mock.secret_config = SecretConfig()
 
     def scan(scannables, scanner_ui=None, **kwargs):
-        leaked = any(needle in scannable.content for scannable in scannables)
+        # One answer per document, carrying that document's url, as the real
+        # scanner does: the url is what ties a result back to its document.
         return Results(
             results=[
                 ScanResult(
-                    filename="url",
+                    filename=scannable.filename,
                     filemode=Filemode.FILE,
                     path=Path("."),
-                    url="url",
-                    secrets=[_make_secret(needle)] if leaked else [],
+                    url=scannable.url,
+                    secrets=(
+                        [_make_secret(needle)] if needle in scannable.content else []
+                    ),
                     ignored_secrets_count_by_kind=Counter(),
                 )
+                for scannable in scannables
             ],
             errors=[],
         )

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import os
 import subprocess
 import time
 from collections import Counter
@@ -77,10 +78,8 @@ def _mock_scanner(
     mock.secret_config = secret_config or SecretConfig()
 
     def scan(scannables, scanner_ui=None, **kwargs):
-        # Like the real scanner, the answer is about the documents that were
-        # sent, so it carries their url -- that is what ties a result back to
-        # its document. This fixture answers about the first one, which is all
-        # a single-payload test sends.
+        # Answers about the first document sent, carrying its url (all a
+        # single-payload test needs).
         first = list(scannables)[0]
         return Results(
             results=[
@@ -313,12 +312,10 @@ def _scanner_per_document(
     ignored_urls: Set[str] = frozenset(),
     reverse: bool = False,
 ) -> MagicMock:
-    """A scanner answering per document, the way a multi-document scan does:
-    one result per document, identified by its url.
+    """A scanner answering one result per document, keyed by url.
 
-    `skipped_urls` documents get no result at all (the scanner drops what it
-    could not scan) and `reverse` returns the results in another order than the
-    documents were sent (chunks are collected as they complete).
+    `skipped_urls` documents get no result at all; `reverse` returns results in
+    another order than they were sent.
     """
     secrets_by_url = secrets_by_url or {}
     mock = _mock_scanner([])
@@ -357,9 +354,8 @@ def _scanned_urls(mock_scanner: MagicMock, call: int = 0) -> List[str]:
 
 
 class TestBatchedPayloadScan:
-    """One event carries several payloads (a prompt mentioning files, a `cat`
-    command...). They must cost one API call, not one each — while blocking on
-    exactly the payload a per-payload loop blocked on.
+    """Several payloads of one event cost one API call, not one each, and block on
+    the payload that holds a secret.
     """
 
     @staticmethod
@@ -406,9 +402,8 @@ class TestBatchedPayloadScan:
         """GIVEN a UserPromptSubmit prompt mentioning three files
         WHEN the hook scans it
         THEN the four resulting payloads are sent in one call, all of them."""
-        # Mentioned by relative name, from inside tmp_path: an absolute Windows path
-        # (@C:/...) stops the @file regex at the drive-letter colon, and that gap in
-        # find_filepaths is not what this test is about.
+        # Relative name from inside tmp_path: an absolute Windows path (@C:/...) trips
+        # the @file regex on the drive-letter colon, which this test is not about.
         monkeypatch.chdir(tmp_path)
         files = []
         for index in range(3):
@@ -431,6 +426,59 @@ class TestBatchedPayloadScan:
         for file in files:
             assert any(url.endswith(file.name) for url in urls)
 
+    def test_prompt_mention_and_tool_read_of_one_file_scan_it_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """GIVEN a UserPromptSubmit mentioning @secret.txt (a relative path)
+        followed by a PreToolUse Read of the same file by its absolute path,
+        both events reporting the same cwd
+        WHEN the hook scans them
+        THEN the file's path is canonicalized to the same absolute path both
+        times, so it shares one verdict-cache key: it is scanned on the prompt
+        and the Read is served from the cache -- one API call, not two.
+
+        Without the canonicalization the two events key the cache on different
+        filenames (relative vs absolute) and the file is scanned twice.
+        """
+        # The real hook runs in the agent's cwd, which is why the relative
+        # @-mention resolves to a real file; mirror that here.
+        monkeypatch.chdir(tmp_path)
+        file = tmp_path / "secret.txt"
+        file.write_text("clean file content")
+        mock_scanner = _scanner_per_document()
+        hook_scanner = AIHookScanner(mock_scanner)
+
+        # Cursor reports its cwd as workspace_roots (exercises the override).
+        prompt = json.dumps(
+            {
+                "hook_event_name": "beforeSubmitPrompt",
+                "prompt": "please read @secret.txt",
+                "workspace_roots": [str(tmp_path)],
+                "cursor_version": "1.2.3",
+            }
+        )
+        read = json.dumps(
+            {
+                "hook_event_name": "preToolUse",
+                "tool_name": "read",
+                "tool_input": {"file_path": str(file)},
+                "workspace_roots": [str(tmp_path)],
+                "cursor_version": "1.2.3",
+            }
+        )
+
+        assert hook_scanner.scan(prompt) == 0
+        assert hook_scanner.scan(read) == 0
+
+        # The prompt scanned the file (and the prompt text); the Read added no
+        # call because the file's absolute-path key was already cached.
+        mock_scanner.scan.assert_called_once()
+        absolute = os.path.abspath(os.path.join(str(tmp_path), "secret.txt"))
+        key = verdict_key(
+            INSTANCE, API_KEY, SecretConfig(), absolute, "clean file content"
+        )
+        assert has_clean_verdict(key)
+
     def test_secret_in_the_second_payload_blocks_with_the_same_message(
         self, tmp_path: Path
     ):
@@ -450,10 +498,10 @@ class TestBatchedPayloadScan:
         assert result.block is True
         assert result.payload is payloads[1]
         assert result.nbr_secrets == 1
-        # The exact wording of the PreToolUse/Read block, unchanged.
+        # The exact wording of the PreToolUse/Read block.
         assert f"Detected 1 secret in {payloads[1].identifier}" in result.message
         assert "The file content was not shown to the agent" in result.message
-        # ... and it is the very message a one-payload scan produces.
+        # ... and it matches the message a one-payload scan produces.
         alone = AIHookScanner(_scanner_per_document(secrets))._scan_content(payloads[1])
         assert result.message == alone.message
 
@@ -963,6 +1011,19 @@ class TestMessageFromSecrets:
         assert "The prompt was not sent to the agent" in message
         assert "remove the secret from your prompt" in message
 
+    def test_message_for_file_mentioned_in_user_prompt(self):
+        """USER_PROMPT + Read: a file mentioned in the prompt gets the file wording,
+        not the prompt wording, since the secret is in the file."""
+        payload = self._payload(
+            event_type=EventType.USER_PROMPT,
+            tool=Tool.READ,
+            identifier="/tmp/config.py",
+        )
+        message = AIHookScanner._message_from_secrets([_make_secret("sk-xxx")], payload)
+        assert "in /tmp/config.py" in message
+        assert "in your prompt" not in message
+        assert "remove the secret from your prompt" not in message
+
     def test_escape_markdown_adds_hard_breaks(self):
         """escape_markdown turns single newlines into markdown hard breaks
         (two trailing spaces) so agents rendering the message as markdown
@@ -1347,7 +1408,7 @@ class TestAIHookScannerParseInput:
         payload = parse_hook_input(json.dumps(data))[0]
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
-        assert payload.identifier == tmp_file.as_posix()
+        assert payload.identifier == os.path.abspath(tmp_file)
         assert payload.content == ""
         assert payload.scannable.content == "this is the content"
         assert isinstance(payload.agent, Cursor)
@@ -1427,7 +1488,7 @@ class TestAIHookScannerParseInput:
         payload = parse_hook_input(json.dumps(data))[0]
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
-        assert payload.identifier == tmp_file.as_posix()
+        assert payload.identifier == os.path.abspath(tmp_file)
         assert payload.content == ""
         assert payload.scannable.content == "this is the content"
         assert isinstance(payload.agent, Claude)
@@ -1498,7 +1559,9 @@ class TestAIHookScannerParseInput:
         payload = payloads[0]
         assert payload.event_type == EventType.USER_PROMPT
         assert payload.tool == Tool.READ
-        assert payload.identifier == "folder/file.txt"
+        # The relative @-mention is canonicalized against the event's cwd so it
+        # shares a verdict-cache key with the tool's (absolute) read of the file.
+        assert payload.identifier == os.path.abspath("/home/user1/foo/folder/file.txt")
         assert payload.content == ""  # empty because inexistent file
         assert isinstance(payload.agent, Claude)
 
@@ -1578,7 +1641,7 @@ class TestAIHookScannerParseInput:
         payload = parse_hook_input(json.dumps(data))[0]
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
-        assert payload.identifier == tmp_file.as_posix()
+        assert payload.identifier == os.path.abspath(tmp_file)
         assert payload.content == ""
         assert payload.scannable.content == "this is the content"
         assert isinstance(payload.agent, VSCode)
@@ -1684,7 +1747,7 @@ class TestAIHookScannerParseInput:
         payload = parse_hook_input(json.dumps(data))[0]
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
-        assert payload.identifier == tmp_file.as_posix()
+        assert payload.identifier == os.path.abspath(tmp_file)
         assert payload.content == ""
         assert payload.scannable.content == "this is the content"
         assert isinstance(payload.agent, Copilot)
@@ -1888,7 +1951,8 @@ class TestAIHookScannerParseInput:
         payload = parse_hook_input(json.dumps(data))[0]
         assert payload.event_type == EventType.PRE_TOOL_USE
         assert payload.tool == Tool.READ
-        assert payload.identifier == "README.md"
+        # Canonicalized against the event's cwd (see _abs_read_path).
+        assert payload.identifier == os.path.abspath("/home/user/project/README.md")
 
     @staticmethod
     def _bash_hook_input(command: str) -> str:
@@ -2382,8 +2446,7 @@ def _scanner_finding(needle: str) -> MagicMock:
     mock.secret_config = SecretConfig()
 
     def scan(scannables, scanner_ui=None, **kwargs):
-        # One answer per document, carrying that document's url, as the real
-        # scanner does: the url is what ties a result back to its document.
+        # One answer per document, carrying its url, as the real scanner does.
         return Results(
             results=[
                 ScanResult(

--- a/tests/unit/verticals/secret/test_secret_scan_collection.py
+++ b/tests/unit/verticals/secret/test_secret_scan_collection.py
@@ -27,6 +27,35 @@ class MyException(Exception):
     pass
 
 
+def test_results_by_url():
+    """
+    GIVEN a scan that answered about several documents, out of send order and
+    saying nothing about one of them
+    WHEN looking the results up by url
+    THEN each document finds its own result, and the unanswered one finds none
+    """
+    scannables = [
+        StringScannable(url="second.py", content="SECOND = 2\n"),
+        StringScannable(url="first.py", content="FIRST = 1\n"),
+    ]
+    secret_config = SecretConfig()
+    results = Results(
+        results=[
+            Result.from_scan_result(
+                scannable, ScanResultFactory(policy_breaks=[]), secret_config
+            )
+            # Reversed: a batch comes back in completion order, not send order.
+            for scannable in reversed(scannables)
+        ]
+    )
+
+    by_url = results.by_url()
+
+    assert by_url["first.py"].url == "first.py"
+    assert by_url["second.py"].url == "second.py"
+    assert by_url.get("never-sent.py") is None
+
+
 def test_results_from_exception():
     """
     GIVEN an exception


### PR DESCRIPTION
## Context

A prompt mentioning three files costs **4 serial API round trips**: `_parse_user_prompt`
adds a `Tool.READ` payload per file, `_parse_command` one for `cat`/`Get-Content`, plus
the base payload — each scanned on its own. This is the most latency-visible event (the
prompt scan is the wait before every turn), and neither the verdict cache (#1376) nor
read-range slicing (#1382) helps it. `SecretScanner` already chunks and batches for
`secret scan path`; the ai-hook was the only caller passing it a single-element list.

## What has been done

All the payloads of an event that still need scanning go to `SecretScanner` in one call.
Measured against a local mock at the production p50 latency (380 ms), n=30, arms
alternated:

| event | before p50 | after p50 | before p90 | after p90 |
|---|---|---|---|---|
| `UserPromptSubmit` mentioning 3 files | 1561 ms | **395 ms** | 1564 ms | **398 ms** |
| single-payload prompt | 389 ms | 391 ms | 392 ms | 392 ms |

Behaviour:

- **Attribution**: results are matched to their document by url, not by position — a
  batch comes back neither in send order nor once per document. The lookup answers once
  per url and a round sends at most one entry per url, so no document inherits another's
  verdict.
- **Blocking**: verdicts are applied one payload at a time, in order.
- **Verdict cache**: still per document. A cached document is left out of the batch; a
  document is remembered as clean only if its own result came back with nothing filtered
  out locally.
- Empty payloads never reach the API; over 20 payloads are chunked by `SecretScanner`,
  none dropped.
- **Documents sent** — the one behaviour change: a blocking event now transmits every
  payload, not just up to the first block. On a prompt mentioning 25 files where one
  holds a secret, `main` sends 4 documents, this sends 26.

The batch cap is a global preference (default 20) served through `/v1/metadata`; the
ai-hook builds its `SecretScanner` with `check_api_key=True`, so
`client.secret_scan_preferences` carries the instance's real value before `_start_scans`
chunks on it — an on-prem install that lowered it still gets conforming batches. Backend
`multi_content_scan` appends exactly one result per document, in document order.

### Interaction with #1383

#1383 has merged; this branch is rebased on top and the textual conflict in
`_scan_payloads` is resolved so both wins survive. The loop submits the MCP activity
calls to the executor, runs the one batched scan alongside them, then applies verdicts
in payload order (scan verdict first). Non-MCP payloads get no activity call, and the
activity is still logged even when the scan blocks.

## Validation

End to end against a local ward instance (real server, not a mock), request counts from
the server's access log:

| payload | `main` | this PR |
|---|---|---|
| clean 3-file prompt | 4 requests x 1 doc | **1 request x 4 docs** |
| blocking 3-file prompt | 3 | **1** |
| 25-file prompt (26 docs) | 4 | **2** (20 + 6) |

- Attribution holds on the real server: with a GitHub token in a mentioned file and a
  Slack token in the prompt, the block reports the file's secret; a `cat` event names
  the file, not the command. Across two chunks completing out of order, the block still
  carries the right secret.
- The server answers `/v1/multiscan` with one result per document in request order,
  including two documents sharing a filename, and 400s at 21 documents. The client reads
  the cap from `/v1/metadata` (20) before every scan and chunks to it — no 400.
- Not verified: that a *lowered* on-prem cap is honoured.
- `pytest tests/unit` — 2610 passed, 11 new tests in `TestBatchedPayloadScan`. With
  `hooks.py` reverted, the new tests fail on the real signal (`Expected 'scan' to have
  been called once. Called 4 times.`, `assert 25 == 2`).

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.
