### PR TITLE
feat(packaging): ship the Rust ai-hook in per-platform wheels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,6 @@
 !README.md
 !LICENSE
 !pyproject.toml
+!hatch_build.py
+!hatch_meta.py
 !docker

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -43,9 +43,18 @@ jobs:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
+      # No GGSHIELD_BUILD_RUST: this is the sdist plus the pure-Python
+      # `py3-none-any` fallback wheel, where `ggshield` is the Python entry
+      # point. The platform wheels come from .github/workflows/wheels.yml.
       - name: Create packages
         run: |
           uv build
+
+      - name: Smoke test the pure wheel
+        run: |
+          uv venv /tmp/smoke
+          VIRTUAL_ENV=/tmp/smoke uv pip install dist/*-py3-none-any.whl
+          /tmp/smoke/bin/ggshield --version
 
       - name: Upload packages
         uses: actions/upload-artifact@v6

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,9 @@ jobs:
   # `push_to_pypi` below can download them.
   build_platform_wheels:
     uses: ./.github/workflows/wheels.yml
+    secrets: inherit
+    with:
+      sign: true
 
   push_to_pypi:
     needs: [build_release_assets, build_platform_wheels]

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
+          # A release now uploads eight files from two jobs instead of two from
+          # one. PyPI takes them one at a time and refuses a filename it already
+          # has, so a failure partway through leaves the rest unpublished and a
+          # plain re-run dies on what already landed — with no way to replace it,
+          # because a PyPI filename cannot be reused. Skipping what is already
+          # there makes the re-run finish the job instead.
+          skip-existing: true
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,8 +13,14 @@ jobs:
       release_mode: true
       sign: true
 
+  # The platform wheels carrying the Rust `ggshield`. Called from here rather
+  # than triggered on the tag itself, so its artifacts land in this run and
+  # `push_to_pypi` below can download them.
+  build_platform_wheels:
+    uses: ./.github/workflows/wheels.yml
+
   push_to_pypi:
-    needs: build_release_assets
+    needs: [build_release_assets, build_platform_wheels]
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
@@ -24,11 +30,21 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Download wheel and sdist
+      # Two artifacts, never one: both jobs would name a pure wheel
+      # `ggshield-<version>-py3-none-any.whl`, so only `build_wheel_sdist`
+      # builds one. See .github/workflows/wheels.yml.
+      - name: Download the sdist and the pure-Python wheel
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
+
+      - name: Download the platform wheels
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -115,11 +115,6 @@ jobs:
           name: wheel-macos-universal2
           path: dist/*.whl
 
-  # Not Authenticode-signed, unlike the .msi and .zip: nothing on Windows binds a
-  # stored credential to a binary's signature the way a macOS Keychain ACL does,
-  # so the only thing signing buys the wheel is SmartScreen reputation on a
-  # binary users reach through pip rather than a download. Separate concern,
-  # separate ticket.
   windows:
     name: wheel windows-amd64
     runs-on: windows-latest
@@ -129,6 +124,55 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - uses: dtolnay/rust-toolchain@stable
+      # Authenticode-signed like the .msi and the .zip. A signature binds no
+      # stored credential here the way a macOS Keychain ACL does, but this is the
+      # `ggshield` every invocation runs, and an unsigned native executable inside
+      # a venv is what AV and EDR heuristics react to. Fail rather than ship one:
+      # `pip install` offers nobody a second chance to check.
+      - name: Prepare code signing
+        if: inputs.sign
+        shell: bash
+        env:
+          WINDOWS_CERT_FINGERPRINT: ${{ secrets.WINDOWS_CERT_FINGERPRINT }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SM_API_KEY" ] ; then
+            echo "sign: true, but the signing secrets are not readable here" >&2
+            exit 1
+          fi
+
+          signtool_dir="/c/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64"
+          if [ ! -x "$signtool_dir/signtool.exe" ] ; then
+            echo "signtool.exe is not in '$signtool_dir'" >&2
+            exit 1
+          fi
+          echo "$signtool_dir" >> "$GITHUB_PATH"
+          # The next step installs smctl, so do not look for it yet.
+          echo "/c/Program Files/DigiCert/DigiCert Keylocker Tools" >> "$GITHUB_PATH"
+
+          SECRETS_DIR=$RUNNER_TEMP/secrets
+          mkdir -p "$SECRETS_DIR"
+          # The client certificate is base64-encoded because it is binary.
+          echo "$SM_CLIENT_CERT_FILE" | base64 --decode > "$SECRETS_DIR/cert.p12"
+          cat >> "$GITHUB_ENV" <<EOF
+          WINDOWS_CERT_FINGERPRINT=$WINDOWS_CERT_FINGERPRINT
+          SM_API_KEY=$SM_API_KEY
+          SM_HOST=$SM_HOST
+          SM_CLIENT_CERT_FILE=$SECRETS_DIR/cert.p12
+          SM_CLIENT_CERT_PASSWORD=$SM_CLIENT_CERT_PASSWORD
+          EOF
+
+      - name: Install the signing tools
+        if: inputs.sign
+        shell: bash
+        run: scripts/build-os-packages/install-keylockertools
+
+      # hatch_build.py signs the binary itself, right after cargo: nothing outside
+      # the build can, because the wheel is zipped around it.
       - name: Build wheel
         shell: bash
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,118 @@
+name: wheels
+
+concurrency:
+  group: wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+# Builds the platform wheels carrying the Rust `ggshield` binary, plus the
+# pure-Python fallback wheel and the sdist. Each platform wheel is tagged
+# py3-none-<platform>: a binary but no Python extension module, so it is
+# Python-version-independent.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['**']
+
+jobs:
+  macos:
+    name: wheel macos-universal2
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: Build wheel
+        env:
+          GGSHIELD_BUILD_RUST: '1'
+        run: |
+          python -m pip install --upgrade build
+          python -m build --wheel --outdir dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-macos-universal2
+          path: dist/*.whl
+
+  windows:
+    name: wheel windows-amd64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build wheel
+        shell: bash
+        env:
+          GGSHIELD_BUILD_RUST: '1'
+        run: |
+          python -m pip install --upgrade build
+          python -m build --wheel --outdir dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-windows-amd64
+          path: dist/*.whl
+
+  # glibc (manylinux) and musl (musllinux, e.g. Alpine) wheels, each built in
+  # its pypa image so the binary links that libc, then relabelled from the raw
+  # linux_* tag to the image's platform tag. `docker run` rather than a job
+  # `container:`, because manylinux2014's glibc 2.17 is too old to run the
+  # node-based actions.
+  linux:
+    name: wheel ${{ matrix.tag }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {
+              runs-on: ubuntu-latest,
+              image: 'quay.io/pypa/manylinux2014_x86_64',
+              tag: manylinux2014_x86_64,
+            }
+          - {
+              runs-on: ubuntu-24.04-arm,
+              image: 'quay.io/pypa/manylinux2014_aarch64',
+              tag: manylinux2014_aarch64,
+            }
+          - {
+              runs-on: ubuntu-latest,
+              image: 'quay.io/pypa/musllinux_1_2_x86_64',
+              tag: musllinux_1_2_x86_64,
+            }
+          - {
+              runs-on: ubuntu-24.04-arm,
+              image: 'quay.io/pypa/musllinux_1_2_aarch64',
+              tag: musllinux_1_2_aarch64,
+            }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and relabel wheel in ${{ matrix.image }}
+        run: |
+          docker run --rm -v "$PWD:/io" -w /io -e GGSHIELD_BUILD_RUST=1 \
+            "${{ matrix.image }}" bash -euo pipefail -c '
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+              source "$HOME/.cargo/env"
+              git config --global --add safe.directory "*"
+              PY=/opt/python/cp311-cp311/bin/python
+              "$PY" -m pip install --upgrade build wheel
+              "$PY" -m build --wheel --outdir dist_raw
+              "$PY" -m wheel tags --remove \
+                --platform-tag "${{ matrix.tag }}" dist_raw/*.whl
+              mkdir -p dist && mv dist_raw/*.whl dist/
+            '
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.tag }}
+          path: dist/*.whl
+
+  # The universal fallback: pure py3-none-any wheel + sdist, no Rust.
+  pure:
+    name: pure wheel + sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pipx run build --outdir dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pure-and-sdist
+          path: dist/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,17 @@ on:
   # Called by tag.yml, so a release actually publishes these. Same run as
   # `build_wheel_sdist`, which is what lets `push_to_pypi` download both.
   workflow_call:
+    inputs:
+      sign:
+        description: 'Code-sign the macOS binary (needs secrets, so no PR from a fork can)'
+        type: boolean
+        default: false
   workflow_dispatch:
+    inputs:
+      sign:
+        description: 'Code-sign the macOS binary (needs secrets, so no PR from a fork can)'
+        type: boolean
+        default: false
   # Only the packaging inputs: nothing else changes what these wheels contain,
   # and six jobs on every push is a lot of runner time for that.
   pull_request:
@@ -36,6 +46,11 @@ env:
   # standalone bundles; bump both together. Checksums from
   # https://static.rust-lang.org/rustup/archive/$RUSTUP_VERSION/$triple/rustup-init.sha256
   RUSTUP_VERSION: 1.29.0
+  # Same rcodesign as build_release_assets.yml installs for the standalone
+  # bundles; bump both together. The checksum is the aarch64 one -- the macOS
+  # wheel is built on macos-14 and lipo'd, so there is no Intel runner here.
+  RCODESIGN_VERSION: 0.27.0
+  RCODESIGN_SHA256: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
 
 jobs:
   macos:
@@ -49,6 +64,44 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+      # Only `sign: true` callers get here, and for them signing is not
+      # best-effort: an unsigned `ggshield` publishes fine and only shows up
+      # months later, as every upgrade re-prompting for Keychain access. Fail
+      # instead of shipping one.
+      - name: Prepare code signing
+        if: inputs.sign
+        env:
+          MACOS_P12_FILE: ${{ secrets.MACOS_P12_FILE }}
+          MACOS_P12_PASSWORD: ${{ secrets.MACOS_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MACOS_P12_FILE" ] ; then
+            echo "sign: true, but the signing secrets are not readable here" >&2
+            exit 1
+          fi
+
+          # scripts/download needs `sha256sum`, which macOS does not ship.
+          brew install coreutils
+          # Unpacked outside the checkout: `python -m build` runs on it next.
+          scripts/download \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F$RCODESIGN_VERSION/apple-codesign-$RCODESIGN_VERSION-aarch64-apple-darwin.tar.gz" \
+            "$RUNNER_TEMP/rcodesign.tar.gz" \
+            "$RCODESIGN_SHA256"
+          tar -C "$RUNNER_TEMP" --strip-components=1 -xzf "$RUNNER_TEMP/rcodesign.tar.gz"
+          cp "$RUNNER_TEMP/rcodesign" /usr/local/bin
+
+          SECRETS_DIR=$RUNNER_TEMP/secrets
+          mkdir -p "$SECRETS_DIR"
+          # The p12 is base64-encoded because it is binary.
+          echo "$MACOS_P12_FILE" | base64 --decode > "$SECRETS_DIR/cert.p12"
+          echo "$MACOS_P12_PASSWORD" > "$SECRETS_DIR/cert.pwd"
+          cat >> "$GITHUB_ENV" <<EOF
+          MACOS_P12_FILE=$SECRETS_DIR/cert.p12
+          MACOS_P12_PASSWORD_FILE=$SECRETS_DIR/cert.pwd
+          EOF
+
+      # hatch_build.py signs the binary itself, right after lipo: nothing outside
+      # the build can, because the wheel is zipped around it.
       - name: Build wheel
         env:
           GGSHIELD_BUILD_RUST: '1'
@@ -62,6 +115,11 @@ jobs:
           name: wheel-macos-universal2
           path: dist/*.whl
 
+  # Not Authenticode-signed, unlike the .msi and .zip: nothing on Windows binds a
+  # stored credential to a binary's signature the way a macOS Keychain ACL does,
+  # so the only thing signing buys the wheel is SmartScreen reputation on a
+  # binary users reach through pip rather than a download. Separate concern,
+  # separate ticket.
   windows:
     name: wheel windows-amd64
     runs-on: windows-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,25 +1,51 @@
 name: wheels
 
 concurrency:
-  group: wheels-${{ github.ref }}
+  group: wheels-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Builds the platform wheels carrying the Rust `ggshield` binary, plus the
-# pure-Python fallback wheel and the sdist. Each platform wheel is tagged
-# py3-none-<platform>: a binary but no Python extension module, so it is
-# Python-version-independent.
+# Builds the platform wheels carrying the Rust `ggshield` binary, and nothing
+# else: the sdist and the pure-Python `py3-none-any` fallback come from
+# build_release_assets.yml's `build_wheel_sdist` job. Both would otherwise emit
+# the same `ggshield-<version>-py3-none-any.whl`, and PyPI rejects a duplicate
+# file. The two sets meet again in tag.yml's `push_to_pypi`, under artifact names
+# `dist` and `wheel-*`.
+#
+# Each platform wheel is tagged py3-none-<platform>: a native binary but no
+# Python extension module, so it is Python-version-independent.
 
 on:
+  # Called by tag.yml, so a release actually publishes these. Same run as
+  # `build_wheel_sdist`, which is what lets `push_to_pypi` download both.
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches: ['**']
+  # Only the packaging inputs: nothing else changes what these wheels contain,
+  # and six jobs on every push is a lot of runner time for that.
+  pull_request:
+    paths:
+      - '.github/workflows/wheels.yml'
+      - 'hatch_build.py'
+      - 'hatch_meta.py'
+      - 'pyproject.toml'
+      - 'scripts/smoke-test-wheel'
+      - 'rust/**'
+
+env:
+  DEFAULT_PYTHON_VERSION: '3.14'
+  # Same rustup as scripts/build-os-packages/build-os-packages pins for the
+  # standalone bundles; bump both together. Checksums from
+  # https://static.rust-lang.org/rustup/archive/$RUSTUP_VERSION/$triple/rustup-init.sha256
+  RUSTUP_VERSION: 1.29.0
 
 jobs:
   macos:
     name: wheel macos-universal2
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
@@ -29,7 +55,9 @@ jobs:
         run: |
           python -m pip install --upgrade build
           python -m build --wheel --outdir dist
-      - uses: actions/upload-artifact@v4
+      - name: Smoke test the wheel
+        run: scripts/smoke-test-wheel dist/*.whl
+      - uses: actions/upload-artifact@v6
         with:
           name: wheel-macos-universal2
           path: dist/*.whl
@@ -38,7 +66,10 @@ jobs:
     name: wheel windows-amd64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Build wheel
         shell: bash
@@ -47,7 +78,10 @@ jobs:
         run: |
           python -m pip install --upgrade build
           python -m build --wheel --outdir dist
-      - uses: actions/upload-artifact@v4
+      - name: Smoke test the wheel
+        shell: bash
+        run: scripts/smoke-test-wheel dist/*.whl
+      - uses: actions/upload-artifact@v6
         with:
           name: wheel-windows-amd64
           path: dist/*.whl
@@ -63,56 +97,65 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Images are digest-pinned: `latest` is rebuilt several times a week, and
+        # the whole point of building here is a reproducible libc floor. Bump the
+        # tag and the digest together.
         include:
           - {
               runs-on: ubuntu-latest,
-              image: 'quay.io/pypa/manylinux2014_x86_64',
+              image: 'quay.io/pypa/manylinux2014_x86_64:2026.08.08-1@sha256:0a42cb7e5f4ba6bbfb8d0a86d1aab0c8876ba9c3be16bd99360ae42bf010ec77',
               tag: manylinux2014_x86_64,
+              rustup_triple: x86_64-unknown-linux-gnu,
+              rustup_sha256: 4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10,
             }
           - {
               runs-on: ubuntu-24.04-arm,
-              image: 'quay.io/pypa/manylinux2014_aarch64',
+              image: 'quay.io/pypa/manylinux2014_aarch64:2026.08.08-1@sha256:63bfa74be47f0277e998cb7c1b571b27664ac848bb356b0f4588438f930285dd',
               tag: manylinux2014_aarch64,
+              rustup_triple: aarch64-unknown-linux-gnu,
+              rustup_sha256: 9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792,
             }
           - {
               runs-on: ubuntu-latest,
-              image: 'quay.io/pypa/musllinux_1_2_x86_64',
+              image: 'quay.io/pypa/musllinux_1_2_x86_64:2026.08.08-1@sha256:b06e331e36f400fa1529b4dd2ee37016f2828422b2e5d054a66257fcf4535697',
               tag: musllinux_1_2_x86_64,
+              rustup_triple: x86_64-unknown-linux-musl,
+              rustup_sha256: 9cd3fda5fd293890e36ab271af6a786ee22084b5f6c2b83fd8323cec6f0992c1,
             }
           - {
               runs-on: ubuntu-24.04-arm,
-              image: 'quay.io/pypa/musllinux_1_2_aarch64',
+              image: 'quay.io/pypa/musllinux_1_2_aarch64:2026.08.08-1@sha256:23371d5e69a9c90f17d8b36571204c7164c8fac0685725d05696aa8fd607f43b',
               tag: musllinux_1_2_aarch64,
+              rustup_triple: aarch64-unknown-linux-musl,
+              rustup_sha256: 88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759,
             }
     steps:
-      - uses: actions/checkout@v4
-      - name: Build and relabel wheel in ${{ matrix.image }}
+      - uses: actions/checkout@v5
+      - name: Build, relabel and smoke test the wheel in ${{ matrix.tag }}
         run: |
           docker run --rm -v "$PWD:/io" -w /io -e GGSHIELD_BUILD_RUST=1 \
             "${{ matrix.image }}" bash -euo pipefail -c '
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+              # A pinned, checksum-verified rustup-init, not `curl | sh`.
+              # --default-toolchain none: rust/rust-toolchain.toml pins it.
+              scripts/download \
+                "https://static.rust-lang.org/rustup/archive/${{ env.RUSTUP_VERSION }}/${{ matrix.rustup_triple }}/rustup-init" \
+                /tmp/rustup-init \
+                "${{ matrix.rustup_sha256 }}"
+              chmod +x /tmp/rustup-init
+              /tmp/rustup-init -y --profile minimal --default-toolchain none \
+                --no-modify-path
               source "$HOME/.cargo/env"
-              git config --global --add safe.directory "*"
+
               PY=/opt/python/cp311-cp311/bin/python
               "$PY" -m pip install --upgrade build wheel
               "$PY" -m build --wheel --outdir dist_raw
               "$PY" -m wheel tags --remove \
                 --platform-tag "${{ matrix.tag }}" dist_raw/*.whl
               mkdir -p dist && mv dist_raw/*.whl dist/
+
+              PYTHON="$PY" scripts/smoke-test-wheel dist/*.whl
             '
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.tag }}
           path: dist/*.whl
-
-  # The universal fallback: pure py3-none-any wheel + sdist, no Rust.
-  pure:
-    name: pure wheel + sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: pipx run build --outdir dist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pure-and-sdist
-          path: dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,10 +49,10 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        # Scoped to scripts/install: the repo's other shell scripts
-        # (docker/, scripts/check-import-linter-config.sh) have pre-existing
-        # findings that are out of scope here.
-        files: ^scripts/install/.*\.sh$
+        # Opt-in, not repo-wide: the other shell scripts (docker/,
+        # scripts/check-import-linter-config.sh) have pre-existing findings that
+        # are out of scope here.
+        files: ^scripts/(install/.*\.sh|smoke-test-wheel)$
 
   - repo: https://github.com/thlorenz/doctoc
     rev: v2.2.0

--- a/changelog.d/20260806_120000_achille.mascia_ai_hook_wheel.md
+++ b/changelog.d/20260806_120000_achille.mascia_ai_hook_wheel.md
@@ -1,0 +1,5 @@
+- `pip`/`pipx` installs now ship the native Rust `ggshield` on common platforms
+  (Linux x86-64/aarch64 for glibc and musl, macOS universal2, Windows x86-64); the Python implementation is installed
+  alongside as `ggshield-py`. Platforms without a native wheel fall back to the
+  pure-Python wheel, where `ggshield` is the Python entry point — as does
+  Homebrew, which builds from the source distribution.

--- a/doc/dev/os-packages.md
+++ b/doc/dev/os-packages.md
@@ -70,6 +70,8 @@ Although PyInstaller supports signing, it did not work at the time we tried it, 
 
 For Gatekeeper to accept the app, the executable and all the dynamic libraries must be signed, as well as the .pkg archive itself. Signing the executable and the libraries is done by the `sign` step, whereas signing the .pkg archive is done by the `create_archive` step.
 
+The `rcodesign` invocation lives in its own script, `scripts/build-os-packages/macos-sign-file`, because the macOS wheel signs the same `ggshield` from Python (`hatch_build.py`). Both must produce the same designated requirement, or a Keychain grant given to one artifact does not apply to the other.
+
 [rcodesign]: https://gregoryszorc.com/docs/apple-codesign/
 
 ## Windows specific information

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -63,17 +63,17 @@ def build_hook_command() -> str:
 
     How the path is recovered depends on the launch:
 
-    - Frozen standalone bundle (``.pkg``/``.deb``/``.rpm``): the ``ggshield``
-      dispatcher sitting next to ``sys.executable``, when there is one.
-      PyInstaller derives ``sys.executable`` from the OS, so under the Rust
-      dispatcher it names the internal ``ggshield-py`` launcher — correct to run,
-      but it would bypass the dispatcher and pay the Python startup on every
-      call. Older bundles with no dispatcher keep using ``sys.executable``.
+    - Frozen standalone bundle (``.pkg``/``.deb``/``.rpm``): ``sys.executable``.
+      PyInstaller derives it from the OS, so under the Rust dispatcher it names
+      the internal ``ggshield-py`` launcher.
     - Bare name (``ggshield``, the pip/pipx/Homebrew case): the shell does not
       absolutize ``sys.argv[0]``, so resolve it against PATH with
       ``shutil.which``.
     - Explicit or relative path (``/opt/homebrew/bin/ggshield``,
       ``./ggshield``): ``abspath``.
+
+    Whatever comes out, a sibling ``ggshield`` dispatcher wins over it — see
+    :func:`_prefer_dispatcher_sibling`.
 
     Symlinks are left unresolved in the code paths that see them: the
     pip/pipx/Homebrew cases go through ``shutil.which``/``abspath``, which do not
@@ -92,17 +92,9 @@ def build_hook_command() -> str:
 
 def hook_executable() -> str:
     """The ggshield binary the hook should run. See `build_hook_command`."""
-    if getattr(sys, "frozen", False):
+    frozen = getattr(sys, "frozen", False)
+    if frozen:
         executable = sys.executable
-        dispatcher = os.path.join(
-            os.path.dirname(executable),
-            "ggshield" + (".exe" if os.name == "nt" else ""),
-        )
-        if os.path.normpath(dispatcher) != os.path.normpath(executable) and os.access(
-            dispatcher, os.X_OK
-        ):
-            executable = dispatcher
-        executable = _stable_launcher(executable)
     else:
         argv0 = sys.argv[0]
         if os.path.dirname(argv0):
@@ -111,6 +103,35 @@ def hook_executable() -> str:
             # On a PATH miss fall back to abspath, never sys.executable
             # (the Python interpreter, not ggshield).
             executable = shutil.which(argv0) or os.path.abspath(argv0)
+    executable = _prefer_dispatcher_sibling(executable)
+    # The stable launcher points at the dispatcher, so it can only match once
+    # the sibling preference has run. Only the frozen path needs it: elsewhere
+    # the path never went through a symlink resolution.
+    return _stable_launcher(executable) if frozen else executable
+
+
+def _prefer_dispatcher_sibling(executable: str) -> str:
+    """Return the Rust ``ggshield`` dispatcher next to ``executable``, if any.
+
+    Every install that ships the dispatcher puts it next to the Python entry
+    point, under the two names ``ggshield`` and ``ggshield-py``: the standalone
+    bundles (where PyInstaller's ``sys.executable`` is the ``ggshield-py``
+    launcher) and the platform wheels (where ``ggshield`` execs ``ggshield-py``,
+    so by the time Python runs, ``sys.argv[0]`` is ``ggshield-py`` too). Writing
+    that Python path into the hook works, but pays the whole Python startup on
+    every agent tool call — the one cost the dispatcher exists to remove.
+
+    Installs with no dispatcher (pure wheel, older bundles) keep ``executable``:
+    there, it already *is* ``ggshield``.
+    """
+    dispatcher = os.path.join(
+        os.path.dirname(executable),
+        "ggshield" + (".exe" if os.name == "nt" else ""),
+    )
+    if os.path.normpath(dispatcher) != os.path.normpath(executable) and os.access(
+        dispatcher, os.X_OK
+    ):
+        return dispatcher
     return executable
 
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,147 @@
+"""Embed the Rust ``ggshield`` dispatcher into a platform-specific wheel.
+
+Active only when ``GGSHIELD_BUILD_RUST=1`` (set by the wheel CI matrix);
+otherwise the build is the pure-Python ``py3-none-any`` fallback wheel. When
+active the wheel installs both ``ggshield`` (the dispatcher) and ``ggshield-py``
+(the Python entry point, renamed by hatch_meta.py), the layout the dispatcher
+expects to exec its sibling from.
+"""
+
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+# macOS wheels are universal2: the arm64 runner builds an Intel slice too and
+# lipo-fuses them, so no Intel runner is needed.
+MACOS_TARGETS = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+
+# The same two slices as MACOS_TARGETS, spelled the way `lipo -archs` spells them
+# (`arm64`, not `aarch64`).
+MACOS_ARCHS = {"arm64", "x86_64"}
+
+# ELF `e_machine` values, as they are spelled in a wheel platform tag.
+ELF_MACHINES = {62: "x86_64", 183: "aarch64"}
+
+
+class WrongBinaryError(Exception):
+    """The built binary does not match the platform tag we are about to write."""
+
+
+class RustDispatcherBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "ggshield-rust"
+
+    def initialize(self, version, build_data):
+        if os.environ.get("GGSHIELD_BUILD_RUST") != "1":
+            return
+
+        crate = Path(self.root) / "rust"
+        name = "ggshield" + (".exe" if sys.platform == "win32" else "")
+        binary = crate / "target" / "release" / name
+
+        # Unconditionally, never `if not binary.exists()`: a leftover
+        # target/release/ggshield from another arch -- or another OS -- is
+        # indistinguishable from a fresh one by existence alone, and cargo is
+        # nearly free when the artifact is already current.
+        self._build(crate, binary)
+
+        # A native binary but no Python extension module: platform-specific yet
+        # valid for any Python 3 -> py3-none-<platform>. (Linux relabels the raw
+        # linux_* tag to manylinux/musllinux in CI.)
+        build_data["pure_python"] = False
+        build_data["tag"] = f"py3-none-{self._platform_tag(binary)}"
+        build_data["shared_scripts"][str(binary)] = name
+
+    def _platform_tag(self, binary: Path) -> str:
+        """The wheel's platform tag, checked against what ``binary`` really is.
+
+        Cargo decides freshness from its fingerprint database and dependency
+        mtimes, not from the content of the output file, so an artifact that was
+        replaced behind its back is reported as "Finished" and shipped as-is.
+        Reading the binary is the only way the tag and the payload cannot
+        disagree; a mismatch is a build failure, not a wheel.
+        """
+        if sys.platform == "darwin":
+            # Not sysconfig: it reports the building interpreter's own arch
+            # (`_arm64` under an arm64 Python), not the universal2 we lipo.
+            archs = subprocess.run(
+                ["lipo", "-archs", str(binary)],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.split()
+            if set(archs) != MACOS_ARCHS:
+                raise WrongBinaryError(
+                    f"{binary} holds {archs or ['nothing']}, not the "
+                    f"{sorted(MACOS_ARCHS)} macosx_11_0_universal2 promises"
+                )
+            return "macosx_11_0_universal2"
+
+        plat = sysconfig.get_platform().replace("-", "_").replace(".", "_")
+        if sys.platform.startswith("linux"):
+            self._verify_elf(binary, plat)
+        # No equivalent check on Windows: reading the PE machine field means
+        # following e_lfanew, and the unconditional build above already rules
+        # out the stale-artifact case the ELF/lipo checks exist for.
+        return plat
+
+    @staticmethod
+    def _verify_elf(binary: Path, plat: str) -> None:
+        with binary.open("rb") as fp:
+            header = fp.read(20)
+        if header[:4] != b"\x7fELF":
+            raise WrongBinaryError(
+                f"{binary} is not an ELF binary (magic {header[:4]!r}), "
+                f"so it cannot go in a {plat} wheel"
+            )
+        # Little-endian read: both machines we ship are, and a big-endian header
+        # reads as an unknown value here, which fails below -- correctly.
+        machine = ELF_MACHINES.get(int.from_bytes(header[18:20], "little"))
+        if machine is None or not plat.endswith(machine):
+            raise WrongBinaryError(
+                f"{binary} is an ELF for {machine or 'an unsupported machine'}, "
+                f"which does not match the {plat} wheel tag"
+            )
+
+    def _build(self, crate: Path, binary: Path) -> None:
+        # --locked: build the dependency versions committed in rust/Cargo.lock,
+        # not whatever resolves today.
+        if sys.platform == "darwin":
+            for target in MACOS_TARGETS:
+                # cwd=crate: add the target to the toolchain pinned by
+                # rust-toolchain.toml, which is the one cargo below uses.
+                subprocess.run(
+                    ["rustup", "target", "add", target], cwd=crate, check=True
+                )
+                subprocess.run(
+                    [
+                        "cargo",
+                        "build",
+                        "--release",
+                        "--locked",
+                        "--target",
+                        target,
+                        "--bin",
+                        "ggshield",
+                    ],
+                    cwd=crate,
+                    check=True,
+                )
+            binary.parent.mkdir(parents=True, exist_ok=True)
+            slices = [
+                str(crate / "target" / t / "release" / "ggshield")
+                for t in MACOS_TARGETS
+            ]
+            subprocess.run(
+                ["lipo", "-create", "-output", str(binary), *slices], check=True
+            )
+        else:
+            subprocess.run(
+                ["cargo", "build", "--release", "--locked", "--bin", "ggshield"],
+                cwd=crate,
+                check=True,
+            )

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -107,6 +107,25 @@ class RustDispatcherBuildHook(BuildHookInterface):
                 f"which does not match the {plat} wheel tag"
             )
 
+    def _sign(self, binary: Path) -> None:
+        """Code-sign the fused binary, when the build was given a certificate.
+
+        On the fused file rather than the slices: one signature covers both, and
+        cargo leaves the x86_64 slice unsigned altogether.
+
+        Unsigned -- local builds and PRs from forks, neither of which can read the
+        secrets -- the wheel still installs and runs. What it loses is a stable
+        designated requirement: an ad-hoc signature carries no signing identity,
+        so the requirement degenerates to the binary's cdhash, which changes on
+        every build. That requirement is what a Keychain item's ACL records, so
+        the grant the user gives `ggshield` for the API token stops matching on
+        the next upgrade.
+        """
+        if not os.environ.get("MACOS_P12_FILE"):
+            return
+        script = Path(self.root) / "scripts/build-os-packages/macos-sign-file"
+        subprocess.run([str(script), str(binary)], check=True)
+
     def _build(self, crate: Path, binary: Path) -> None:
         # --locked: build the dependency versions committed in rust/Cargo.lock,
         # not whatever resolves today.
@@ -139,6 +158,7 @@ class RustDispatcherBuildHook(BuildHookInterface):
             subprocess.run(
                 ["lipo", "-create", "-output", str(binary), *slices], check=True
             )
+            self._sign(binary)
         else:
             subprocess.run(
                 ["cargo", "build", "--release", "--locked", "--bin", "ggshield"],

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -108,23 +108,34 @@ class RustDispatcherBuildHook(BuildHookInterface):
             )
 
     def _sign(self, binary: Path) -> None:
-        """Code-sign the fused binary, when the build was given a certificate.
+        """Code-sign the binary, when the build was given a certificate.
 
-        On the fused file rather than the slices: one signature covers both, and
-        cargo leaves the x86_64 slice unsigned altogether.
+        On macOS this is the fused file rather than the slices: one signature
+        covers both, and cargo leaves the x86_64 slice unsigned altogether.
 
         Unsigned -- local builds and PRs from forks, neither of which can read the
-        secrets -- the wheel still installs and runs. What it loses is a stable
-        designated requirement: an ad-hoc signature carries no signing identity,
-        so the requirement degenerates to the binary's cdhash, which changes on
-        every build. That requirement is what a Keychain item's ACL records, so
-        the grant the user gives `ggshield` for the API token stops matching on
-        the next upgrade.
+        secrets -- the wheel still installs and runs. On macOS what it loses is a
+        stable designated requirement: an ad-hoc signature carries no signing
+        identity, so the requirement degenerates to the binary's cdhash, which
+        changes on every build. That requirement is what a Keychain item's ACL
+        records, so the grant the user gives `ggshield` for the API token stops
+        matching on the next upgrade. On Windows nothing binds a stored credential
+        to a signature, so an unsigned build costs only the trust an AV or EDR
+        heuristic extends to a native executable sitting in a venv.
         """
-        if not os.environ.get("MACOS_P12_FILE"):
-            return
-        script = Path(self.root) / "scripts/build-os-packages/macos-sign-file"
-        subprocess.run([str(script), str(binary)], check=True)
+        scripts = Path(self.root) / "scripts/build-os-packages"
+        if sys.platform == "darwin":
+            if not os.environ.get("MACOS_P12_FILE"):
+                return
+            subprocess.run([str(scripts / "macos-sign-file"), str(binary)], check=True)
+        elif sys.platform == "win32":
+            if not os.environ.get("SM_API_KEY"):
+                return
+            # Through bash explicitly: Windows honours no shebang, and Git Bash is
+            # already what drives this build on the runner.
+            subprocess.run(
+                ["bash", str(scripts / "windows-sign-file"), str(binary)], check=True
+            )
 
     def _build(self, crate: Path, binary: Path) -> None:
         # --locked: build the dependency versions committed in rust/Cargo.lock,
@@ -165,3 +176,4 @@ class RustDispatcherBuildHook(BuildHookInterface):
                 cwd=crate,
                 check=True,
             )
+            self._sign(binary)

--- a/hatch_meta.py
+++ b/hatch_meta.py
@@ -1,0 +1,23 @@
+"""The console script name the wheel installs.
+
+A platform wheel ships the Rust dispatcher as ``ggshield``, so the Python entry
+point moves to ``ggshield-py`` -- the name the dispatcher execs, and the same
+two-name layout the standalone bundle uses. The pure wheel keeps ``ggshield`` as
+the Python entry point.
+"""
+
+import os
+
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+
+class ScriptsMetadataHook(MetadataHookInterface):
+    PLUGIN_NAME = "ggshield-scripts"
+
+    def update(self, metadata):
+        name = (
+            "ggshield-py"
+            if os.environ.get("GGSHIELD_BUILD_RUST") == "1"
+            else "ggshield"
+        )
+        metadata["scripts"] = {name: "ggshield.__main__:main"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ggshield"
-dynamic = ["version"]
+dynamic = ["version", "scripts"]
 description = "Detect secrets from all sources using GitGuardian's brains"
 keywords = [
     "cli",
@@ -73,15 +73,26 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/GitGuardian/ggshield"
 
-[project.scripts]
-ggshield = "ggshield.__main__:main"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
 path = "ggshield/__init__.py"
+
+# `ggshield` is the Rust dispatcher and the Python entry point is `ggshield-py`
+# when GGSHIELD_BUILD_RUST=1 (the wheel CI matrix); otherwise `ggshield` is the
+# Python entry point. See hatch_meta.py / hatch_build.py.
+[tool.hatch.metadata.hooks.custom]
+path = "hatch_meta.py"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
+# The Rust sources are needed only to build the platform wheels (from the repo,
+# in CI); keep them out of the sdist so an sdist install stays pure Python.
+[tool.hatch.build.targets.sdist]
+exclude = ["rust"]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/scripts/build-os-packages/macos-functions.bash
+++ b/scripts/build-os-packages/macos-functions.bash
@@ -1,5 +1,7 @@
 MACOS_P12_FILE=${MACOS_P12_FILE:-}
 MACOS_P12_PASSWORD_FILE=${MACOS_P12_PASSWORD_FILE:-}
+# macos-sign-file is a separate process: without this it sees neither.
+export MACOS_P12_FILE MACOS_P12_PASSWORD_FILE
 
 # Path to a file used by rcodesign for notarizing.
 # Follow the instructions from
@@ -37,40 +39,11 @@ macos_sign() {
     done
 }
 
-# $1 is the file to sign, $2 an optional entitlements plist.
+# $1 is the file to sign, $2 an optional entitlements plist. The invocation lives
+# in macos-sign-file, shared with the macOS wheel build.
 macos_sign_file() {
     check_var MACOS_P12_FILE
-
-    local file entitlements
-    file="$1"
-    entitlements="${2:-}"
-    info "- Signing $file${entitlements:+ (with entitlements)}"
-
-    local args=(
-        --p12-file "$MACOS_P12_FILE"
-        --p12-password-file "$MACOS_P12_PASSWORD_FILE"
-        --code-signature-flags runtime
-        --for-notarization
-    )
-    if [ -n "$entitlements" ] ; then
-        args+=(--entitlements-xml-path "$entitlements")
-    fi
-
-    # Left alone, rcodesign keeps the ad-hoc identifier the linker left in the
-    # Mach-O, which carries a per-build hash: 1.53.0 shipped as
-    # `ggshield-55554944c60d09a76c903cb78828e61396fa0721`. The identifier is part
-    # of the designated requirement, and the designated requirement is what a
-    # Keychain item's ACL records when the user clicks "Always Allow" — so a
-    # per-build identifier means the grant stops matching on the next release and
-    # every upgrade re-prompts for the token. Both launchers read the token, so
-    # both need a stable one; libraries keep their own, they are never the
-    # process asking for the secret.
-    case "$(basename "$file")" in
-        ggshield)    args+=(--binary-identifier com.gitguardian.ggshield) ;;
-        ggshield-py) args+=(--binary-identifier com.gitguardian.ggshield-py) ;;
-    esac
-
-    rcodesign sign "${args[@]}" "$file"
+    "$SCRIPT_DIR/macos-sign-file" "$@"
 }
 
 # Every Mach-O in the bundle, because notarization rejects the .pkg if a single

--- a/scripts/build-os-packages/macos-sign-file
+++ b/scripts/build-os-packages/macos-sign-file
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Code-sign one Mach-O with the GitGuardian Developer ID certificate.
+#
+# A script rather than a function in macos-functions.bash because the macOS wheel
+# signs from Python (hatch_build.py) and the standalone bundle from bash: the
+# `ggshield` in both is the same dispatcher reading the same Keychain item, so
+# both must produce the same designated requirement — one invocation, one set of
+# identifiers.
+#
+# $1 is the file to sign, $2 an optional entitlements plist. $MACOS_P12_FILE and
+# $MACOS_P12_PASSWORD_FILE must point to the certificate and to its password.
+set -euo pipefail
+
+file="${1:?usage: $0 FILE [ENTITLEMENTS]}"
+entitlements="${2:-}"
+if [ -z "${MACOS_P12_FILE:-}" ] || [ -z "${MACOS_P12_PASSWORD_FILE:-}" ] ; then
+    echo "$0: MACOS_P12_FILE and MACOS_P12_PASSWORD_FILE must be set" >&2
+    exit 1
+fi
+
+echo "- Signing $file${entitlements:+ (with entitlements)}"
+
+args=(
+    --p12-file "$MACOS_P12_FILE"
+    --p12-password-file "$MACOS_P12_PASSWORD_FILE"
+    --code-signature-flags runtime
+    --for-notarization
+)
+if [ -n "$entitlements" ] ; then
+    args+=(--entitlements-xml-path "$entitlements")
+fi
+
+# Left alone, rcodesign keeps the ad-hoc identifier the linker left in the
+# Mach-O, which carries a per-build hash: 1.53.0 shipped as
+# `ggshield-55554944c60d09a76c903cb78828e61396fa0721`. The identifier is part of
+# the designated requirement, and the designated requirement is what a Keychain
+# item's ACL records when the user clicks "Always Allow" — so a per-build
+# identifier means the grant stops matching on the next release and every upgrade
+# re-prompts for the token. Both launchers read the token, so both need a stable
+# one; libraries keep their own, they are never the process asking for the secret.
+identifier=""
+case "$(basename "$file")" in
+    ggshield)    identifier=com.gitguardian.ggshield ;;
+    ggshield-py) identifier=com.gitguardian.ggshield-py ;;
+esac
+[ -z "$identifier" ] || args+=(--binary-identifier "$identifier")
+
+rcodesign sign "${args[@]}" "$file"
+
+# A wrong identifier signs, notarizes and installs perfectly happily; it only
+# surfaces later as a re-prompt on upgrade. Check the one thing the ACL depends on.
+if [ -n "$identifier" ] ; then
+    # --verbose, or codesign prints only the path. Everything goes to stderr.
+    signed_as=$(codesign --display --verbose "$file" 2>&1 | sed -n 's/^Identifier=//p')
+    if [ "$signed_as" != "$identifier" ] ; then
+        echo "FAIL: $file is signed as '$signed_as', not $identifier" >&2
+        exit 1
+    fi
+fi

--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -26,31 +26,13 @@ windows_sign() {
     done
 }
 
-# smctl rejects any path holding a character signtool does not support, `+`
-# among them, and our "X.Y.Z+sha" builds put one in the archive directory name.
-# So sign a copy placed under a name built from safe characters only, then move
-# the signed bytes back to the original path.
+# $1 is the file to sign. The invocation lives in windows-sign-file, shared with
+# the Windows wheel build.
 windows_sign_file() {
-    local path="$1"
-    local base="${path##*/}"
-
-    # Under $BUILD_DIR rather than $TMPDIR: the runner's temp path is outside
-    # our control and signtool's accepted set is narrow, while $BUILD_DIR is the
-    # directory every release has already signed from.
-    local tmp_dir
-    tmp_dir=$(mktemp -d "$BUILD_DIR/sign.XXXXXX")
-    local tmp_path="$tmp_dir/${base//[^A-Za-z0-9._-]/_}"
-    cp "$path" "$tmp_path"
-
-    smctl sign \
-        --verbose \
-        --exit-non-zero-on-fail \
-        --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
-        --tool signtool \
-        --input "$tmp_path"
-
-    mv "$tmp_path" "$path"
-    rm -rf "$tmp_dir"
+    # Staged under $BUILD_DIR rather than $TMPDIR: the runner's temp path is
+    # outside our control and signtool's accepted set is narrow, while $BUILD_DIR
+    # is the directory every release has already signed from.
+    "$SCRIPT_DIR/windows-sign-file" "$1" "$BUILD_DIR"
 }
 
 windows_create_archive() {

--- a/scripts/build-os-packages/windows-sign-file
+++ b/scripts/build-os-packages/windows-sign-file
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Authenticode-sign one file with the GitGuardian certificate, through DigiCert
+# KeyLocker.
+#
+# A script rather than a function in windows-functions.bash because the Windows
+# wheel signs from Python (hatch_build.py) and the standalone bundle from bash:
+# the `ggshield.exe` in both is the same dispatcher, signed with the same
+# certificate.
+#
+# $1 is the file to sign, $2 the directory to stage a copy in (see below),
+# defaulting to the file's own. $WINDOWS_CERT_FINGERPRINT and the SM_* variables
+# are what smctl needs.
+set -euo pipefail
+
+file="${1:?usage: $0 FILE [STAGING_DIR]}"
+staging_dir="${2:-$(dirname "$file")}"
+
+for var in WINDOWS_CERT_FINGERPRINT SM_API_KEY SM_HOST SM_CLIENT_CERT_FILE \
+           SM_CLIENT_CERT_PASSWORD ; do
+    if [ -z "${!var:-}" ] ; then
+        echo "$0: $var must be set" >&2
+        exit 1
+    fi
+done
+if [ ! -f "$SM_CLIENT_CERT_FILE" ] ; then
+    echo "$0: $SM_CLIENT_CERT_FILE does not exist" >&2
+    exit 1
+fi
+
+echo "- Signing $file"
+
+# smctl rejects any path holding a character signtool does not support, `+` among
+# them, and our "X.Y.Z+sha" builds put one in the archive directory name. So sign
+# a copy staged under a name built from safe characters only, then move the signed
+# bytes back. Picking the staging directory is the caller's job: it has to be free
+# of those characters itself.
+tmp_dir=$(mktemp -d "$staging_dir/sign.XXXXXX")
+base="${file##*/}"
+tmp_path="$tmp_dir/${base//[^A-Za-z0-9._-]/_}"
+cp "$file" "$tmp_path"
+
+smctl sign \
+    --verbose \
+    --exit-non-zero-on-fail \
+    --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
+    --tool signtool \
+    --input "$tmp_path"
+
+mv "$tmp_path" "$file"
+rm -rf "$tmp_dir"

--- a/scripts/download
+++ b/scripts/download
@@ -56,4 +56,6 @@ curl --fail --location \
     "$url"
 
 echo "Verifying integrity"
-echo "$sum  $filename" | sha256sum --check
+# `-c`, not `--check`: the musllinux images used to build the wheels give us
+# BusyBox's sha256sum, which takes only the short form.
+echo "$sum  $filename" | sha256sum -c

--- a/scripts/smoke-test-wheel
+++ b/scripts/smoke-test-wheel
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Install a freshly built platform wheel and prove the `ggshield` it puts on PATH
+# is the Rust dispatcher.
+#
+# Everything a wrong wheel gets wrong is invisible until something installs it:
+# a wheel carrying a stale or foreign binary, or one tagged for the wrong
+# platform, builds and uploads perfectly happily. Run this in the environment the
+# wheel claims to target (inside the manylinux/musllinux container, on the macOS
+# and Windows runners), so pip's own platform check is part of the test.
+#
+# $PYTHON overrides the interpreter (the manylinux images have no plain
+# `python`).
+set -euo pipefail
+
+wheel="${1:?usage: $0 WHEEL}"
+python="${PYTHON:-python}"
+
+venv="$(mktemp -d)/venv"
+"$python" -m venv "$venv"
+# `Scripts` on Windows, `bin` everywhere else.
+bin="$venv/bin"
+[ -d "$bin" ] || bin="$venv/Scripts"
+
+"$bin/python" -m pip install --quiet --disable-pip-version-check "$wheel"
+
+echo "--- ggshield --version"
+"$bin/ggshield" --version
+echo "--- ggshield-py --version"
+"$bin/ggshield-py" --version
+
+# Both names answer, but that alone does not say which one ran: the dispatcher
+# execs `ggshield-py`, so the two print the same thing. Hide the sibling and the
+# dispatcher says so and exits 128, where the Python console script would just
+# print its version again -- the one difference that needs no platform-specific
+# file sniffing.
+launcher="$bin/ggshield-py"
+[ -f "$launcher" ] || launcher="$launcher.exe"
+mv "$launcher" "$launcher.hidden"
+set +e
+output="$("$bin/ggshield" --version 2>&1)"
+status=$?
+set -e
+mv "$launcher.hidden" "$launcher"
+
+if [ "$status" != 128 ] ; then
+    echo "FAIL: expected exit 128 from the dispatcher, got $status: $output" >&2
+    exit 1
+fi
+case "$output" in
+    *"installation is incomplete"*) ;;
+    *)
+        echo "FAIL: '$bin/ggshield' is not the Rust dispatcher: $output" >&2
+        exit 1
+        ;;
+esac
+
+echo "OK: $wheel installs and runs the Rust dispatcher"

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -915,6 +915,34 @@ class TestBuildHookCommand:
         ):
             assert build_hook_command() == "/tmp/ggshield secret scan ai-hook"
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="asserts POSIX executable-bit / no-.exe-suffix semantics",
+    )
+    def test_wheel_install_prefers_the_dispatcher_sibling(self, tmp_path):
+        """In a platform-wheel install the user runs `ggshield` (the Rust
+        dispatcher), which execs its `ggshield-py` sibling -- so argv[0] names
+        ggshield-py by the time Python builds the hook command. Pin the hook to
+        the dispatcher, or every hook call pays the Python startup the wheel
+        shipped a native binary to avoid."""
+        launcher = tmp_path / "ggshield-py"
+        launcher.write_text("")
+        dispatcher = tmp_path / "ggshield"
+        dispatcher.write_text("")
+        dispatcher.chmod(0o755)
+        with _simulate_platform([str(launcher), "machine", "setup"], windows=False):
+            assert build_hook_command() == f"{dispatcher} secret scan ai-hook"
+
+    def test_pure_wheel_install_keeps_its_own_path(self):
+        """The pure-Python wheel installs no dispatcher: `ggshield` IS the Python
+        entry point, and the sibling lookup must not turn it into a self-exec."""
+        with _simulate_platform(
+            ["/proj/.venv/bin/ggshield", "machine", "setup"], windows=False
+        ):
+            assert (
+                build_hook_command() == "/proj/.venv/bin/ggshield secret scan ai-hook"
+            )
+
     def test_frozen_bundle_uses_sys_executable(self):
         """In a PyInstaller standalone bundle (.pkg/.deb/.rpm) the frozen binary
         IS ggshield, so sys.executable is the correct self-path -- and PATH must
@@ -986,6 +1014,20 @@ class TestBuildHookCommand:
         THEN the hook is pinned to the launcher, which survives an upgrade."""
         versioned = "/opt/gitguardian/ggshield-1.53.0/ggshield"
         with _simulate_platform(windows=False, frozen=versioned), patch(
+            "ggshield.verticals.ai.installation.os.path.realpath",
+            lambda path: versioned if path == "/usr/local/bin/ggshield" else path,
+        ):
+            assert build_hook_command() == "/usr/local/bin/ggshield secret scan ai-hook"
+
+    def test_frozen_dispatcher_bundle_prefers_the_stable_launcher(self):
+        """GIVEN a frozen bundle whose hook binary is the sibling dispatcher
+        WHEN /usr/local/bin/ggshield resolves to that dispatcher
+        THEN the launcher wins: the sibling is picked first, so the launcher has
+        the dispatcher to match against and no versioned path is written."""
+        versioned = "/opt/gitguardian/ggshield-1.53.0/ggshield"
+        with _simulate_platform(windows=False, frozen=f"{versioned}-py"), patch(
+            "ggshield.verticals.ai.installation.os.access", return_value=True
+        ), patch(
             "ggshield.verticals.ai.installation.os.path.realpath",
             lambda path: versioned if path == "/usr/local/bin/ggshield" else path,
         ):


