### PR TITLE
feat(ai): report the assistant subscription each AI agent uses

### DIFF
--- a/changelog.d/20260812_121000_achille.mascia_ai_agent_subscription_email.md
+++ b/changelog.d/20260812_121000_achille.mascia_ai_agent_subscription_email.md
@@ -1,0 +1,5 @@
+### Added
+
+- AI discovery now reports, per agent, the email of the assistant subscription that agent is signed into, so a personal
+  subscription can be told apart from a company one. Read locally from Claude Code, Codex and Cursor. Mistral Vibe and
+  VSCode keep no account on disk and report nothing.

--- a/ggshield/verticals/ai/agents/claude_code.py
+++ b/ggshield/verticals/ai/agents/claude_code.py
@@ -293,6 +293,15 @@ class Claude(Agent):
                 display_name=name,
             )
 
+    def subscription_email(self) -> Optional[str]:
+        """Read the signed-in claude.ai account from ~/.claude.json."""
+        data = self._load_file(self.user_mcp_file) or {}
+        account = data.get("oauthAccount")
+        if not isinstance(account, dict):
+            return None
+        email = account.get("emailAddress")
+        return email if isinstance(email, str) and email else None
+
     def discover_project_directories(self) -> Iterator[Path]:
         """Discover project directories by scraping config files."""
         history_file = self.config_folder / "history.jsonl"

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, Literal, Optional
 
 import click
+import jwt
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
 from ggshield.core.dirs import get_user_home_dir
@@ -31,6 +32,22 @@ class CodexActivitySource(JSONLActivitySource):
         )
 
 
+def _id_token_email(token: Any) -> Optional[str]:
+    """Return the email claim of an unverified id_token, or None.
+
+    Signature and expiry are unchecked on purpose: it is our own local token, read
+    only to name the subscription, and a stale one still names it correctly.
+    """
+    if not isinstance(token, str):
+        return None
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None
+    email = claims.get("email")
+    return email if isinstance(email, str) and email else None
+
+
 class Codex(Agent):
     """Behavior specific to OpenAI Codex."""
 
@@ -47,6 +64,14 @@ class Codex(Agent):
     @property
     def config_folder(self) -> Path:
         return get_user_home_dir() / ".codex"
+
+    def subscription_email(self) -> Optional[str]:
+        """Read the ChatGPT account email out of ~/.codex/auth.json's id_token."""
+        data = self._load_file(self.config_folder / "auth.json") or {}
+        tokens = data.get("tokens")
+        if not isinstance(tokens, dict):
+            return None
+        return _id_token_email(tokens.get("id_token"))
 
     def output_result(self, result: HookResult) -> int:
         response: Dict[str, Any] = {}

--- a/ggshield/verticals/ai/agents/cursor.py
+++ b/ggshield/verticals/ai/agents/cursor.py
@@ -90,6 +90,30 @@ class Cursor(Agent):
     def config_folder(self) -> Path:
         return get_user_home_dir() / ".cursor"
 
+    def subscription_email(self) -> Optional[str]:
+        """Read the signed-in Cursor account from cursorAuth/cachedEmail in state.vscdb."""
+        db_path = get_editor_user_data_dir("Cursor") / "globalStorage" / "state.vscdb"
+        if not db_path.is_file():
+            return None
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error as exc:
+            logger.warning("Cursor: could not open state database %s: %s", db_path, exc)
+            return None
+        try:
+            row = conn.execute(
+                "SELECT value FROM ItemTable WHERE key = 'cursorAuth/cachedEmail'"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        finally:
+            conn.close()
+        if not row or not isinstance(row[0], (str, bytes)):
+            return None
+        value = row[0].decode(errors="replace") if isinstance(row[0], bytes) else row[0]
+        # Some ItemTable values are bare strings, others JSON-quoted.
+        return value.strip('"') or None
+
     def output_result(self, result: HookResult) -> int:
         message = result.message or result.warning
         response = {}

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -82,6 +82,7 @@ def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
                     name=agent.name,
                     hooks_installed=installed,
                     hooks_command=command,
+                    subscription_email=agent.subscription_email(),
                 )
             )
 

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -529,6 +529,14 @@ class Agent(ABC):
             return ai_config.user
         return UserInfo(hostname="", username="", machine_id="")
 
