### PR TITLE
fix(ai-hook): say when an MCP tool call was not checked against policy

### DIFF
--- a/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
+++ b/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
@@ -1,5 +1,6 @@
 ### Fixed
 
 - The AI hook now warns when an MCP tool call could not be checked against your
-  organization's policy, instead of allowing it silently. The call is still allowed:
-  a network problem must not block your work.
+  organization's policy because GitGuardian could not be reached, instead of allowing
+  it silently. The call is still allowed: a network problem must not block your work.
+  An instance that does not offer MCP policy stays silent.

--- a/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
+++ b/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The AI hook now warns when an MCP tool call could not be checked against your
+  organization's policy. Previously a failed policy check was indistinguishable from
+  an approval, so an unreachable endpoint silently permitted every MCP tool call. The
+  call is still allowed — a network problem must not block your work — but the hook now
+  says it was not checked.

--- a/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
+++ b/changelog.d/20260805_140000_achille.mascia_mcp_policy_not_checked.md
@@ -1,7 +1,5 @@
 ### Fixed
 
 - The AI hook now warns when an MCP tool call could not be checked against your
-  organization's policy. Previously a failed policy check was indistinguishable from
-  an approval, so an unreachable endpoint silently permitted every MCP tool call. The
-  call is still allowed — a network problem must not block your work — but the hook now
-  says it was not checked.
+  organization's policy, instead of allowing it silently. The call is still allowed:
+  a network problem must not block your work.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -233,11 +233,10 @@ def emit_fail_open_response(stdin_content: str, error: Exception) -> int:
     return payload.agent.output_result(HookResult.allow_with_warning(payload, warning))
 
 
-# Mirrors _cannot_scan_warning's shape: what did not happen, then what to do.
 MCP_NOT_CHECKED_WARNING = (
-    "ggshield could not reach the GitGuardian MCP policy endpoint — this MCP tool "
-    "call was NOT checked against your organization's policy (it was still scanned "
-    "for secrets). Run 'ggshield api-status' to diagnose."
+    "This MCP tool call was NOT checked against your organization's policy: "
+    "ggshield got no answer from GitGuardian. The call was allowed anyway — run "
+    "'ggshield api-status' to diagnose."
 )
 
 
@@ -574,10 +573,8 @@ class AIHookScanner:
         """
         if not payloads:
             raise ValueError("Error: no payloads to scan")
-        # A non-blocking MCP result can still carry a warning ("we could not reach
-        # the policy endpoint"). Only a *blocking* result is returned from the loop,
-        # so collect those warnings and hand them to the final allow, or they are
-        # dropped and the fail-open goes silent again.
+        # Only a blocking result leaves the loop, so a non-blocking MCP warning has
+        # to be kept for the final allow, or it is dropped.
         warnings: List[str] = []
         for payload in payloads:
             if not is_mcp_activity_payload(payload):
@@ -614,9 +611,8 @@ class AIHookScanner:
         # This works even if the payload is not an MCP pre-tool use.
         result = send_mcp_activity(self.scanner.client, payload)
         if result is None:
-            # No policy answer. Fail open -- a broken endpoint must not block a
-            # tool call -- but say so, because silently allowing is how an
-            # unreachable endpoint permits every MCP call without anyone noticing.
+            # No policy answer: fail open, since a broken endpoint must not block a
+            # tool call, but say so instead of allowing silently.
             ui.display_warning(MCP_NOT_CHECKED_WARNING)
             return HookResult.allow_with_warning(payload, MCP_NOT_CHECKED_WARNING)
         return HookResult(

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -233,6 +233,14 @@ def emit_fail_open_response(stdin_content: str, error: Exception) -> int:
     return payload.agent.output_result(HookResult.allow_with_warning(payload, warning))
 
 
+# Mirrors _cannot_scan_warning's shape: what did not happen, then what to do.
+MCP_NOT_CHECKED_WARNING = (
+    "ggshield could not reach the GitGuardian MCP policy endpoint — this MCP tool "
+    "call was NOT checked against your organization's policy (it was still scanned "
+    "for secrets). Run 'ggshield api-status' to diagnose."
+)
+
+
 def _cannot_scan_warning(error: Exception) -> str:
     if isinstance(error, AuthError):
         reason = "ggshield could not authenticate to GitGuardian"
@@ -566,6 +574,11 @@ class AIHookScanner:
         """
         if not payloads:
             raise ValueError("Error: no payloads to scan")
