### PR TITLE
feat(ai-hook): enforce MCP permissions natively

### DIFF
--- a/changelog.d/20260811_150000_achille.mascia_ai_hook_native_mcp_policy.md
+++ b/changelog.d/20260811_150000_achille.mascia_ai_hook_native_mcp_policy.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The native AI hook now checks MCP tool calls against your organization's
+  policies, instead of only scanning their arguments for secrets. A call the
+  dashboard denies is denied again, and the calls it permits reach the dashboard
+  as MCP activity. When the local inventory of MCP servers is older than an hour,
+  the hook hands the event to the bundled Python implementation, which refreshes
+  it — so a missing or stale inventory delays the check rather than skipping it.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -633,6 +633,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ggshield-discovery"
+version = "0.1.0"
+dependencies = [
+ "ggshield-common",
+ "ggshield-config",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "ggshield-dispatcher"
 version = "0.1.0"
 dependencies = [
@@ -645,8 +656,10 @@ dependencies = [
 name = "ggshield-hook"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "ggshield-common",
  "ggshield-config",
+ "ggshield-discovery",
  "regex",
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["common", "config", "hook", "dispatcher"]
+members = ["common", "config", "discovery", "hook", "dispatcher"]
 resolver = "2"
 
 [workspace.package]
@@ -72,6 +72,7 @@ tempfile = "3"
 
 ggshield-common = { path = "common" }
 ggshield-config = { path = "config" }
+ggshield-discovery = { path = "discovery" }
 
 [workspace.lints.clippy]
 unwrap_used = "warn"

--- a/rust/discovery/Cargo.toml
+++ b/rust/discovery/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ggshield-discovery"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Reads the AI inventory ggshield's discovery walk leaves in ai_discovery.json."
+
+[dependencies]
+ggshield-common = { workspace = true }
+ggshield-config = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/discovery/src/lib.rs
+++ b/rust/discovery/src/lib.rs
@@ -1,0 +1,490 @@
+//! The AI inventory ggshield's discovery walk leaves in `ai_discovery.json`:
+//! who the user is, and which MCP servers the API knows about. The walk itself
+//! stays in Python; this only reads what it wrote.
+//!
+//! Freshness is load-bearing. `refresh_and_maybe_submit_discovery()` rewrites the
+//! file with a one hour TTL, so a fresh file is this session's walk, reconciled
+//! server names included. A stale or absent one means there *is* no inventory,
+//! and a caller must decline rather than invent one: the server names in here are
+//! what an organisation's policies are written against.
+//!
+//! Separate from the hook crate — `ggshield ai discover`, the history backfill
+//! and agent activity all read the same file.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use serde::Deserialize;
+
+use ggshield_common::secure_file;
+use ggshield_config::config;
+
+/// `AI_DISCOVERY_CACHE_FILENAME` in cache.py, in the same cache directory.
+const FILENAME: &str = "ai_discovery.json";
+
+/// `DISCOVERY_CACHE_TTL_SECONDS`.
+const TTL: Duration = Duration::from_secs(3600);
+
+/// `MTIME_SKEW_TOLERANCE_SECONDS`. The wall clock and the filesystem mtime do not
+/// come from the same source, so a just-touched file can read marginally in the
+/// future. Tolerate that much, while still treating a real clock jump as stale
+/// rather than pinning the inventory fresh forever.
+const MTIME_SKEW_TOLERANCE: Duration = Duration::from_secs(5);
+
+/// `UserInfo`. Sent verbatim with every activity report, so it is read rather
+/// than recomputed: `machine_id` is generated once and persisted here, and
+/// regenerating it would split one machine's history in two.
+#[derive(Debug, Clone, Deserialize)]
+pub struct User {
+    pub hostname: String,
+    pub username: String,
+    pub machine_id: String,
+    #[serde(default)]
+    pub user_email: Option<String>,
+}
+
+/// One assistant's declaration of a server. Several can point at the same
+/// [`Server`], so a mangled name is a *configuration* name, not a server name.
+#[derive(Debug, Deserialize)]
+pub struct Configuration {
+    pub name: String,
+    pub agent: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Tool {
+    pub name: String,
+}
+
+/// `MCPServer`. `name` is the canonical one — the dashboard's, once the API has
+/// reconciled the walk — and the only name a policy can be written against.
+#[derive(Debug, Deserialize)]
+pub struct Server {
+    pub name: String,
+    #[serde(default)]
+    pub tools: Vec<Tool>,
+    #[serde(default)]
+    pub configurations: Vec<Configuration>,
+}
+
+/// `AIDiscovery`, minus the fields no per-tool-call decision reads. Unknown
+/// fields are ignored, so the file Python writes deserializes as is.
+#[derive(Debug, Deserialize)]
+pub struct Inventory {
+    pub user: User,
+    #[serde(default)]
+    pub servers: Vec<Server>,
+}
+
+/// The inventory, but only while it is fresh.
+///
+/// `None` covers every reason there is no usable inventory — no file, a file
+/// another user could have written, unparseable content, a walk older than the
+/// TTL — because they all mean the same thing to a caller: nothing here is
+/// trustworthy enough to decide with.
+pub fn load_fresh() -> Option<Inventory> {
+    let path = config::cache_dir()?.join(FILENAME);
+    if !is_fresh(&path) {
+        return None;
+    }
+    serde_json::from_str(&secure_file::read_if_trusted(&path)?).ok()
+}
+
+/// `is_discovery_cache_fresh()`: refreshed less than the TTL ago, allowing for
+/// clock skew in the other direction.
+fn is_fresh(path: &Path) -> bool {
+    let Ok(mtime) = std::fs::metadata(path).and_then(|meta| meta.modified()) else {
+        return false;
+    };
+    match SystemTime::now().duration_since(mtime) {
+        Ok(age) => age < TTL,
+        Err(ahead) => ahead.duration() <= MTIME_SKEW_TOLERANCE,
+    }
+}
+
+/// `_mangle_server_name()`: Claude Code (and Codex) replace every character
+/// outside `[A-Za-z0-9-]` with an underscore, one for one.
+fn mangle_claude(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// VS Code mangles harder: *runs* of those characters collapse into a single
+/// underscore, the result is lower-cased, and only the first 13 characters
+/// survive. Two configurations can therefore mangle to the same key.
+fn mangle_vscode(name: &str) -> String {
+    let mut out = String::new();
+    let mut in_run = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '-' {
+            out.push(c.to_ascii_lowercase());
+            in_run = false;
+        } else if !in_run {
+            out.push('_');
+            in_run = true;
+        }
+    }
+    out.chars().take(13).collect()
+}
+
+/// Copilot CLI lower-cases and replaces every non-word character with a hyphen.
+///
+/// Python then IDNA-encodes the result, which is the identity for an ASCII name
+/// and punycode for anything else. Not reproduced: a non-ASCII configuration name
+/// falls through to the positional split below, the same answer Python gives for
+/// any name it cannot find in the inventory.
+fn mangle_copilot(name: &str) -> String {
+    name.chars()
+        .flat_map(char::to_lowercase)
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+impl Inventory {
+    fn configurations(&self) -> impl DoubleEndedIterator<Item = (&Server, &Configuration)> {
+        self.servers
+            .iter()
+            .flat_map(|server| server.configurations.iter().map(move |conf| (server, conf)))
+    }
+
+    /// `_resolve_server_name()`: the canonical server behind a Claude Code or
+    /// Codex configuration name, falling back to the configuration name for a
+    /// server the walk has not seen yet.
+    pub fn server_for_config_name(&self, cfg_name: &str) -> String {
+        self.configurations()
+            .find(|(_, conf)| mangle_claude(&conf.name) == cfg_name)
+            .map_or_else(|| cfg_name.to_string(), |(server, _)| server.name.clone())
+    }
+
+    /// Cursor names only the tool, so the server is whichever discovered one owns
+    /// a tool by that name. The *last* such server wins, as Python's dict build
+    /// leaves it; duplicate tool names across servers are unresolvable either way.
+    pub fn server_for_tool_name(&self, tool: &str) -> String {
+        self.servers
+            .iter()
+            .rfind(|server| server.tools.iter().any(|owned| owned.name == tool))
+            .map_or_else(String::new, |server| server.name.clone())
+    }
+
+    /// `_lookup_server_name()`: split `mcp_<server>_<tool>`, where both halves can
+    /// contain the separator, so the widest prefix that is a known configuration
+    /// wins. Returns `(server, tool)`.
+    ///
+    /// On a prefix two configurations mangle to alike — easy to reach, since
+    /// truncating to 13 characters is enough to collide — the *last* one wins, as
+    /// Python's map build leaves it. Answering with the other server would check the
+    /// call against a policy written for something else.
+    pub fn split_underscored(&self, raw_tool_name: &str) -> (String, String) {
+        // Drops the "mcp" prefix, as Python's `_, *parts` does.
+        let parts: Vec<&str> = raw_tool_name.split('_').skip(1).collect();
+        self.split_on(&parts, "_", |candidate| {
+            self.configurations()
+                .rfind(|(_, conf)| mangle_vscode(&conf.name) == candidate)
+                .map(|(server, _)| server.name.clone())
+        })
+        // No prefix matched: the first part is the server and the rest the tool.
+        .unwrap_or_else(|| match parts.split_first() {
+            Some((first, rest)) => (first.to_string(), rest.join("_")),
+            None => (String::new(), String::new()),
+        })
+    }
+
+    /// The same walk, and the same last-one-wins, for Copilot CLI's
+    /// `<server>-<tool>`, whose configuration names really do contain hyphens.
+    /// Restricted to `agent`'s own configurations: Copilot cannot import another
+    /// assistant's servers.
+    pub fn split_hyphenated(&self, raw_tool_name: &str, agent: &str) -> (String, String) {
+        let parts: Vec<&str> = raw_tool_name.split('-').collect();
+        self.split_on(&parts, "-", |candidate| {
+            // Lower-cased because Copilot preserves the case of the tool name
+            // while the mangled key does not.
+            let candidate = candidate.to_lowercase();
+            self.configurations()
+                .rfind(|(_, conf)| conf.agent == agent && mangle_copilot(&conf.name) == candidate)
+                .map(|(server, _)| server.name.clone())
+        })
+        // No prefix matched: everything but the last part is the server name.
+        .unwrap_or_else(|| match parts.split_last() {
+            Some((tool, head)) => (head.join("-"), tool.to_string()),
+            None => (String::new(), String::new()),
+        })
+    }
+
+    /// The widest prefix of `parts` that `resolve` recognises, and the rest as the
+    /// tool name.
+    ///
+    /// Widest is `parts` minus its last element, never the whole of it: Python
+    /// starts its loop at `parts[:-0]` == `parts[:0]`, the *empty* prefix, so a
+    /// configuration can never claim the entire name.
+    fn split_on(
+        &self,
+        parts: &[&str],
+        separator: &str,
+        resolve: impl Fn(&str) -> Option<String>,
+    ) -> Option<(String, String)> {
+        (1..parts.len()).rev().find_map(|head_len| {
+            let (head, tail) = parts.split_at(head_len);
+            resolve(&head.join(separator)).map(|server| (server, tail.join(separator)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `GG_CACHE_DIR` is process-wide, so the tests that point it somewhere else
+    /// take this lock.
+    static CACHE_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_cache_dir() -> (std::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
+        let guard = CACHE_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialised by the mutex above.
+        unsafe { std::env::set_var("GG_CACHE_DIR", dir.path()) };
+        (guard, dir)
+    }
+
+    /// One `ai_discovery.json` in the shape ggshield writes, with a few keys this
+    /// crate must ignore.
+    const CACHE: &str = r#"{
+        "user": {"hostname": "laptop", "username": "dev",
+                 "machine_id": "m-1", "user_email": null},
+        "discovery_duration": 1.5,
+        "agents": [{"name": "claude-code", "hooks_installed": true}],
+        "servers": [
+            {"name": "GitHub", "display_name": "GitHub", "resources": [], "prompts": [],
+             "tools": [{"name": "delete_repository"}],
+             "configurations": [
+                {"name": "git hub", "agent": "claude-code", "scope": "user",
+                 "transport": "stdio", "project": null},
+                {"name": "git.hub", "agent": "copilot", "scope": "user",
+                 "transport": "stdio", "project": null}]},
+            {"name": "Sentry",
+             "tools": [{"name": "find_issues"}],
+             "configurations": [
+                {"name": "sentry-prod", "agent": "vscode", "scope": "user",
+                 "transport": "http"}]}
+        ]
+    }"#;
+
+    fn inventory() -> Inventory {
+        serde_json::from_str(CACHE).expect("the shipped shape parses")
+    }
+
+    /// GIVEN an `ai_discovery.json` carrying fields this crate does not read
+    /// WHEN it is deserialized
+    /// THEN the user and the servers come through and the rest is ignored.
+    #[test]
+    fn the_python_cache_shape_deserializes() {
+        let inventory = inventory();
+        assert_eq!(inventory.user.machine_id, "m-1");
+        assert_eq!(inventory.user.user_email, None);
+        assert_eq!(inventory.servers.len(), 2);
+        assert_eq!(inventory.servers[0].configurations[1].agent, "copilot");
+    }
+
+    /// GIVEN a fresh cache file, then one aged past the TTL, then none at all
+    /// WHEN a fresh inventory is asked for
+    /// THEN only the first answers. A stale or absent walk must read as "no
+    /// inventory", never as an empty one, which resolves every server name to a
+    /// guess.
+    #[test]
+    fn only_a_fresh_cache_loads() {
+        let (_guard, dir) = with_cache_dir();
+        let path = dir.path().join(FILENAME);
+        assert!(load_fresh().is_none(), "no file at all");
+
+        secure_file::write_private(&path, CACHE).expect("write");
+        assert!(load_fresh().is_some(), "just written");
+
+        let stale = SystemTime::now() - TTL - Duration::from_secs(1);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .expect("open")
+            .set_modified(stale)
+            .expect("set mtime");
+        assert!(load_fresh().is_none(), "older than the TTL");
+    }
+
+    /// GIVEN mtimes on both sides of "now"
+    /// WHEN freshness is tested
+    /// THEN the tolerance covers a file that reads marginally in the future, but a
+    /// clock jump does not pin the inventory fresh forever.
+    #[test]
+    fn a_future_mtime_is_tolerated_only_within_the_skew() {
+        let (_guard, dir) = with_cache_dir();
+        let path = dir.path().join(FILENAME);
+        secure_file::write_private(&path, CACHE).expect("write");
+        let touch = |offset: Duration, ahead: bool| {
+            let when = if ahead {
+                SystemTime::now() + offset
+            } else {
+                SystemTime::now() - offset
+            };
+            std::fs::File::options()
+                .write(true)
+                .open(&path)
+                .expect("open")
+                .set_modified(when)
+                .expect("set mtime");
+            is_fresh(&path)
+        };
+        assert!(touch(Duration::from_secs(1), true), "within the skew");
+        assert!(!touch(Duration::from_secs(600), true), "a clock jump");
+        assert!(touch(TTL - Duration::from_secs(10), false), "just in time");
+        assert!(!touch(TTL + Duration::from_secs(10), false), "expired");
+    }
+
+    /// GIVEN a cache file another local user could write
+    /// WHEN the inventory is loaded
+    /// THEN it is refused: the server names in it decide which policy applies.
+    #[cfg(unix)]
+    #[test]
+    fn a_widely_writable_cache_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_guard, dir) = with_cache_dir();
+        let path = dir.path().join(FILENAME);
+        secure_file::write_private(&path, CACHE).expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).expect("chmod");
+        assert!(load_fresh().is_none());
+    }
+
+    /// GIVEN a Claude Code or Codex configuration name, as those agents mangle it
+    /// WHEN the server is resolved
+    /// THEN it is the canonical name, and an unknown configuration keeps its own.
+    #[test]
+    fn a_mangled_configuration_name_resolves_to_the_canonical_server() {
+        let inventory = inventory();
+        // "git hub" reaches us as "git_hub".
+        assert_eq!(inventory.server_for_config_name("git_hub"), "GitHub");
+        assert_eq!(inventory.server_for_config_name("unheard-of"), "unheard-of");
+    }
+
+    /// GIVEN a tool name, which is all Cursor reports
+    /// WHEN the server is resolved
+    /// THEN the server owning that tool answers, and an unknown tool resolves to
+    /// no server rather than to a guess.
+    #[test]
+    fn cursor_resolves_the_server_from_the_tool_it_owns() {
+        let inventory = inventory();
+        assert_eq!(inventory.server_for_tool_name("find_issues"), "Sentry");
+        assert_eq!(inventory.server_for_tool_name("no_such_tool"), "");
+    }
+
+    /// GIVEN VS Code tool names whose server and tool halves both contain "_"
+    /// WHEN they are split
+    /// THEN the widest prefix that is a known configuration wins, and with no
+    /// match the first part is taken as the server.
+    #[test]
+    fn vscode_splits_on_the_widest_known_configuration() {
+        let inventory = inventory();
+        // "sentry-prod" mangles to itself: 11 characters, already lower case.
+        assert_eq!(
+            inventory.split_underscored("mcp_sentry-prod_find_issues"),
+            ("Sentry".to_string(), "find_issues".to_string())
+        );
+        // Nothing matches: the first part is the server, the rest the tool.
+        assert_eq!(
+            inventory.split_underscored("mcp_other_do_a_thing"),
+            ("other".to_string(), "do_a_thing".to_string())
+        );
+        // A configuration can never claim the whole name: no tool left to report.
+        assert_eq!(
+            inventory.split_underscored("mcp_sentry-prod"),
+            ("sentry-prod".to_string(), String::new())
+        );
+    }
+
+    /// GIVEN Copilot CLI tool names, whose separator also occurs in the server
+    /// configuration name
+    /// WHEN they are split
+    /// THEN the mangled configuration matches case-insensitively, only for
+    /// Copilot's own configurations, and the fallback keeps the last part as the
+    /// tool.
+    #[test]
+    fn copilot_splits_on_its_own_configurations_only() {
+        let inventory = inventory();
+        // "git.hub" mangles to "git-hub", and Copilot preserves the tool's case.
+        assert_eq!(
+            inventory.split_hyphenated("git-hub-delete_repository", "copilot"),
+            ("GitHub".to_string(), "delete_repository".to_string())
+        );
+        // That configuration is Copilot's, not VS Code's, so the split falls back.
+        assert_eq!(
+            inventory.split_hyphenated("git-hub-delete_repository", "vscode"),
+            ("git-hub".to_string(), "delete_repository".to_string())
+        );
+    }
+
+    /// Two servers whose configuration names mangle to the same VS Code key
+    /// ("github_enterp", both truncated at 13 characters) and the same Copilot key
+    /// ("github-enterprise").
+    const COLLIDING: &str = r#"{
+        "user": {"hostname": "laptop", "username": "dev",
+                 "machine_id": "m-1", "user_email": null},
+        "servers": [
+            {"name": "GitHub-Public",
+             "configurations": [
+                {"name": "GitHub Enterprise", "agent": "vscode"},
+                {"name": "GitHub Enterprise", "agent": "copilot"}]},
+            {"name": "GitHub-Internal",
+             "configurations": [
+                {"name": "GitHub Enterprise Prod", "agent": "vscode"},
+                {"name": "GitHub.Enterprise", "agent": "copilot"}]}
+        ]
+    }"#;
+
+    /// GIVEN a mangled prefix two configurations resolve to
+    /// WHEN a VS Code or Copilot tool name is split on it
+    /// THEN the last of them answers, which is the server Python's map build names.
+    /// The other one is a different server with a different policy: reporting it
+    /// would have the API permit a call an administrator denied.
+    #[test]
+    fn colliding_mangled_names_resolve_to_the_last_configuration() {
+        let inventory: Inventory = serde_json::from_str(COLLIDING).expect("parses");
+        assert_eq!(
+            inventory.split_underscored("mcp_github_enterp_delete_repository"),
+            (
+                "GitHub-Internal".to_string(),
+                "delete_repository".to_string()
+            )
+        );
+        assert_eq!(
+            inventory.split_hyphenated("github-enterprise-delete_repository", "copilot"),
+            (
+                "GitHub-Internal".to_string(),
+                "delete_repository".to_string()
+            )
+        );
+    }
+
+    /// GIVEN each agent's mangling of one server configuration name
+    /// WHEN it is applied
+    /// THEN it matches that agent's own rules: one underscore per character for
+    /// Claude Code, collapsed and truncated for VS Code, hyphens and lower case
+    /// for Copilot.
+    #[test]
+    fn each_agent_mangles_a_name_its_own_way() {
+        assert_eq!(mangle_claude("My Server.v2"), "My_Server_v2");
+        // Runs collapse, lower case, and cut at 13 characters.
+        assert_eq!(mangle_vscode("My  Server.v2 is long"), "my_server_v2_");
+        assert_eq!(mangle_copilot("My Server.v2"), "my-server-v2");
+        // A hyphen is not a word character for Copilot, but it maps to itself.
+        assert_eq!(mangle_copilot("claude-ai"), "claude-ai");
+    }
+}

--- a/rust/hook/Cargo.toml
+++ b/rust/hook/Cargo.toml
@@ -12,11 +12,14 @@ path = "src/lib.rs"
 [dependencies]
 ggshield-common = { workspace = true }
 ggshield-config = { workspace = true }
+ggshield-discovery = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ureq = { workspace = true }
 regex = { workspace = true }
 sha2 = { workspace = true }
+# The MCP activity report's `timestamp`, an ISO 8601 instant.
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/rust/hook/src/api.rs
+++ b/rust/hook/src/api.rs
@@ -1,7 +1,9 @@
-//! `POST /v1/multiscan`, and the instance limits that decide how a scan is split.
+//! `POST /v1/multiscan` and `POST /v1/agent-activity/mcp-activity`, and the
+//! instance limits that decide how a scan is split.
 //!
-//! Detection is entirely server-side: this module ships bytes and interprets a
-//! verdict. There is no detector, no regex and no rule here.
+//! Neither decision is taken here: this module ships bytes and interprets a
+//! verdict. There is no detector, no regex, no rule and no policy here, and there
+//! must never be one.
 
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -10,6 +12,9 @@ use ggshield_common::error::Error;
 use ggshield_common::hash::sha256_hex;
 use ggshield_config::config::{self, Config, Limits, SIZE_METADATA_OVERHEAD};
 use ggshield_config::user_config::SecretConfig;
+use ggshield_discovery::{Inventory, User};
+
+use crate::payload::Payload;
 
 /// `_API_PATH_MAX_LENGTH` in secret_scanner.py.
 const API_PATH_MAX_LENGTH: usize = 256;
@@ -411,6 +416,108 @@ fn send_once(
         .read_to_string()
         .map_err(|e| Error::scan(e.to_string()))?;
     Ok((status, text))
+}
+
+/// `MCPActivityRequest`, field for field and in pygitguardian's order.
+fn activity_body(payload: &Payload, inventory: &Inventory) -> String {
+    let activity = payload.agent.mcp_activity(&payload.raw, inventory);
+    let User {
+        hostname,
+        username,
+        machine_id,
+        user_email,
+    } = &inventory.user;
+    // The arguments verbatim; `preserve_order` keeps the agent's own key order
+    // (see the workspace manifest). Absent, or anything but an object, sends the
+    // empty object the field is declared as rather than a body the API rejects.
+    let input = payload
+        .raw
+        .get("tool_input")
+        .filter(|value| value.is_object())
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
+    json!({
+        "user": {
+            "hostname": hostname,
+            "username": username,
+            "machine_id": machine_id,
+            "user_email": user_email,
+        },
+        "tool": activity.tool,
+        "server": activity.server,
+        "agent": payload.agent.name(),
+        "model": activity.model,
+        "cwd": activity.cwd,
+        "input": input,
+        // `HookPayload.timestamp` is the moment the hook ran, not a field of the
+        // event; marshmallow dumps it as an ISO 8601 instant with microseconds.
+        "timestamp": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, false),
+    })
+    .to_string()
+}
+
+/// `log_mcp_activity()`: report the MCP tool call and read back whether the
+/// organisation permits it.
+///
+/// `Some(reason)` is a denial the caller must apply. `None` allows — and so does a
+/// failed request, matching mcp.py, which swallows the exception and returns
+/// allowed. No warning either, for the same reason.
+///
+/// An unreadable token is the exception: Python's client needs it before it can ask
+/// at all, so it fails open *visibly*. Here nothing else needs it for an MCP call
+/// with no arguments — no content to scan means no verdict-cache key — so reading
+/// it late and shrugging would allow the call with no request and no warning.
+///
+/// What must *not* fail open is a missing inventory, which is why one is a
+/// parameter rather than looked up here: deciding "allowed" without a fresh one
+/// would let anyone lift an administrator's block by deleting a cache file. The
+/// caller declines the whole event to `ggshield-py` instead.
+pub fn mcp_activity(
+    config: &Config,
+    payload: &Payload,
+    inventory: &Inventory,
+) -> Result<Option<String>, Error> {
+    let token = config.token()?;
+    Ok(activity_verdict(
+        config,
+        token,
+        &activity_body(payload, inventory),
+    ))
+}
+
+fn activity_verdict(config: &Config, token: &str, body: &str) -> Option<String> {
+    let url = format!("{}/v1/agent-activity/mcp-activity", config.api_url);
+    let mut builder = ureq::post(&url)
+        .config()
+        .timeout_global(Some(std::time::Duration::from_secs(TIMEOUT_SECS)));
+    if let Some(tls) = insecure_tls(config) {
+        builder = builder.tls_config(tls);
+    }
+    let mut response = builder
+        .build()
+        .header("Authorization", format!("Token {token}"))
+        .header("Content-Type", "application/json")
+        .header(
+            "User-Agent",
+            concat!("ggshield-hook/", env!("GGSHIELD_VERSION")),
+        )
+        .send(body)
+        .ok()?;
+    // `is_ok()` requires a 200; anything else is a `Detail`, which mcp.py reads as
+    // allowed rather than as a denial.
+    if response.status().as_u16() != 200 {
+        return None;
+    }
+    let verdict: ActivityVerdict = response.body_mut().read_json().ok()?;
+    (!verdict.allowed).then_some(verdict.reason)
+}
+
+/// `MCPActivityResponse`. Both fields are required on the wire; a body missing
+/// either fails to parse, which allows.
+#[derive(Debug, Deserialize)]
+struct ActivityVerdict {
+    allowed: bool,
+    reason: String,
 }
 
 fn split_result(result: ScanResult, secret_config: &SecretConfig) -> DocumentResult {

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -21,6 +21,7 @@ mod verdict_cache;
 
 use ggshield_common::{binary_extensions, error};
 use ggshield_config::config;
+use ggshield_discovery::Inventory;
 
 use std::io::Read;
 use std::path::Path;
@@ -169,23 +170,31 @@ fn apply_exit_zero(code: i32, exit_zero: bool) -> i32 {
 }
 
 fn scan(config: &config::Config, stdin_content: &str) -> Result<i32, Error> {
+    let mut payloads = payload::parse(stdin_content)?;
+
+    // Before the debounce, not after: declining hands this same stdin to
+    // `ggshield-py`, and a debounce entry we had already written would make it
+    // exit 0 with no verdict at all — an allow nobody decided.
+    let inventory = mcp_inventory(&payloads)?;
+
     if !stdin_content.is_empty() && has_already_been_seen(stdin_content) {
         return Ok(0);
     }
 
-    let mut payloads = payload::parse(stdin_content)?;
-    let (index, secrets) = scan_payloads(config, &mut payloads)?;
+    let (index, verdict) = scan_payloads(config, &mut payloads, inventory.as_ref())?;
     let payload = &payloads[index];
 
-    if secrets.is_empty() {
-        return Ok(output::output_result(&HookResult::allow(payload)));
-    }
-
-    let result = HookResult::block(
-        payload,
-        message::from_secrets(&secrets, payload),
-        secrets.len(),
-    );
+    let result = match verdict {
+        Verdict::Allowed => return Ok(output::output_result(&HookResult::allow(payload))),
+        // Not a secret, so no count and no remediation steps: the reason is the
+        // organisation's own, and it is shown as it was written.
+        Verdict::NotPermitted(reason) => HookResult::block(payload, reason, 0),
+        Verdict::Secrets(secrets) => HookResult::block(
+            payload,
+            message::from_secrets(&secrets, payload),
+            secrets.len(),
+        ),
+    };
     // `has_secret_already_leaked()`: on PostToolUse the secret is already in the
     // agent's context, so tell the user out-of-band. Best effort.
     if payload.event_type == EventType::PostToolUse {
@@ -206,23 +215,43 @@ struct Pending {
     key: Option<String>,
 }
 
-/// `_scan_payloads()` plus `_scan_contents()`: scan everything the event still
-/// needs scanned, in as few requests as possible.
+/// What the event is allowed to do, once both of the API's answers are in.
+enum Verdict {
+    Allowed,
+    /// Secrets the scan found, which the block message is built from.
+    Secrets(Vec<api::Secret>),
+    /// The MCP activity endpoint refused this tool call, with the organisation's
+    /// own reason. The arguments were clean; the call itself is denied.
+    NotPermitted(String),
+}
+
+/// `_scan_payloads()` plus `_scan_contents()` and `_send_mcp_activity()`: settle
+/// everything this event needs settled, in as few requests as possible.
 ///
-/// Returns the secrets found and the index of the first payload holding them, or
-/// index 0 with no secrets — the caller only reads that payload for its output
-/// contract.
+/// Returns the verdict and the index of the payload it belongs to, or index 0 when
+/// nothing blocks — the caller only reads that payload for its output contract.
 ///
-/// `send_mcp_activity()` is not implemented, and not warned about either: it
-/// swallows every exception and returns "allowed" (mcp.py).
+/// An MCP tool call needs both of the API's answers: the arguments can carry a
+/// secret, *and* the call itself can be one the organisation does not permit.
+/// Neither implies the other.
+///
+/// Verdicts are applied one payload at a time, in the order the payloads were
+/// parsed, and a scan verdict takes precedence over an activity verdict for the
+/// same payload, exactly as in `_scan_payloads()`.
+///
+/// A chunk the API refused is reported — a fail-open `Err` — only when nothing
+/// blocks: any verdict already settled outranks it, so a denial in hand is not
+/// discarded by a later chunk that could not be scanned.
 fn scan_payloads(
     config: &config::Config,
     payloads: &mut [Payload],
-) -> Result<(usize, Vec<api::Secret>), Error> {
+    inventory: Option<&Inventory>,
+) -> Result<(usize, Verdict), Error> {
     if payloads.is_empty() {
         return Err(Error::Invalid("Error: no payloads to scan".into()));
     }
     let agent = payloads[0].agent;
+    let denial = mcp_denial(config, payloads, inventory)?;
 
     let mut pending: Vec<Pending> = Vec::new();
     for (index, payload) in payloads.iter_mut().enumerate() {
@@ -268,7 +297,7 @@ fn scan_payloads(
         });
     }
     if pending.is_empty() {
-        return Ok((0, Vec::new()));
+        return Ok(apply(None, denial));
     }
 
     let mut found: Option<(usize, Vec<api::Secret>)> = None;
@@ -306,13 +335,93 @@ fn scan_payloads(
             }
         }
     }
-    match (found, failure) {
-        // A secret beats a partial failure: blocking on what was found is never
-        // worse than failing the whole event open.
-        (Some(found), _) => Ok(found),
-        (None, Some(failure)) => Err(failure),
-        (None, None) => Ok((0, Vec::new())),
+    match apply(found, denial) {
+        // Nothing to block on, but a chunk went unscanned: fail open with the
+        // API's reason rather than report the event clean.
+        (_, Verdict::Allowed) => match failure {
+            Some(failure) => Err(failure),
+            None => Ok((0, Verdict::Allowed)),
+        },
+        // A verdict beats a partial failure: blocking on what was settled is never
+        // worse than failing the whole event open — and a denial already in hand
+        // must not be thrown away by a later chunk the API refused.
+        settled => Ok(settled),
     }
+}
+
+/// `_scan_payloads()`'s final loop: the earlier blocking index wins, and on the
+/// same index the secret does.
+fn apply(
+    secrets: Option<(usize, Vec<api::Secret>)>,
+    denial: Option<(usize, String)>,
+) -> (usize, Verdict) {
+    match (secrets, denial) {
+        (Some((index, secrets)), None) => (index, Verdict::Secrets(secrets)),
+        (None, Some((index, reason))) => (index, Verdict::NotPermitted(reason)),
+        (Some((scanned, secrets)), Some((denied, reason))) => {
+            if scanned <= denied {
+                (scanned, Verdict::Secrets(secrets))
+            } else {
+                (denied, Verdict::NotPermitted(reason))
+            }
+        }
+        (None, None) => (0, Verdict::Allowed),
+    }
+}
+
+/// `is_mcp_activity_payload()`: only a `PreToolUse` on an MCP tool is activity.
+/// There is nothing to permit or deny after the fact.
+fn is_mcp_activity(payload: &Payload) -> bool {
+    payload.event_type == EventType::PreToolUse && payload.tool == Some(Tool::Mcp)
+}
+
+/// The inventory this event's MCP payloads need, or a decline if there is none.
+///
+/// `refresh_and_maybe_submit_discovery()` in one line: a fresh `ai_discovery.json`
+/// is trusted rather than re-walked. What this cannot do is *produce* one, so a
+/// stale or absent file declines the whole event to `ggshield-py`, which owns the
+/// walk — it then submits and rewrites the file, and the next hour runs natively.
+///
+/// Deliberately not a fail-open: allowing without an inventory would make deleting
+/// one cache file enough to lift an administrator's block.
+fn mcp_inventory(payloads: &[Payload]) -> Result<Option<Inventory>, Error> {
+    if !payloads.iter().any(is_mcp_activity) {
+        return Ok(None);
+    }
+    ggshield_discovery::load_fresh().map(Some).ok_or_else(|| {
+        Error::unimplemented(
+            "checking MCP tool calls against your organization's policies without a \
+             recent inventory of your MCP servers",
+            "Reinstall ggshield: the bundled Python implementation, which builds that \
+             inventory, should sit next to the 'ggshield' executable.",
+        )
+    })
+}
+
+/// `send_mcp_activity()` for every MCP payload in the event, and the first denial
+/// it comes back with.
+///
+/// Sequential with the scan, where Python overlaps the two on a thread pool:
+/// `Config` memoises the token in a `OnceCell` and so is not `Sync`, and sharing
+/// it across a scope would mean resolving the credential store up front — the one
+/// call that can block on a macOS Keychain prompt.
+fn mcp_denial(
+    config: &config::Config,
+    payloads: &[Payload],
+    inventory: Option<&Inventory>,
+) -> Result<Option<(usize, String)>, Error> {
+    let Some(inventory) = inventory else {
+        return Ok(None);
+    };
+    for (index, payload) in payloads.iter().enumerate() {
+        if !is_mcp_activity(payload) {
+            continue;
+        }
+        if let Some(reason) = api::mcp_activity(config, payload, inventory)? {
+            return Ok(Some((index, reason)));
+        }
+    }
+    Ok(None)
 }
 
 /// `_start_scans()`'s chunking: the API caps a scan both in documents and in
@@ -494,6 +603,7 @@ fn notify(result: &HookResult) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::io::{BufRead, BufReader, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -502,38 +612,46 @@ mod tests {
     /// Recognised by the mock below as "this document holds a secret".
     const SECRET: &str = "AKIAsomething";
 
-    /// What the mock reports on `/v1/metadata`, plus which multiscan it refuses.
+    /// How the mock answers: the limits it reports on `/v1/metadata`, which
+    /// multiscan it refuses, and what the MCP activity endpoint says about the tool
+    /// call — `None` permits it.
     #[derive(Clone, Copy)]
-    struct MockLimits {
+    struct Mock {
         max_documents_per_scan: usize,
         max_document_size: usize,
         /// The 0-based multiscan request that answers 400 instead of a verdict.
         fail_scan: Option<usize>,
+        deny: Option<&'static str>,
     }
 
-    impl Default for MockLimits {
+    impl Default for Mock {
         fn default() -> Self {
-            MockLimits {
+            Mock {
                 max_documents_per_scan: config::DEFAULT_MAX_DOCUMENTS_PER_SCAN,
                 max_document_size: config::MAXIMUM_DOCUMENT_SIZE,
                 fail_scan: None,
+                deny: None,
             }
         }
     }
 
-    /// Every multiscan batch's filenames, plus the `/v1/metadata` fetch count.
+    /// What the mock recorded: every multiscan batch's filenames, every MCP
+    /// activity report, and how many times `/v1/metadata` was fetched.
     struct Recorded {
         batches: Mutex<Vec<Vec<String>>>,
+        activities: Mutex<Vec<serde_json::Value>>,
         metadata_hits: AtomicUsize,
     }
 
     /// A localhost stand-in for the API: answers `/v1/metadata` (with the given
-    /// limits) and `/v1/multiscan`, recording what it was sent.
-    fn mock_api(limits: MockLimits) -> (String, Arc<Recorded>) {
+    /// limits), `/v1/multiscan` and `/v1/agent-activity/mcp-activity`, recording
+    /// what it was sent. Nothing ever leaves the machine.
+    fn mock_api(limits: Mock) -> (String, Arc<Recorded>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let url = format!("http://{}", listener.local_addr().expect("addr"));
         let recorded = Arc::new(Recorded {
             batches: Mutex::new(Vec::new()),
+            activities: Mutex::new(Vec::new()),
             metadata_hits: AtomicUsize::new(0),
         });
         let served = Arc::clone(&recorded);
@@ -545,9 +663,10 @@ mod tests {
         (url, recorded)
     }
 
-    /// One request: the metadata a client reads before chunking, or a multiscan
-    /// answering one result per document, in the order they were sent.
-    fn serve(mut stream: TcpStream, recorded: &Recorded, limits: MockLimits) {
+    /// One request: the metadata a client reads before chunking, the policy answer
+    /// for an MCP tool call, or a multiscan answering — as the real one does —
+    /// exactly one result per document, in the order the documents were sent.
+    fn serve(mut stream: TcpStream, recorded: &Recorded, limits: Mock) {
         let mut reader = BufReader::new(stream.try_clone().expect("clone"));
         let mut request_line = String::new();
         reader.read_line(&mut request_line).expect("request line");
@@ -564,7 +683,7 @@ mod tests {
 
         let body = if request_line.starts_with("GET") {
             recorded.metadata_hits.fetch_add(1, Ordering::SeqCst);
-            let MockLimits {
+            let Mock {
                 max_documents_per_scan,
                 max_document_size,
                 ..
@@ -572,6 +691,18 @@ mod tests {
             format!(
                 r#"{{"preferences": {{"general__maximum_payload_size": 2621440}}, "secret_scan_preferences": {{"maximum_document_size": {max_document_size}, "maximum_documents_per_scan": {max_documents_per_scan}}}}}"#
             )
+        } else if request_line.contains("/v1/agent-activity/mcp-activity") {
+            let mut raw = vec![0u8; length];
+            reader.read_exact(&mut raw).expect("body");
+            recorded
+                .activities
+                .lock()
+                .expect("lock")
+                .push(serde_json::from_slice(&raw).expect("activity"));
+            match limits.deny {
+                Some(reason) => json!({"allowed": false, "reason": reason}).to_string(),
+                None => json!({"allowed": true, "reason": ""}).to_string(),
+            }
         } else {
             let mut raw = vec![0u8; length];
             reader.read_exact(&mut raw).expect("body");
@@ -625,6 +756,22 @@ mod tests {
         test_config("http://127.0.0.1:1".into())
     }
 
+    /// `scan_payloads` for an event with no MCP payload in it, reduced to the
+    /// secrets found — which is all the scan-side cases below assert on.
+    fn scan_for_secrets(
+        config: &config::Config,
+        payloads: &mut [Payload],
+    ) -> Result<(usize, Vec<api::Secret>), Error> {
+        let (index, verdict) = scan_payloads(config, payloads, None)?;
+        Ok((
+            index,
+            match verdict {
+                Verdict::Secrets(secrets) => secrets,
+                Verdict::Allowed | Verdict::NotPermitted(_) => Vec::new(),
+            },
+        ))
+    }
+
     fn text_payload(identifier: &str, content: &str) -> Payload {
         Payload {
             event_type: EventType::UserPrompt,
@@ -644,7 +791,7 @@ mod tests {
     #[test]
     fn one_event_is_one_request_and_the_block_lands_on_the_right_payload() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, recorded) = mock_api(MockLimits::default());
+        let (url, recorded) = mock_api(Mock::default());
         let mut payloads = [
             text_payload("empty.txt", ""),
             text_payload("clean.txt", "nothing here"),
@@ -652,7 +799,7 @@ mod tests {
             text_payload("also-clean.txt", "nothing here either"),
         ];
 
-        let (index, secrets) = scan_payloads(&test_config(url), &mut payloads).expect("scan");
+        let (index, secrets) = scan_for_secrets(&test_config(url), &mut payloads).expect("scan");
 
         assert_eq!(index, 2);
         assert_eq!(secrets.len(), 1);
@@ -668,15 +815,15 @@ mod tests {
     #[test]
     fn a_batch_over_the_limit_is_chunked_to_what_metadata_reports() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, recorded) = mock_api(MockLimits {
+        let (url, recorded) = mock_api(Mock {
             max_documents_per_scan: 8,
-            ..MockLimits::default()
+            ..Mock::default()
         });
         let mut payloads: Vec<Payload> = (0..21)
             .map(|i| text_payload(&format!("file{i}.txt"), &format!("content {i}")))
             .collect();
 
-        let (_, secrets) = scan_payloads(&test_config(url), &mut payloads).expect("scan");
+        let (_, secrets) = scan_for_secrets(&test_config(url), &mut payloads).expect("scan");
 
         assert!(secrets.is_empty());
         let batches = recorded.batches.lock().expect("lock");
@@ -690,15 +837,15 @@ mod tests {
     #[test]
     fn a_batch_is_chunked_to_a_sub_default_instance_limit() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, recorded) = mock_api(MockLimits {
+        let (url, recorded) = mock_api(Mock {
             max_documents_per_scan: 3,
-            ..MockLimits::default()
+            ..Mock::default()
         });
         let mut payloads: Vec<Payload> = (0..8)
             .map(|i| text_payload(&format!("file{i}.txt"), &format!("content {i}")))
             .collect();
 
-        let (_, secrets) = scan_payloads(&test_config(url), &mut payloads).expect("scan");
+        let (_, secrets) = scan_for_secrets(&test_config(url), &mut payloads).expect("scan");
 
         assert!(secrets.is_empty());
         let batches = recorded.batches.lock().expect("lock");
@@ -711,9 +858,9 @@ mod tests {
     #[test]
     fn a_large_document_under_the_raised_instance_limit_is_scanned() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, recorded) = mock_api(MockLimits {
+        let (url, recorded) = mock_api(Mock {
             max_document_size: 4 * 1024 * 1024,
-            ..MockLimits::default()
+            ..Mock::default()
         });
         // Over the 1 MiB trigger, under the 4 MiB instance limit.
         let big = format!(
@@ -724,7 +871,7 @@ mod tests {
         assert!(big.len() > config::MAXIMUM_DOCUMENT_SIZE);
         let mut payloads = [text_payload("big.txt", &big)];
 
-        let (index, secrets) = scan_payloads(&test_config(url), &mut payloads).expect("scan");
+        let (index, secrets) = scan_for_secrets(&test_config(url), &mut payloads).expect("scan");
 
         assert_eq!(index, 0);
         assert_eq!(secrets.len(), 1);
@@ -741,9 +888,9 @@ mod tests {
     #[test]
     fn a_document_over_a_sub_default_instance_limit_is_skipped() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, recorded) = mock_api(MockLimits {
+        let (url, recorded) = mock_api(Mock {
             max_document_size: 512 * 1024,
-            ..MockLimits::default()
+            ..Mock::default()
         });
         let big = format!("{SECRET}\n{}", "x".repeat(700_000));
         assert!(big.len() < config::MAXIMUM_DOCUMENT_SIZE);
@@ -752,7 +899,7 @@ mod tests {
             text_payload("small.txt", &format!("aws_key = {SECRET}")),
         ];
 
-        let (index, secrets) = scan_payloads(&test_config(url), &mut payloads).expect("scan");
+        let (index, secrets) = scan_for_secrets(&test_config(url), &mut payloads).expect("scan");
 
         // The oversized document never reached the API.
         assert_eq!(index, 1);
@@ -772,10 +919,10 @@ mod tests {
     fn a_refused_chunk_does_not_discard_the_other_chunks() {
         for (fail_scan, leaky_at) in [(1, 0), (0, 4)] {
             let (_guard, _dir) = verdict_cache::with_cache_dir();
-            let (url, recorded) = mock_api(MockLimits {
+            let (url, recorded) = mock_api(Mock {
                 max_documents_per_scan: 2,
                 fail_scan: Some(fail_scan),
-                ..MockLimits::default()
+                ..Mock::default()
             });
             let mut payloads: Vec<Payload> = (0..6)
                 .map(|i| {
@@ -788,7 +935,7 @@ mod tests {
                 })
                 .collect();
 
-            let (index, secrets) = scan_payloads(&test_config(url), &mut payloads)
+            let (index, secrets) = scan_for_secrets(&test_config(url), &mut payloads)
                 .unwrap_or_else(|e| panic!("fail_scan={fail_scan}: {e:?}"));
 
             assert_eq!(index, leaky_at, "fail_scan={fail_scan}");
@@ -804,16 +951,16 @@ mod tests {
     #[test]
     fn an_all_refused_scan_fails_open_instead_of_reporting_clean() {
         let (_guard, _dir) = verdict_cache::with_cache_dir();
-        let (url, _) = mock_api(MockLimits {
+        let (url, _) = mock_api(Mock {
             max_documents_per_scan: 2,
             // `fail_scan` matches the first request; the mock repeats nothing, so
             // one chunk is enough to prove the error is not swallowed.
             fail_scan: Some(0),
-            ..MockLimits::default()
+            ..Mock::default()
         });
         let mut payloads = [text_payload("clean.txt", "nothing here")];
 
-        let outcome = scan_payloads(&test_config(url), &mut payloads);
+        let outcome = scan_for_secrets(&test_config(url), &mut payloads);
 
         assert!(
             matches!(&outcome, Err(Error::Fail(m)) if m.contains("(refused)")),
@@ -1136,5 +1283,256 @@ mod tests {
             scannable(&offline_config(), &mut p).expect("scannable").0,
             ""
         );
+    }
+
+    /// An `ai_discovery.json` in the shape `save_discovery_cache()` writes. Its one
+    /// server's Claude Code configuration name mangles to "git_hub", so a resolved
+    /// report proves the inventory was read, not echoed.
+    const INVENTORY: &str = r#"{
+        "user": {"hostname": "laptop", "username": "dev", "machine_id": "m-1",
+                 "user_email": "dev@example.com"},
+        "discovery_duration": 0.5,
+        "servers": [{"name": "GitHub", "tools": [],
+                     "configurations": [{"name": "git hub", "agent": "claude-code"}]}]
+    }"#;
+
+    fn write_inventory(dir: &Path) {
+        std::fs::write(dir.join("ai_discovery.json"), INVENTORY).expect("write inventory");
+    }
+
+    /// One Claude Code MCP tool call with nothing incriminating in its arguments.
+    fn mcp_event() -> String {
+        json!({
+            "session_id": "abc",
+            "transcript_path": "/Users/x/.claude/projects/p/abc.jsonl",
+            "cwd": "/home/dev/proj",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__git_hub__delete_repository",
+            "tool_input": {"owner": "acme", "repo": "prod"},
+        })
+        .to_string()
+    }
+
+    /// GIVEN an MCP tool call whose arguments hold no secret, and an organisation
+    /// that does not permit the call
+    /// WHEN the event is settled
+    /// THEN it blocks with the reason the API gave, and the report it sent names the
+    /// canonical server the inventory resolved.
+    #[test]
+    fn a_call_the_api_does_not_permit_blocks_even_with_clean_arguments() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        write_inventory(dir.path());
+        let (url, recorded) = mock_api(Mock {
+            deny: Some("Deleting repositories is not allowed by your organization."),
+            ..Mock::default()
+        });
+        let mut payloads = payload::parse(&mcp_event()).expect("parses");
+        let inventory = ggshield_discovery::load_fresh().expect("fresh inventory");
+
+        let (index, verdict) =
+            scan_payloads(&test_config(url), &mut payloads, Some(&inventory)).expect("settled");
+
+        assert_eq!(index, 0);
+        match verdict {
+            Verdict::NotPermitted(reason) => assert_eq!(
+                reason,
+                "Deleting repositories is not allowed by your organization."
+            ),
+            other => panic!(
+                "expected a denial, got {:?}",
+                matches!(other, Verdict::Allowed)
+            ),
+        }
+        let activities = recorded.activities.lock().expect("lock");
+        assert_eq!(activities.len(), 1);
+        let sent = &activities[0];
+        // "mcp__git_hub__delete_repository" split, and "git hub" resolved.
+        assert_eq!(sent["server"], "GitHub");
+        assert_eq!(sent["tool"], "delete_repository");
+        assert_eq!(sent["agent"], "claude-code");
+        assert_eq!(sent["cwd"], "/home/dev/proj");
+        assert_eq!(sent["model"], "");
+        assert_eq!(sent["input"], json!({"owner": "acme", "repo": "prod"}));
+        assert_eq!(sent["user"]["machine_id"], "m-1");
+        assert_eq!(sent["user"]["user_email"], "dev@example.com");
+        // An ISO 8601 instant, which is what marshmallow's DateTime dumps.
+        assert!(
+            sent["timestamp"]
+                .as_str()
+                .is_some_and(|t| t.ends_with("+00:00")),
+            "{:?}",
+            sent["timestamp"]
+        );
+    }
+
+    /// GIVEN the same call, permitted this time
+    /// WHEN the event is settled
+    /// THEN it is allowed, and the arguments were still scanned: the two questions
+    /// are asked independently.
+    #[test]
+    fn a_permitted_call_is_allowed_and_its_arguments_are_still_scanned() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        write_inventory(dir.path());
+        let (url, recorded) = mock_api(Mock::default());
+        let mut payloads = payload::parse(&mcp_event()).expect("parses");
+        let inventory = ggshield_discovery::load_fresh().expect("fresh inventory");
+
+        let (_, verdict) =
+            scan_payloads(&test_config(url), &mut payloads, Some(&inventory)).expect("settled");
+
+        assert!(matches!(verdict, Verdict::Allowed));
+        assert_eq!(recorded.activities.lock().expect("lock").len(), 1);
+        assert_eq!(recorded.batches.lock().expect("lock").len(), 1);
+    }
+
+    /// GIVEN an MCP tool call and no inventory to check it against — no cache file,
+    /// then one older than the TTL
+    /// WHEN the event is scanned
+    /// THEN it is declined, which the dispatcher turns into `Outcome::Delegate` and
+    /// answers from `ggshield-py`. Never an allow: failing open here would make
+    /// deleting a cache file enough to lift an administrator's block.
+    #[test]
+    fn a_stale_inventory_hands_the_event_over_instead_of_allowing_it() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        let (url, recorded) = mock_api(Mock::default());
+        let config = test_config(url);
+
+        // No inventory at all.
+        assert!(
+            matches!(scan(&config, &mcp_event()), Err(Error::Unsupported(_))),
+            "an absent inventory must decline, not allow"
+        );
+
+        // One from two hours ago: written, but past the TTL the Python honours.
+        write_inventory(dir.path());
+        let stale = std::time::SystemTime::now() - std::time::Duration::from_secs(7200);
+        std::fs::File::options()
+            .write(true)
+            .open(dir.path().join("ai_discovery.json"))
+            .expect("open")
+            .set_modified(stale)
+            .expect("set mtime");
+        assert!(
+            matches!(scan(&config, &mcp_event()), Err(Error::Unsupported(_))),
+            "a stale inventory must decline, not allow"
+        );
+        // Declining costs no requests: the answer is Python's, whole.
+        assert_eq!(recorded.activities.lock().expect("lock").len(), 0);
+        assert_eq!(recorded.batches.lock().expect("lock").len(), 0);
+        // ...and the debounce is untouched, so `ggshield-py` does not answer the
+        // hand-over with silence because it thinks it has seen this payload.
+        assert!(!dir.path().join("latest_ai_hook.txt").exists());
+
+        // Refreshed: handled natively, no hand-over.
+        write_inventory(dir.path());
+        assert!(scan(&config, &mcp_event()).is_ok());
+        assert_eq!(recorded.activities.lock().expect("lock").len(), 1);
+    }
+
+    /// GIVEN an MCP tool call that takes no arguments — nothing to scan, so the
+    /// token is needed for the policy check and nothing else — and a credential
+    /// store that cannot answer
+    /// WHEN the event is scanned
+    /// THEN it fails open with a warning, as Python does by needing the token before
+    /// it can ask at all. A silent allow here would wave through every
+    /// argument-less MCP tool without one request or one word to the user.
+    #[test]
+    fn an_unreadable_token_warns_instead_of_allowing_an_argument_less_call() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        write_inventory(dir.path());
+        std::fs::write(
+            dir.path().join("auth_config.yaml"),
+            format!(
+                "instances:\n- url: https://keyring-absent.invalid\n  accounts:\n  - token: {}\n",
+                config::KEYRING_SENTINEL
+            ),
+        )
+        .expect("write");
+        // SAFETY: serialised by the guard above; restored below.
+        unsafe {
+            std::env::set_var("GG_CONFIG_DIR", dir.path());
+            std::env::set_var("GG_USER_HOME_DIR", dir.path());
+            std::env::set_var("GITGUARDIAN_INSTANCE", "https://keyring-absent.invalid");
+            std::env::set_var("GITGUARDIAN_DONT_LOAD_ENV", "1");
+            std::env::remove_var("GITGUARDIAN_API_KEY");
+            std::env::remove_var("GGSHIELD_NO_KEYRING");
+        }
+        let resolved = config::resolve();
+        let outcome = resolved.as_ref().map(|config| {
+            scan(
+                config,
+                &json!({
+                    "session_id": "abc",
+                    "transcript_path": "/Users/x/.claude/projects/p/abc.jsonl",
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "mcp__git_hub__list_repositories",
+                })
+                .to_string(),
+            )
+        });
+        unsafe {
+            std::env::remove_var("GG_CONFIG_DIR");
+            std::env::remove_var("GG_USER_HOME_DIR");
+            std::env::remove_var("GITGUARDIAN_INSTANCE");
+            std::env::remove_var("GITGUARDIAN_DONT_LOAD_ENV");
+        }
+
+        assert!(resolved.is_ok(), "config resolution failed: {resolved:?}");
+        match outcome {
+            Ok(Err(Error::Fail(warning))) => {
+                assert!(warning.contains("could not authenticate"), "{warning}")
+            }
+            other => panic!("expected a fail-open warning, got {other:?}"),
+        }
+    }
+
+    /// GIVEN an event where a secret and a denial land on different payloads, and
+    /// then on the same one
+    /// WHEN the verdicts are applied
+    /// THEN the earlier payload's verdict wins, and on a tie the scan does —
+    /// `_scan_payloads()`'s order, which decides which message the user sees.
+    #[test]
+    fn the_earlier_payload_wins_and_a_tie_goes_to_the_scan() {
+        let secrets = || Some((1, Vec::new()));
+        let denial = |index| Some((index, "denied".to_string()));
+
+        assert!(matches!(apply(secrets(), denial(2)).1, Verdict::Secrets(_)));
+        assert!(matches!(
+            apply(secrets(), denial(0)).1,
+            Verdict::NotPermitted(_)
+        ));
+        // Same payload: Python's loop checks the scan result first.
+        assert!(matches!(apply(secrets(), denial(1)).1, Verdict::Secrets(_)));
+        assert_eq!(apply(secrets(), denial(0)).0, 0);
+        assert!(matches!(apply(None, None).1, Verdict::Allowed));
+    }
+
+    /// GIVEN an MCP payload at PostToolUse, and a non-MCP tool call at PreToolUse
+    /// WHEN the event is settled with a denying API
+    /// THEN neither reports activity: `is_mcp_activity_payload()` is a PreToolUse on
+    /// an MCP tool and nothing else, and there is nothing to permit after the fact.
+    #[test]
+    fn only_a_pre_tool_use_on_an_mcp_tool_is_activity() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        write_inventory(dir.path());
+        let (url, recorded) = mock_api(Mock {
+            deny: Some("nope"),
+            ..Mock::default()
+        });
+        let config = test_config(url);
+        for event in [
+            json!({"session_id": "a", "transcript_path": "/x/.claude/p.jsonl",
+                   "hook_event_name": "PostToolUse",
+                   "tool_name": "mcp__git_hub__delete_repository",
+                   "tool_input": {"repo": "prod"},
+                   "tool_response": {"ok": true}}),
+            json!({"session_id": "a", "transcript_path": "/x/.claude/p.jsonl",
+                   "hook_event_name": "PreToolUse", "tool_name": "WebFetch",
+                   "tool_input": {"url": "https://example.com"}}),
+        ] {
+            let code = scan(&config, &event.to_string()).expect("settled");
+            assert_eq!(code, 0, "{event}");
+        }
+        assert_eq!(recorded.activities.lock().expect("lock").len(), 0);
     }
 }

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 use serde_json::Value;
 
 use ggshield_common::error::Error;
+use ggshield_discovery::Inventory;
 
 pub use ggshield_common::hash::sha256_hex;
 
@@ -112,6 +113,63 @@ impl Agent {
         AGENTS.into_iter().find(|agent| agent.is_caller(data))
     }
 
+    /// `parse_mcp_activity()`, minus the parts that are the same for every agent:
+    /// which MCP server this tool call is going to, which tool, and which model
+    /// asked for it.
+    ///
+    /// Per-agent by necessity: each joins the server configuration name and the
+    /// tool name with its own separator, mangles the configuration name its own
+    /// way, and both halves can contain that separator — so the split is a lookup
+    /// against the inventory, not a `split_once`.
+    ///
+    /// Vibe is absent because the Rust hook has no Vibe adapter yet; that lands
+    /// with the separate Vibe work. A payload already classified as `Tool::Mcp`
+    /// flows through here whatever the agent.
+    pub fn mcp_activity(self, data: &Value, inventory: &Inventory) -> McpActivity {
+        let raw_tool_name = lookup_str(data, &["tool_name"]);
+        let (server, tool) = match self {
+            // "mcp__<server>__<tool>". The server configuration name can be
+            // anything, but no MCP tool has "__" in its name, so the last segment
+            // is the tool and everything between is the configuration.
+            Agent::Claude | Agent::Codex => {
+                let parts: Vec<&str> = raw_tool_name.split("__").collect();
+                let tool = parts.last().copied().unwrap_or_default().to_string();
+                let middle = parts
+                    .get(1..parts.len().saturating_sub(1))
+                    .unwrap_or_default()
+                    .join("__");
+                // Claude Code prefixes the servers it installs itself.
+                let cfg_name = if self == Agent::Claude {
+                    middle.strip_prefix("claude_ai_").unwrap_or(&middle)
+                } else {
+                    &middle
+                };
+                (inventory.server_for_config_name(cfg_name), tool)
+            }
+            // Cursor sends the tool and nothing else, so the server comes from
+            // the capabilities the walk probed.
+            Agent::Cursor => {
+                let tool = raw_tool_name
+                    .strip_prefix("MCP:")
+                    .unwrap_or(&raw_tool_name)
+                    .to_string();
+                (inventory.server_for_tool_name(&tool), tool)
+            }
+            Agent::VsCode => inventory.split_underscored(&raw_tool_name),
+            Agent::Copilot => inventory.split_hyphenated(&raw_tool_name, self.name()),
+        };
+        McpActivity {
+            server,
+            tool,
+            model: match self {
+                // Python sends the empty string for the others.
+                Agent::Codex | Agent::Cursor => lookup_str(data, &["model"]),
+                _ => String::new(),
+            },
+            cwd: self.event_cwd(data),
+        }
+    }
+
     /// The working directory the event happened in, used to resolve a relative
     /// Read path to the absolute identifier a tool call would produce, so both
     /// share one verdict-cache key. "" when unknown.
@@ -171,6 +229,14 @@ impl Agent {
             Agent::Codex | Agent::Copilot | Agent::Cursor => None,
         }
     }
+}
+
+/// One MCP tool call in the terms the activity endpoint speaks.
+pub struct McpActivity {
+    pub server: String,
+    pub tool: String,
+    pub model: String,
+    pub cwd: String,
 }
 
 /// `(first, last)`, 1-based and inclusive, `None` for "to the end of the file".

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -24,6 +24,8 @@ Five matrices:
            code page, and a file too large to scan at all
   mention  relative and absolute `@`-mentions, resolved against the event cwd
   batch    a prompt mentioning more files than fit in one scan
+  mcp      MCP tool calls: the activity report each side sends, the server name
+           it resolves, and the policy verdict it honours
   cache    the clean-verdict cache: what gets remembered, what does
            not, and that both implementations share one cache file
   dotenv   a `.env` naming GITGUARDIAN_* settings: the instance and token both
@@ -1082,15 +1084,237 @@ def compare_verdict_cache(tmp):
     return failures
 
 
+# One MCP server, as `save_discovery_cache()` writes it. Schema-valid on purpose:
+# `AIDiscovery.from_dict` rejects a partial configuration, and a rejected cache
+# sends the Python side off to redo the whole discovery walk — which would probe
+# the developer's real machine and make this matrix meaningless.
+#
+# "git hub" covers Claude Code, Codex and VS Code, "git.hub" is Copilot's (which
+# only looks at its own), and the tool covers Cursor, which reports no server at
+# all. All of them must come back as the canonical "GitHub".
+#
+# "Decoy" comes first and mangles to the same VS Code key ("git_hub") and the same
+# Copilot key ("git-hub") as GitHub's own configurations, which is the interesting
+# case: the two sides have to agree on *which* of the two servers answers, or a
+# policy denying a tool on one is checked against the other. Its own names differ
+# in case, so Claude Code and Codex — which do not lower-case, and where the first
+# match wins on both sides — still resolve to GitHub.
+AI_DISCOVERY = {
+    "user": {
+        "hostname": "equivalence-host",
+        "username": "equivalence-user",
+        "machine_id": "00000000-0000-4000-8000-00000000dead",
+        "user_email": None,
+    },
+    "discovery_duration": 0.125,
+    "agents": [],
+    "servers": [
+        {
+            "name": "Decoy",
+            "display_name": "Decoy",
+            "tools": [],
+            "resources": [],
+            "prompts": [],
+            "configurations": [
+                {
+                    "name": "GIT HUB",
+                    "agent": "claude-code",
+                    "scope": "user",
+                    "transport": "stdio",
+                    "project": None,
+                    "command": "npx",
+                    "args": [],
+                    "env": {},
+                    "url": None,
+                    "headers": {},
+                },
+                {
+                    "name": "GIT.HUB",
+                    "agent": "copilot",
+                    "scope": "user",
+                    "transport": "stdio",
+                    "project": None,
+                    "command": "npx",
+                    "args": [],
+                    "env": {},
+                    "url": None,
+                    "headers": {},
+                },
+            ],
+        },
+        {
+            "name": "GitHub",
+            "display_name": "GitHub",
+            "tools": [{"name": "delete_repository", "description": None, "arguments": None}],
+            "resources": [],
+            "prompts": [],
+            "configurations": [
+                {
+                    "name": "git hub",
+                    "agent": "claude-code",
+                    "scope": "user",
+                    "transport": "stdio",
+                    "project": None,
+                    "command": "npx",
+                    "args": [],
+                    "env": {},
+                    "url": None,
+                    "headers": {},
+                },
+                {
+                    "name": "git.hub",
+                    "agent": "copilot",
+                    "scope": "user",
+                    "transport": "stdio",
+                    "project": None,
+                    "command": "npx",
+                    "args": [],
+                    "env": {},
+                    "url": None,
+                    "headers": {},
+                },
+            ],
+        }
+    ],
+}
+
+# What each agent calls the same tool on the same server. Three of the five cannot
+# be split without the inventory above.
+MCP_TOOL_NAMES = {
+    "claude": "mcp__git_hub__delete_repository",
+    "codex": "mcp__git_hub__delete_repository",
+    # Copilot joins with "-" and its configuration name contains one.
+    "copilot": "git-hub-delete_repository",
+    # Cursor names the tool and nothing else.
+    "cursor": "MCP:delete_repository",
+    # VS Code joins with "_", and so do both halves.
+    "vscode": "mcp_git_hub_delete_repository",
+}
+
+MCP_ARGUMENTS = {"owner": "acme", "repo": "prod", "confirm": True}
+
+
+def mcp_payloads():
+    """One MCP `PreToolUse` per agent, in that agent's own dialect."""
+    bases = agent_bases()
+    return {
+        agent: {
+            **bases[agent],
+            "hook_event_name": "preToolUse" if agent == "cursor" else "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": MCP_ARGUMENTS,
+        }
+        for agent, tool_name in MCP_TOOL_NAMES.items()
+    }
+
+
+def seed_discovery_cache(workdir):
+    """Install a *fresh* inventory, which is what makes the native path eligible.
+
+    Both sides read this same file: Python trusts a cache younger than its TTL
+    instead of re-walking, and the Rust hook has no walk at all — with a stale or
+    absent file it declines the event to `ggshield-py`.
+    """
+    cache = workdir / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "ai_discovery.json").write_text(json.dumps(AI_DISCOVERY))
+
+
+def activity_bodies(entries):
+    """Every MCP activity report in `entries`, timestamps dropped.
+
+    Filtered by path rather than compared in order: Python overlaps the activity
+    report with the scan on a thread, so their arrival order is not a property to
+    assert on. `timestamp` is the moment the hook ran, so it can only differ.
+    """
+    bodies = []
+    for entry in entries:
+        if "mcp-activity" not in entry["path"]:
+            continue
+        body = json.loads(entry["body"])
+        body.pop("timestamp", None)
+        bodies.append(body)
+    return bodies
+
+
+def compare_mcp(tmp):
+    """An MCP tool call is two questions, and the hook has to ask both.
+
+    Both sides must report the call, resolve the server to its canonical name, and
+    honour the verdict — an organisation that denies `delete_repository` denies it
+    whether or not the arguments carry a secret.
+    """
+    failures = []
+    print("\nMCP activity: the call itself is checked, not just its arguments")
+    for case, deny, expected in (
+        ("permitted", "", "allow"),
+        ("denied", "Deleting repositories is not allowed by your organization.", "block"),
+    ):
+        log = tmp / f"requests-mcp-{case}.jsonl"
+        # Clean, so the verdict on show is the policy one and not a secret.
+        mock, port = start_mock("clean", log, mcp_deny=deny)
+        try:
+            for agent, payload in mcp_payloads().items():
+                name = f"mcp/{case}/{agent}"
+                results, entries = {}, {}
+                for side, cmd in (("python", PY_CMD), ("rust", RS_CMD)):
+                    workdir = make_workdir(tmp, f"mcp-{case}-{agent}-{side}")
+                    seed_discovery_cache(workdir)
+                    before = len(read_requests(log))
+                    results[side], _ = run(cmd, payload, port, workdir)
+                    entries[side] = read_requests(log)[before:]
+                py, rs = results["python"], results["rust"]
+                reports = {side: activity_bodies(entries[side]) for side in entries}
+
+                verdict_ok = (
+                    same_stdout(py.stdout, rs.stdout) and py.returncode == rs.returncode
+                )
+                request_ok = reports["python"] == reports["rust"]
+                report(failures, name, verdict_ok, request_ok, py, rs)
+                if not request_ok:
+                    print(f"        python sent {reports['python']}")
+                    print(f"          rust sent {reports['rust']}")
+
+                # Teeth. Without these the two could agree by both doing nothing.
+                for side, sent in reports.items():
+                    if len(sent) != 1:
+                        failures.append(f"{name} ({side} sent {len(sent)} reports)")
+                        print(f"        ^ {side} reported {len(sent)} activities, wanted 1")
+                        continue
+                    # The canonical server name, which is what a policy names.
+                    wanted = {
+                        "server": "GitHub",
+                        "tool": "delete_repository",
+                        "input": MCP_ARGUMENTS,
+                    }
+                    got = {key: sent[0].get(key) for key in wanted}
+                    if got != wanted:
+                        failures.append(f"{name} ({side} reported the wrong call)")
+                        print(f"        ^ {side} reported {got}, wanted {wanted}")
+
+                actual = "block" if b"deny" in py.stdout else "allow"
+                if actual != expected:
+                    failures.append(f"{name} (expected {expected}, got {actual})")
+                    print(f"        ^ expected the policy to {expected}, but it did not")
+        finally:
+            mock.kill()
+    return failures
+
+
 def free_port():
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
-def start_mock(mode, request_log):
+def start_mock(mode, request_log, mcp_deny=""):
     port = free_port()
-    env = {**os.environ, "MODE": mode, "REQUEST_LOG": str(request_log)}
+    env = {
+        **os.environ,
+        "MODE": mode,
+        "REQUEST_LOG": str(request_log),
+        "MCP_DENY": mcp_deny,
+    }
     proc = subprocess.Popen(
         [sys.executable, str(ROOT / "tests" / "mock_api.py"), str(port)],
         env=env,
@@ -1738,6 +1962,7 @@ def main():
         failures += compare_content(tmp)
         failures += compare_mentions(tmp)
         failures += compare_batches(tmp)
+        failures += compare_mcp(tmp)
         failures += compare_verdict_cache(tmp)
         failures += compare_dotenv(tmp)
         failures += extra_cases(tmp)

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -1145,7 +1145,9 @@ AI_DISCOVERY = {
         {
             "name": "GitHub",
             "display_name": "GitHub",
-            "tools": [{"name": "delete_repository", "description": None, "arguments": None}],
+            "tools": [
+                {"name": "delete_repository", "description": None, "arguments": None}
+            ],
             "resources": [],
             "prompts": [],
             "configurations": [
@@ -1174,7 +1176,7 @@ AI_DISCOVERY = {
                     "headers": {},
                 },
             ],
-        }
+        },
     ],
 }
 
@@ -1248,7 +1250,11 @@ def compare_mcp(tmp):
     print("\nMCP activity: the call itself is checked, not just its arguments")
     for case, deny, expected in (
         ("permitted", "", "allow"),
-        ("denied", "Deleting repositories is not allowed by your organization.", "block"),
+        (
+            "denied",
+            "Deleting repositories is not allowed by your organization.",
+            "block",
+        ),
     ):
         log = tmp / f"requests-mcp-{case}.jsonl"
         # Clean, so the verdict on show is the policy one and not a secret.
@@ -1279,7 +1285,9 @@ def compare_mcp(tmp):
                 for side, sent in reports.items():
                     if len(sent) != 1:
                         failures.append(f"{name} ({side} sent {len(sent)} reports)")
-                        print(f"        ^ {side} reported {len(sent)} activities, wanted 1")
+                        print(
+                            f"        ^ {side} reported {len(sent)} activities, wanted 1"
+                        )
                         continue
                     # The canonical server name, which is what a policy names.
                     wanted = {
@@ -1295,7 +1303,9 @@ def compare_mcp(tmp):
                 actual = "block" if b"deny" in py.stdout else "allow"
                 if actual != expected:
                     failures.append(f"{name} (expected {expected}, got {actual})")
-                    print(f"        ^ expected the policy to {expected}, but it did not")
+                    print(
+                        f"        ^ expected the policy to {expected}, but it did not"
+                    )
         finally:
             mock.kill()
     return failures

--- a/rust/tests/mock_api.py
+++ b/rust/tests/mock_api.py
@@ -6,6 +6,8 @@ full scan without a single byte leaving the machine.
   MODE=clean   -> no policy breaks
   MODE=secret  -> one "AWS Keys" policy break, with matches located in the
                   document that was actually submitted
+  MCP_DENY=... -> the MCP activity endpoint refuses the tool call with that
+                  reason; unset or empty permits it
 
 The indices matter: the Python side maps every match back onto the document's
 lines and errors out if a match falls outside them, so the mock cannot return
@@ -25,6 +27,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 MODE = os.environ.get("MODE", "clean")
 REQUEST_LOG = os.environ.get("REQUEST_LOG")
+# The organisation's answer for an MCP tool call: a reason denies it, empty allows.
+MCP_DENY = os.environ.get("MCP_DENY", "")
 
 # Fake credentials, shaped like AWS keys. Never valid anywhere.
 CLIENT_ID = "AKIA4SVQEXAMPLE01"
@@ -170,6 +174,10 @@ class Handler(BaseHTTPRequestHandler):
                     )
                     + "\n"
                 )
+        if "mcp-activity" in self.path:
+            # MCPActivityResponse: both fields are required on the wire.
+            self._send({"allowed": not MCP_DENY, "reason": MCP_DENY})
+            return
         if "multiscan" not in self.path:
             self._send({"detail": "not found"}, 404)
             return


### PR DESCRIPTION
Stacked on #1392. Addresses @clement-tourriere's comment there: "org denies `mcp__github__delete_repository`, the args have no secret, multiscan is clean, we allow. IMO this needs to be implemented, not skipped."

## What it does

The native hook now asks both questions an MCP tool call raises, not one:

- the arguments, via `/v1/multiscan` — already there;
- the call itself, via `POST /v1/agent-activity/mcp-activity` — new. A `{"allowed": false, "reason": ...}` blocks with that reason; the scan verdict wins per payload, in payload order, as in `_scan_payloads()`. A *failed* request still allows, matching `mcp.py`.

MCP telemetry therefore reaches the dashboard again.

## Why the discovery walk is not ported

`parse_mcp_activity` needs only `ai_config.user` and `ai_config.servers`, and both already sit in the `ai_discovery.json` that Python writes with a one hour TTL. So the ~2,700-line walk stays in Python and the new `ggshield-discovery` crate just reads what it left: the inventory, its freshness check (same TTL and skew tolerance as `cache.py`), and the per-agent server-name resolution.

With a **stale or absent** inventory the event is declined to `ggshield-py` via the existing `Outcome::Delegate`, which walks, submits and rewrites the file — so the next hour runs natively. Never allowed: failing open there would let anyone lift an administrator's block by deleting a cache file. Fail-open stays correct only for a failed request.

Full native discovery is future work, behind the crate boundary — `ggshield ai discover`, the history backfill and agent activity all read the same file.

## Notes

- Vibe MCP detection lands with the separate Vibe work; any payload already classified as `Tool::Mcp` flows through this path whatever the agent.
- The freshness check moved ahead of the payload debounce: handing over replays the same stdin, and a debounce entry we had already written would make `ggshield-py` exit 0 with no verdict.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (138 tests) all clean. The equivalence harness prints `RESULT: EQUIVALENT`, now including a new `mcp` matrix — 5 agents x {permitted, denied}, comparing the verdict *and* the activity report body, which is what proves the server name each dialect resolves to is the same on both sides.