### PR TITLE
fix(honeytoken): request the honeytokens:write scope by default

### DIFF
--- a/changelog.d/20260817_120000_achille.mascia_plant_forbidden_message.md
+++ b/changelog.d/20260817_120000_achille.mascia_plant_forbidden_message.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `ggshield honeytoken plant` explains a `403` (honeytoken module disabled, insufficient
+  user permissions, or a token without `honeytokens:write`) instead of printing the raw
+  API response body.

--- a/changelog.d/20260817_121000_achille.mascia_login_honors_requested_scopes.md
+++ b/changelog.d/20260817_121000_achille.mascia_login_honors_requested_scopes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `ggshield auth login --scopes` no longer reports "already authenticated" when the
+  configured token lacks one of the requested scopes: it authenticates again to get a
+  token that carries them.

--- a/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
+++ b/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
@@ -1,0 +1,11 @@
+### Changed
+
+- `ggshield machine setup` skips honeytoken planting when the token has no
+  `honeytokens:write` scope, instead of failing the run on a workspace that cannot be
+  granted it.
+
+- `ggshield machine doctor` reports the plan-gated scopes it cannot require
+  (`honeytokens:write`, `ai-discover:send`) as unavailable (`!`) instead of failing, so
+  it no longer exits non-zero on a workspace whose plan does not offer them. The
+  `endpoints:send` scope stays required, since installing the `machine_scan` plugin is
+  an explicit opt-in.

--- a/changelog.d/20260817_123000_achille.mascia_honeytokens_write_default_scope.md
+++ b/changelog.d/20260817_123000_achille.mascia_honeytokens_write_default_scope.md
@@ -1,0 +1,6 @@
+### Changed
+
+- `ggshield auth login` requests the `honeytokens:write` scope by default, so
+  `ggshield machine setup` can plant a honeytoken without a second login. As with the
+  other plan-gated default scopes, the workspace decides whether it is granted, and a
+  login that does not get it still succeeds with a warning.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -4,14 +4,13 @@ from typing import Any, List, Optional, Tuple
 import click
 import requests
 from pygitguardian import GGClient
-from pygitguardian.models import APITokensResponse
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import (
     create_client,
     create_client_from_config,
-    safe_api_tokens,
+    granted_scopes,
     safe_response_json,
 )
 from ggshield.core.config import Config
@@ -22,17 +21,11 @@ from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
 def _warn_missing_scopes(client: GGClient) -> None:
-    try:
-        token_info = safe_api_tokens(client)
-    except (UnexpectedError, requests.exceptions.RequestException):
-        # Best-effort warning: never fail an already-successful login if the
-        # token-info fetch errors out (non-JSON body, network blip, timeout...).
+    # Best-effort warning: never fail an already-successful login when the scopes cannot
+    # be read (non-JSON body, network blip, an error Detail that says nothing about them).
+    granted = granted_scopes(client)
+    if granted is None:
         return
-    if not isinstance(token_info, APITokensResponse):
-        # An error Detail (e.g. 401/500) tells us nothing about scopes; don't
-        # warn that scopes are "missing" when we never managed to read them.
-        return
-    granted = token_info.scopes or []
     missing = [s for s in DEFAULT_SCOPES if s not in granted]
     if missing:
         click.echo(
@@ -122,7 +115,9 @@ def print_default_instance_message(config: Config) -> None:
     type=str,
     help=(
         "Space-separated list of extra scopes to request in addition to the default"
-        " scopes (scan, honeytokens:check, endpoints:send, ai-discover:send)."
+        " scopes (scan, honeytokens:check, endpoints:send, ai-discover:send). If the"
+        " current token lacks one of them, ggshield authenticates again instead of"
+        " reusing it."
     ),
     metavar="SCOPES",
 )
