### PR TITLE
ci(release): make signing independent of release mode

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -7,13 +7,21 @@ on:
   workflow_call:
     inputs:
       release_mode:
-        description: 'Release mode (signed binaries, no commit sha in version number)'
+        description: 'Release mode (no commit sha in version number)'
+        type: boolean
+        default: false
+      sign:
+        description: 'Code-sign the binaries (needs secrets, so no PR from a fork can)'
         type: boolean
         default: false
   workflow_dispatch:
     inputs:
       release_mode:
-        description: 'Release mode (signed binaries, no commit sha in version number)'
+        description: 'Release mode (no commit sha in version number)'
+        type: boolean
+        default: false
+      sign:
+        description: 'Code-sign the binaries (needs secrets, so no PR from a fork can)'
         type: boolean
         default: false
 
@@ -185,7 +193,7 @@ jobs:
           uv sync --locked --no-default-groups --group tests --group standalone
 
       - name: Prepare macOS secrets
-        if: startsWith(matrix.os, 'macos-') && inputs.release_mode
+        if: startsWith(matrix.os, 'macos-') && inputs.sign
         run: |
           set -euo pipefail
           SECRETS_DIR=$TMPDIR/secrets
@@ -208,7 +216,7 @@ jobs:
           MACOS_API_KEY_FILE: ${{ secrets.MACOS_API_KEY_FILE }}
 
       - name: Setup Windows environment
-        if: startsWith(matrix.os, 'windows-') && inputs.release_mode
+        if: startsWith(matrix.os, 'windows-') && inputs.sign
         shell: bash
         run: |
           signtool_install_dir="/c/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64"
@@ -239,7 +247,7 @@ jobs:
           EOF
 
       - name: Install Windows dependencies
-        if: startsWith(matrix.os, 'windows-') && inputs.release_mode
+        if: startsWith(matrix.os, 'windows-') && inputs.sign
         shell: bash
         run: |
           scripts/build-os-packages/install-keylockertools
@@ -247,10 +255,13 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          if [ "${{ inputs.release_mode }}" = "true" ] ; then
-            args="--sign"
-          else
-            args="--suffix +${GITHUB_SHA:0:7}"
+          args=""
+          if [ "${{ inputs.sign }}" = "true" ] ; then
+            args="$args --sign"
+          fi
+          # The +sha stamp is what tells an internal build apart from the release.
+          if [ "${{ inputs.release_mode }}" != "true" ] ; then
+            args="$args --suffix +${GITHUB_SHA:0:7}"
           fi
           # Run the script with `bash -c` because `uv run` does not
           # automatically do it on Windows

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,6 +11,7 @@ jobs:
     secrets: inherit
     with:
       release_mode: true
+      sign: true
 
   push_to_pypi:
     needs: build_release_assets


### PR DESCRIPTION
`release_mode` gated two unrelated things at once: code signing, and whether the version number carries a `+sha` stamp. That made a build either signed (`1.53.0`) or commit-stamped (`1.53.0+abc1234`), never both. Pushing a pre-GA build to employee machines via MDM needs both: signing for macOS Gatekeeper and to pin the Keychain code-signing identifier, and the stamp to tell an internal build apart from the eventual public release.

A separate `sign` input (default `false`, wording borrowed from the `sign` input in `wheels.yml`) now gates the macOS/Windows signing-secret steps and `--sign`. `release_mode` keeps only its version-suffix meaning. `tag.yml` passes `sign: true` alongside `release_mode: true`, so the GA release is unchanged; `ci.yml`'s `build_os_packages` passes no inputs and keeps both defaults. Those are the only two callers.

`--sign` and `--suffix` are orthogonal in `scripts/build-os-packages/build-os-packages`: they set `DO_SIGN` and `VERSION_SUFFIX` independently, with no interaction.

The arg-building snippet, run for all four combinations (with `GITHUB_SHA=abc1234...`), showing both `$args` and the argv the unquoted expansion produces:

```
sign=false release_mode=false
  args: ' --suffix +abc1234'
  argv (2): [--suffix] [+abc1234]
sign=false release_mode=true
  args: ''
  argv (0):
sign=true release_mode=false
  args: ' --sign --suffix +abc1234'
  argv (3): [--sign] [--suffix] [+abc1234]
sign=true release_mode=true
  args: ' --sign'
  argv (1): [--sign]
```

The leading space is inert: `$args` is expanded unquoted inside the `bash -c` string, exactly as before.