### PR DESCRIPTION
**Stacked on #1392 — do not merge first.**

Brings the native Rust `ggshield` to `pip` / `pipx` / Homebrew installs, so the AI hook starts in milliseconds there too — not just in the OS bundles.

## How
A platform wheel installs the **same two binaries the standalone bundle does**:

| | Bundle (#1392) | Platform wheel (this PR) | Pure wheel (fallback) |
|---|---|---|---|
| `ggshield` | Rust dispatcher | **Rust dispatcher** | Python entry point |
| `ggshield-py` | PyInstaller launcher | **Python entry point** | — |

So the command a user types is always `ggshield`, and the dispatcher reuses its existing contract unchanged: commands ported to Rust run natively, everything else `exec`s the `ggshield-py` sibling. **No dispatcher change, and `build_hook_command()` keeps writing the same `<abs path>/ggshield secret scan ai-hook`.** As more commands port to Rust, the same binary handles more — no rename, no stored hook path to migrate.

- `hatch_meta.py` names the Python entry point `ggshield-py` when the binary ships, `ggshield` otherwise.
- `hatch_build.py` builds the dispatcher and tags the wheel `py3-none-<platform>`; macOS is a single **universal2** binary (arm64 + x86_64, `lipo`-fused).
- A pure `py3-none-any` wheel is the floor: on a platform with no native wheel, `ggshield` is the Python entry point as before, so `pip install ggshield` never breaks — it just runs the Python hook (same detection, slower start).
- The Rust sources stay out of the sdist, so an sdist install is pure Python.

## Coverage
Linux `manylinux2014` + `musllinux_1_2` (x86_64, aarch64), macOS `universal2`, Windows `amd64`, plus the pure wheel and sdist — built by `.github/workflows/wheels.yml` on GitHub-hosted runners.

## Validation
Matrix validated on a fork; verified end-to-end on an installed wheel: `ggshield` is the fat Rust binary, `ggshield secret scan ai-hook` runs natively, `ggshield --version` delegates to Python, `ggshield-py` works directly, and the pure wheel ships no binary with `ggshield` as the Python entry point.
