### PR TITLE
fix(ai-hook): never create incidents from the AI hook

### DIFF
--- a/changelog.d/20260810_120000_achille.mascia_ai_hook_no_incidents.md
+++ b/changelog.d/20260810_120000_achille.mascia_ai_hook_no_incidents.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The AI hooks no longer create incidents on your dashboard when `secret.source_uuid` is set
+  in your configuration (a setting shared with CI scanning): a hook event is not a source
+  scan, and every prompt and every file the agent read was creating an incident. They also
+  now always scan with `all_secrets`, so they can block on a secret that is already known to
+  GitGuardian instead of letting it through.

--- a/ggshield/cmd/secret/scan/ai_hook.py
+++ b/ggshield/cmd/secret/scan/ai_hook.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import replace
 from typing import Any
 
 import click
@@ -59,7 +60,10 @@ def ai_hook_cmd(
                 command_path=ctx.command_path,
                 extra_headers=build_agent_headers(stdin_content),
             ),
-            secret_config=config.user_config.secret,
+            # The hook always scans and never creates incidents: source_uuid
+            # would route it to scan_and_create_incidents, which cannot request
+            # `all_secrets`. Other commands keep it.
+            secret_config=replace(config.user_config.secret, source_uuid=None),
         )
         return AIHookScanner(scanner).scan(stdin_content)
     except ValueError as e:

--- a/ggshield/verticals/ai/cache.py
+++ b/ggshield/verticals/ai/cache.py
@@ -75,7 +75,9 @@ def config_fingerprint(secret_config: SecretConfig) -> str:
     - all_secrets moves locally-ignored breaks into `secrets` instead of
       `ignored_secrets_count_by_kind`, which is the guard that decides whether a
       verdict is cacheable at all
-    - source_uuid switches the endpoint to scan_and_create_incidents
+    - source_uuid switches the endpoint to scan_and_create_incidents; the hook
+      clears it, so it is constant today, but stays in the key so a verdict from
+      an older ggshield is never served here
 
     The ignore settings (ignored_matches, ignored_detectors,
     ignore_known_secrets) are deliberately absent: a verdict that depended on

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -3,14 +3,18 @@ from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
 import click
+import pytest
 from click.testing import CliRunner
+from pygitguardian.config import DOCUMENT_SIZE_THRESHOLD_BYTES, MAXIMUM_PAYLOAD_SIZE
 from pygitguardian.models import (
     AgentInfo,
     AIDiscovery,
     MCPConfiguration,
     MCPServer,
-    UserInfo,
+    MultiScanResult,
 )
+from pygitguardian.models import ScanResult as ApiScanResult
+from pygitguardian.models import UserInfo
 
 from ggshield.__main__ import cli
 from ggshield.cmd.ai.discover import print_summary
@@ -29,6 +33,33 @@ CLAUDE_PRE_TOOL_USE_PAYLOAD = json.dumps(
         "tool_input": {"command": "echo hello"},
     }
 )
+
+
+SOURCE_UUID = "11111111-1111-1111-1111-111111111111"
+
+
+def _scanning_client() -> MagicMock:
+    """A client that answers every scan with "nothing found"."""
+    client = MagicMock()
+    # The verdict cache key is built from both, and joins them as strings.
+    client.base_uri = "https://api.example.com"
+    client.api_key = "some-api-key"
+    client.maximum_payload_size = MAXIMUM_PAYLOAD_SIZE
+    client.secret_scan_preferences.maximum_document_size = DOCUMENT_SIZE_THRESHOLD_BYTES
+    client.secret_scan_preferences.maximum_documents_per_scan = 20
+
+    def multi_content_scan(documents, *args, **kwargs):
+        result = MultiScanResult(
+            [
+                ApiScanResult(policy_break_count=0, policy_breaks=[], policies=[])
+                for _ in documents
+            ]
+        )
+        result.status_code = 200
+        return result
+
+    client.multi_content_scan.side_effect = multi_content_scan
+    return client
 
 
 def _user():
