### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,96 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.tif binary
+*.tiff binary
+*.ico binary
+*.webp binary
+*.bmp binary
+*.psd binary
+# SVG is XML text, not binary
+*.svg text
+
+# Fonts
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.otf binary
+
+# Archives
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.rar binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.zip binary
+*.zst binary
+
+# Compiled objects and libraries
+*.a binary
+*.lib binary
+*.o binary
+*.obj binary
+
+# Executables and shared libraries
+*.dll binary
+*.dylib binary
+*.exe binary
+*.so binary
+
+# Documents and data
+*.pdf binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
+
+# Preserve byte sequences in patches
+*.patch -text
+*.diff -text
+
+# Audio
+*.aac binary
+*.aif binary
+*.aiff binary
+*.flac binary
+*.m4a binary
+*.mid binary
+*.midi binary
+*.mp3 binary
+*.ogg binary
+*.wav binary
+*.wma binary
+
+# Video
+*.3gp binary
+*.avi binary
+*.flv binary
+*.m4v binary
+*.mkv binary
+*.mov binary
+*.mp4 binary
+*.mpeg binary
+*.mpg binary
+*.ogv binary
+*.webm binary
+*.wmv binary
+
+# Lockfiles
+uv.lock binary
+Pipfile.lock binary
+poetry.lock binary
+
+# Python bytecode and data (Python.gitattributes, CPython)
+*.pyc binary
+*.pyo binary
+*.pyd binary
+*.whl binary
+*.pkl binary
+*.pickle binary


### PR DESCRIPTION
## Context

The repository has no `.gitattributes` file. Without one, Git's line-ending
handling is left to each contributor's local settings, which can cause noisy
diffs on Windows (CRLF vs LF) and misidentify binary files (lockfiles, fonts,
archives). ggshield's CI already runs on ubuntu-22.04, macOS-15-intel, and
windows-2022 — consistent normalization matters across all three.

## What has been done

Added a `.gitattributes` file using the `standard` preset appropriate for a
Python project:

- `* text=auto` as the root normalization rule
- Binary markers for images, fonts, archives, compiled objects, and executables
- `*.patch` / `*.diff` marked `-text` to preserve byte sequences
- Lockfile entries (`uv.lock`, `Pipfile.lock`, `poetry.lock`) marked `binary`
  so they don't get line-ending rewritten on checkout

No other files were changed.

## Validation

This is a configuration-only change with no functional impact on ggshield
itself. Validation steps:

- `git check-attr text uv.lock` → should report `binary`
- `git check-attr text ggshield/cmd/main.py` → should report `auto` (text=auto inherited)
- Existing CI passes unchanged — `.gitattributes` has no effect on tests

- [x] Changes include tests (unit and/or functional) — N/A: configuration file only
- [ ] Changelog entry added — please apply the `skip-changelog` label (fork PRs cannot apply labels)

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