@@ -182,7 +177,9 @@ def login_cmd(
     available scopes in [GitGuardian API documentation][1].
 
     If a valid personal access token is already configured, this command simply displays
-    a success message indicating that ggshield is already ready to use.
+    a success message indicating that ggshield is already ready to use — unless
+    `--scopes` asks for a scope that token does not carry, in which case ggshield
+    authenticates again to get one that does.
 
     [1]: https://docs.gitguardian.com/api-docs/authentication#scopes
     """
@@ -285,7 +282,7 @@ def web_login(
 
     client = OAuthClient(config, defined_instance)
 
-    if client.check_existing_token():
+    if client.check_existing_token(required_scopes=extra_scopes):
         # skip the process if a valid token is already saved
         return
 

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -115,9 +115,9 @@ def print_default_instance_message(config: Config) -> None:
     type=str,
     help=(
         "Space-separated list of extra scopes to request in addition to the default"
-        " scopes (scan, honeytokens:check, endpoints:send, ai-discover:send). If the"
-        " current token lacks one of them, ggshield authenticates again instead of"
-        " reusing it."
+        " scopes (scan, honeytokens:check, honeytokens:write, endpoints:send,"
+        " ai-discover:send). If the current token lacks one of them, ggshield"
+        " authenticates again instead of reusing it."
     ),
     metavar="SCOPES",
 )
@@ -172,7 +172,8 @@ def login_cmd(
     The minimum required scope for the token is `scan`.
 
     By default, the created token will have the `scan`, `honeytokens:check`,
-    `endpoints:send`, and `ai-discover:send` scopes.
+    `honeytokens:write`, `endpoints:send`, and `ai-discover:send` scopes. Your plan
+    decides which of them are granted; ggshield reports the ones that were not.
     Use the `--scopes` option to request extra scopes. You can find the list of
     available scopes in [GitGuardian API documentation][1].
 

--- a/ggshield/cmd/honeytoken/plant.py
+++ b/ggshield/cmd/honeytoken/plant.py
@@ -32,6 +32,18 @@ from ggshield.verticals.honeytoken.targets import (
 )
 
 
+# A 403 on reconcile is an entitlement problem, not a broken machine, and the raw API
+# body does not say which of the three prerequisites is missing.
+_FORBIDDEN_HELP = """ggshield is not allowed to plant honeytokens on your workspace. Make sure that:
+
+- the honeytoken module is enabled for your GitGuardian workspace,
+- you have the necessary permissions as a user (Manager access level),
+- the token used by ggshield has the `honeytokens:write` scope
+  (run `ggshield auth login --scopes honeytokens:write`).
+
+To learn more, visit https://docs.gitguardian.com/honeytoken/getting-started."""
+
+
 @dataclass
 class _Outcome:
     """Per-target reconciliation result, aggregated into the final exit code."""
@@ -202,7 +214,10 @@ def _reconcile_for_user(
                 profile_name=profile_name,
             )
     except EndpointDeploymentsError as exc:
-        click.echo(f"[{target.username}] {exc}", err=True)
+        if exc.status_code == 403:
+            click.echo(f"[{target.username}] {_FORBIDDEN_HELP}", err=True)
+        else:
+            click.echo(f"[{target.username}] {exc}", err=True)
         outcome.api_failure = True
         outcome.api_auth_failure = exc.is_auth
         return outcome

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -28,7 +28,7 @@ _GIT_HOOK_TYPES = ("pre-commit", "pre-push")
 
 # Scopes the configured protections need.
 _SCAN_SCOPE = "scan"  # the AI and git hooks run `ggshield secret scan`
-_HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
+HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
 _ENDPOINT_SCOPE = "endpoints:send"  # the machine_scan plugin uploads endpoint data
 _AI_DISCOVER_SCOPE = "ai-discover:send"  # `ai discover` uploads AI agent discovery
 
@@ -46,6 +46,10 @@ class Check:
     ok: bool
     detail: str = ""
     fix: str = ""
+    # An optional check reports a protection that is unavailable rather than a machine
+    # that is misconfigured, so a failure is a warning: it is printed with its fix but
+    # does not fail the run. Nothing the user can do on this machine would turn it green.
+    optional: bool = False
 
 
 @click.command(name="doctor")
@@ -68,7 +72,8 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     shadowing `core.hooksPath`, which git precedence means must be integrated into
     that hook manager or unset; scopes via a token that carries them; the plugin via
     `ggshield plugin install`). Exits non-zero if any check fails, so it can gate an