@@ -213,6 +244,79 @@ class TestAiHookCmd:
         )
 
         assert result.exit_code == 1
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [[], ["--source-uuid", SOURCE_UUID]],
+        ids=["without-source-uuid", "with-source-uuid"],
+    )
+    @patch("ggshield.verticals.secret.secret_scanner.check_client_api_key")
+    @patch("ggshield.cmd.secret.scan.ai_hook.create_client_from_config")
+    def test_hook_never_creates_incidents(
+        self,
+        mock_create_client: MagicMock,
+        mock_check_api_key: MagicMock,
+        extra_args: List[str],
+    ):
+        """GIVEN `secret.source_uuid` set (or not)
+        WHEN the AI hook scans
+        THEN it scans with multi_content_scan and all_secrets, and never creates
+        incidents: scan_and_create_incidents cannot request all_secrets, which the
+        hook needs to block on an already-known secret."""
+        client = _scanning_client()
+        mock_create_client.return_value = client
+
+        result = CliRunner().invoke(
+            cli,
+            ["secret", "scan", "ai-hook", *extra_args],
+            input=CLAUDE_PRE_TOOL_USE_PAYLOAD,
+        )
+
+        assert result.exit_code == 0
+        client.scan_and_create_incidents.assert_not_called()
+        client.multi_content_scan.assert_called_once()
+        assert client.multi_content_scan.call_args.kwargs["all_secrets"] is True
+
+    @patch("ggshield.cmd.secret.scan.ai_hook.AIHookScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.SecretScanner")
+    @patch("ggshield.cmd.secret.scan.ai_hook.create_client_from_config")
+    def test_only_source_uuid_is_dropped_from_the_config(
+        self,
+        mock_client: MagicMock,
+        mock_scanner_cls: MagicMock,
+        mock_hook_scanner: MagicMock,
+    ):
+        """GIVEN a config where source_uuid sits next to other secret settings
+        WHEN the AI hook builds its scanner
+        THEN only source_uuid is cleared; every other setting reaches the scanner."""
+        mock_hook_scanner.return_value.scan.return_value = 0
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "secret",
+                "scan",
+                "ai-hook",
+                "--source-uuid",
+                SOURCE_UUID,
+                "--ignore-known-secrets",
+                "--all-secrets",
+                "--show-secrets",
+                "--filename-only",
+                "--banlist-detector",
+                "dummy_detector",
+            ],
+            input=CLAUDE_PRE_TOOL_USE_PAYLOAD,
+        )
+
+        assert result.exit_code == 0
+        secret_config = mock_scanner_cls.call_args.kwargs["secret_config"]
+        assert secret_config.source_uuid is None
+        assert secret_config.ignore_known_secrets is True
+        assert secret_config.all_secrets is True
+        assert secret_config.show_secrets is True
+        assert secret_config.filename_only is True
+        assert secret_config.ignored_detectors == {"dummy_detector"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Independent of the Rust work — fixes two live bugs in the **current** AI hook.

`secret.source_uuid` is a shared `.gitguardian.yaml` setting (also written by `--source-uuid`), so anyone using it for CI scanning silently changes the AI hook too. Today that means:

1. **The hook creates a dashboard incident for every prompt and every file the agent reads.** Almost certainly not the intent.
2. **The hook loses `all_secrets`.** `scan_and_create_incidents` has no `all_secrets` parameter, but the hook needs it to see already-known secrets and apply its own ignore policy — so it can fail to block on a secret it should block on.
3. **A token without `scan:create_incidents` makes the hook fail open on every event.** `SecretScanner.__init__` → `get_required_token_scopes_from_config` adds that scope when `source_uuid` is set, so the API-key check fails and nothing gets scanned.

## The fix
One line, at the only place the hook's scanner is constructed:

```python
secret_config=replace(config.user_config.secret, source_uuid=None),
```

Cleared **only** on the hook path. `secret_scanner.py` is untouched, so every other scan command keeps `scan_and_create_incidents` — covered by the existing `test_source_uuid_is_used` and friends.

## Tests
`test_hook_never_creates_incidents[with/without-source-uuid]` drives a real `AIHookScanner` over a stub client and asserts `multi_content_scan` is called with `all_secrets=True` and `scan_and_create_incidents` is not. `test_only_source_uuid_is_dropped_from_the_config` pins that no other config field is affected. Both fail on the unfixed code.
