### PR TITLE
Clarify invalid API key message on scan 401

### DIFF
--- a/ggshield/core/errors.py
+++ b/ggshield/core/errors.py
@@ -220,6 +220,8 @@ def handle_api_error(detail: Detail) -> None:
         # The cached metadata/scopes check must not keep masking a revoked
         # or rotated API key within its TTL.
         auth_check_cache.invalidate()
+        if detail.detail == "Invalid API key":
+            raise click.UsageError("Invalid GitGuardian API key")
         raise click.UsageError(detail.detail)
     if detail.status_code is None:
         raise UnexpectedError(f"Scanning failed: {detail.detail}")


### PR DESCRIPTION
## Summary
Scan-time 401 errors relayed the raw API detail string, which was less clear than the existing pre-flight auth-check message.

Refs: [END-837](https://linear.app/gitguardian/issue/END-837/enhance-clarity-of-invalid-api-key-error-message-in-ggshield)

## Changes
`handle_api_error` now emits the same clear wording as the pre-flight check when the scan API itself returns a 401 with detail "Invalid API key".