### PR TITLE
fix(packaging): keep the version suffix when naming OS packages

### DIFF
--- a/scripts/build-os-packages/build-os-packages
+++ b/scripts/build-os-packages/build-os-packages
@@ -72,10 +72,11 @@ EOF
 }
 
 read_version() {
-    # Match the full `__version__ = "X.Y.Z"` assignment, not just any X.Y.Z in
-    # the file: other lines (type hints, examples in messages, ...) can hold
-    # version-like substrings that would otherwise corrupt VERSION.
-    VERSION=$(sed -n 's/^__version__ *= *"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    # Anchor on the `__version__` assignment, not just any version-like
+    # substring: other lines (type hints, examples in messages, ...) can hold
+    # one and would corrupt VERSION. The whole quoted value is kept, so a
+    # pre-release suffix survives into the package name.
+    VERSION=$(sed -n 's/^__version__ *= *"\([0-9][^"]*\)".*/\1/p' \
         "$ROOT_DIR/ggshield/__init__.py")
     if [ -n "$VERSION_SUFFIX" ] ; then
         VERSION="${VERSION}${VERSION_SUFFIX}"


### PR DESCRIPTION
`read_version` parsed `__version__` with `[0-9]*\.[0-9]*\.[0-9]*`, which captures only the numeric core. A `__version__` of `1.54.0rc1` therefore produced packages, archives and install prefixes all labelled `1.54.0`, indistinguishable from the real release. The capture now keeps the whole quoted value.

This is inert today, since `__version__` holds a plain `X.Y.Z` and the `-s` suffix is appended separately. It matters as soon as anyone tries to build a release candidate, which is currently impossible to do correctly for that reason.

Note that this only makes the version honest. Shipping an rc through every channel still needs per-channel work, since dpkg wants `~rc1`, NuGet wants `-rc1`, and an MSI `ProductVersion` cannot express a pre-release at all. The MSI strip at `windows-functions.bash:89` only cuts a `+` suffix, so an rc build would fail there rather than mislabel, which is the behaviour I would want until that path is designed.