-    MDM rollout.
+    MDM rollout — except checks marked `!`, which report a protection the workspace
+    does not offer (honeytokens on a plan without them) rather than a machine to fix.
     """
     config = ContextObj.get(ctx).config
 
@@ -84,7 +89,7 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
         checks.append(_check_plugin_native())
 
     _render(checks)
-    return 0 if all(check.ok for check in checks) else 1
+    return 0 if all(check.ok or check.optional for check in checks) else 1
 
 
 def _check_auth_and_scopes(config: Any) -> "tuple[Optional[List[str]], Check]":
@@ -192,9 +197,12 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
     # server-side on a paid plan (Business or Enterprise).
     def _scope_fix(scope: str, *, paid_plan: bool = False) -> str:
         account = " from a Business or Enterprise account" if paid_plan else ""
+        # `--scopes` matters: plain `auth login` reuses a still-valid token and would
+        # report "already authenticated" without ever asking for the missing scope.
         return (
             f"use a token{account} that has the `{scope}` scope "
-            f"(re-run `ggshield auth login` or create a service-account token)"
+            f"(run `ggshield auth login --scopes {scope}` or create a "
+            "service-account token)"
         )
 
     checks = [
@@ -204,17 +212,24 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
             "required by the AI and git hooks",
             fix=_scope_fix(_SCAN_SCOPE),
         ),
+        # Both plan-gated: a workspace whose plan does not offer them can never be
+        # granted them, so failing the run would gate an MDM rollout on something out
+        # of the fleet's reach. Neither is needed by a `machine setup` protection that
+        # is already in place — honeytoken planting skips without its scope, and
+        # `ai discover` is a separate command.
         Check(
-            f"Scope `{_HONEYTOKEN_SCOPE}`",
-            _HONEYTOKEN_SCOPE in scopes,
+            f"Scope `{HONEYTOKEN_SCOPE}`",
+            HONEYTOKEN_SCOPE in scopes,
             "honeytoken protection — Business or Enterprise plans only",
-            fix=_scope_fix(_HONEYTOKEN_SCOPE, paid_plan=True),
+            fix=_scope_fix(HONEYTOKEN_SCOPE, paid_plan=True),
+            optional=True,
         ),
         Check(
             f"Scope `{_AI_DISCOVER_SCOPE}`",
             _AI_DISCOVER_SCOPE in scopes,
             "AI agent discovery upload — Business or Enterprise plans only",
             fix=_scope_fix(_AI_DISCOVER_SCOPE, paid_plan=True),
+            optional=True,
         ),
     ]
     if plugin_installed:
@@ -262,12 +277,18 @@ def _check_plugin_native() -> Check:
 
 def _render(checks: List[Check]) -> None:
     for check in checks:
-        mark = click.style("✓", fg="green") if check.ok else click.style("✗", fg="red")
+        if check.ok:
+            mark = click.style("✓", fg="green")
+        elif check.optional:
+            mark = click.style("!", fg="yellow")
+        else:
+            mark = click.style("✗", fg="red")
         detail = f" — {check.detail}" if check.detail else ""
         click.echo(f"  {mark} {check.name}{detail}")
         if not check.ok and check.fix:
             click.echo(f"      {click.style('↳ fix:', fg='yellow')} {check.fix}")
-    failed = [check for check in checks if not check.ok]
+    failed = [check for check in checks if not check.ok and not check.optional]
+    unavailable = [check for check in checks if not check.ok and check.optional]
     click.echo()
     if failed:
         click.echo(
@@ -278,6 +299,10 @@ def _render(checks: List[Check]) -> None:
             )
         )
     else:
-        click.echo(
-            click.style("This machine is correctly set up.", fg="green", bold=True)
-        )
+        message = "This machine is correctly set up."
+        if unavailable:
+            message += (
+                f" {len(unavailable)} optional protection(s) unavailable on this"
+                " workspace (marked !)."
+            )
+        click.echo(click.style(message, fg="green", bold=True))

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -13,9 +13,11 @@ from ggshield.cmd.install import (
     install_global,
     install_system,
 )
+from ggshield.cmd.machine.doctor import HONEYTOKEN_SCOPE
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config, granted_scopes
 from ggshield.utils.os import is_root
 from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.installation import (
@@ -185,6 +187,20 @@ def _setup_git_hooks(system: bool) -> bool:
 
 
 def _setup_honeytokens(ctx: click.Context) -> bool:
-    """Plant a honeytoken on this machine (idempotent reconcile via `plant`)."""
+    """Plant a honeytoken on this machine (idempotent reconcile via `plant`).
+
+    Planting needs `honeytokens:write`, which only a plan offering honeytokens grants,
+    and only to a Manager. Without it this is a skip, not a failure: the machine is not
+    misconfigured, the feature is unavailable — and failing here would gate the whole
+    setup on something the workspace cannot have.
+    """
     click.echo(click.style("Honeytoken", bold=True))
+    scopes = granted_scopes(create_client_from_config(ContextObj.get(ctx).config))
+    if scopes is not None and HONEYTOKEN_SCOPE not in scopes:
+        ui.display_warning(
+            f"  skipped: the token does not have the `{HONEYTOKEN_SCOPE}` scope "
+            "(Business or Enterprise plan, Manager access level). Run "
+            f"`ggshield auth login --scopes {HONEYTOKEN_SCOPE}` to request it."
+        )
+        return True
     return ctx.invoke(plant_cmd) == 0

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -194,6 +194,24 @@ def safe_api_tokens(client: GGClient) -> Union[APITokensResponse, Detail]:
         raise _non_json_error(client.base_uri, exc) from exc
 
 
+def granted_scopes(client: GGClient) -> Optional[set[str]]:
+    """The scopes the client's token carries, or None when they could not be read.
+
+    Scopes are raw strings, not ``TokenScope``: a scope newer than pygitguardian's enum
+    (e.g. ``endpoints:send``) must still count as granted. ``None`` means "unknown",
+    never "none granted" — a caller must not report a scope as missing because the
+    lookup itself failed.
+    """
+    try:
+        token_info = safe_api_tokens(client)
+    except (UnexpectedError, requests.exceptions.RequestException):
+        return None
+    if not isinstance(token_info, APITokensResponse):
+        # An error Detail (401/500...) tells us nothing about the scopes.
+        return None
+    return set(token_info.scopes or [])
+
+
 def safe_response_json(response: requests.Response) -> Any:
     """Parse a JSON response body, raising a clean UnexpectedError that names the
     instance URL instead of letting a raw JSONDecodeError escape when the body is

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -33,6 +33,10 @@ SCAN_SCOPE = "scan"
 DEFAULT_SCOPES = [
     SCAN_SCOPE,
     "honeytokens:check",
+    # `ggshield machine setup` plants a honeytoken by default, so the default token must
+    # be able to. Like endpoints:send and ai-discover:send, the backend grants it only on
+    # a plan that offers it and drops it otherwise (`_warn_missing_scopes` reports that).
+    "honeytokens:write",
     "endpoints:send",
     "ai-discover:send",
 ]

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -18,10 +18,12 @@ from ggshield.core.client import (
     create_client,
     create_client_from_config,
     create_session,
+    granted_scopes,
     safe_response_json,
 )
 from ggshield.core.config import Config, InstanceConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
