### PR TITLE
fix(ai-hook): honour secret.ignored_paths, and show the ignore sha on a block

### DIFF
--- a/changelog.d/20260811_150000_achille.mascia_ai_hook_ignored_paths.md
+++ b/changelog.d/20260811_150000_achille.mascia_ai_hook_ignored_paths.md
@@ -7,7 +7,7 @@
   `ignored_detectors` were never affected. This also brings the default
   exclusions to the hook: reads under `node_modules/`, `.venv/`, `vendor/`,
   `.git/` and the other `IGNORED_DEFAULT_WILDCARDS` entries are no longer
-  scanned. Those defaults are matched against the path *relative to the project*
+  scanned. Those defaults are matched against the path _relative to the project_
   and with symlinks resolved, so a checkout that itself lives under a directory
   named `vendor/`, `node_modules/` or `.venv/` is still scanned normally, and a
   symlink parked in a vendored tree cannot hide a file living outside it.

--- a/changelog.d/20260811_150000_achille.mascia_ai_hook_ignored_paths.md
+++ b/changelog.d/20260811_150000_achille.mascia_ai_hook_ignored_paths.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- `secret scan ai-hook` now honours `secret.ignored_paths` from
+  `.gitguardian.yaml`, as every other `secret scan` command already did. A file
+  excluded there is no longer read, sent, or blocked on when an agent reads it.
+  Previously the setting was silently inert on this path. `ignored_matches` and
+  `ignored_detectors` were never affected. This also brings the default
+  exclusions to the hook: reads under `node_modules/`, `.venv/`, `vendor/`,
+  `.git/` and the other `IGNORED_DEFAULT_WILDCARDS` entries are no longer
+  scanned. Those defaults are matched against the path *relative to the project*
+  and with symlinks resolved, so a checkout that itself lives under a directory
+  named `vendor/`, `node_modules/` or `.venv/` is still scanned normally, and a
+  symlink parked in a vendored tree cannot hide a file living outside it.
+
+### Changed
+
+- When the AI hook blocks, its message now shows the `secret.ignored_matches`
+  entry that would silence it, one line per detected secret. The message censors
+  every match, so the entry could not previously be written by hand from what it
+  showed. The value shown is the ignore sha, a digest rather than the secret,
+  and is the same one `ggshield secret ignore --last-found` writes.

--- a/ggshield/cmd/secret/scan/ai_hook.py
+++ b/ggshield/cmd/secret/scan/ai_hook.py
@@ -65,7 +65,7 @@ def ai_hook_cmd(
             # `all_secrets`. Other commands keep it.
             secret_config=replace(config.user_config.secret, source_uuid=None),
         )
-        return AIHookScanner(scanner).scan(stdin_content)
+        return AIHookScanner(scanner, ctx_obj.exclusion_regexes).scan(stdin_content)
     except ValueError as e:
         ui.display_error(str(e.args[0]))
         return 1

--- a/ggshield/core/scan/scanner.py
+++ b/ggshield/core/scan/scanner.py
@@ -36,6 +36,8 @@ class SecretProtocol(Protocol):
     @property
     def matches(self) -> Sequence[Match]: ...
 
+    def get_ignore_sha(self) -> str: ...
+
 
 class ResultProtocol(Protocol):
     @property

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Pattern, Sequence, Set, Tuple
 
 import filelock
 from notifypy import Notify
@@ -20,6 +20,7 @@ from ggshield.core.scan import Scannable, ScannerProtocol
 from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
+from ggshield.utils.files import is_path_excluded
 from ggshield.utils.os import getenv_bool
 from ggshield.verticals.ai.mcp import is_mcp_activity_payload, send_mcp_activity
 
@@ -567,14 +568,29 @@ def _post_remediation_steps(secrets: List[Secret]) -> str:
     return "\n".join(f"  {i}. {step}" for i, step in enumerate(steps, start=1))
 
 
-def _false_positive_block(count: int) -> str:
+def _false_positive_block(secrets: Sequence[Secret]) -> str:
+    """The remediation for a false positive, with the entries it would write.
+
+    The shas are spelled out because the message censors every match, so the sha
+    is otherwise unknowable and a hand-written `ignored_matches` entry silently
+    never matches. The sha is a digest, not the secret, and `secret ignore`
+    already writes it in clear.
+    """
+    count = len(secrets)
     this_is_a_false_positive = pluralize(
         "this is a false positive", count, "these are false positives"
     )
+    # dict, not set: one entry per sha, in the order the secrets are reported.
+    shas = dict.fromkeys(secret.get_ignore_sha() for secret in secrets)
+    entries = "\n".join(f"    - match: {sha}" for sha in shas)
     return f"""\
 > If {this_is_a_false_positive}, run:
 
-    ggshield secret ignore --last-found"""
+    ggshield secret ignore --last-found
+
+  which adds to secret.ignored_matches in .gitguardian.yaml:
+
+{entries}"""
 
 
 class AIHookScanner:
@@ -591,8 +607,24 @@ class AIHookScanner:
         ValueError: If the input is not valid.
     """
 
-    def __init__(self, scanner: ScannerProtocol):
+    def __init__(
+        self,
+        scanner: ScannerProtocol,
+        exclusion_regexes: Optional[Set[Pattern[str]]] = None,
+    ):
         self.scanner = scanner
+        self.exclusion_regexes = exclusion_regexes or set()
+
+    def _is_excluded(self, payload: HookPayload) -> bool:
+        """Whether `secret.ignored_paths` covers what this payload would scan.
+
+        READ only: every other tool's identifier is a command or a content hash,
+        which a path pattern must not be tested against. A USER_PROMPT
+        @-mention is a READ too, so both ways of naming a file are covered.
+        """
+        if not self.exclusion_regexes or payload.tool != Tool.READ:
+            return False
+        return is_path_excluded(payload.identifier, self.exclusion_regexes)
 
     def scan(self, content: str) -> int:
         """Scan the content, print the result and return the exit code."""
@@ -681,6 +713,10 @@ class AIHookScanner:
         # (index in `payloads`, document to scan, verdict cache key).
         to_scan: List[Tuple[int, Scannable, Optional[str]]] = []
         for index, payload in enumerate(payloads):
+            # Excluded by secret.ignored_paths: never read, never sent, allowed.
+            # Before payload.scannable, which would read the file.
+            if self._is_excluded(payload):
+                continue
             # One Scannable for both the cache key and the scan, so the two can
             # never disagree about what was scanned.
             scannable = payload.scannable
@@ -830,7 +866,7 @@ class AIHookScanner:
             identifier=payload.identifier,
             secret_lines="\n".join(_secret_lines(secrets, escape_markdown)),
             post_remediation_steps=_post_remediation_steps(secrets),
-            false_positive_instructions=_false_positive_block(count),
+            false_positive_instructions=_false_positive_block(secrets),
         )
         if escape_markdown:
             message = markdown_hard_breaks(message)

--- a/rust/config/src/user_config.rs
+++ b/rust/config/src/user_config.rs
@@ -8,8 +8,6 @@
 //! (and a versionless file IS v1) is converted rather than refused.
 //!
 //! Keys treated as no-ops, because they do not reach this path:
-//!   secret.ignored_paths          only builds `ctx_obj.exclusion_regexes`; the
-//!                                 ai-hook builds its scannables directly
 //!   secret.show_secrets           the hook always censors (`censor_match`)
 //!   secret.with_incident_details  only adds a token scope to the API-key
 //!                                 precheck, which this binary skips
