### PR TITLE
feat(ai-hook): recognize Mistral Vibe in the native hook

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "toml",
  "ureq",
 ]
 
@@ -1435,6 +1436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1635,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1678,12 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,10 @@ ureq = { version = "3", default-features = false, features = ["rustls", "platfor
 # `@file` extraction out of user prompts — mirrors _FILE_PATH_REGEX in hooks.py.
 regex = "1"
 
+# Vibe's `config.toml`, for the MCP server names that tell a `{server}_{tool}`
+# call from one of Vibe's own tools. No `display`: we only ever read.
+toml = { version = "1", default-features = false, features = ["std", "parse", "serde"] }
+
 # Payload debounce hash + the content identifier, both sha256 in the Python.
 sha2 = "0.10"
 

--- a/rust/config/src/user_config.rs
+++ b/rust/config/src/user_config.rs
@@ -211,7 +211,7 @@ impl RawUserConfig {
     }
 }
 
-fn home_dir() -> Option<PathBuf> {
+pub fn home_dir() -> Option<PathBuf> {
     if let Ok(dir) = std::env::var("GG_USER_HOME_DIR") {
         return Some(PathBuf::from(dir));
     }

--- a/rust/hook/Cargo.toml
+++ b/rust/hook/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 ureq = { workspace = true }
 regex = { workspace = true }
 sha2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -18,6 +18,7 @@ mod notify;
 mod output;
 mod payload;
 mod verdict_cache;
+mod vibe;
 
 use ggshield_common::{binary_extensions, error};
 use ggshield_config::config;
@@ -213,8 +214,10 @@ struct Pending {
 /// index 0 with no secrets — the caller only reads that payload for its output
 /// contract.
 ///
-/// `send_mcp_activity()` is not implemented, and not warned about either: it
-/// swallows every exception and returns "allowed" (mcp.py).
+/// KNOWN LIMITATION — `send_mcp_activity()` is not implemented, so Python can
+/// block an MCP tool call on policy grounds with no secret involved and the native
+/// hook cannot. Not warned about either: Python swallows every exception from that
+/// call and returns "allowed" (mcp.py).
 fn scan_payloads(
     config: &config::Config,
     payloads: &mut [Payload],

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -1,9 +1,10 @@
 //! The per-agent output contracts. One transcription of `output_result()` per
 //! adapter in `ggshield/verticals/ai/agents/`.
 //!
-//! The five schemas disagree about which key blocks, which events can block at
-//! all, whether a warning is carried, and what the exit code means. Getting one
-//! wrong produces a verdict the agent silently ignores, not an error.
+//! The six schemas disagree about which key blocks, which events can block at
+//! all, whether a warning is carried, whether anything is printed when the action
+//! is allowed, and what the exit code means. Getting one wrong produces a verdict
+//! the agent silently ignores, not an error.
 
 use serde_json::{Map, Value};
 
@@ -51,11 +52,15 @@ impl<'a> HookResult<'a> {
     }
 }
 
-/// What an adapter decided to emit: a JSON document on stdout, or (Codex's
-/// unknown-event branch) a bare message on stderr.
+/// What an adapter decided to emit: a JSON document on stdout, (Codex's
+/// unknown-event branch) a bare message on stderr, or (Vibe's passthrough)
+/// nothing at all.
 pub enum Emission {
     Stdout(Value, i32),
     Stderr(String, i32),
+    /// No output whatsoever. Distinct from `Stdout({})`: Vibe's documented
+    /// passthrough is an empty stdout, and a bare `{}` is not that.
+    Silent(i32),
 }
 
 fn obj(pairs: Vec<(&str, Value)>) -> Value {
@@ -100,6 +105,27 @@ pub fn emission(result: &HookResult) -> Emission {
     let message = result.message.as_str();
     let event = result.payload.event_type;
     match result.payload.agent {
+        // vibe.py: the event type plays no part here, a plain allow prints
+        // nothing, and the keys are `system_message` and `deny`.
+        Agent::Vibe => {
+            if result.block {
+                Emission::Stdout(
+                    obj(vec![
+                        ("decision", "deny".into()),
+                        ("reason", Value::from(message)),
+                    ]),
+                    0,
+                )
+            } else if !result.warning.is_empty() {
+                Emission::Stdout(
+                    obj(vec![("system_message", result.warning.clone().into())]),
+                    0,
+                )
+            } else {
+                Emission::Silent(0)
+            }
+        }
+
         // claude_code.py
         Agent::Claude => Emission::Stdout(
             if !result.block {
@@ -208,6 +234,7 @@ pub fn output_result(result: &HookResult) -> i32 {
             eprintln!("{message}");
             code
         }
+        Emission::Silent(code) => code,
     }
 }
 
@@ -228,11 +255,12 @@ mod tests {
         }
     }
 
-    /// stdout bytes for a result, or `None` when the adapter writes to stderr.
+    /// stdout bytes for a result, or `None` when the adapter writes to stderr or
+    /// emits nothing at all.
     fn emitted(result: &HookResult) -> Option<String> {
         match emission(result) {
             Emission::Stdout(value, _) => Some(value.to_string()),
-            Emission::Stderr(..) => None,
+            Emission::Stderr(..) | Emission::Silent(..) => None,
         }
     }
 
@@ -252,6 +280,36 @@ mod tests {
     }
 
     const DENY: &str = r#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"nope"}}"#;
+
+    /// GIVEN an allow, a fail-open warning and a block on each Vibe event
+    /// WHEN they are emitted
+    /// THEN an allow prints nothing at all, a block denies in snake_case, and the
+    /// verdict is the same whatever the event — Vibe's schema ignores it.
+    #[test]
+    fn vibe_contract() {
+        for event in [
+            EventType::UserPrompt,
+            EventType::PreToolUse,
+            EventType::PostToolUse,
+            EventType::Other,
+        ] {
+            let p = payload(Agent::Vibe, event);
+            assert!(
+                matches!(emission(&HookResult::allow(&p)), Emission::Silent(0)),
+                "vibe must emit nothing when allowing {event:?}"
+            );
+            assert_eq!(
+                blocked(Agent::Vibe, event).as_deref(),
+                Some(r#"{"decision":"deny","reason":"nope"}"#),
+                "{event:?}"
+            );
+            assert_eq!(
+                warned(Agent::Vibe, event).as_deref(),
+                Some(r#"{"system_message":"could not scan"}"#),
+                "{event:?}"
+            );
+        }
+    }
 
     /// GIVEN an allow, a fail-open warning and a block on each Claude event
     /// WHEN they are emitted

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -28,10 +28,11 @@ pub enum Tool {
     Other,
 }
 
-/// The five assistants ggshield supports, in the registry order of `AGENTS`
+/// The six assistants ggshield supports, in the registry order of `AGENTS`
 /// (agents/__init__.py). Detection takes the FIRST match, so the order matters.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Agent {
+    Vibe,
     Claude,
     Codex,
     Copilot,
@@ -39,7 +40,8 @@ pub enum Agent {
     VsCode,
 }
 
-pub const AGENTS: [Agent; 5] = [
+pub const AGENTS: [Agent; 6] = [
+    Agent::Vibe,
     Agent::Claude,
     Agent::Codex,
     Agent::Copilot,
@@ -51,6 +53,7 @@ impl Agent {
     /// Sent as the `GGShield-Agent-Name` header.
     pub fn name(self) -> &'static str {
         match self {
+            Agent::Vibe => "vibe",
             Agent::Claude => "claude-code",
             Agent::Codex => "codex",
             Agent::Copilot => "copilot",
@@ -63,6 +66,7 @@ impl Agent {
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub fn display_name(self) -> &'static str {
         match self {
+            Agent::Vibe => "Mistral Vibe",
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
             Agent::Copilot => "Copilot CLI",
@@ -80,6 +84,13 @@ impl Agent {
             .and_then(Value::as_str)
             .unwrap_or_default();
         match self {
+            // Vibe's snake_case event names are exact, which is why it is
+            // registered first: a Vibe transcript path under /home/claude would
+            // otherwise be claimed by Claude's "claude" substring heuristic below.
+            Agent::Vibe => matches!(
+                data.get("hook_event_name").and_then(Value::as_str),
+                Some("pre_tool" | "post_tool" | "post_agent")
+            ),
             Agent::Claude => data.get("session_id").is_some() && transcript.contains("claude"),
             Agent::Codex => {
                 data.get("turn_id").is_some() || transcript.to_lowercase().contains(".codex")
@@ -166,9 +177,10 @@ impl Agent {
                     Some((first, last))
                 }
             }
-            // No range ever seen from these three: Copilot CLI's `view` carries
-            // only `path`, Cursor's Read has no range keys, Codex shells out.
-            Agent::Codex | Agent::Copilot | Agent::Cursor => None,
+            // No range ever seen from these four: Copilot CLI's `view` carries
+            // only `path`, Cursor's Read has no range keys, Codex shells out, and
+            // Vibe's `read_file` carries only `path`.
+            Agent::Codex | Agent::Copilot | Agent::Cursor | Agent::Vibe => None,
         }
     }
 }
@@ -228,8 +240,11 @@ fn event_type_from_name(name: &str) -> EventType {
     match name.to_lowercase().as_str() {
         // Copilot CLI's and Cursor's spellings of the prompt event.
         "userpromptsubmit" | "userpromptsubmitted" | "beforesubmitprompt" => EventType::UserPrompt,
-        "pretooluse" => EventType::PreToolUse,
-        "posttooluse" => EventType::PostToolUse,
+        // "pre_tool"/"post_tool" are Vibe's spelling. Its "post_agent" is
+        // deliberately absent: it falls through to EventType::Other, which
+        // carries no content to scan.
+        "pretooluse" | "pre_tool" => EventType::PreToolUse,
+        "posttooluse" | "post_tool" => EventType::PostToolUse,
         _ => EventType::Other,
     }
 }
@@ -240,7 +255,9 @@ fn parse_tool(data: &Value) -> Tool {
         return Tool::Mcp;
     }
     match name.as_str() {
-        "shell" | "bash" | "run_in_terminal" => Tool::Bash,
+        // `git_bash` and `powershell` are Vibe's other two shells; mapping them to
+        // Bash is what gets their command parsed for file reads.
+        "shell" | "bash" | "git_bash" | "powershell" | "run_in_terminal" => Tool::Bash,
         "read" | "read_file" | "view" => Tool::Read,
         _ => Tool::Other,
     }
@@ -412,8 +429,20 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
             let parsed = parse_tool(&data);
             tool = Some(parsed);
             let empty = Value::Object(Default::default());
+            let empty_text = Value::String(String::new());
             let output =
                 lookup(&data, &["tool_output", "tool_response", "tool_result"]).unwrap_or(&empty);
+            // Vibe nulls the structured output when the tool call failed and
+            // leaves the text the model sees in `tool_output_text`. Without this
+            // the scanned content would be the literal "null".
+            let output = if output.is_null() {
+                match data.get("tool_output_text") {
+                    Some(text) if !text.is_null() => text,
+                    _ => &empty_text,
+                }
+            } else {
+                output
+            };
             content = match output {
                 // With no tool output at all this is the *string* "{}", which is
                 // non-empty, so Python does scan it.
@@ -447,16 +476,28 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
         read_range,
     });
 
-    // `post_process_payload()`. Only Copilot overrides it: its MCP tools carry no
-    // prefix, so they are identified by the "-" its own snake_case tools lack.
-    if agent == Agent::Copilot {
-        for payload in &mut payloads {
-            if payload.tool == Some(Tool::Other)
-                && lookup_str(&payload.raw, &["tool_name"]).contains('-')
-            {
-                payload.tool = Some(Tool::Mcp);
+    // `post_process_payload()`. Two agents override it, both because their MCP
+    // tool names carry no `mcp` prefix for `parse_tool()` to key off.
+    match agent {
+        // Copilot's MCP tools are "<server>-<tool>", and its own tools are
+        // snake_case, so a "-" is the only signal.
+        Agent::Copilot => {
+            for payload in &mut payloads {
+                if payload.tool == Some(Tool::Other)
+                    && lookup_str(&payload.raw, &["tool_name"]).contains('-')
+                {
+                    payload.tool = Some(Tool::Mcp);
+                }
             }
         }
+        // Vibe's are "{server}_{tool}", which only its configured server names
+        // can distinguish. See `vibe::post_process`.
+        Agent::Vibe => {
+            for payload in &mut payloads {
+                crate::vibe::post_process(payload);
+            }
+        }
+        _ => {}
     }
     Ok(payloads)
 }
@@ -552,6 +593,144 @@ mod tests {
         for (label, data, expected) in cases {
             assert_eq!(Agent::detect(&data), expected, "{label}");
         }
+    }
+
+    fn vibe(extra: Value) -> Value {
+        let mut base = json!({
+            "session_id": "session-123",
+            "transcript_path": "/home/user/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+        });
+        for (k, v) in extra.as_object().expect("object") {
+            base[k] = v.clone();
+        }
+        base
+    }
+
+    /// GIVEN a Vibe payload whose transcript path also contains "claude"
+    /// WHEN the agent is detected
+    /// THEN it is Vibe: its snake_case event names are exact, so it is registered
+    /// ahead of Claude's transcript-path substring heuristic.
+    #[test]
+    fn vibe_wins_over_claude_when_the_path_contains_claude() {
+        let data = json!({
+            "session_id": "session-123",
+            "transcript_path": "/home/claude/.vibe/logs/session-123.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "pre_tool",
+            "tool_name": "bash",
+            "tool_input": {"command": "whoami"},
+        });
+        assert_eq!(Agent::detect(&data), Some(Agent::Vibe));
+    }
+
+    /// GIVEN each of Vibe's three event names, and one it does not emit
+    /// WHEN the agent is detected
+    /// THEN only its own three identify it — detection keys on the event name
+    /// alone, so a near-miss must not be claimed.
+    #[test]
+    fn vibe_is_detected_from_its_event_names_alone() {
+        for event in ["pre_tool", "post_tool", "post_agent"] {
+            let data = json!({"hook_event_name": event});
+            assert_eq!(Agent::detect(&data), Some(Agent::Vibe), "{event}");
+        }
+        assert_eq!(
+            Agent::detect(&json!({"hook_event_name": "pre_tool_use"})),
+            None
+        );
+    }
+
+    /// GIVEN Vibe's `post_agent` event
+    /// WHEN it is parsed
+    /// THEN Vibe is recognised but the event maps to no type, so there is nothing
+    /// to scan — exactly as in Python.
+    #[test]
+    fn vibe_post_agent_parses_as_an_other_event() {
+        let raw = vibe(json!({"hook_event_name": "post_agent"})).to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0].agent, Agent::Vibe);
+        assert_eq!(payloads[0].event_type, EventType::Other);
+        assert_eq!(payloads[0].content, "");
+    }
+
+    /// GIVEN a `cat` command from each of Vibe's three shells
+    /// WHEN it is parsed
+    /// THEN all three are Bash, so the command is parsed for the file read rather
+    /// than scanned as an opaque tool input.
+    #[test]
+    fn vibe_shell_tools_are_all_bash() {
+        for tool_name in ["bash", "git_bash", "powershell"] {
+            let raw = vibe(json!({
+                "hook_event_name": "pre_tool",
+                "tool_name": tool_name,
+                "tool_input": {"command": "cat /tmp/secret.txt"},
+            }))
+            .to_string();
+            let payloads = parse(&raw).expect("parses");
+            assert_eq!(
+                payloads.last().expect("non-empty").tool,
+                Some(Tool::Bash),
+                "{tool_name}"
+            );
+            // The command names a file, so it is also scanned as a read.
+            assert!(
+                payloads.iter().any(|p| p.tool == Some(Tool::Read)),
+                "{tool_name}: no synthesised read"
+            );
+        }
+    }
+
+    /// GIVEN a failed Vibe tool call, which reports a null structured output
+    /// WHEN it is parsed
+    /// THEN the text the model actually sees is scanned, not the literal "null".
+    #[test]
+    fn vibe_failed_post_tool_scans_the_output_text() {
+        let raw = vibe(json!({
+            "hook_event_name": "post_tool",
+            "tool_name": "bash",
+            "tool_input": {"command": "failing-command"},
+            "tool_status": "failure",
+            "tool_output": null,
+            "tool_output_text": "failure output",
+        }))
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert_eq!(payloads[0].event_type, EventType::PostToolUse);
+        assert_eq!(payloads[0].content, "failure output");
+
+        // Null output and no text either: nothing to scan, still not "null".
+        let raw = vibe(json!({
+            "hook_event_name": "post_tool",
+            "tool_name": "bash",
+            "tool_input": {"command": "x"},
+            "tool_output": null,
+        }))
+        .to_string();
+        assert_eq!(parse(&raw).expect("parses")[0].content, "");
+    }
+
+    /// GIVEN a successful Vibe `read_file`, which names the file in `path`
+    /// WHEN it is parsed
+    /// THEN the path is the identifier and the structured output is the content,
+    /// so the null fallback does not disturb the normal case.
+    #[test]
+    fn vibe_post_tool_read_uses_the_path_and_the_structured_output() {
+        let raw = vibe(json!({
+            "hook_event_name": "post_tool",
+            "tool_name": "read_file",
+            "tool_input": {"path": "/tmp/secret.txt"},
+            "tool_status": "success",
+            "tool_output": {"content": "file content"},
+            "tool_output_text": "file content",
+        }))
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert_eq!(payloads[0].tool, Some(Tool::Read));
+        assert_eq!(payloads[0].identifier, "/tmp/secret.txt");
+        assert_eq!(payloads[0].content, r#"{"content":"file content"}"#);
+        // Vibe's read_file carries no range: the whole file is scanned.
+        assert_eq!(payloads[0].read_range, None);
     }
 
     /// GIVEN a Cursor payload arriving at a Claude-Code-format hook

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -727,7 +727,7 @@ mod tests {
         .to_string();
         let payloads = parse(&raw).expect("parses");
         assert_eq!(payloads[0].tool, Some(Tool::Read));
-        assert_eq!(payloads[0].identifier, "/tmp/secret.txt");
+        assert_eq!(payloads[0].identifier, native("/tmp/secret.txt"));
         assert_eq!(payloads[0].content, r#"{"content":"file content"}"#);
         // Vibe's read_file carries no range: the whole file is scanned.
         assert_eq!(payloads[0].read_range, None);

--- a/rust/hook/src/vibe.rs
+++ b/rust/hook/src/vibe.rs
@@ -1,0 +1,266 @@
+//! Vibe's `post_process_payload()`, from `ggshield/verticals/ai/agents/vibe.py`.
+//!
+//! Vibe names an MCP tool `{server}_{tool}`, with no `mcp` prefix to key off, so
+//! `parse_tool()` gets it wrong in both directions — `github_create_issue` reads
+//! as an ordinary tool, and one of Vibe's own tools starting with "mcp" reads as
+//! MCP — and only the configured server names can settle it.
+//!
+//! `is_mcp_activity_payload()` gates MCP activity on this classification, and
+//! that call is itself unported (see the KNOWN LIMITATION on `scan_payloads` in
+//! lib.rs), so nothing observable depends on it yet.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::payload::{Payload, Tool};
+
+/// `Vibe.config_folder`: `$VIBE_HOME`, else `~/.vibe`.
+fn config_folder() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("VIBE_HOME")
+        && !home.is_empty()
+    {
+        return Some(expand_user(&home, ggshield_config::user_config::home_dir()));
+    }
+    // `get_user_home_dir()`, GG_USER_HOME_DIR included.
+    ggshield_config::user_config::home_dir().map(|home| home.join(".vibe"))
+}
+
+/// `Path.expanduser()` for a leading `~`, which `std::path` leaves alone.
+///
+/// `~user` needs a passwd lookup, so it stays a literal directory name; Python
+/// would resolve it, and a `VIBE_HOME` of that shape is the one case that still
+/// diverges.
+fn expand_user(path: &str, home: Option<PathBuf>) -> PathBuf {
+    let Some(rest) = path.strip_prefix('~') else {
+        return PathBuf::from(path);
+    };
+    let tail = rest.trim_start_matches(['/', '\\']);
+    // A `~` that is not alone and not followed by a separator names a user.
+    if !rest.is_empty() && tail.len() == rest.len() {
+        return PathBuf::from(path);
+    }
+    match home {
+        Some(home) if tail.is_empty() => home,
+        Some(home) => home.join(tail),
+        None => PathBuf::from(path),
+    }
+}
+
+/// The `name` of every server in a `config.toml`'s `mcp_servers` array.
+///
+/// Anything unreadable, unparsable or the wrong shape yields nothing rather than
+/// failing the hook, as `_load_file()` does. The `Value` is walked by hand rather
+/// than deserialized into a struct so that, like `vibe.py`, one malformed entry
+/// is skipped instead of discarding every server in the file.
+fn server_names(path: &Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    // `toml::from_str`, NOT `text.parse::<Value>()`: the latter parses a single
+    // TOML *value*, so it reads a leading `[[mcp_servers]]` as an array literal
+    // and rejects the rest of the file as trailing content.
+    let Ok(value) = toml::from_str::<toml::Value>(&text) else {
+        return Vec::new();
+    };
+    let Some(servers) = value.get("mcp_servers").and_then(toml::Value::as_array) else {
+        return Vec::new();
+    };
+    servers
+        .iter()
+        .filter_map(|entry| entry.get("name")?.as_str().map(str::to_string))
+        .collect()
+}
+
+/// `Vibe._match_mcp_tool_name()`, reduced to the only question asked here: does
+/// any configured server own this tool name? Python's longest-first sort only
+/// decides *which* server matched, so it is left out until
+/// `parse_mcp_activity()` is ported and needs the server's identity.
+fn is_mcp_tool_name(raw_tool_name: &str, names: &[String]) -> bool {
+    names
+        .iter()
+        .any(|name| raw_tool_name.starts_with(&format!("{name}_")))
+}
+
+/// `Vibe.post_process_payload()`.
+pub fn post_process(payload: &mut Payload) {
+    // Only MCP and OTHER are in play: re-deciding Bash or Read would undo a
+    // synthesised read.
+    if !matches!(payload.tool, Some(Tool::Mcp) | Some(Tool::Other)) {
+        return;
+    }
+    let raw_tool_name = payload
+        .raw
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let cwd = payload
+        .raw
+        .get("cwd")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let mut names = Vec::new();
+    if let Some(folder) = config_folder() {
+        names.extend(server_names(&folder.join("config.toml")));
+    }
+    if !cwd.is_empty() {
+        names.extend(server_names(
+            &Path::new(cwd).join(".vibe").join("config.toml"),
+        ));
+    }
+
+    // Undo the generic "mcp" prefix heuristic unless a configured server really
+    // owns the name, so a custom tool called `mcp_*` is not reported as MCP.
+    payload.tool = Some(if is_mcp_tool_name(raw_tool_name, &names) {
+        Tool::Mcp
+    } else {
+        Tool::Other
+    });
+}
+
+/// `VIBE_HOME` is process-wide, so every test that pins it takes this one lock.
+#[cfg(test)]
+static VIBE_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Points `VIBE_HOME` at an empty directory, so a `~/.vibe/config.toml` on
+    /// the machine running the tests cannot add servers to the ones under test.
+    fn with_empty_vibe_home() -> (std::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
+        let guard = VIBE_ENV.lock().unwrap_or_else(|error| error.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialised by the mutex above.
+        unsafe { std::env::set_var("VIBE_HOME", dir.path()) };
+        (guard, dir)
+    }
+
+    /// GIVEN a `VIBE_HOME` written with a leading `~`
+    /// WHEN it is expanded
+    /// THEN only a bare `~` or a `~/` prefix resolves, and `~user` stays literal.
+    #[test]
+    fn only_a_bare_tilde_or_a_tilde_slash_expands() {
+        let home = Some(PathBuf::from("/home/me"));
+        assert_eq!(expand_user("~", home.clone()), PathBuf::from("/home/me"));
+        assert_eq!(
+            expand_user("~/.vibe", home.clone()),
+            PathBuf::from("/home/me/.vibe")
+        );
+        // Not a tilde path at all.
+        assert_eq!(
+            expand_user("/tmp/vibe", home.clone()),
+            PathBuf::from("/tmp/vibe")
+        );
+        // `~user` is a passwd lookup we do not do, so it stays as written.
+        assert_eq!(
+            expand_user("~other/.vibe", home),
+            PathBuf::from("~other/.vibe")
+        );
+        // Without a home there is nothing to substitute.
+        assert_eq!(expand_user("~/.vibe", None), PathBuf::from("~/.vibe"));
+    }
+
+    /// GIVEN a tool name and a set of configured servers
+    /// WHEN each is matched
+    /// THEN only the `{server}_` prefix counts — a bare server name, a different
+    /// separator, or a server that is merely a substring are all misses.
+    #[test]
+    fn only_a_server_prefix_makes_a_tool_an_mcp_tool() {
+        let names = vec!["github".to_string(), "my_server".to_string()];
+        assert!(is_mcp_tool_name("github_create_issue", &names));
+        assert!(is_mcp_tool_name("my_server_do_thing", &names));
+        // The separator is required: the bare name is not a tool call.
+        assert!(!is_mcp_tool_name("github", &names));
+        assert!(!is_mcp_tool_name("github-create_issue", &names));
+        assert!(!is_mcp_tool_name("gitlab_create_issue", &names));
+        assert!(!is_mcp_tool_name("mcp_something", &names));
+        assert!(!is_mcp_tool_name("anything", &[]));
+    }
+
+    /// GIVEN a Vibe `config.toml`, and files that are missing, malformed or the
+    /// wrong shape
+    /// WHEN the server names are read
+    /// THEN the good one yields its names and none of the others raise.
+    #[test]
+    fn unreadable_or_malformed_config_yields_no_names() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let good = tmp.path().join("config.toml");
+        std::fs::write(
+            &good,
+            r#"
+            [[mcp_servers]]
+            name = "github"
+            transport = "stdio"
+            command = "docker"
+
+            [[mcp_servers]]
+            name = "sentry"
+            url = "https://mcp.sentry.dev"
+            "#,
+        )
+        .expect("write");
+        assert_eq!(server_names(&good), vec!["github", "sentry"]);
+
+        // Missing file.
+        assert!(server_names(&tmp.path().join("absent.toml")).is_empty());
+        // Not TOML at all.
+        let bad = tmp.path().join("bad.toml");
+        std::fs::write(&bad, "{not toml").expect("write");
+        assert!(server_names(&bad).is_empty());
+        // Valid TOML, no mcp_servers.
+        let other = tmp.path().join("other.toml");
+        std::fs::write(&other, "model = \"large\"\n").expect("write");
+        assert!(server_names(&other).is_empty());
+        // mcp_servers present but entries have no usable name.
+        let nameless = tmp.path().join("nameless.toml");
+        std::fs::write(&nameless, "[[mcp_servers]]\ncommand = \"x\"\n").expect("write");
+        assert!(server_names(&nameless).is_empty());
+    }
+
+    fn payload_named(tool_name: &str, tool: Tool, cwd: &str) -> Payload {
+        Payload {
+            event_type: crate::payload::EventType::PreToolUse,
+            tool: Some(tool),
+            content: String::new(),
+            identifier: "id".into(),
+            agent: crate::payload::Agent::Vibe,
+            raw: json!({"tool_name": tool_name, "cwd": cwd}),
+            read_range: None,
+        }
+    }
+
+    /// GIVEN a project `.vibe/config.toml` declaring one server
+    /// WHEN a call to that server and a lookalike are post-processed
+    /// THEN only the configured one becomes MCP, and a tool merely named `mcp_*`
+    /// is demoted.
+    #[test]
+    fn project_config_decides_which_tools_are_mcp() {
+        let (_vibe_home, _empty) = with_empty_vibe_home();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join(".vibe");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("config.toml"),
+            "[[mcp_servers]]\nname = \"github\"\n",
+        )
+        .expect("write");
+        let cwd = tmp.path().to_string_lossy().to_string();
+
+        let mut p = payload_named("github_create_issue", Tool::Other, &cwd);
+        post_process(&mut p);
+        assert_eq!(p.tool, Some(Tool::Mcp));
+
+        // Named like the generic heuristic expects, but no server owns it.
+        let mut p = payload_named("mcp_lookalike", Tool::Mcp, &cwd);
+        post_process(&mut p);
+        assert_eq!(p.tool, Some(Tool::Other));
+
+        // A settled classification is never revisited.
+        let mut p = payload_named("github_create_issue", Tool::Read, &cwd);
+        post_process(&mut p);
+        assert_eq!(p.tool, Some(Tool::Read));
+    }
+}

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -15,7 +15,7 @@ sides must produce but whose value is allowed to differ (see `same_request`).
   python3 tests/equivalence.py --bench N  # also time both, N iterations/side
 
 Five matrices:
-  agents   5 assistants x 6 payload shapes x {clean, secret}
+  agents   6 assistants x their own payload shapes x {clean, secret}
   config   .gitguardian.yaml cases: discovery, precedence, and every key that
            changes the verdict or the request
   range    ranged reads: the lines an agent reads are the lines that
@@ -137,31 +137,54 @@ def agent_bases():
             "/home/user1/.cursor/projects/foo/agent-transcripts/75fed8a8/75fed8a8.jsonl"
         ),
     }
+    # Vibe is detected from its event names alone. The "claude" in the path is
+    # deliberate: it makes registry order (Vibe before Claude) observable.
+    vibe = {
+        "session_id": "session-123",
+        "parent_session_id": None,
+        "transcript_path": "/home/claude/.vibe/logs/session-123.jsonl",
+        "cwd": "/home/user1/foo",
+    }
     return {
         "claude": claude,
         "codex": codex,
         "copilot": copilot,
         "cursor": cursor,
+        "vibe": vibe,
         "vscode": vscode,
     }
 
 
 def agent_payloads():
-    """5 agents x 6 payload shapes, each in that agent's own dialect.
+    """6 agents x 6 payload shapes, each in that agent's own dialect.
+
+    Vibe differs: no prompt event, plus four shapes of its own.
 
     Shapes are copied from tests/unit/verticals/ai/test_hooks.py.
     """
     bases = agent_bases()
     claude, codex = bases["claude"], bases["codex"]
     copilot, cursor, vscode = bases["copilot"], bases["cursor"], bases["vscode"]
+    vibe = bases["vibe"]
 
     command = (
         f"aws configure set aws_access_key_id {CLIENT_ID} --secret {CLIENT_SECRET}"
     )
     prompt = f"deploy with key {CLIENT_ID} please"
 
-    def shapes(base, *, prompt_event, pre, post, bash, read, output_key, output_value):
-        return {
+    def shapes(
+        base,
+        *,
+        prompt_event,
+        pre,
+        post,
+        bash,
+        read,
+        output_key,
+        output_value,
+        read_key="file_path",
+    ):
+        built = {
             "user_prompt": {**base, "hook_event_name": prompt_event, "prompt": prompt},
             "pre_bash": {
                 **base,
@@ -173,7 +196,7 @@ def agent_payloads():
                 **base,
                 "hook_event_name": pre,
                 "tool_name": read,
-                "tool_input": {"file_path": READ_FILE},
+                "tool_input": {read_key: READ_FILE},
             },
             "pre_other": {
                 **base,
@@ -201,6 +224,10 @@ def agent_payloads():
                 },
             },
         }
+        # Vibe hooks tools only: no prompt event, so there is no shape to send.
+        if prompt_event is None:
+            del built["user_prompt"]
+        return built
 
     return {
         "claude": shapes(
@@ -244,6 +271,49 @@ def agent_payloads():
             # Cursor sends the tool output as an already-serialised string.
             output_value=json.dumps({"output": CLIENT_ID, "exitCode": 0}),
         ),
+        "vibe": {
+            **shapes(
+                vibe,
+                prompt_event=None,
+                pre="pre_tool",
+                post="post_tool",
+                bash="bash",
+                read="read_file",
+                read_key="path",
+                output_key="tool_output",
+                output_value={"content": CLIENT_ID},
+            ),
+            # A failed tool call: Vibe nulls the structured output and leaves the
+            # text the model sees in tool_output_text. Scanning the literal "null"
+            # instead would miss this secret.
+            "post_bash_failed": {
+                **vibe,
+                "hook_event_name": "post_tool",
+                "tool_name": "bash",
+                "tool_input": {"command": "printenv"},
+                "tool_status": "failure",
+                "tool_output": None,
+                "tool_output_text": f"AWS_SECRET_ACCESS_KEY={CLIENT_SECRET}",
+                "tool_error": "failed",
+            },
+            # git_bash and powershell are Vibe's other two shells, so the `cat`
+            # must be parsed as a file read.
+            "pre_git_bash_cat": {
+                **vibe,
+                "hook_event_name": "pre_tool",
+                "tool_name": "git_bash",
+                "tool_input": {"command": f"cat {READ_FILE}"},
+            },
+            "pre_powershell_cat": {
+                **vibe,
+                "hook_event_name": "pre_tool",
+                "tool_name": "powershell",
+                "tool_input": {"command": f"Get-Content {READ_FILE}"},
+            },
+            # post_agent is recognised as Vibe but maps to no event type, so it
+            # must parse and pass through rather than being refused.
+            "post_agent": {**vibe, "hook_event_name": "post_agent"},
+        },
         "vscode": shapes(
             vscode,
             prompt_event="UserPromptSubmit",
@@ -1339,7 +1409,7 @@ def report(failures, label, verdict_ok, request_ok, py, rs):
 
 def compare_agents(tmp):
     failures = []
-    print("Agents: 5 assistants x 6 payload shapes x {clean, secret}")
+    print("Agents: 6 assistants x their own payload shapes x {clean, secret}")
     for mode in ("clean", "secret"):
         log = tmp / f"requests-agents-{mode}.jsonl"
         mock, port = start_mock(mode, log)


### PR DESCRIPTION
Vibe landed in the Python hook (#1371) after the Rust port was written, so the native hook refused every Vibe event as an unrecognized agent — no Vibe tool call was scanned.

Two commits: recognizing Vibe, then its MCP tool classification.

### Recognizing Vibe

- **`Agent::Vibe`, registered first.** Its snake_case event names are exact, so they settle detection before Claude's `"claude"`-in-`transcript_path` heuristic can claim a Vibe payload — same reason Python puts `Vibe()` ahead of `Claude()`.
- **`pre_tool` / `post_tool` event names.** `post_agent` identifies Vibe but maps to no event type, so it parses as `Other` and scans nothing, exactly as in Python.
- **`git_bash` and `powershell` as shells**, so their commands are parsed for file reads instead of scanned as opaque tool input.
- **Failed tool calls.** Vibe nulls `tool_output` and leaves the text the model sees in `tool_output_text`. That is now what gets scanned; previously it would have been the literal `"null"`.
- **Vibe's output contract:** `decision: deny`, snake_case `system_message`, and an allow that prints *nothing at all* — hence a new `Emission::Silent`, because a bare `{}` is not an empty stdout.

### MCP tool classification

Vibe names an MCP tool `{server}_{tool}`, with no `mcp` prefix, so `parse_tool()` is wrong in both directions: a real MCP call reads as an ordinary tool, and one of Vibe's own tools starting with `mcp` reads as MCP. `Vibe.post_process_payload()` settles it from the configured server names, read out of `$VIBE_HOME/config.toml` (or `~/.vibe`) and `<cwd>/.vibe/config.toml`.

Adds the `toml` crate (read-only features). Malformed or unreadable files yield no names rather than failing the hook, and individual bad entries are skipped as `vibe.py` does — which is why the parsed `Value` is walked by hand rather than deserialized into a struct.

### Still missing, and it is not Vibe-specific

`send_mcp_activity()` is not implemented in the Rust hook at all — a pre-existing gap from #1381, for **all six agents**. It is not merely telemetry: `_scan_payloads` applies its verdict, so **Python can block an MCP tool call on policy grounds with no secret involved**, and the native hook currently cannot.

Porting it needs `refresh_and_maybe_submit_discovery` (the `ai_discovery.json` cache, the walk over every agent's MCP config files, the change diff and the submit call), each agent's `parse_mcp_activity`, and `log_mcp_activity`. That is a subsystem, not a patch, and it belongs in its own PR rather than one about Vibe.

### Verification

- 79 Rust tests pass (10 new), `clippy -D warnings` and `cargo fmt` clean.
- Equivalence harness: Vibe covered by 9 payload shapes x {clean, secret}. **All 18 fail against the un-ported binary and pass after** — I reverted just the source files to confirm the cases have teeth. `RESULT: EQUIVALENT`, `known_divergences = {}`.

Based on #1396 to keep the stack linear. Happy to re-base onto #1392 if you'd rather this land ahead of the wheel.