### PR TITLE
fix(build): sign Windows artifacts through a path smctl accepts

### DIFF
--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -34,8 +34,11 @@ windows_sign_file() {
     local path="$1"
     local base="${path##*/}"
 
+    # Under $BUILD_DIR rather than $TMPDIR: the runner's temp path is outside
+    # our control and signtool's accepted set is narrow, while $BUILD_DIR is the
+    # directory every release has already signed from.
     local tmp_dir
-    tmp_dir=$(mktemp -d)
+    tmp_dir=$(mktemp -d "$BUILD_DIR/sign.XXXXXX")
     local tmp_path="$tmp_dir/${base//[^A-Za-z0-9._-]/_}"
     cp "$path" "$tmp_path"
 

--- a/scripts/build-os-packages/windows-functions.bash
+++ b/scripts/build-os-packages/windows-functions.bash
@@ -22,13 +22,32 @@ windows_sign() {
     local archive_dir="$BUILD_DIR/$ARCHIVE_DIR_NAME"
     local exe
     for exe in ggshield.exe ggshield-py.exe ; do
-        smctl sign \
-            --verbose \
-            --exit-non-zero-on-fail \
-            --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
-            --tool signtool \
-            --input "$archive_dir/$INSTALL_PREFIX/$exe"
+        windows_sign_file "$archive_dir/$INSTALL_PREFIX/$exe"
     done
+}
+
+# smctl rejects any path holding a character signtool does not support, `+`
+# among them, and our "X.Y.Z+sha" builds put one in the archive directory name.
+# So sign a copy placed under a name built from safe characters only, then move
+# the signed bytes back to the original path.
+windows_sign_file() {
+    local path="$1"
+    local base="${path##*/}"
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local tmp_path="$tmp_dir/${base//[^A-Za-z0-9._-]/_}"
+    cp "$path" "$tmp_path"
+
+    smctl sign \
+        --verbose \
+        --exit-non-zero-on-fail \
+        --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
+        --tool signtool \
+        --input "$tmp_path"
+
+    mv "$tmp_path" "$path"
+    rm -rf "$tmp_dir"
 }
 
 windows_create_archive() {
@@ -108,12 +127,7 @@ windows_build_msi_package() {
 
     if [ "$DO_SIGN" -eq 1 ] ; then
         info "Signing MSI package"
-        smctl sign \
-            --verbose \
-            --exit-non-zero-on-fail \
-            --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
-            --tool signtool \
-            --input "$msi_path"
+        windows_sign_file "$msi_path"
     fi
 
     info "MSI package created in $msi_path"


### PR DESCRIPTION
Run 32149208590 (`sign: true`, `release_mode: false`) failed on Windows only: DigiCert's `smctl` refuses any file path containing a character `signtool` does not support, `+` included. A commit-stamped build lays its files down under `ggshield-1.53.0+210f76a-x86_64-pc-windows-msvc/`, so every path handed to `smctl` carried one. GA is unaffected because `release_mode: true` produces no `+`.

The version string, archive name and `+` separator stay as they are: `+<sha>` is correct semver build metadata, it is what the macOS and Linux artifacts use, and `1.53.0+<sha>` deliberately sorts below `1.54.0` for dpkg. Instead the Windows signing path signs a copy placed under a temporary name built from safe characters, then moves the signed bytes back over the original path, so MSI packaging, choco and the zip see exactly what they saw before.

Two choices worth naming. The temp name is built from an allowlist (`A-Za-z0-9._-`) rather than by deleting `+`: it is the same single parameter expansion, it covers the rest of the unsupported set (`&`, `^`, `!`, spaces, ...) should a branch name or path ever reach a filename, and it does not require trusting DigiCert's list to be complete. And the three `smctl` call sites (both `.exe` files and the `.msi`, whose name carries `+` too) now go through one `windows_sign_file` helper: the MSI was equally broken, it just never got reached because the `sign` step dies first.

Verification, with `smctl` stubbed to record the path it is given and refuse the unsupported characters (no DigiCert credentials, and signing cannot run on macOS):

```
orig path : /var/.../tmp.jmwATNdPb7/ggshield-1.53.0+210f76a-x86_64-pc-windows-msvc/ggshield.exe
smctl saw : /var/.../tmp.ORVVOloNQo/ggshield.exe
content   : SIGNED:payload
OK

orig path : /var/.../tmp.jmwATNdPb7/dist/ggshield-1.53.0+210f76a-x86_64-pc-windows-msvc.msi
smctl saw : /var/.../tmp.1cEFeIGfM0/ggshield-1.53.0_210f76a-x86_64-pc-windows-msvc.msi
content   : SIGNED:payload
OK

ALL OK
```

The stub exits non-zero on any unsupported character, and each case also asserts that the signed bytes are back at the original `+` path and the temp copy is gone. `bash -n` passes; `shellcheck -S warning` reports the same four pre-existing SC2164 `pushd`/`popd` warnings as on `main`, nothing new.