@@ -33,6 +31,9 @@ pub struct SecretConfig {
     /// literal secret value; `is_in_ignored_matches` accepts both.
     pub ignored_matches: Vec<String>,
     pub ignored_detectors: BTreeSet<String>,
+    /// Globs, as written in the file. Compiled by `ggshield_hook::exclusion`,
+    /// which also adds the default wildcards.
+    pub ignored_paths: Vec<String>,
     pub ignore_known_secrets: bool,
     /// When true, ignored secrets are still reported — so they still block.
     pub all_secrets: bool,
@@ -81,6 +82,8 @@ struct RawSecretConfig {
     ignored_matches: Vec<IgnoredMatch>,
     #[serde(alias = "ignored-detectors")]
     ignored_detectors: BTreeSet<String>,
+    #[serde(alias = "ignored-paths")]
+    ignored_paths: Vec<String>,
     #[serde(alias = "ignore-known-secrets")]
     ignore_known_secrets: Option<bool>,
     #[serde(alias = "all-secrets")]
@@ -107,6 +110,8 @@ struct V1Config {
     matches_ignore: Vec<V1IgnoredMatch>,
     #[serde(alias = "banlisted-detectors")]
     banlisted_detectors: BTreeSet<String>,
+    #[serde(alias = "paths-ignore")]
+    paths_ignore: Vec<String>,
     #[serde(alias = "api-url")]
     api_url: Option<String>,
     #[serde(alias = "allow-self-signed")]
@@ -155,6 +160,8 @@ impl From<V1Config> for RawUserConfig {
                     })
                     .collect(),
                 ignored_detectors: v1.banlisted_detectors,
+                // `copy_if_set(secret_dct, "ignored_paths", "paths_ignore")`.
+                ignored_paths: v1.paths_ignore,
                 ..RawSecretConfig::default()
             },
         }
