### PR TITLE
style(tests): fix the isort failure in test_cmd_ai

### DIFF
--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -12,9 +12,9 @@ from pygitguardian.models import (
     MCPConfiguration,
     MCPServer,
     MultiScanResult,
+    ScanResult,
+    UserInfo,
 )
-from pygitguardian.models import ScanResult as ApiScanResult
-from pygitguardian.models import UserInfo
 
 from ggshield.__main__ import cli
 from ggshield.cmd.ai.discover import print_summary
@@ -51,7 +51,7 @@ def _scanning_client() -> MagicMock:
     def multi_content_scan(documents, *args, **kwargs):
         result = MultiScanResult(
             [
-                ApiScanResult(policy_break_count=0, policy_breaks=[], policies=[])
+                ScanResult(policy_break_count=0, policy_breaks=[], policies=[])
                 for _ in documents
             ]
         )


### PR DESCRIPTION
`flake8-isort` fails on `main` in `tests/unit/verticals/ai/test_cmd_ai.py` (`I001`, `I005`) — reported by @beavuck on #1400.

Cause: `#1400` added `MultiScanResult` to the parenthesized `pygitguardian.models` import and pulled `ScanResult as ApiScanResult` into its own statement. Once the module is imported in three statements with a wrapped one first, isort wants the trailing `UserInfo` parenthesized too.

Nothing else in the file is named `ScanResult`, so the alias is dropped and both names fold into the single import. `isort`, `black`, `flake8` clean; 25 tests in the file pass.