+    def subscription_email(self) -> Optional[str]:
+        """Email of the assistant subscription this agent is signed into, or None.
+
+        Never approximated: `git config user.email` names the repository, not the
+        subscription, so an agent on a personal plan would report a work address.
+        """
+        return None
+
     # Helper methods
 
     def _load_file(self, path: Path) -> Optional[Dict[str, Any]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     "marshmallow-dataclass>=8.7.0,<9",
     "oauthlib>=3.2.1,<4",
     "packaging>=22.0",
-    "pygitguardian~=1.33.1",
+    # TODO: replace this with a real version number as soon as a new version of
+    # py-gitguardian is out (needs AgentInfo.subscription_email, PR #190).
+    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@0b9278889119f1535b072a997caa13a781e4cd59",
     "pyjwt>=2.13.0,<3",
     "python-dotenv>=0.21.0,<2",
     "pyyaml>=6.0.1,<7",

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1,8 +1,10 @@
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
+import jwt
 import pytest
 from pygitguardian.models import MCPToolInfo, UserInfo
 
@@ -1784,3 +1786,141 @@ class TestParseToolArguments:
     )
     def test_non_dict_schema_returns_none(self, schema: Any):
         assert _parse_tool_arguments(schema) is None
+
+
+def _jwt(payload: Dict[str, Any]) -> str:
+    """Build a JWT carrying payload. The signature is never checked on read."""
+    return jwt.encode(payload, "k" * 32)
+
+
+class TestSubscriptionEmail:
+    """Each agent reports the account it is logged into, or nothing at all."""
+
+    def test_claude_reads_oauth_account(self, tmp_path: Path):
+        """GIVEN a ~/.claude.json holding an oauthAccount
+        WHEN subscription_email is read
+        THEN the account's emailAddress is returned"""
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            json.dumps({"oauthAccount": {"emailAddress": "dev@example.com"}})
+        )
+        with patch.object(
+            Claude,
+            "user_mcp_file",
+            new_callable=lambda: property(lambda self: claude_json),
+        ):
+            assert Claude().subscription_email() == "dev@example.com"
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param({}, id="no-oauth-account"),
+            pytest.param({"oauthAccount": {}}, id="no-email"),
+            pytest.param({"oauthAccount": "nope"}, id="account-not-a-dict"),
+            pytest.param({"oauthAccount": {"emailAddress": ""}}, id="empty-email"),
+        ],
+    )
+    def test_claude_returns_none_without_an_account(
+        self, tmp_path: Path, content: Dict[str, Any]
+    ):
+        """GIVEN a ~/.claude.json with no usable account
+        WHEN subscription_email is read
+        THEN None is returned"""
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(json.dumps(content))
+        with patch.object(
+            Claude,
+            "user_mcp_file",
+            new_callable=lambda: property(lambda self: claude_json),
+        ):
+            assert Claude().subscription_email() is None
+
+    def test_claude_returns_none_when_the_file_is_missing(self, tmp_path: Path):
+        """GIVEN no ~/.claude.json at all
+        WHEN subscription_email is read
+        THEN None is returned"""
+        with patch.object(
+            Claude,
+            "user_mcp_file",
+            new_callable=lambda: property(lambda self: tmp_path / "absent.json"),
+        ):
+            assert Claude().subscription_email() is None
+
+    def test_codex_decodes_the_id_token(self, tmp_path: Path):
+        """GIVEN a ~/.codex/auth.json whose id_token carries an email claim
+        WHEN subscription_email is read
+        THEN the claim is decoded and returned"""
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"tokens": {"id_token": _jwt({"email": "dev@example.com"})}})
+        )
+        with patch.object(
+            Codex,
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path),
+        ):
+            assert Codex().subscription_email() == "dev@example.com"
+
+    @pytest.mark.parametrize(
+        "tokens",
+        [
+            pytest.param({}, id="no-id-token"),
+            pytest.param({"id_token": "not-a-jwt"}, id="not-a-jwt"),
+            pytest.param(
+                {"id_token": "a.!!!not-base64!!!.c"}, id="undecodable-payload"
+            ),
+            pytest.param({"id_token": _jwt({"sub": "x"})}, id="no-email-claim"),
+            pytest.param({"id_token": 42}, id="token-not-a-string"),
+        ],
+    )
+    def test_codex_returns_none_on_an_unusable_token(
+        self, tmp_path: Path, tokens: Dict[str, Any]
+    ):
+        """GIVEN a ~/.codex/auth.json with no readable email claim
+        WHEN subscription_email is read
+        THEN None is returned rather than raising"""
+        (tmp_path / "auth.json").write_text(json.dumps({"tokens": tokens}))
+        with patch.object(
+            Codex,
+            "config_folder",
+            new_callable=lambda: property(lambda self: tmp_path),
+        ):
+            assert Codex().subscription_email() is None
+
+    def test_cursor_returns_none_without_a_state_database(self, tmp_path: Path):
+        """GIVEN no Cursor state.vscdb on disk
+        WHEN subscription_email is read
+        THEN None is returned"""
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_editor_user_data_dir",
+            return_value=tmp_path,
+        ):
+            assert Cursor().subscription_email() is None
+
+    def test_cursor_reads_cached_email(self, tmp_path: Path):
+        """GIVEN a Cursor state.vscdb holding cursorAuth/cachedEmail
+        WHEN subscription_email is read
+        THEN the cached email is returned"""
+        db_dir = tmp_path / "globalStorage"
+        db_dir.mkdir()
+        conn = sqlite3.connect(db_dir / "state.vscdb")
+        conn.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)")
+        conn.execute(
+            "INSERT INTO ItemTable VALUES ('cursorAuth/cachedEmail', 'dev@example.com')"
+        )
+        conn.commit()
+        conn.close()
+        with patch(
+            "ggshield.verticals.ai.agents.cursor.get_editor_user_data_dir",
+            return_value=tmp_path,
+        ):
+            assert Cursor().subscription_email() == "dev@example.com"
+
+    @pytest.mark.parametrize(
+        "agent",
+        [pytest.param(Vibe(), id="vibe"), pytest.param(VSCode(), id="vscode")],
+    )
+    def test_agents_without_a_local_account_report_nothing(self, agent: Agent):
+        """GIVEN an agent that keeps no account on disk
+        WHEN subscription_email is read
+        THEN None is returned, never a stand-in from git config"""
+        assert agent.subscription_email() is None

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-09T11:35:38.727439Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1161,7 +1161,7 @@ requires-dist = [
     { name = "oauthlib", specifier = ">=3.2.1,<4" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", specifier = "~=1.33.1" },
+    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=0b9278889119f1535b072a997caa13a781e4cd59" },
     { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-dotenv", specifier = ">=0.21.0,<2" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
@@ -2933,7 +2933,7 @@ wheels = [
 [[package]]
 name = "pygitguardian"
 version = "1.33.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=0b9278889119f1535b072a997caa13a781e4cd59#0b9278889119f1535b072a997caa13a781e4cd59" }
 dependencies = [
     { name = "marshmallow", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "marshmallow", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2942,10 +2942,6 @@ dependencies = [
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "setuptools" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/9c/aded3498a510e3886d42c8882ae7e281daf8fa4d811f068f038135bc8746/pygitguardian-1.33.1.tar.gz", hash = "sha256:e93bdd6d45b2bbe8dca50840f5aaacb7d7af113b749c3b8838302a72936675ce", size = 59190, upload-time = "2026-07-28T12:29:41.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/83/c882abce7474364543fc6a65765c74d9eb89ab3b30045d192932d2bb5cc8/pygitguardian-1.33.1-py3-none-any.whl", hash = "sha256:ec241824b09af8a42264d55548f75db92278d3fcc38e08a320c82512bd0a7af9", size = 24530, upload-time = "2026-07-28T12:29:40.149Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
AI discovery tells us which agents run on a machine, but not which assistant subscription they are signed into — so a company Claude seat and a personal one look identical.

`Agent.subscription_email()` reads that email from each agent's own local state and sends it per-agent on `AgentInfo`:

| Agent | Source |
| --- | --- |
| Claude Code | `oauthAccount.emailAddress` in `~/.claude.json` |
| Codex | `email` claim of the `id_token` in `~/.codex/auth.json` |
| Cursor | `cursorAuth/cachedEmail` in `state.vscdb` |
| Mistral Vibe, VSCode | nothing — see below |

Local file reads only, on the already-cached discovery path.

**Why two agents report nothing.** Vibe fetches its identity at runtime and caches it in memory only; VSCode keeps its GitHub session in the OS keychain, which would prompt mid-hook. They report nothing rather than falling back to `git config user.email`, which names the repository — a personal-plan agent in a company repo would show a company address.

**The Codex token** is decoded without signature or expiry checks: it is our own local token, read only to name the subscription, and never sent anywhere.

**Merge blocker:** `pygitguardian` is pinned to the branch of [py-gitguardian#190](https://github.com/GitGuardian/py-gitguardian/pull/190). The TODO in `pyproject.toml` must become a real version once that releases.