### PR TITLE
fix(devx): let dev group unconditionally depend on tomli

### DIFF
--- a/changelog.d/20260811_121800_alexis.drai_make_ty_more_reliable.md
+++ b/changelog.d/20260811_121800_alexis.drai_make_ty_more_reliable.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `tomli` was added to the dev dependency group, without a marker, so dev environments always have it regardless of the
+  Python interpreter, and ty can resolve the fallback branch it insists on analyzing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,5 +178,9 @@ dev = [
     "ipython>=8.12.3",
     "ipdb>=0.13.13",
     "ty>=0.0.32",
+    # ty resolves imports against the dev environment, but targets the minimum
+    # version of `requires-python`. The `tomli` fallback of `tomllib` is therefore
+    # analyzed whatever the interpreter, so devs should install it unconditionally
+    "tomli>=2.4.0",
 ]
 standalone = ["pyinstaller==6.21.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1123,6 +1123,7 @@ dev = [
     { name = "pyright" },
     { name = "scriv", version = "1.7.0", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
     { name = "scriv", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "tomli" },
     { name = "ty" },
 ]
 standalone = [
@@ -1190,6 +1191,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright", specifier = "==1.1.367" },
     { name = "scriv", extras = ["toml"] },
+    { name = "tomli", specifier = ">=2.4.0" },
     { name = "ty", specifier = ">=0.0.32" },
 ]
 standalone = [{ name = "pyinstaller", specifier = "==6.21.0" }]


### PR DESCRIPTION
## Context

Fixes #1393

`ty` fails in pre-commit on a fresh venv for any developer running Python 3.11 or later, with a diagnostic unrelated to what they are committing:

```
(.venv)$ uv run pre-commit run --show-diff-on-failure --all-files
black....................................................................Passed
flake8...................................................................Passed
[...]
error[unresolved-import]: Cannot resolve imported module `tomli`
  --> ggshield/verticals/ai/models.py:19:12
   |
19 |     import tomli as tomllib
   |            ^^^^^^^^^^^^^^^^
   |
info: Searched in the following paths during module resolution:
info:   1. /path/to/repo/ggshield (first-party code)
info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
info:   3. /path/to/repo/ggshield/.venv/lib/python3.14/site-packages (site-packages)
info:   4. /path/to/repo/ggshield/.venv/lib64/python3.14/site-packages (site-packages)
info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment

Found 1 diagnostic
```

This is a devX regression from bd43a5f6, which added a `python_version < "3.11"` marker to the `tomli` runtime dependency.

The marker itself is correct: `../ggshield/verticals/ai/models.py` only needs `tomli` on old interpreters, since it reads TOML through the usual fallback.

```python
if sys.version_info >= (3, 11):
    import tomllib
else:
    import tomli as tomllib
```

It is wrong for type checking, though. I think `ty` resolves imports against the environment it finds, but targets the *minimum* version of `requires-python`, while `uv sync` uses what the local interpreter uses. The import is checked, the package is absent (as it should be), the hook fails.

The task's outcome therefore depends on the dev's local Python version rather than on the code.

## What has been done

This is the fix proposed in the issue.

- **Add `tomli` to the `dev` dependency group, without a marker**, so the development environment always has it regardless of the interpreter, and `ty` can resolve the fallback branch it insists on analyzing
- **Keep the runtime dependency untouched.** The marker bd43a5f6 introduced is still correct: released packages must not pull `tomli` on Python 3.11+. Only the dev environment gains the unconditional one
- **Update `../uv.lock`** accordingly

## Validation

On a Python 3.11 or later interpreter.

- Reproduce, from `main`: a fresh venv, then the full hook run

  ```sh
  rm -rf .venv && uv venv .venv && source .venv/bin/activate
  uv sync --all-groups
  uv run pre-commit run --show-diff-on-failure --all-files
  ```

 `ty` fails with `unresolved-import` on `models.py:19`

- Validate, from this branch: same steps → `ty` passes

## PR check list

- [x] All tests pass
- [x] Linters are happy
- _Changes include tests_ — not applicable, this only changes the development environment
- _PR has a changelog entry_ — not applicable, nothing changes for ggshield users