+from ggshield.core.text_utils import pluralize
 from ggshield.core.url_utils import urljoin
 from ggshield.utils.datetime import get_pretty_date
 
@@ -411,12 +413,16 @@ class OAuthClient:
             )
         return self._state
 
-    def check_existing_token(self) -> bool:
+    def check_existing_token(self, required_scopes: Optional[List[str]] = None) -> bool:
         """
         Check if the config already has a non expired token.
         If one could be found, outputs a message including the expiry date
         and return True.
         Else return False
+
+        ``required_scopes`` holds the scopes asked for explicitly with ``--scopes``: a
+        token lacking one cannot do what the user just asked for, so fall through to a
+        fresh login instead of reporting "already authenticated" and doing nothing.
         """
         account = self.instance_config.account
         if account is None or not account.token or self.instance_config.expired:
@@ -432,6 +438,24 @@ class OAuthClient:
                 "Account had an API key recorded but it's no longer valid, removing it"
             )
             self.instance_config.account = None
+            return False
+
+        # Only when `--scopes` asked for something: with nothing to check there is
+        # nothing to learn, and the lookup would cost a round trip on every login.
+        scopes = granted_scopes(client) if required_scopes else None
+        missing = (
+            []
+            if scopes is None
+            else [s for s in required_scopes or [] if s not in scopes]
+        )
+        if missing:
+            # Keep the account: the new login overwrites it on success, and dropping it
+            # first would leave an aborted login with no token at all.
+            click.echo(
+                "The current token is missing the requested "
+                f"{pluralize('scope', len(missing))} {', '.join(missing)}. "
+                "Authenticating again to get a new token."
+            )
             return False
 
         # Trigger a save to migrate cleartext tokens to keyring if needed

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -3,7 +3,7 @@ import urllib.parse as urlparse
 from datetime import datetime, timedelta, timezone
 from enum import IntEnum, auto
 from typing import Optional, Set
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import requests.exceptions
@@ -1409,3 +1409,63 @@ def test_warn_missing_scopes_swallows_connection_error(capsys):
     _warn_missing_scopes(client_mock)  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