@@ -176,6 +183,7 @@ impl RawUserConfig {
         secret
             .ignored_detectors
             .extend(later.secret.ignored_detectors);
+        secret.ignored_paths.extend(later.secret.ignored_paths);
         secret.ignore_known_secrets = later
             .secret
             .ignore_known_secrets
@@ -199,6 +207,7 @@ impl RawUserConfig {
                     .map(|entry| entry.value)
                     .collect(),
                 ignored_detectors: self.secret.ignored_detectors,
+                ignored_paths: self.secret.ignored_paths,
                 ignore_known_secrets: self
                     .secret
                     .ignore_known_secrets
@@ -324,18 +333,39 @@ mod tests {
         assert!(config.secret.filename_only);
     }
 
-    /// GIVEN keys that do not reach the ai-hook path (`ignored_paths` above all)
+    /// GIVEN keys that do not reach the ai-hook path
     /// WHEN the config is loaded
     /// THEN they are accepted and ignored rather than rejected.
     #[test]
     fn keys_that_do_not_reach_this_path_are_accepted_and_ignored() {
         let config = parse(
-            "version: 2\nsecret:\n  ignored_paths: ['**/README.md']\n  show_secrets: true\n  \
+            "version: 2\nsecret:\n  show_secrets: true\n  \
              with_incident_details: true\n  fail_on_server_error: false\nverbose: true\n",
         )
         .expect("parses");
         assert!(config.secret.ignored_matches.is_empty());
         assert!(!config.secret.all_secrets);
+    }
+
+    /// GIVEN `secret.ignored_paths`, in v2 and in the v1 `paths_ignore` spelling
+    /// WHEN the config is loaded
+    /// THEN both reach `SecretConfig`, where the hook compiles them.
+    #[test]
+    fn ignored_paths_are_read_from_both_schemas() {
+        assert_eq!(
+            parse("version: 2\nsecret:\n  ignored_paths: ['**/README.md']\n")
+                .expect("parses")
+                .secret
+                .ignored_paths,
+            vec!["**/README.md"]
+        );
+        assert_eq!(
+            parse("version: 1\npaths-ignore:\n  - '**/*.env'\n")
+                .expect("parses")
+                .secret
+                .ignored_paths,
+            vec!["**/*.env"]
+        );
     }
 
     /// GIVEN the dashed spelling of a key, or the root-level

--- a/rust/hook/src/api.rs
+++ b/rust/hook/src/api.rs
@@ -130,7 +130,7 @@ struct ScanResult {
 /// `get_ignore_sha()`: sha256 over the policy break's matches rendered as
 /// "<match>,<match_type>", stably sorted by match_type. Users paste this value
 /// into `ignored_matches`, so it has to hash identically.
-fn ignore_sha(matches: &[Match]) -> String {
+pub(crate) fn ignore_sha(matches: &[Match]) -> String {
     let mut sorted: Vec<&Match> = matches.iter().collect();
     sorted.sort_by(|a, b| a.match_type.cmp(&b.match_type));
     let hashable: String = sorted

--- a/rust/hook/src/exclusion.rs
+++ b/rust/hook/src/exclusion.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use regex::Regex;
+use regex::{Regex, RegexSet};
 
 use ggshield_config::user_config::SecretConfig;
 
@@ -38,9 +38,9 @@ const REGEX_SPECIAL_CHARS: &str = ".^$+*?{}()[]\\|";
 #[derive(Debug, Default)]
 pub struct Exclusions {
     /// The user's own globs, tested against the identifier as it reaches us.
-    user: Vec<Regex>,
-    /// `IGNORED_DEFAULT_WILDCARDS`, tested project-relative — see `is_excluded`.
-    default: Vec<Regex>,
+    user: RegexSet,
+    /// `IGNORED_DEFAULT_WILDCARDS`, tested project-relative, see `is_excluded`.
+    default: RegexSet,
 }
 
 impl Exclusions {
@@ -73,19 +73,26 @@ impl Exclusions {
     /// match) is not reproduced: the hook only asks about files a tool named.
     #[must_use]
     pub fn is_excluded(&self, path: &str, cwd: &str) -> bool {
-        if self.user.iter().any(|regex| regex.is_match(&posix(path))) {
-            return true;
-        }
-        let relative = project_relative(path, cwd);
-        self.default.iter().any(|regex| regex.is_match(&relative))
+        self.user.is_match(&posix(path)) || self.default.is_match(&project_relative(path, cwd))
     }
 }
 
-fn compile<'a>(patterns: impl Iterator<Item = &'a str>) -> Vec<Regex> {
-    patterns
+/// One set per group: the whole group compiles into a single automaton, and
+/// every hook run pays that compilation.
+fn compile<'a>(patterns: impl Iterator<Item = &'a str>) -> RegexSet {
+    let translated: Vec<String> = patterns
         .filter(|pattern| is_pattern_valid(pattern))
-        .filter_map(|pattern| Regex::new(&translate_user_pattern(pattern)).ok())
-        .collect()
+        .map(translate_user_pattern)
+        .collect();
+    RegexSet::new(&translated).unwrap_or_else(|_| {
+        // A glob `regex` rejects drops itself rather than the whole set.
+        RegexSet::new(
+            translated
+                .iter()
+                .filter(|pattern| Regex::new(pattern).is_ok()),
+        )
+        .unwrap_or_else(|_| RegexSet::empty())
+    })
 }
 
 /// `path` with the separators the patterns are written with. Only Windows has
@@ -343,5 +350,18 @@ mod tests {
         let excluded = exclusions(&["a***b", "tests/fixtures/**"]);
         assert!(excluded.is_excluded("/repo/tests/fixtures/creds.py", ""));
         assert!(!excluded.is_excluded("/repo/a-b", ""));
+    }
+
+    /// GIVEN a glob whose translation is past what `regex` will compile
+    /// WHEN the set is compiled
+    /// THEN only that glob is dropped, and the others still exclude.
+    #[test]
+    fn an_oversized_glob_does_not_take_the_rest_of_the_set_with_it() {
+        let oversized = "**/".repeat(10_000);
+        assert!(is_pattern_valid(&oversized));
+        assert!(RegexSet::new([translate_user_pattern(&oversized)]).is_err());
+
+        let excluded = exclusions(&[&oversized, "tests/fixtures/**"]);
+        assert!(excluded.is_excluded("/repo/tests/fixtures/creds.py", ""));
     }
 }

--- a/rust/hook/src/exclusion.rs
+++ b/rust/hook/src/exclusion.rs
@@ -6,7 +6,7 @@
 //! `IGNORED_DEFAULT_WILDCARDS` for every `secret scan` command, so the hook
 //! does too.
 
-use std::path::Path;
+use std::path::PathBuf;
 
 use regex::{Regex, RegexSet};
 
@@ -112,22 +112,18 @@ fn posix(path: &str) -> String {
 /// there is no cwd, when the file is gone, or when it resolves outside the
 /// project — there is no project-relative form then.
 fn project_relative(path: &str, cwd: &str) -> String {
-    let real = |raw: &str| {
-        std::fs::canonicalize(raw)
-            .map(|resolved| resolved.to_string_lossy().into_owned())
-            .unwrap_or_else(|_| raw.to_string())
-    };
+    let real = |raw: &str| std::fs::canonicalize(raw).unwrap_or_else(|_| PathBuf::from(raw));
     let resolved = real(path);
-    if cwd.is_empty() {
-        return posix(&resolved);
-    }
-    // Component-wise, so a sibling directory sharing a name prefix with the
-    // project is not mistaken for being inside it.
-    let relative = Path::new(&resolved)
-        .strip_prefix(real(cwd))
-        .map(|rest| rest.to_string_lossy().into_owned())
-        .unwrap_or(resolved);
-    posix(&relative)
+    let relative = if cwd.is_empty() {
+        resolved.as_path()
+    } else {
+        // Component-wise, so a sibling directory sharing a name prefix with the
+        // project is not mistaken for being inside it.
+        resolved
+            .strip_prefix(real(cwd))
+            .unwrap_or(resolved.as_path())
+    };
+    posix(&relative.to_string_lossy())
 }
 
 /// `is_pattern_valid()`: `***` is never valid, and a `**` must be a whole path
@@ -301,6 +297,19 @@ mod tests {
                 "{root}"
             );
         }
+    }
+
+    /// GIVEN a sibling directory whose name starts with the project's own name
+    /// WHEN a file inside it is tested
+    /// THEN nothing is stripped: `strip_prefix` compares whole components, so the
+    /// sibling is not taken for being inside the project.
+    #[test]
+    fn a_sibling_sharing_a_name_prefix_is_not_inside_the_project() {
+        let excluded = exclusions(&[]);
+        // Stripping "/home/me/proj" as a string would leave "top-1000.txt.bak",
+        // which `top-1000.txt*` matches.
+        assert!(!excluded.is_excluded("/home/me/projtop-1000.txt.bak", "/home/me/proj"));
+        assert!(excluded.is_excluded("/home/me/proj/top-1000.txt.bak", "/home/me/proj"));
     }
 
     /// GIVEN a user glob naming a directory the project itself sits under

--- a/rust/hook/src/exclusion.rs
+++ b/rust/hook/src/exclusion.rs
@@ -1,0 +1,347 @@
+//! `secret.ignored_paths`: which files a scan never reads.
+//!
+//! Port of `core/filter.py`'s `translate_user_pattern()` /
+//! `init_exclusion_regexes()` and `utils/files.py`'s `is_path_excluded()`.
+//! `add_secret_scan_common_options()` unions the user's globs with
+//! `IGNORED_DEFAULT_WILDCARDS` for every `secret scan` command, so the hook
+//! does too.
+
+use std::path::Path;
+
+use regex::Regex;
+
+use ggshield_config::user_config::SecretConfig;
+
+/// `IGNORED_DEFAULT_WILDCARDS`, in `cmd/secret/scan/secret_scan_common_options.py`.
+const IGNORED_DEFAULT_WILDCARDS: [&str; 14] = [
+    "**/.git/*/**/*",
+    "**/.pytest_cache/**/*",
+    "**/.mypy_cache/**/*",
+    "**/.venv/**/*",
+    "**/.eggs/**/*",
+    "**/.eggs-info/**/*",
+    "**/vendor/**/*",
+    "**/vendors/**/*",
+    "**/node_modules/**/*",
+    "top-1000.txt*",
+    "**/*.storyboard*",
+    "**/*.xib",
+    "**/*.mdx*",
+    "**/*.sops",
+];
+
+/// `REGEX_SPECIAL_CHARS`. `*` is escaped here and unescaped by the two
+/// substitutions below, as Python does it.
+const REGEX_SPECIAL_CHARS: &str = ".^$+*?{}()[]\\|";
+
+/// The compiled `secret.ignored_paths`, ready to test paths against.
+#[derive(Debug, Default)]
+pub struct Exclusions {
+    /// The user's own globs, tested against the identifier as it reaches us.
+    user: Vec<Regex>,
+    /// `IGNORED_DEFAULT_WILDCARDS`, tested project-relative — see `is_excluded`.
+    default: Vec<Regex>,
+}
+
+impl Exclusions {
+    /// Compile the user's globs and the default wildcards.
+    ///
+    /// Diverges from Python on an invalid pattern: Python raises `UsageError`,
+    /// which here would fail every event closed over a typo. Dropping the glob
+    /// scans more, not less.
+    pub fn new(secret_config: &SecretConfig) -> Self {
+        Exclusions {
+            user: compile(secret_config.ignored_paths.iter().map(String::as_str)),
+            default: compile(IGNORED_DEFAULT_WILDCARDS.into_iter()),
+        }
+    }
+
+    /// `is_path_excluded()` for the file a Read names, in a project rooted at
+    /// `cwd`.
+    ///
+    /// The user's globs are tested against the identifier itself, which is what
+    /// their config was written about. The default wildcards are tested against
+    /// the path *relative to the project*, and with symlinks resolved: they name
+    /// vendored and cache trees inside a checkout, so against an absolute path
+    /// they also match on an ancestor outside it — a checkout under `~/vendor/`
+    /// would have every read excluded — and on the name of a link parked in
+    /// `node_modules/` that points anywhere at all. Both diverge from Python's
+    /// hook, which tests the identifier as given; see `known_divergences` in
+    /// tests/equivalence.py.
+    ///
+    /// Python's directory branch (a trailing `/`, so a directory pattern can
+    /// match) is not reproduced: the hook only asks about files a tool named.
+    #[must_use]
+    pub fn is_excluded(&self, path: &str, cwd: &str) -> bool {
+        if self.user.iter().any(|regex| regex.is_match(&posix(path))) {
+            return true;
+        }
+        let relative = project_relative(path, cwd);
+        self.default.iter().any(|regex| regex.is_match(&relative))
+    }
+}
+
+fn compile<'a>(patterns: impl Iterator<Item = &'a str>) -> Vec<Regex> {
+    patterns
+        .filter(|pattern| is_pattern_valid(pattern))
+        .filter_map(|pattern| Regex::new(&translate_user_pattern(pattern)).ok())
+        .collect()
+}
+
+/// `path` with the separators the patterns are written with. Only Windows has
+/// `\` as a separator; on POSIX it is an ordinary filename character, which is
+/// why `PurePosixPath` leaves it alone there.
+#[cfg(windows)]
+fn posix(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+#[cfg(not(windows))]
+fn posix(path: &str) -> String {
+    path.to_string()
+}
+
+/// `path` relative to `cwd`, symlinks resolved. Falls back to `path` itself when
+/// there is no cwd, when the file is gone, or when it resolves outside the
+/// project — there is no project-relative form then.
+fn project_relative(path: &str, cwd: &str) -> String {
+    let real = |raw: &str| {
+        std::fs::canonicalize(raw)
+            .map(|resolved| resolved.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| raw.to_string())
+    };
+    let resolved = real(path);
+    if cwd.is_empty() {
+        return posix(&resolved);
+    }
+    // Component-wise, so a sibling directory sharing a name prefix with the
+    // project is not mistaken for being inside it.
+    let relative = Path::new(&resolved)
+        .strip_prefix(real(cwd))
+        .map(|rest| rest.to_string_lossy().into_owned())
+        .unwrap_or(resolved);
+    posix(&relative)
+}
+
+/// `is_pattern_valid()`: `***` is never valid, and a `**` must be a whole path
+/// segment.
+fn is_pattern_valid(pattern: &str) -> bool {
+    if pattern.is_empty() || pattern.contains("***") {
+        return false;
+    }
+    let bytes = pattern.as_bytes();
+    for (index, window) in bytes.windows(2).enumerate() {
+        if window != b"**" {
+            continue;
+        }
+        // A "**" must be immediately followed by a "/" ...
+        if bytes.get(index + 2).is_some_and(|byte| *byte != b'/') {
+            return false;
+        }
+        // ... and be at the start, or immediately preceded by a "/".
+        if index > 0 && bytes[index - 1] != b'/' {
+            return false;
+        }
+    }
+    true
+}
+
+/// `translate_user_pattern()`: a glob to the regex Python compiles for it.
+fn translate_user_pattern(pattern: &str) -> String {
+    let mut escaped = String::with_capacity(pattern.len() * 2);
+    for character in pattern.chars() {
+        if REGEX_SPECIAL_CHARS.contains(character) {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+
+    // Anchor the end unless the pattern names a directory, and the start only
+    // when the pattern is absolute; otherwise it may begin at any segment.
+    if !escaped.ends_with('/') {
+        escaped.push('$');
+    }
+    let mut translated = if let Some(rest) = escaped.strip_prefix('/') {
+        format!("^{rest}")
+    } else {
+        format!("(^|/){escaped}")
+    };
+
+    // Order matters: "**/" first, so the "*" rule cannot eat half of one.
+    translated = translated.replace("\\*\\*/", "([^/]+/)*");
+    translated.replace("\\*", "([^/]+)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exclusions(patterns: &[&str]) -> Exclusions {
+        Exclusions::new(&SecretConfig {
+            ignored_paths: patterns.iter().map(|p| (*p).to_string()).collect(),
+            ..SecretConfig::default()
+        })
+    }
+
+    /// GIVEN the globs Python's own tests translate
+    /// WHEN they are translated here
+    /// THEN the regex is `translate_user_pattern()`'s, character for character.
+    #[test]
+    fn the_translation_is_the_python_one() {
+        for (pattern, expected) in [
+            ("tests/fixtures/**", "(^|/)tests/fixtures/([^/]+)([^/]+)$"),
+            ("**/tmp/**", "(^|/)([^/]+/)*tmp/([^/]+)([^/]+)$"),
+            ("/rooted/path", "^rooted/path$"),
+            ("a directory/", "(^|/)a directory/"),
+            ("**/*.sops", "(^|/)([^/]+/)*([^/]+)\\.sops$"),
+            ("top-1000.txt*", "(^|/)top-1000\\.txt([^/]+)$"),
+        ] {
+            assert_eq!(translate_user_pattern(pattern), expected, "{pattern}");
+        }
+    }
+
+    /// GIVEN patterns Python's `is_pattern_valid()` rejects
+    /// WHEN they are validated
+    /// THEN they are rejected here too.
+    #[test]
+    fn invalid_patterns_are_rejected() {
+        for bad in ["", "a***b", "a**/b", "**a/b", "x/**y"] {
+            assert!(!is_pattern_valid(bad), "{bad} should be invalid");
+        }
+        for good in ["**/a", "a/**/b", "a/**", "*.py", "/rooted"] {
+            assert!(is_pattern_valid(good), "{good} should be valid");
+        }
+    }
+
+    /// GIVEN a glob written relative to the repo
+    /// WHEN an absolute path is tested, as the hook always gets from an agent
+    /// THEN it still matches: the translation anchors on `(^|/)`.
+    #[test]
+    fn a_relative_glob_matches_an_absolute_path() {
+        let excluded = exclusions(&["tests/fixtures/**"]);
+        assert!(excluded.is_excluded("tests/fixtures/creds.py", ""));
+        assert!(excluded.is_excluded("/home/me/repo/tests/fixtures/creds.py", ""));
+        assert!(!excluded.is_excluded("/home/me/repo/src/creds.py", ""));
+    }
+
+    /// GIVEN a trailing `**`, which Python expands to `([^/]+)([^/]+)$`
+    /// WHEN a nested path is tested
+    /// THEN it does NOT match: a trailing `**` spans one segment only. Python's
+    /// quirk, pinned so the two agree.
+    #[test]
+    fn a_trailing_double_star_spans_one_segment_as_in_python() {
+        let excluded = exclusions(&["tests/fixtures/**"]);
+        assert!(excluded.is_excluded("tests/fixtures/creds.py", ""));
+        assert!(!excluded.is_excluded("tests/fixtures/sub/creds.py", ""));
+        assert!(!excluded.is_excluded("/abs/tests/fixtures/sub/creds.py", ""));
+    }
+
+    /// GIVEN a Windows path
+    /// WHEN it is tested against a glob written with forward slashes
+    /// THEN it matches, because `\` is a separator there and is normalized first.
+    #[cfg(windows)]
+    #[test]
+    fn a_windows_path_matches_a_posix_glob() {
+        assert!(
+            exclusions(&["tests/fixtures/**"])
+                .is_excluded(r"C:\Users\me\repo\tests\fixtures\creds.py", "")
+        );
+    }
+
+    /// GIVEN a POSIX filename containing backslashes
+    /// WHEN it is tested against the default wildcards
+    /// THEN they do not match: there `\` is an ordinary filename character, and
+    /// `PurePosixPath` leaves it alone, so Python scans this file too.
+    #[cfg(not(windows))]
+    #[test]
+    fn backslashes_are_ordinary_characters_on_posix() {
+        let excluded = exclusions(&[]);
+        assert!(!excluded.is_excluded(r"/repo/node_modules\pkg\x.py", "/repo"));
+        assert!(!excluded.is_excluded(r"node_modules\pkg\x.py", ""));
+        assert!(excluded.is_excluded("/repo/node_modules/pkg/x.py", "/repo"));
+    }
+
+    /// GIVEN no user config at all
+    /// WHEN a vendored path inside the project is tested
+    /// THEN the default wildcards still exclude it.
+    #[test]
+    fn the_default_wildcards_apply_without_any_user_config() {
+        let excluded = exclusions(&[]);
+        assert!(excluded.is_excluded("/repo/node_modules/pkg/creds.py", "/repo"));
+        assert!(excluded.is_excluded("/repo/.venv/lib/thing.py", "/repo"));
+        assert!(!excluded.is_excluded("/repo/src/creds.py", "/repo"));
+    }
+
+    /// GIVEN a project whose own path runs through a vendor-like directory
+    /// WHEN a file inside it is tested
+    /// THEN the default wildcards do not match: they are tested relative to the
+    /// project, so an ancestor outside it cannot exclude the whole checkout.
+    #[test]
+    fn the_default_wildcards_ignore_ancestors_above_the_project() {
+        let excluded = exclusions(&[]);
+        for root in [
+            "/home/me/vendor/proj",
+            "/home/me/node_modules/proj",
+            "/home/me/.venv/proj",
+        ] {
+            assert!(
+                !excluded.is_excluded(&format!("{root}/src/creds.env"), root),
+                "{root}"
+            );
+            // ...and a vendored tree *inside* the project still is.
+            assert!(
+                excluded.is_excluded(&format!("{root}/vendor/lib/creds.env"), root),
+                "{root}"
+            );
+        }
+    }
+
+    /// GIVEN a user glob naming a directory the project itself sits under
+    /// WHEN a file inside the project is tested
+    /// THEN it is excluded: the user's own globs are tested against the
+    /// identifier as written, exactly as every other `secret scan` does.
+    #[test]
+    fn a_user_glob_still_matches_anywhere_in_the_path() {
+        let excluded = exclusions(&["**/vendor/**/*"]);
+        assert!(excluded.is_excluded("/home/me/vendor/proj/src/creds.env", "/home/me/vendor/proj"));
+    }
+
+    /// GIVEN a symlink parked in `node_modules` pointing outside it
+    /// WHEN the link is read
+    /// THEN it is not excluded: the default wildcards are tested against where
+    /// the bytes live, so a link cannot hide a file behind an excluded name.
+    ///
+    /// Unix only: creating a symlink on Windows needs a privilege a test runner
+    /// is not guaranteed to have.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_out_of_a_vendored_tree_is_not_excluded() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("node_modules/.cache")).expect("mkdir");
+        let outside = root.join("credentials");
+        std::fs::write(&outside, "TOKEN=abc").expect("write");
+        let link = root.join("node_modules/.cache/x");
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+
+        let excluded = exclusions(&[]);
+        let cwd = root.to_string_lossy();
+        assert!(!excluded.is_excluded(&link.to_string_lossy(), &cwd));
+
+        // A real file in the same tree stays excluded.
+        let real = root.join("node_modules/pkg/creds.env");
+        std::fs::create_dir_all(real.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&real, "TOKEN=abc").expect("write");
+        assert!(excluded.is_excluded(&real.to_string_lossy(), &cwd));
+    }
+
+    /// GIVEN one unparseable glob among good ones
+    /// WHEN the set is compiled
+    /// THEN the bad one is dropped and the rest still exclude.
+    #[test]
+    fn a_bad_glob_is_dropped_rather_than_fatal() {
+        let excluded = exclusions(&["a***b", "tests/fixtures/**"]);
+        assert!(excluded.is_excluded("/repo/tests/fixtures/creds.py", ""));
+        assert!(!excluded.is_excluded("/repo/a-b", ""));
+    }
+}

--- a/rust/hook/src/exclusion.rs
+++ b/rust/hook/src/exclusion.rs
@@ -149,7 +149,9 @@ fn is_pattern_valid(pattern: &str) -> bool {
     true
 }
 
-/// `translate_user_pattern()`: a glob to the regex Python compiles for it.
+/// `translate_user_pattern()`: a glob to the same pattern string Python builds
+/// for it. `regex` and `re` are different flavors, so the translation stays
+/// within the constructs both read alike.
 fn translate_user_pattern(pattern: &str) -> String {
     let mut escaped = String::with_capacity(pattern.len() * 2);
     for character in pattern.chars() {

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -13,6 +13,7 @@
 //! rather than guessing — see `config::dotenv_overrides()` and `user_config`.
 
 mod api;
+mod exclusion;
 mod message;
 mod notify;
 mod output;
@@ -226,9 +227,18 @@ fn scan_payloads(
         return Err(Error::Invalid("Error: no payloads to scan".into()));
     }
     let agent = payloads[0].agent;
+    let exclusions = exclusion::Exclusions::new(&config.user.secret);
 
     let mut pending: Vec<Pending> = Vec::new();
     for (index, payload) in payloads.iter_mut().enumerate() {
+        // Excluded by `secret.ignored_paths`: never read, never sent, allowed.
+        // READ only: every other tool's identifier is a command or a content
+        // hash, which a path pattern must not be tested against.
+        if payload.tool == Some(Tool::Read)
+            && exclusions.is_excluded(&payload.identifier, &payload.cwd)
+        {
+            continue;
+        }
         let Some((content, filename)) = scannable(config, payload) else {
             continue;
         };
@@ -649,6 +659,7 @@ mod tests {
             content: content.into(),
             identifier: identifier.into(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         }
@@ -960,6 +971,7 @@ mod tests {
             content: "inline".into(),
             identifier: "/nonexistent/nope.txt".into(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         };
@@ -983,6 +995,7 @@ mod tests {
             content: String::new(),
             identifier: path.to_string_lossy().to_string(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         };
@@ -1012,6 +1025,7 @@ mod tests {
             content: String::new(),
             identifier: path.to_string_lossy().to_string(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range,
         };
@@ -1113,6 +1127,7 @@ mod tests {
             content: String::new(),
             identifier: path.to_string_lossy().to_string(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         };
@@ -1143,6 +1158,7 @@ mod tests {
             content: String::new(),
             identifier: path.to_string_lossy().to_string(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         };
@@ -1163,6 +1179,7 @@ mod tests {
             content: String::new(),
             identifier: path.to_string_lossy().to_string(),
             agent: payload::Agent::Claude,
+            cwd: String::new(),
             raw: serde_json::Value::Object(Default::default()),
             read_range: None,
         };

--- a/rust/hook/src/message.rs
+++ b/rust/hook/src/message.rs
@@ -66,6 +66,26 @@ pub fn censor_string(text: &str) -> String {
     out
 }
 
+/// The `ignored_matches` entries `ggshield secret ignore --last-found` would
+/// write, one per distinct ignore sha, in the order the secrets are reported.
+///
+/// Spelled out because the message censors every match, so the sha is otherwise
+/// unknowable and a hand-written entry never matches. See
+/// `_false_positive_block()`.
+fn ignore_shas(secrets: &[Secret]) -> String {
+    let mut seen: Vec<String> = Vec::new();
+    for secret in secrets {
+        let sha = crate::api::ignore_sha(&secret.matches);
+        if !seen.contains(&sha) {
+            seen.push(sha);
+        }
+    }
+    seen.iter()
+        .map(|sha| format!("    - match: {sha}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// One bullet per secret, plus its incident URL when we know one. The censoring
 /// asterisks become bullets, which markdown would otherwise read as emphasis.
 fn secret_lines(secrets: &[Secret]) -> String {
@@ -155,6 +175,7 @@ pub fn from_secrets(secrets: &[Secret], payload: &Payload) -> String {
         ),
         ("identifier", payload.identifier.clone()),
         ("secret_lines", secret_lines(secrets)),
+        ("ignore_shas", ignore_shas(secrets)),
     ];
     let steps = if nb_incidents > 0 {
         REMEDIATION_STEPS_WITH_INCIDENT_TEMPLATE
@@ -231,6 +252,7 @@ mod tests {
             content: String::new(),
             identifier: identifier.into(),
             agent: crate::payload::Agent::Claude,
+            cwd: String::new(),
             raw: Value::Object(Default::default()),
             read_range: None,
         }
@@ -295,7 +317,30 @@ mod tests {
         // The censoring asterisks are rendered as bullets.
         assert!(!msg.contains("): byI*"), "{msg}");
         assert!(msg.contains("The command was not executed and the secret was not leaked."));
-        assert!(msg.ends_with("    ggshield secret ignore --last-found"));
+        assert!(msg.contains("    ggshield secret ignore --last-found"));
+        assert!(
+            msg.ends_with(&format!(
+                "    - match: {}",
+                crate::api::ignore_sha(&secrets[0].matches)
+            )),
+            "{msg}"
+        );
+    }
+
+    /// GIVEN two secrets that share one ignore sha
+    /// WHEN the false-positive block is built
+    /// THEN the entry appears once: it is a config to paste, not a tally.
+    #[test]
+    fn the_ignore_sha_entries_are_deduplicated() {
+        let one = secret("AWS Keys", "valid", &["aaa"]);
+        let same = secret("AWS Keys", "valid", &["aaa"]);
+        let other = secret("Generic Password", "valid", &["bbb"]);
+        let rendered = ignore_shas(&[one, same, other]);
+
+        assert_eq!(rendered.lines().count(), 2, "{rendered}");
+        for line in rendered.lines() {
+            assert!(line.starts_with("    - match: "), "{line}");
+        }
     }
 
     /// GIVEN two secrets found in a file the agent already read

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -250,6 +250,7 @@ mod tests {
             content: String::new(),
             identifier: "id".into(),
             agent,
+            cwd: String::new(),
             raw: Value::Object(Default::default()),
             read_range: None,
         }

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -125,7 +125,8 @@ impl Agent {
 
     /// The working directory the event happened in, used to resolve a relative
     /// Read path to the absolute identifier a tool call would produce, so both
-    /// share one verdict-cache key. "" when unknown.
+    /// share one verdict-cache key — and as the project root the default
+    /// exclusions are tested relative to. "" when unknown.
     fn event_cwd(self, data: &Value) -> String {
         match self {
             // Cursor reports its workspace roots instead of a `cwd`; the first
@@ -217,6 +218,9 @@ pub struct Payload {
     pub content: String,
     pub identifier: String,
     pub agent: Agent,
+    /// The `cwd` the identifier was resolved against, see `Agent::event_cwd()`.
+    pub cwd: String,
+
     /// The original hook JSON, `{}` for synthesised payloads as in Python. Only
     /// read for the desktop notification's command text.
     pub raw: Value,
@@ -355,13 +359,14 @@ fn normpath(path: &Path) -> String {
     out.to_string_lossy().into_owned()
 }
 
-fn read_payload(identifier: String, agent: Agent) -> Payload {
+fn read_payload(identifier: String, agent: Agent, cwd: &str) -> Payload {
     Payload {
         event_type: EventType::UserPrompt,
         tool: Some(Tool::Read),
         content: String::new(),
         identifier,
         agent,
+        cwd: cwd.to_string(),
         raw: Value::Object(Default::default()),
         read_range: None,
     }
@@ -398,7 +403,7 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
             content = lookup_str(&data, &["prompt"]);
             // Files named in the prompt can be read without a PreToolUse event.
             for path in find_filepaths(&content) {
-                payloads.push(read_payload(abs_read_path(&path, &cwd), agent));
+                payloads.push(read_payload(abs_read_path(&path, &cwd), agent, &cwd));
             }
         }
         EventType::PreToolUse => {
@@ -472,6 +477,7 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
         content,
         identifier,
         agent,
+        cwd,
         raw: data,
         read_range,
     });
@@ -514,6 +520,7 @@ fn parse_command(content: &str, agent: Agent, cwd: &str) -> Vec<Payload> {
         content: String::new(),
         identifier: abs_read_path(identifier.trim(), cwd),
         agent,
+        cwd: cwd.to_string(),
         raw: Value::Object(Default::default()),
         // `cat`/`Get-Content` read the whole file, and a partial read (`sed -n`,
         // `head`) is not treated as a read at all.

--- a/rust/hook/src/templates/false_positive.in
+++ b/rust/hook/src/templates/false_positive.in
@@ -1,3 +1,7 @@
 > If {this_is}, run:
 
     ggshield secret ignore --last-found
+
+  which adds to secret.ignored_matches in .gitguardian.yaml:
+
+{ignore_shas}

--- a/rust/hook/src/vibe.rs
+++ b/rust/hook/src/vibe.rs
@@ -229,6 +229,7 @@ mod tests {
             agent: crate::payload::Agent::Vibe,
             raw: json!({"tool_name": tool_name, "cwd": cwd}),
             read_range: None,
+            cwd: cwd.into(),
         }
     }
 

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -14,7 +14,7 @@ sides must produce but whose value is allowed to differ (see `same_request`).
   python3 tests/equivalence.py            # equivalence only
   python3 tests/equivalence.py --bench N  # also time both, N iterations/side
 
-Five matrices:
+Ten matrices:
   agents   6 assistants x their own payload shapes x {clean, secret}
   config   .gitguardian.yaml cases: discovery, precedence, and every key that
            changes the verdict or the request
@@ -28,6 +28,8 @@ Five matrices:
            not, and that both implementations share one cache file
   dotenv   a `.env` naming GITGUARDIAN_* settings: the instance and token both
            implementations resolve from it
+  exclude  the default ignored-path wildcards: which files a vendored *name*
+           may and may not swallow
   extra    fail-open, and the unrecognized-agent case
 
 Every payload fixture is copied from tests/unit/verticals/ai/test_hooks.py, so
@@ -92,6 +94,18 @@ COPY_FILE = "/tmp/ggshield-hook-equivalence-creds-copy.env"
 CONTENT_DIR = "/tmp"
 CONTENT_NAME = "ggshield-hook-equivalence-content.env"
 CONTENT_FILE = f"{CONTENT_DIR}/{CONTENT_NAME}"
+
+# The exclusion matrix's two checkouts: one that itself sits under a `vendor/`
+# directory, one whose path names nothing the default wildcards mention. Fixed
+# absolute paths, so both sides see the identical identifier -- which the
+# reported prose is built from.
+EXCL_ROOT = Path("/tmp/ggshield-hook-equivalence-exclusions")
+EXCL_VENDORED = EXCL_ROOT / "vendor" / "proj"
+EXCL_PLAIN = EXCL_ROOT / "proj"
+# `\` is a separator on Windows, not a filename character, so this fixture
+# cannot even be created there.
+BACKSLASH_NAME = r"node_modules\pkg\x.py"
+POSIX_ONLY = os.name != "nt"
 
 
 def agent_bases():
@@ -366,6 +380,38 @@ def config_cases(ignore_sha):
             None,
             "allow",
         ),
+        # secret.ignored_paths covers the file the READ names: never read, never
+        # sent, allowed -- as it already is for every other `secret scan`.
+        (
+            "ignored_path_matches",
+            "version: 2\nsecret:\n  ignored_paths:\n  - '**/*.env'\n",
+            None,
+            "allow",
+        ),
+        # A glob that does not cover it must leave the block intact: an exclusion
+        # must not widen past what was written.
+        (
+            "ignored_path_irrelevant",
+            "version: 2\nsecret:\n  ignored_paths:\n  - 'src/**'\n",
+            None,
+            "block",
+        ),
+        # A directory glob, the shape an agent writes for a fixtures dir.
+        (
+            "ignored_path_directory_glob",
+            "version: 2\nsecret:\n  ignored_paths:\n  - 'tmp/**'\n",
+            None,
+            "allow",
+        ),
+        # ...but the same glob with a leading slash does NOT match an absolute
+        # path: `translate_user_pattern()` turns a leading "/" into "^", which
+        # anchors at the start of the string, not at the filesystem root.
+        (
+            "ignored_path_rooted_glob_is_not_filesystem_absolute",
+            "version: 2\nsecret:\n  ignored_paths:\n  - '/tmp/**'\n",
+            None,
+            "block",
+        ),
         (
             "ignored_detector_other",
             "version: 2\nsecret:\n  ignored_detectors:\n  - Generic Password\n",
@@ -399,13 +445,6 @@ def config_cases(ignore_sha):
         (
             "filename_only",
             "version: 2\nsecret:\n  filename_only: true\n",
-            None,
-            "block",
-        ),
-        # ignored_paths must be a no-op on this path: the file is still scanned.
-        (
-            "ignored_paths_is_a_noop_here",
-            "version: 2\nsecret:\n  ignored_paths:\n  - '**/*.env'\n  - 'tmp/*'\n",
             None,
             "block",
         ),
@@ -483,12 +522,12 @@ def config_cases(ignore_sha):
             None,
             "block",
         ),
-        # paths-ignore converts to ignored_paths, still a no-op on this path.
+        # paths-ignore converts to secret.ignored_paths, which the hook honors.
         (
-            "v1_paths_ignore_is_a_noop_here",
+            "v1_paths_ignore",
             "version: 1\npaths-ignore:\n  - '**/*.env'\n",
             None,
-            "block",
+            "allow",
         ),
         # A v1 global config merged with a v2 local one.
         (
@@ -1458,6 +1497,15 @@ def compare_configs(tmp, ignore_sha):
             if actual != expected:
                 failures.append(f"config/{case} (expected {expected}, got {actual})")
                 print(f"        ^ expected the config to {expected}, but it did not")
+
+            # A block must carry the `ignored_matches` entry that would silence
+            # it: both sides agreeing on a message that dropped it would still
+            # read as equivalent.
+            if actual == "block":
+                for side, out in (("python", py), ("rust", rs)):
+                    if f"- match: {ignore_sha}".encode() not in out.stdout:
+                        failures.append(f"config/{case} ({side} has no ignore sha)")
+                        print(f"        ^ {side} blocked without the ignore sha")
     finally:
         mock.kill()
 
@@ -1467,6 +1515,94 @@ def compare_configs(tmp, ignore_sha):
     if same_requests(default, only):
         failures.append("config/filename_only had no effect on the request")
         print("  [DIFF ] config/filename_only did not change the POSTed filename")
+    return failures
+
+
+def write_exclusion_tree():
+    """The same files in both checkouts, so only the project path varies."""
+    shutil.rmtree(EXCL_ROOT, ignore_errors=True)
+    creds = f"AWS_KEY={CLIENT_ID}\n"
+    for project in (EXCL_VENDORED, EXCL_PLAIN):
+        for relative in ("src/creds.env", "node_modules/pkg/creds.env", "credentials"):
+            target = project / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(creds)
+        link = project / "node_modules" / ".cache" / "x"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(project / "credentials")
+        if POSIX_ONLY:
+            (project / BACKSLASH_NAME).write_text(creds)
+
+
+def exclusion_cases():
+    """(name, project, path read inside it, python verdict, rust verdict)."""
+    cases = [
+        # Teeth: with nothing excluded, this payload shape does block.
+        ("plain_file", EXCL_PLAIN, "src/creds.env", "block", "block"),
+        # The checkout's own path runs through `vendor/`. Python tests the
+        # absolute identifier, so `**/vendor/**/*` matches on that ancestor and
+        # nothing in the project is ever scanned; Rust tests the path relative
+        # to the event cwd. Tracked in `known_divergences`.
+        ("vendor_ancestor", EXCL_VENDORED, "src/creds.env", "allow", "block"),
+        # A symlink parked in `node_modules` pointing outside it. Python
+        # excludes on the link's name; Rust resolves it first. Also tracked.
+        (
+            "symlink_out_of_node_modules",
+            EXCL_PLAIN,
+            "node_modules/.cache/x",
+            "allow",
+            "block",
+        ),
+        # A file that really does live in a vendored tree inside the project
+        # must stay excluded on both sides.
+        (
+            "real_file_in_node_modules",
+            EXCL_PLAIN,
+            "node_modules/pkg/creds.env",
+            "allow",
+            "allow",
+        ),
+    ]
+    if POSIX_ONLY:
+        # Backslashes are ordinary filename characters here, so neither side may
+        # read this name as a `node_modules/` path.
+        cases.append(
+            ("backslash_filename", EXCL_PLAIN, BACKSLASH_NAME, "block", "block")
+        )
+    return cases
+
+
+def compare_exclusions(tmp):
+    """The default ignored-path wildcards: a vendored name vs. a vendored file."""
+    failures = []
+    print("\nDefault ignored-path wildcards: which reads they may swallow")
+    log = tmp / "requests-exclusions.jsonl"
+    mock, port = start_mock("secret", log)
+    try:
+        for case, project, relative, expect_py, expect_rs in exclusion_cases():
+            payload = {
+                **agent_bases()["claude"],
+                "cwd": str(project),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": str(project / relative)},
+            }
+            verdict_ok, request_ok, py, rs, _ = compare_one(
+                tmp, log, port, f"excl-{case}", payload, setup=write_exclusion_tree
+            )
+            report(failures, f"exclusion/{case}", verdict_ok, request_ok, py, rs)
+            # Each side's own verdict is asserted too: two sides that both stop
+            # excluding, or both exclude everything, would still agree.
+            for side, out, expected in (
+                ("python", py, expect_py),
+                ("rust", rs, expect_rs),
+            ):
+                actual = "block" if b"deny" in out.stdout else "allow"
+                if actual != expected:
+                    failures.append(f"exclusion/{case} ({side} {actual})")
+                    print(f"        ^ {side} {actual}ed, expected {expected}")
+    finally:
+        mock.kill()
     return failures
 
 
@@ -1846,6 +1982,7 @@ def main():
         failures += compare_batches(tmp)
         failures += compare_verdict_cache(tmp)
         failures += compare_dotenv(tmp)
+        failures += compare_exclusions(tmp)
         failures += extra_cases(tmp)
         if "--bench" in sys.argv:
             n = int(sys.argv[sys.argv.index("--bench") + 1])
@@ -1853,7 +1990,22 @@ def main():
         # Expected, tracked divergences: the gate stays green for these but
         # still reddens on anything new. Keep this list empty in the steady
         # state; every entry needs a reason and a removal condition.
-        known_divergences = {}
+        known_divergences = {
+            "exclusion/vendor_ancestor": (
+                "the default wildcards are tested against the path relative to "
+                "the event cwd, not the absolute identifier. Python's hook "
+                "matches `**/vendor/**/*` on an ancestor *above* the checkout, "
+                "so a project living under any vendor-like directory has every "
+                "read excluded and is never scanned at all. Remove once the "
+                "Python hook tests the project-relative path too."
+            ),
+            "exclusion/symlink_out_of_node_modules": (
+                "the default wildcards are tested against the resolved path, so "
+                "a symlink parked in `node_modules/` cannot hide a file that "
+                "lives outside it. Python excludes on the link's own name. "
+                "Remove once the Python hook resolves the path too."
+            ),
+        }
         known = [f for f in failures if f in known_divergences]
         unexpected = [f for f in failures if f not in known_divergences]
         for name in known:
@@ -1871,6 +2023,7 @@ def main():
         return 0
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
+        shutil.rmtree(EXCL_ROOT, ignore_errors=True)
         Path(READ_FILE).unlink(missing_ok=True)
 
 

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -15,6 +15,7 @@ from pygitguardian.models import MCPActivityResponse, MultiScanResult
 from pygitguardian.models import ScanResult as ApiScanResult
 
 from ggshield.core.config.user_config import SecretConfig
+from ggshield.core.filter import init_exclusion_regexes
 from ggshield.core.scan import File, ScanContext, ScanMode, StringScannable
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.ai.agents import (
@@ -116,10 +117,13 @@ def _make_secret(
     incident_url: Optional[str] = None,
 ):
     """Minimal Secret for tests; _message_from_secrets only uses
-    detector_display_name, validity, matches[].match, known_secret and
-    incident_url."""
+    detector_display_name, validity, matches[].match, matches[].match_type,
+    known_secret and incident_url."""
     mock_match = MagicMock()
     mock_match.match = match_str
+    # get_ignore_sha() hashes "<match>,<match_type>": a MagicMock would hash its
+    # repr, unique per instance, and the sha reaches the message.
+    mock_match.match_type = "client_secret"
     return Secret(
         detector_display_name="dummy-detector",
         detector_name="dummy-detector",
@@ -404,6 +408,58 @@ class TestBatchedPayloadScan:
         for call in mock_scanner.scan.call_args_list:
             urls = [document.url for document in call.args[0]]
             assert len(urls) == len(set(urls))
+
+    def test_a_read_of_an_ignored_path_is_never_scanned(self, tmp_path: Path):
+        """GIVEN secret.ignored_paths covering the file a READ names
+        WHEN the hook scans the event
+        THEN the file is never sent to the API and the read is allowed."""
+        file = tmp_path / "fixtures" / "creds.py"
+        file.parent.mkdir()
+        file.write_text("token = 'xxx'")
+        mock_scanner = _scanner_per_document()
+
+        results = AIHookScanner(
+            mock_scanner, init_exclusion_regexes(["fixtures/**"])
+        )._scan_contents([self._read_payload(file)])
+
+        mock_scanner.scan.assert_not_called()
+        assert [result.block for result in results] == [False]
+
+    def test_a_read_outside_the_ignored_paths_is_still_scanned(self, tmp_path: Path):
+        """GIVEN secret.ignored_paths that does not cover the file a READ names
+        WHEN the hook scans the event
+        THEN the file is scanned: an exclusion must not widen past its glob."""
+        file = tmp_path / "src" / "creds.py"
+        file.parent.mkdir()
+        file.write_text("token = 'xxx'")
+        mock_scanner = _scanner_per_document()
+
+        AIHookScanner(
+            mock_scanner, init_exclusion_regexes(["fixtures/**"])
+        )._scan_contents([self._read_payload(file)])
+
+        mock_scanner.scan.assert_called_once()
+
+    def test_an_ignored_path_does_not_exclude_a_command_that_mentions_it(self):
+        """GIVEN a BASH payload whose command text contains an excluded path
+        WHEN the hook scans it
+        THEN it is still scanned: a command is not a file, so a substring match
+        must not silence it."""
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.BASH,
+            content="cat fixtures/creds.py && export TOKEN=xxx",
+            identifier="cat fixtures/creds.py && export TOKEN=xxx",
+            agent=Cursor(),
+            raw={},
+        )
+        mock_scanner = _scanner_per_document()
+
+        AIHookScanner(
+            mock_scanner, init_exclusion_regexes(["fixtures/**"])
+        )._scan_contents([payload])
+
+        mock_scanner.scan.assert_called_once()
 
     def test_a_prompt_mentioning_files_makes_a_single_api_call(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1241,11 +1297,14 @@ class TestMessageFromSecrets:
     def test_message_always_ends_with_false_positive_block(
         self, event_type: EventType, tool: Optional[Tool]
     ):
-        """Every message ends with the false positive escape hatch."""
+        """Every message ends with the false positive escape hatch, and with the
+        `ignored_matches` entry it would write."""
         payload = self._payload(event_type=event_type, tool=tool)
-        message = AIHookScanner._message_from_secrets([_make_secret("sk-xxx")], payload)
-        assert message.endswith("    ggshield secret ignore --last-found")
+        secret = _make_secret("sk-xxx")
+        message = AIHookScanner._message_from_secrets([secret], payload)
+        assert "    ggshield secret ignore --last-found" in message
         assert "> If this is a false positive, run:" in message
+        assert message.endswith(f"    - match: {secret.get_ignore_sha()}")
 
     def test_false_positive_block_is_plural_for_several_secrets(self):
         """The false positive block says "these are false positives" when


### PR DESCRIPTION
Two fixes behind the same report: a user excludes a false positive in `.gitguardian.yaml`, the hook blocks anyway, and the agent concludes it "doesn't read my local .gitguardian.yaml".

Stacked on #1396.

## 1. `ignored_paths` was silently inert

`ignored_paths` is enforced when files are *collected*, via `ctx_obj.exclusion_regexes`. Every other `secret scan` command threads it into its collection call; the ai-hook builds scannables straight from the payload, so it computed the regexes and never used them. `ignored_matches` / `ignored_detectors` were unaffected — they apply to the API's answer.

Reproduced before the fix, same file and config, only the key differs:

| `.gitguardian.yaml` | before | after |
|---|---|---|
| `ignored_paths` | **blocked** | allowed |
| `ignored_detectors` | allowed | allowed |
| `ignored_matches` | allowed | allowed |
| *(none)* | blocked | blocked |

For comparison, `secret scan path` on that same file already refused: *"An ignored file or directory cannot be scanned."*

Only a READ is checked. Every other tool's identifier is a command or a content hash, and testing path patterns against those would silence a scan on an accidental substring match; a prompt's `@`-mention is a READ payload, so it is covered.

**Behaviour change worth knowing:** `IGNORED_DEFAULT_WILDCARDS` is unioned into `ignored_paths` for every scan command, so it now applies here too — reads under `node_modules/`, `.venv/`, `vendor/`, `.git/` and friends are no longer scanned. That is what "align with the other commands" means; flagged in the changelog.

## 2. A hand-written `ignored_matches` entry could never work

The message censors every match, so neither a human nor an agent can write a valid entry from it — the value is unknown and so is its hash. The block message now prints the entry `ggshield secret ignore --last-found` would write. The sha is a digest, not the secret, and the command already writes it in clear.

## Parity

Both fixes land in the Rust hook too, including a port of `translate_user_pattern()`, verified against Python's actual output for every pattern and validity case. Harness: `RESULT: EQUIVALENT`, `known_divergences = {}`.

Two Python quirks are **pinned rather than fixed**, since the implementations must agree quirk included:
- a trailing `**` spans one path segment, so `tests/fixtures/**` does not match `tests/fixtures/sub/creds.py`
- a leading `/` anchors at the start of the string, not the filesystem root, so `/tmp/**` does not match `/tmp/x.env`

The harness also gained teeth for fix 2: two implementations that both dropped the entry would still be "equivalent", so a block is now asserted to carry the sha the harness computes itself.

## Verification

2652 Python tests, 78 Rust hook tests, harness `EQUIVALENT`, clippy and fmt clean.

`tests/unit/verticals/ai/test_cmd_ai.py` fails `flake8-isort` under a local venv's isort 8 — inherited from the stack predating #1401, untouched here, and clean under the isort 5.13.2 that CI pins. It resolves when the stack rebases onto `main`.