+        # A non-blocking MCP result can still carry a warning ("we could not reach
+        # the policy endpoint"). Only a *blocking* result is returned from the loop,
+        # so collect those warnings and hand them to the final allow, or they are
+        # dropped and the fail-open goes silent again.
+        warnings: List[str] = []
         for payload in payloads:
             if not is_mcp_activity_payload(payload):
                 # No activity to send: keep the plain, single-threaded path.
@@ -590,12 +603,22 @@ class AIHookScanner:
                 return scan_result
             if mcp_result.block:
                 return mcp_result
+            if mcp_result.warning and mcp_result.warning not in warnings:
+                warnings.append(mcp_result.warning)
+        if warnings:
+            return HookResult.allow_with_warning(payloads[0], " ".join(warnings))
         return HookResult.allow(payloads[0])
 
     def _send_mcp_activity(self, payload: HookPayload) -> HookResult:
         """Send MCP activity to the GitGuardian API."""
         # This works even if the payload is not an MCP pre-tool use.
         result = send_mcp_activity(self.scanner.client, payload)
+        if result is None:
+            # No policy answer. Fail open -- a broken endpoint must not block a
+            # tool call -- but say so, because silently allowing is how an
+            # unreachable endpoint permits every MCP call without anyone noticing.
+            ui.display_warning(MCP_NOT_CHECKED_WARNING)
+            return HookResult.allow_with_warning(payload, MCP_NOT_CHECKED_WARNING)
         return HookResult(
             block=not result.allowed,
             message=result.reason,

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Set
 
@@ -233,10 +234,11 @@ def emit_fail_open_response(stdin_content: str, error: Exception) -> int:
     return payload.agent.output_result(HookResult.allow_with_warning(payload, warning))
 
 
+# No remediation step: this warning also reaches the agent (Cursor puts it in
+# agent_message), and the model would run whatever command it names.
 MCP_NOT_CHECKED_WARNING = (
-    "This MCP tool call was NOT checked against your organization's policy: "
-    "ggshield got no answer from GitGuardian. The call was allowed anyway — run "
-    "'ggshield api-status' to diagnose."
+    "GitGuardian could not be reached, so this MCP tool call was NOT checked "
+    "against your organization's policy. The call was allowed anyway."
 )
 
 
@@ -594,14 +596,17 @@ class AIHookScanner:
                 scan_result = self._scan_content(payload)
                 mcp_result = activity.result()
 
+            if mcp_result.warning and mcp_result.warning not in warnings:
+                warnings.append(mcp_result.warning)
+
             # The scan verdict keeps precedence, as it did when it short-circuited
             # the activity call.
             if scan_result.block:
-                return scan_result
+                # Carry the warning along: an auditor wants both the block and
+                # the fact that the policy check did not run.
+                return replace(scan_result, warning=" ".join(warnings))
             if mcp_result.block:
                 return mcp_result
-            if mcp_result.warning and mcp_result.warning not in warnings:
-                warnings.append(mcp_result.warning)
         if warnings:
             return HookResult.allow_with_warning(payloads[0], " ".join(warnings))
         return HookResult.allow(payloads[0])

--- a/ggshield/verticals/ai/mcp.py
+++ b/ggshield/verticals/ai/mcp.py
@@ -34,35 +34,26 @@ def send_mcp_activity(
 
     Returns:
         The API's policy answer, or ``None`` when no answer could be obtained.
-
-        ``None`` is deliberately *not* an allow. Returning an allow here is how an
-        unreachable policy endpoint silently permits every MCP tool call: the
-        caller cannot tell "the API said yes" from "we never managed to ask". The
-        caller still fails open -- a network blip must never block a tool call --
-        but it warns, the way the secret scan already warns when it could not scan.
+        ``None`` is not an allow: the caller fails open, but warns.
     """
 
-    # Not an MCP pre-tool use: nothing to evaluate, so this is a real allow and
-    # must stay silent. Warning here would fire on every Read, Bash and Edit call.
+    # Nothing to evaluate: a genuine allow, and it must stay silent, or every
+    # Read, Bash and Edit call would carry a warning.
     if not is_mcp_activity_payload(payload):
         return _mcp_activity_allow()
 
     try:
-        # Inside the try on purpose: this walks the filesystem for MCP configs and
-        # talks to the API, so it fails for the same reasons the request below
-        # does. Left outside, its failures skipped the MCP fail-open entirely and
-        # surfaced as the generic "could not scan" warning -- the wrong message,
-        # since the secret scan itself was fine.
+        # Inside the try: discovery walks the filesystem and calls the API, so it
+        # fails for the same reasons the request below does.
         ai_config = refresh_and_maybe_submit_discovery(client)
         request = payload.agent.parse_mcp_activity(payload, ai_config)
         response = client.log_mcp_activity(request)
     except requests.exceptions.RequestException as exc:
-        # Expected and uninteresting: offline, timeout, TLS, DNS.
+        # Expected: offline, timeout, TLS, DNS.
         logger.debug("MCP policy check could not reach the API: %s", exc)
         return None
     except Exception as exc:
-        # Not expected. A bug here used to be indistinguishable from a network
-        # blip; log it louder so it is findable, but still fail open.
+        # Louder, so a bug does not look like a network blip.
         logger.warning("MCP policy check failed unexpectedly: %s", exc)
         return None
 

--- a/ggshield/verticals/ai/mcp.py
+++ b/ggshield/verticals/ai/mcp.py
@@ -1,3 +1,7 @@
+import logging
+from typing import Optional
+
+import requests
 from pygitguardian import GGClient
 from pygitguardian.models import Detail, MCPActivityResponse
 
@@ -6,7 +10,11 @@ from ggshield.verticals.ai.discovery import refresh_and_maybe_submit_discovery
 from .models import EventType, HookPayload, Tool
 
 
-def _mcp_activity_fail_open() -> MCPActivityResponse:
+logger = logging.getLogger(__name__)
+
+
+def _mcp_activity_allow() -> MCPActivityResponse:
+    """A genuine allow: there is no MCP policy to evaluate for this payload."""
     return MCPActivityResponse(allowed=True, reason="")
 
 
@@ -15,7 +23,9 @@ def is_mcp_activity_payload(payload: HookPayload) -> bool:
     return payload.event_type == EventType.PRE_TOOL_USE and payload.tool == Tool.MCP
 
 
-def send_mcp_activity(client: GGClient, payload: HookPayload) -> MCPActivityResponse:
+def send_mcp_activity(
+    client: GGClient, payload: HookPayload
+) -> Optional[MCPActivityResponse]:
     """Build the MCP activity request and send it to the GitGuardian API.
 
     Args:
@@ -23,22 +33,42 @@ def send_mcp_activity(client: GGClient, payload: HookPayload) -> MCPActivityResp
         payload: Hook payload for the MCP pre-tool event.
 
     Returns:
-        Policy response from the API, or allow if the request fails (fail-open).
+        The API's policy answer, or ``None`` when no answer could be obtained.
+
+        ``None`` is deliberately *not* an allow. Returning an allow here is how an
+        unreachable policy endpoint silently permits every MCP tool call: the
+        caller cannot tell "the API said yes" from "we never managed to ask". The
+        caller still fails open -- a network blip must never block a tool call --
+        but it warns, the way the secret scan already warns when it could not scan.
     """
 
-    # if the payload is not an MCP pre-tool use, early return
+    # Not an MCP pre-tool use: nothing to evaluate, so this is a real allow and
+    # must stay silent. Warning here would fire on every Read, Bash and Edit call.
     if not is_mcp_activity_payload(payload):
-        return _mcp_activity_fail_open()
-
-    ai_config = refresh_and_maybe_submit_discovery(client)
-    request = payload.agent.parse_mcp_activity(payload, ai_config)
+        return _mcp_activity_allow()
 
     try:
+        # Inside the try on purpose: this walks the filesystem for MCP configs and
+        # talks to the API, so it fails for the same reasons the request below
+        # does. Left outside, its failures skipped the MCP fail-open entirely and
+        # surfaced as the generic "could not scan" warning -- the wrong message,
+        # since the secret scan itself was fine.
+        ai_config = refresh_and_maybe_submit_discovery(client)
+        request = payload.agent.parse_mcp_activity(payload, ai_config)
         response = client.log_mcp_activity(request)
-    except Exception:
-        return _mcp_activity_fail_open()
+    except requests.exceptions.RequestException as exc:
+        # Expected and uninteresting: offline, timeout, TLS, DNS.
+        logger.debug("MCP policy check could not reach the API: %s", exc)
+        return None
+    except Exception as exc:
+        # Not expected. A bug here used to be indistinguishable from a network
+        # blip; log it louder so it is findable, but still fail open.
+        logger.warning("MCP policy check failed unexpectedly: %s", exc)
+        return None
 
     if isinstance(response, Detail):
-        return _mcp_activity_fail_open()
+        # The API answered, but with an error rather than a policy decision.
+        logger.debug("MCP policy check returned an error: %s", response.detail)
+        return None
 
     return response

--- a/ggshield/verticals/ai/mcp.py
+++ b/ggshield/verticals/ai/mcp.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def _mcp_activity_allow() -> MCPActivityResponse:
-    """A genuine allow: there is no MCP policy to evaluate for this payload."""
+    """A silent allow: there is no MCP policy to evaluate, or none on offer."""
     return MCPActivityResponse(allowed=True, reason="")
 
 
@@ -33,8 +33,9 @@ def send_mcp_activity(
         payload: Hook payload for the MCP pre-tool event.
 
     Returns:
-        The API's policy answer, or ``None`` when no answer could be obtained.
-        ``None`` is not an allow: the caller fails open, but warns.
+        The API's policy answer, or ``None`` when GitGuardian could not be
+        reached. ``None`` is not an allow: the caller fails open, but warns.
+        An instance that answers it has no MCP policy yields a silent allow.
     """
 
     # Nothing to evaluate: a genuine allow, and it must stay silent, or every
@@ -58,7 +59,17 @@ def send_mcp_activity(
         return None
 
     if isinstance(response, Detail):
-        # The API answered, but with an error rather than a policy decision.
+        status_code = response.status_code or 0
+        if 400 <= status_code < 500:
+            # The instance answered that it has no policy for us: the route is
+            # missing on an older on-prem, or the feature is off for this
+            # workspace. A configuration fact, not an outage, so stay silent —
+            # otherwise those users get a warning on every MCP tool call.
+            logger.debug(
+                "MCP policy is not available (%d): %s", status_code, response.detail
+            )
+            return _mcp_activity_allow()
+        # 5xx, or no status at all: GitGuardian is there but not answering.
         logger.debug("MCP policy check returned an error: %s", response.detail)
         return None
 

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -8,9 +8,10 @@ from typing import List, Optional, Set
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pygitguardian import GGClient
 from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MAXIMUM_PAYLOAD_SIZE
-from pygitguardian.models import MCPActivityResponse
+from pygitguardian.models import AIDiscovery, Detail, MCPActivityResponse, UserInfo
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.scan import File, ScanContext, ScanMode, StringScannable
@@ -543,6 +544,49 @@ class TestMCPActivity:
         assert result.block is False
         assert MCP_NOT_CHECKED_WARNING in result.warning
 
+    @pytest.mark.parametrize(
+        ("answer", "warns"),
+        [
+            (Detail(status_code=404, detail="Not found"), False),
+            (Detail(status_code=403, detail="Forbidden"), False),
+            (Detail(status_code=500, detail="Server Error"), True),
+            (requests.exceptions.ConnectionError("offline"), True),
+            (MCPActivityResponse(allowed=True, reason=""), False),
+        ],
+        ids=["404", "403", "500", "connection-error", "allow"],
+    )
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_only_an_outage_warns(
+        self, mock_refresh: MagicMock, answer: object, warns: bool
+    ):
+        """GIVEN an MCP policy endpoint that answers, declines or is unreachable
+        WHEN an MCP PreToolUse is scanned
+        THEN the call is always allowed, and only an outage carries a warning:
+        an instance that does not offer MCP policy would warn on every call."""
+        mock_refresh.return_value = AIDiscovery(
+            user=UserInfo(hostname="host", username="user", machine_id="mid"),
+            servers=[],
+            discovery_duration=0.1,
+        )
+        scanner = _mock_scanner([])
+        if isinstance(answer, Exception):
+            scanner.client.log_mcp_activity.side_effect = answer
+        else:
+            scanner.client.log_mcp_activity.return_value = answer
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__some_server__some_tool",
+            "tool_input": {"arg": "value"},
+            "cursor_version": "2.5.25",
+        }
+
+        result = AIHookScanner(scanner)._scan_payloads(
+            parse_hook_input(json.dumps(data))
+        )
+
+        assert result.block is False
+        assert bool(result.warning) is warns
+
     @patch("ggshield.verticals.ai.hooks.send_mcp_activity")
     def test_a_policy_answer_warns_about_nothing(self, mock_send_mcp: MagicMock):
         """A real allow must stay silent — otherwise every MCP call carries noise."""
@@ -627,6 +671,16 @@ class TestMCPActivityOverlap:
         assert "blocked by policy" not in result.message
         # Approved behaviour change: the activity is logged even when we block.
         mock_send.assert_called_once()
+
+    def test_scan_block_keeps_the_unchecked_policy_warning(self):
+        """Both facts matter to an auditor: the block, and that the policy check
+        did not run."""
+        scanner = _mock_scanner(["sk-secret"])
+        with patch("ggshield.verticals.ai.hooks.send_mcp_activity", return_value=None):
+            result = AIHookScanner(scanner)._scan_payloads([self._payload()])
+
+        assert result.block
+        assert result.warning == MCP_NOT_CHECKED_WARNING
 
     def test_mcp_block_returned_when_the_scan_allows(self):
         scanner = _mock_scanner([])

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -22,6 +22,7 @@ from ggshield.verticals.ai.cache import (
     verdict_key,
 )
 from ggshield.verticals.ai.hooks import (
+    MCP_NOT_CHECKED_WARNING,
     AIHookScanner,
     build_agent_headers,
     find_filepaths,
@@ -521,6 +522,43 @@ class TestMCPActivity:
         call_payload = mock_send_mcp.call_args[0][1]
         assert call_payload.event_type == EventType.PRE_TOOL_USE
         assert call_payload.tool == Tool.MCP
+
+    @patch("ggshield.verticals.ai.hooks.send_mcp_activity")
+    def test_no_policy_answer_allows_but_warns(self, mock_send_mcp: MagicMock):
+        """GIVEN the MCP policy endpoint gives no answer (send_mcp_activity -> None)
+        WHEN an MCP PreToolUse is scanned
+        THEN the call is still allowed, but the result carries a warning so the
+        user can tell it was not checked."""
+        mock_send_mcp.return_value = None
+        scanner = AIHookScanner(_mock_scanner([]))
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__some_server__some_tool",
+            "tool_input": {"arg": "value"},
+            "cursor_version": "2.5.25",
+        }
+
+        result = scanner._scan_payloads(parse_hook_input(json.dumps(data)))
+
+        assert result.block is False
+        assert MCP_NOT_CHECKED_WARNING in result.warning
+
+    @patch("ggshield.verticals.ai.hooks.send_mcp_activity")
+    def test_a_policy_answer_warns_about_nothing(self, mock_send_mcp: MagicMock):
+        """A real allow must stay silent — otherwise every MCP call carries noise."""
+        mock_send_mcp.return_value = MCPActivityResponse(allowed=True, reason="")
+        scanner = AIHookScanner(_mock_scanner([]))
+        data = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__some_server__some_tool",
+            "tool_input": {"arg": "value"},
+            "cursor_version": "2.5.25",
+        }
+
+        result = scanner._scan_payloads(parse_hook_input(json.dumps(data)))
+
+        assert result.block is False
+        assert result.warning == ""
 
 
 class TestMCPActivityOverlap:

--- a/tests/unit/verticals/ai/test_mcp_activity.py
+++ b/tests/unit/verticals/ai/test_mcp_activity.py
@@ -67,8 +67,7 @@ class TestSendMCPActivity:
 
     @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
     def test_an_api_error_is_no_answer_not_an_allow(self, mock_refresh: MagicMock):
-        """A Detail response means the API did not decide. Returning an allow here
-        is what made an unreachable policy endpoint silently permit every call."""
+        """A Detail response means the API did not decide, so it is not an allow."""
         mock_refresh.return_value = _ai_discovery()
         payload = _payload()
         payload.agent.parse_mcp_activity = MagicMock(
@@ -110,8 +109,7 @@ class TestSendMCPActivity:
 
     @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
     def test_discovery_failing_is_no_answer(self, mock_refresh: MagicMock):
-        """refresh_and_maybe_submit_discovery used to sit outside the try, so its
-        failures escaped the MCP fail-open and surfaced as 'could not scan'."""
+        """A discovery failure is not a policy answer either."""
         mock_refresh.side_effect = OSError("cannot walk the filesystem")
 
         assert send_mcp_activity(MagicMock(), _payload()) is None

--- a/tests/unit/verticals/ai/test_mcp_activity.py
+++ b/tests/unit/verticals/ai/test_mcp_activity.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import requests
 from pygitguardian.models import Detail, MCPActivityResponse, UserInfo
 
 from ggshield.verticals.ai.mcp import send_mcp_activity
@@ -65,7 +66,9 @@ class TestSendMCPActivity:
         assert result.reason == "blocked by policy"
 
     @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
-    def test_fail_open_returns_allowed(self, mock_refresh: MagicMock):
+    def test_an_api_error_is_no_answer_not_an_allow(self, mock_refresh: MagicMock):
+        """A Detail response means the API did not decide. Returning an allow here
+        is what made an unreachable policy endpoint silently permit every call."""
         mock_refresh.return_value = _ai_discovery()
         payload = _payload()
         payload.agent.parse_mcp_activity = MagicMock(
@@ -77,8 +80,51 @@ class TestSendMCPActivity:
             status_code=400, detail="Validation Error"
         )
 
-        result = send_mcp_activity(client, payload)
+        assert send_mcp_activity(client, payload) is None
 
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_a_network_error_is_no_answer(self, mock_refresh: MagicMock):
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        client = MagicMock()
+        client.log_mcp_activity.side_effect = requests.exceptions.ConnectionError(
+            "offline"
+        )
+
+        assert send_mcp_activity(client, payload) is None
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_an_unexpected_error_is_no_answer(self, mock_refresh: MagicMock):
+        """A bug must still fail open, and must not masquerade as a policy allow."""
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            side_effect=TypeError("bug in parse_mcp_activity")
+        )
+
+        assert send_mcp_activity(MagicMock(), payload) is None
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_discovery_failing_is_no_answer(self, mock_refresh: MagicMock):
+        """refresh_and_maybe_submit_discovery used to sit outside the try, so its
+        failures escaped the MCP fail-open and surfaced as 'could not scan'."""
+        mock_refresh.side_effect = OSError("cannot walk the filesystem")
+
+        assert send_mcp_activity(MagicMock(), _payload()) is None
+
+    def test_a_non_mcp_payload_is_a_genuine_allow(self):
+        """Nothing to evaluate is not a failure: it must not warn, or every Read,
+        Bash and Edit call would carry a warning."""
+        payload = _payload()
+        payload.tool = Tool.READ
+
+        result = send_mcp_activity(MagicMock(), payload)
+
+        assert result is not None
         assert result.allowed is True
 
     @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")

--- a/tests/unit/verticals/ai/test_mcp_activity.py
+++ b/tests/unit/verticals/ai/test_mcp_activity.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 from pygitguardian.models import Detail, MCPActivityResponse, UserInfo
 
@@ -66,8 +67,11 @@ class TestSendMCPActivity:
         assert result.reason == "blocked by policy"
 
     @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
-    def test_an_api_error_is_no_answer_not_an_allow(self, mock_refresh: MagicMock):
-        """A Detail response means the API did not decide, so it is not an allow."""
+    @pytest.mark.parametrize("status_code", [400, 403, 404, 422])
+    def test_a_4xx_is_a_silent_allow(self, mock_refresh: MagicMock, status_code: int):
+        """The instance does not offer MCP policy (route missing on an older
+        on-prem, feature off for the workspace): a configuration fact, not an
+        outage, so it must not warn on every single MCP tool call."""
         mock_refresh.return_value = _ai_discovery()
         payload = _payload()
         payload.agent.parse_mcp_activity = MagicMock(
@@ -76,8 +80,45 @@ class TestSendMCPActivity:
 
         client = MagicMock()
         client.log_mcp_activity.return_value = Detail(
-            status_code=400, detail="Validation Error"
+            status_code=status_code, detail="Not found"
         )
+
+        result = send_mcp_activity(client, payload)
+
+        assert result is not None
+        assert result.allowed is True
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    @pytest.mark.parametrize("status_code", [500, 502, 503])
+    def test_a_5xx_is_no_answer_not_an_allow(
+        self, mock_refresh: MagicMock, status_code: int
+    ):
+        """A server error is a genuine outage: no policy decision was made."""
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        client = MagicMock()
+        client.log_mcp_activity.return_value = Detail(
+            status_code=status_code, detail="Server Error"
+        )
+
+        assert send_mcp_activity(client, payload) is None
+
+    @patch("ggshield.verticals.ai.mcp.refresh_and_maybe_submit_discovery")
+    def test_an_error_without_a_status_is_no_answer(self, mock_refresh: MagicMock):
+        """No status code means we cannot tell the instance declined, so treat it
+        as an outage."""
+        mock_refresh.return_value = _ai_discovery()
+        payload = _payload()
+        payload.agent.parse_mcp_activity = MagicMock(
+            return_value=_mcp_activity_request()
+        )
+
+        client = MagicMock()
+        client.log_mcp_activity.return_value = Detail(detail="The request timed out.")
 
         assert send_mcp_activity(client, payload) is None
 


### PR DESCRIPTION
## Context

`send_mcp_activity()` returned `MCPActivityResponse(allowed=True, reason="")` on **every** failure path — byte-identical to a genuine policy approval. A timeout, a 500, a malformed response, or a bug in `parse_mcp_activity` all permitted the MCP tool call, and the caller had no way to tell them from *"the API said yes"*.

So an unreachable policy endpoint silently allows every MCP tool call. Same class of invisible fail-open as #1375 (heredoc scans abandoned) and #1378 (keychain write-probe).

## What has been done

`send_mcp_activity()` now returns `Optional[MCPActivityResponse]`, where `None` means "no answer obtained". The caller fails open **with a warning**, reusing what the secret scan already does when it cannot scan (`HookResult.allow_with_warning` → `systemMessage`).

Behaviour stays **fail-open** — a network blip must never block a tool call. The change is visibility, not denial.

Three related fixes on the way through:

- The *"not an MCP pre-tool-use"* early return stays a genuine, silent allow. Warning there would fire on every Read, Bash and Edit call.
- `refresh_and_maybe_submit_discovery()` moves **inside** the try block. It walks the filesystem and calls the API, so it fails for the same reasons the request does. Outside, its failures bypassed the MCP fail-open and surfaced as the generic *"could not scan for secrets"* warning — the wrong message, since the scan itself was fine.
- The bare `except Exception` is split: an expected `RequestException` logs at debug, anything else at warning, so a bug is findable instead of looking like a network blip.

One bug found while wiring it up: `_scan_payloads()` only returns a result for a *blocking* payload and otherwise builds a fresh `HookResult.allow()`, which **dropped the warning**. It now collects non-blocking warnings and attaches them to the final allow.

## Validation

- `pytest tests/unit` → **2603 passed, 4 skipped**
- 7 new tests: API error / network error / unexpected error / discovery failure all yield no answer; a non-MCP payload stays a silent allow; a real allow warns about nothing; and the warning survives `_scan_payloads`
- Revert check: with the source reverted and the tests kept, **4 of the new tests fail** — so they catch the regression rather than restating the code
- `black` / `isort` / `flake8` clean

Not covered: the Rust ai-hook port (#1381) does not implement MCP policy at all, so this widens the Python/Rust behavioural gap. The equivalence harness has no MCP cases yet — tracked separately.

## PR check list

- [x] Tests included
- [x] Changelog entry (`changelog.d/`)