+
+
+class TestCheckExistingTokenScopes:
+    """A valid token is only reusable if it carries the scopes `--scopes` asked for."""
+
+    OAUTH = "ggshield.verticals.auth.oauth"
+
+    def _client(self, cli_fs_runner) -> OAuthClient:
+        add_instance_config(instance_url=DEFAULT_INSTANCE_URL)
+        return OAuthClient(Config(), DEFAULT_INSTANCE_URL)
+
+    def _check(self, cli_fs_runner, granted, required):
+        client = self._client(cli_fs_runner)
+        with patch(f"{self.OAUTH}.create_client_from_config"), patch(
+            f"{self.OAUTH}.check_client_api_key"
+        ), patch(f"{self.OAUTH}.granted_scopes", return_value=granted) as m_scopes:
+            return client.check_existing_token(required_scopes=required), m_scopes
+
+    def test_reuses_token_that_has_the_requested_scope(self, cli_fs_runner, capsys):
+        """
+        GIVEN a valid token that carries the scope asked for with --scopes
+        WHEN auth login checks it
+        THEN the token is reused
+        """
+        reused, _ = self._check(
+            cli_fs_runner, {"scan", "honeytokens:write"}, ["honeytokens:write"]
+        )
+        assert reused is True
+
+    def test_reauthenticates_when_the_requested_scope_is_missing(
+        self, cli_fs_runner, capsys
+    ):
+        """
+        GIVEN a valid token that lacks the scope asked for with --scopes
+        WHEN auth login checks it
+        THEN the token is not reused, so the login flow runs and can grant the scope
+        """
+        reused, _ = self._check(cli_fs_runner, {"scan"}, ["honeytokens:write"])
+        assert reused is False
+        assert "honeytokens:write" in capsys.readouterr().out
+
+    def test_no_scope_lookup_without_requested_scopes(self, cli_fs_runner):
+        """
+        GIVEN a plain `auth login` (no --scopes)
+        WHEN the existing token is checked
+        THEN no scope lookup happens: there is nothing to check and it would cost a
+        round trip on every login
+        """
+        reused, m_scopes = self._check(cli_fs_runner, {"scan"}, None)
+        assert reused is True
+        m_scopes.assert_not_called()
+
+    def test_unreadable_scopes_keep_the_token(self, cli_fs_runner):
+        """
+        GIVEN a token whose scopes cannot be read (network blip, error Detail)
+        WHEN the existing token is checked against --scopes
+        THEN the token is kept: a failed lookup must not force a needless re-login
+        """
+        reused, _ = self._check(cli_fs_runner, None, ["honeytokens:write"])
+        assert reused is True

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -50,6 +50,7 @@ VALID_TOKEN_RESPONSE = create_json_response(
         "scope": [
             "scan",
             "honeytokens:check",
+            "honeytokens:write",
             "endpoints:send",
             "ai-discover:send",
         ],
@@ -81,6 +82,7 @@ VALID_API_TOKENS_RESPONSE = create_json_response(
         "scopes": [
             "scan",
             "honeytokens:check",
+            "honeytokens:write",
             "endpoints:send",
             "ai-discover:send",
         ],
@@ -961,6 +963,7 @@ class TestAuthLoginWeb:
             scope_set = {
                 "scan",
                 "honeytokens:check",
+                "honeytokens:write",
                 "endpoints:send",
                 "ai-discover:send",
             }

--- a/tests/unit/cmd/honeytoken/test_plant.py
+++ b/tests/unit/cmd/honeytoken/test_plant.py
@@ -352,6 +352,9 @@ def test_api_auth_error_exits_authentication(
     result = cli_fs_runner.invoke(cli, ["honeytoken", "plant", "--user-dir", "home"])
     assert_invoke_exited_with(result, ExitCode.AUTHENTICATION_ERROR)
     assert not Path("home/.aws/credentials").exists()
+    # The raw API body never says which prerequisite is missing — name all three.
+    assert "honeytokens:write" in result.output
+    assert "honeytoken module is enabled" in result.output
 
 
 def test_remove_only_foreign_profile_is_kept(

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -65,6 +65,31 @@ class TestDoctorCommand:
         assert result.exit_code == 1
         assert "failed" in result.output
 
+    def test_optional_check_warns_without_failing(self, cli_fs_runner: CliRunner):
+        """An unavailable protection is reported with `!` and its fix, but must not fail
+        the run — it would gate an MDM rollout on a scope the workspace cannot have."""
+        optional = Check(
+            "Scope `honeytokens:write`", False, fix="use a token", optional=True
+        )
+        with patch(
+            f"{BASE}._check_auth_and_scopes",
+            return_value=(["scan"], Check("Authentication", True)),
+        ), patch(f"{BASE}._is_plugin_installed", return_value=False), patch(
+            f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks", return_value=Check("Git hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks_precedence",
+            return_value=Check("Git hook precedence", True),
+        ), patch(
+            f"{BASE}._check_scopes", return_value=[optional]
+        ):
+            result = cli_fs_runner.invoke(cli, ["machine", "doctor"])
+        assert result.exit_code == 0
+        assert "correctly set up" in result.output
+        assert "unavailable" in result.output
+        assert "use a token" in result.output
+
     def test_plugin_check_skipped_without_plugin(self, cli_fs_runner: CliRunner):
         _result, m_plugin = self._run(
             cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=False
@@ -193,6 +218,28 @@ class TestCheckScopes:
         by_name = {c.name: c.ok for c in checks}
         assert by_name["Scope `scan`"] is True
         assert by_name["Scope `honeytokens:write`"] is False
+
+    def test_plan_gated_scopes_are_optional_but_scan_is_not(self):
+        """A workspace whose plan does not offer them can never be granted the
+        plan-gated scopes, so missing them must not fail the run the way a missing
+        `scan` does."""
+        by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
+        assert by_name["Scope `honeytokens:write`"].optional is True
+        assert by_name["Scope `ai-discover:send`"].optional is True
+        assert by_name["Scope `scan`"].optional is False
+
+    def test_endpoint_scope_stays_required_with_the_plugin(self):
+        """Installing the plugin is an explicit opt-in, so a token that cannot upload
+        endpoint data is a real misconfiguration, not an unavailable feature."""
+        with_plugin = _check_scopes(["scan"], plugin_installed=True)
+        endpoint = [c for c in with_plugin if "endpoints:send" in c.name]
+        assert endpoint and endpoint[0].optional is False
+
+    def test_scope_fix_names_the_scopes_flag(self):
+        """Plain `auth login` reuses a valid token and would never ask for the missing
+        scope, so the fix has to spell out `--scopes`."""
+        by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
+        assert "--scopes honeytokens:write" in by_name["Scope `honeytokens:write`"].fix
 
     def test_ai_discover_scope_reported(self):
         checks = _check_scopes(["scan"], plugin_installed=False)

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -324,3 +324,41 @@ class TestHoneytokenPlant:
         """`honeytoken plant` stays a first-class command (not deprecated)."""
         result = cli_fs_runner.invoke(cli, ["honeytoken", "plant"])
         assert "deprecated" not in result.output.lower()
+
+
+class TestSetupHoneytokens:
+    """Planting is skipped, not failed, when the workspace cannot grant the scope."""
+
+    BASE = "ggshield.cmd.machine.setup"
+
+    def _run(self, scopes, plant_exit_code=0):
+        from ggshield.cmd.machine.setup import _setup_honeytokens
+
+        ctx = MagicMock()
+        ctx.invoke.return_value = plant_exit_code
+        with patch(f"{self.BASE}.create_client_from_config"), patch(
+            f"{self.BASE}.granted_scopes", return_value=scopes
+        ):
+            return _setup_honeytokens(ctx), ctx.invoke
+
+    def test_plants_when_the_scope_is_granted(self):
+        ok, invoke = self._run({"scan", "honeytokens:write"})
+        invoke.assert_called_once()
+        assert ok is True
+
+    def test_reports_a_failing_plant(self):
+        ok, _invoke = self._run({"scan", "honeytokens:write"}, plant_exit_code=1)
+        assert ok is False
+
+    def test_skips_without_the_scope_and_does_not_fail(self, capsys):
+        ok, invoke = self._run({"scan"})
+        assert ok is True
+        invoke.assert_not_called()
+        output = capsys.readouterr()
+        assert "honeytokens:write" in output.out + output.err
+
+    def test_plants_when_scopes_are_unreadable(self):
+        """An unreadable token must not silently disable the protection: try to plant
+        and let the API be the judge."""
+        _ok, invoke = self._run(None)
+        invoke.assert_called_once()


### PR DESCRIPTION
`ggshield machine setup` plants a honeytoken by default, but nothing in the default login path could: the token never carried `honeytokens:write`. Setup ended on the raw `403` body from the endpoint-deployments API and failed the run, which reads as a missing workspace entitlement rather than a missing token scope — so the reported fix was to ask for the honeytoken module to be enabled instead of re-authenticating.

Four independent commits, smallest blast radius first:

1. **`fix(honeytoken): explain a 403 from honeytoken plant`** — name the three prerequisites (module enabled, Manager access, token scope) instead of printing the API body. This is the shared reconcile path, so a direct run and the root fan-out get it too.
2. **`fix(auth): honor --scopes when the current token lacks them`** — `auth login` reuses any still-valid token, so `--scopes` was a no-op for anyone already authenticated, which made every "run `auth login --scopes <scope>`" message we print dead advice. Only `--scopes` triggers the scope lookup, and an unreadable scope list keeps the existing token.
3. **`fix(machine): report unavailable protections instead of failing`** — setup skips planting without the scope, and doctor reports `honeytokens:write` / `ai-discover:send` in a new `!` state that prints the fix without failing the run. `endpoints:send` stays required, since installing the `machine_scan` plugin is an explicit opt-in.
4. **`feat(auth): request the honeytokens:write scope by default`** — ⚠️ **needs a second opinion, @clement-tourriere.** This reverts your review call on #1254 (END-309). The scope was dropped from the defaults on 10 Jun, when nothing in the default path needed it — `honeytoken plant` was opt-in. `machine setup` landed on 24 Jun and made planting default behaviour. Requesting it is safe on a workspace that cannot have it (the backend grants the subset it allows and login still succeeds with a warning), but it does put a create capability on every developer PAT, which is presumably why it went. **Drop this commit and the other three still stand** — the opt-in path works either way.

Verified against a token holding neither plan-gated scope: doctor marks both `!` and exits non-zero only for a genuinely fixable check, `machine setup` skips planting and exits 0, `honeytoken plant` prints the prerequisites without touching `~/.aws`, and a full `machine setup` completes end to end. Each of the four commits passes the auth/machine/honeytoken suites on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)