### PR TITLE
fix(packaging): pin the macOS code-signing identifier

### DIFF
--- a/changelog.d/20260807_120000_achille.mascia_macos_signing_identifier.md
+++ b/changelog.d/20260807_120000_achille.mascia_macos_signing_identifier.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- On macOS, `ggshield` no longer asks for Keychain access again after every upgrade. The
+  code-signing identifier embedded a per-build hash, so the "Always Allow" grant recorded
+  for one release stopped matching the next one; it is now pinned to
+  `com.gitguardian.ggshield`. One grant made from a release built with this fix onwards
+  keeps working across upgrades.

--- a/scripts/build-os-packages/macos-functions.bash
+++ b/scripts/build-os-packages/macos-functions.bash
@@ -35,11 +35,23 @@ macos_sign_file() {
     # the entitlement goes on the `ggshield` launcher only — the bundled
     # .so/.dylib libraries inherit the process permission and don't need it.
     if [ "$(basename "$file")" = "ggshield" ] ; then
+        # `--binary-identifier` pins the code-signing identifier of the one
+        # binary that reads the login Keychain. Left alone, rcodesign keeps the
+        # identifier the linker's ad-hoc signature left in the Mach-O, which
+        # carries a per-build hash — 1.53.0 shipped as
+        # `ggshield-55554944c60d09a76c903cb78828e61396fa0721`. The identifier is
+        # part of the designated requirement, and the designated requirement is
+        # what a Keychain item's ACL records when the user clicks "Always
+        # Allow", so a per-build identifier means that grant stops matching on
+        # the very next release and every upgrade re-prompts for the token.
+        # Libraries keep their own identifiers; only the launcher is ever the
+        # process asking for the secret.
         rcodesign sign \
             --p12-file "$MACOS_P12_FILE" \
             --p12-password-file "$MACOS_P12_PASSWORD_FILE" \
             --code-signature-flags runtime \
             --entitlements-xml-path "$SCRIPT_DIR/macos-entitlements.plist" \
+            --binary-identifier com.gitguardian.ggshield \
             --for-notarization \
             "$file"
     else


### PR DESCRIPTION
Independent of the Rust work — fixes a bug in the **current** release. macOS only (Windows Credential Manager and Linux Secret Service don't bind access to code identity).

## The bug
`rcodesign` keeps whatever code-signing identifier the linker left in the Mach-O, and that identifier embeds a per-build hash. The shipped 1.53.0 is signed as:

```
Identifier=ggshield-55554944c60d09a76c903cb78828e61396fa0721
designated => identifier "ggshield-5555…0721" and anchor apple generic
              and certificate leaf[subject.OU] = N67C7J5WQ9
```

That designated requirement is exactly what a Keychain item's ACL records when access is granted. Because the identifier changes whenever the binary changes, the grant stops matching after an upgrade and macOS re-prompts for the stored token.

It's visible in the ACL: on a machine that has been through several builds, the item's *Access Control* tab lists `ggshield` three times and `ggshield-hook` twice — one dead entry per past identity, none of which match the binary now running.

Nothing chose that string: no `--binary-identifier` was ever passed, so an auto-generated default survived into the signed release (the dylibs beside it are clean — `libssl.3`, `libcrypto.3`).

## The fix
Pin the identifier of the binary that reads the Keychain to a stable `com.gitguardian.ggshield`. Libraries keep their own identifiers.

## Notes
- Grants are written at `auth login`, **not** at upgrade time, and an upgrade doesn't re-authenticate — which is why a changing identifier re-prompts even though the user already granted access.
- This change invalidates existing grants **once**; stable from then on.
- Customers who allowlist binaries in EDR/MDM *by designated requirement* may need to re-approve.
- **Merge order matters:** #1392 rewrites `macos_sign_file` into an `args=()` form and adds a second Keychain-reading binary (`ggshield-py`). When it rebases onto a main containing this PR, the pin must be carried into the new form for **both** binaries — the rebase can look clean while silently dropping it.
