### PR TITLE
fix(ai): discover MCP configurations only for the installed agents

### DIFF
--- a/changelog.d/20260819_120000_achille.mascia_ai_discovery_present_agents.md
+++ b/changelog.d/20260819_120000_achille.mascia_ai_discovery_present_agents.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- AI discovery no longer reports MCP server configurations for agents that are not
+  installed. A project `.mcp.json` is read by several agents, and Copilot also declared a
+  hardcoded GitHub MCP server, so machines without those agents reported configurations
+  they could not run.
+
+- On macOS and Windows, `ggshield` now finds VSCode's user directory, so its global MCP
+  servers and its known workspaces are discovered there too.

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, Literal, Optional, Tuple
 import click
 from pygitguardian.models import AIDiscovery, MCPActivityRequest
 
-from ggshield.core.dirs import get_editor_user_data_dir, get_user_home_dir
+from ggshield.core.dirs import get_editor_user_data_dir
 
 from ..agent_activity.sources import JSONLActivitySource
 from ..models import (
@@ -75,7 +75,7 @@ class VSCode(Agent):
 
     @property
     def config_folder(self) -> Path:
-        return get_user_home_dir() / ".config" / "Code" / "User"
+        return get_editor_user_data_dir("Code")
 
     def output_result(self, result: HookResult) -> int:
         response = {}

--- a/ggshield/verticals/ai/discovery.py
+++ b/ggshield/verticals/ai/discovery.py
@@ -63,35 +63,40 @@ def discover_ai_configuration(machine_id: Optional[str] = None) -> AIDiscovery:
     start_time = perf_counter()
     mcp_configurations: List[MCPConfiguration] = []
 
+    # Only the agents installed on this machine, because a configuration file can
+    # belong to several agents (a project `.mcp.json` is read by both Claude Code
+    # and Copilot). Reporting a configuration for an absent agent would attribute
+    # it to an agent missing from `agents` below, which is what the API keys on.
+    present_agents = [agent for agent in AGENTS.values() if agent.is_present()]
+
     # Discovered project directories
     projects = {Path.cwd().resolve()}
-    for agent in AGENTS.values():
+    for agent in present_agents:
         projects.update(agent.discover_project_directories())
 
     # Discover MCP configurations
-    for agent in AGENTS.values():
+    for agent in present_agents:
         mcp_configurations.extend(agent.discover_mcp_configurations(projects))
 
     # Hook installation status
     agents = []
-    for agent in AGENTS.values():
-        if agent.is_present():
-            installed, command = are_hooks_installed_globally(agent.name)
-            agents.append(
-                AgentInfo(
-                    name=agent.name,
-                    hooks_installed=installed,
-                    hooks_command=command,
-                    subscription_email=agent.subscription_email(),
-                )
+    for agent in present_agents:
+        installed, command = are_hooks_installed_globally(agent.name)
+        agents.append(
+            AgentInfo(
+                name=agent.name,
+                hooks_installed=installed,
+                hooks_command=command,
+                subscription_email=agent.subscription_email(),
             )
+        )
 
     # Merge MCP configurations into servers
     servers = _merge_mcp_configurations(mcp_configurations)
 
     # Try to find the servers' capabilities
     for server in servers:
-        for agent in AGENTS.values():
+        for agent in present_agents:
             if agent.discover_capabilities(server):
                 # Discovery succeeded for this server. Early return.
                 break

--- a/tests/unit/verticals/ai/test_discovery.py
+++ b/tests/unit/verticals/ai/test_discovery.py
@@ -144,6 +144,49 @@ class TestDiscoverAIConfiguration:
     )
     @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
     @patch("ggshield.verticals.ai.discovery.AGENTS")
+    def test_ignores_the_configurations_of_absent_agents(
+        self,
+        mock_agents: MagicMock,
+        mock_user_info: MagicMock,
+        mock_hooks: MagicMock,
+    ):
+        present = MagicMock()
+        present.name = "cursor"
+        present.is_present.return_value = True
+        present.discover_project_directories.return_value = iter([])
+        present.discover_mcp_configurations.return_value = [_cfg(name="s1")]
+        present.discover_capabilities.return_value = False
+
+        # Absent agents also parse the configuration files they recognize, and
+        # some of them report a hardcoded server. None of it must be reported.
+        absent = MagicMock()
+        absent.name = "copilot"
+        absent.is_present.return_value = False
+        absent.discover_project_directories.return_value = iter([])
+        absent.discover_mcp_configurations.return_value = [
+            _cfg(name="s1", agent="copilot"),
+            _cfg(name="github-mcp-server", agent="copilot"),
+        ]
+        absent.discover_capabilities.return_value = False
+
+        mock_agents.values.return_value = [present, absent]
+
+        result = discover_ai_configuration()
+
+        absent.discover_mcp_configurations.assert_not_called()
+        assert [s.name for s in result.servers] == ["s1"]
+        assert {
+            configuration.agent
+            for server in result.servers
+            for configuration in server.configurations
+        } == {"cursor"}
+
+    @patch(
+        "ggshield.verticals.ai.discovery.are_hooks_installed_globally",
+        return_value=(False, None),
+    )
+    @patch("ggshield.verticals.ai.discovery.get_user_info", return_value=_user())
+    @patch("ggshield.verticals.ai.discovery.AGENTS")
     def test_stops_capability_discovery_at_first_success(
         self,
         mock_agents: MagicMock,

--- a/tests/unit/verticals/ai/test_vscode_history.py
+++ b/tests/unit/verticals/ai/test_vscode_history.py
@@ -1,11 +1,11 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from pygitguardian.models import AIDiscovery, MCPConfiguration, MCPServer, UserInfo
 
+from ggshield.core.dirs import get_editor_user_data_dir
 from ggshield.verticals.ai.agents.vscode import VSCode, _find_mcp_invocations
 
 
@@ -79,12 +79,12 @@ class TestFindMCPInvocations:
 
 
 class TestVSCodeIterHistoryEvents:
-    def _seed_session(
-        self, tmp_path: Path, lines: list[str], workspace_folder: str
-    ) -> Path:
-        workspace_hash = (
-            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
-        )
+    @pytest.fixture(autouse=True)
+    def fake_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GG_USER_HOME_DIR", str(tmp_path))
+
+    def _seed_session(self, lines: list[str], workspace_folder: str) -> Path:
+        workspace_hash = get_editor_user_data_dir("Code") / "workspaceStorage" / "ws1"
         sessions = workspace_hash / "chatSessions"
         sessions.mkdir(parents=True)
         (workspace_hash / "workspace.json").write_text(
@@ -99,13 +99,9 @@ class TestVSCodeIterHistoryEvents:
     ) -> None:
         ts_ms = 1_778_855_521_780
         line = _request_line(ts_ms, [_invocation("call-1")])
-        self._seed_session(tmp_path, [line], "/repo")
+        self._seed_session([line], "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert len(events) == 1
         ev = events[0]
@@ -124,13 +120,9 @@ class TestVSCodeIterHistoryEvents:
             _request_line(ts_ms, [_invocation("dup", raw_input={"q": "partial"})]),
             _request_line(ts_ms, [_invocation("dup", raw_input={"q": "final"})]),
         ]
-        self._seed_session(tmp_path, lines, "/repo")
+        self._seed_session(lines, "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert len(events) == 1
 
@@ -145,13 +137,9 @@ class TestVSCodeIterHistoryEvents:
             _request_line(ts_ms, []),  # establishes last_ts
             bare_line,
         ]
-        self._seed_session(tmp_path, lines, "/repo")
+        self._seed_session(lines, "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert len(events) == 1
         assert events[0].timestamp == datetime.fromtimestamp(
@@ -177,13 +165,9 @@ class TestVSCodeIterHistoryEvents:
             }
         )
         bare_line = json.dumps({"kind": 2, "v": [_invocation("late")]})
-        self._seed_session(tmp_path, [snapshot, bare_line], "/repo")
+        self._seed_session([snapshot, bare_line], "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert len(events) == 1
         assert events[0].timestamp == datetime.fromtimestamp(
@@ -203,13 +187,9 @@ class TestVSCodeIterHistoryEvents:
             }
         )
         bare_line = json.dumps({"kind": 2, "v": [_invocation("nested")]})
-        self._seed_session(tmp_path, [round_line, bare_line], "/repo")
+        self._seed_session([round_line, bare_line], "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert len(events) == 1
         assert events[0].timestamp == datetime.fromtimestamp(
@@ -221,13 +201,9 @@ class TestVSCodeIterHistoryEvents:
     ) -> None:
         """If no request snapshot has been seen yet, there's no timestamp to attach."""
         bare_line = json.dumps({"kind": 2, "v": [_invocation("orphan")]})
-        self._seed_session(tmp_path, [bare_line], "/repo")
+        self._seed_session([bare_line], "/repo")
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert events == []
 
@@ -235,7 +211,7 @@ class TestVSCodeIterHistoryEvents:
         """``source.label`` matches ``MCPConfiguration.name`` byte-for-byte."""
         ts_ms = 1_778_855_521_780
         line = _request_line(ts_ms, [_invocation("c")])
-        self._seed_session(tmp_path, [line], "/repo")
+        self._seed_session([line], "/repo")
 
         config = AIDiscovery(
             user=UserInfo(hostname="h", username="u", machine_id="m"),
@@ -256,11 +232,7 @@ class TestVSCodeIterHistoryEvents:
             discovery_duration=0.0,
         )
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(config))
+        events = list(VSCode().iter_history_events(config))
 
         assert events[0].server == "Notion"
         assert events[0].tool == "notion-search"
@@ -268,9 +240,7 @@ class TestVSCodeIterHistoryEvents:
     def test_ignores_legacy_json_sessions(
         self, tmp_path: Path, empty_ai_config
     ) -> None:
-        workspace_hash = (
-            tmp_path / ".config" / "Code" / "User" / "workspaceStorage" / "ws1"
-        )
+        workspace_hash = get_editor_user_data_dir("Code") / "workspaceStorage" / "ws1"
         sessions = workspace_hash / "chatSessions"
         sessions.mkdir(parents=True)
         (workspace_hash / "workspace.json").write_text(
@@ -278,10 +248,6 @@ class TestVSCodeIterHistoryEvents:
         )
         (sessions / "legacy.json").write_text(json.dumps({"requests": []}))
 
-        with patch(
-            "ggshield.verticals.ai.agents.vscode.get_user_home_dir",
-            return_value=tmp_path,
-        ):
-            events = list(VSCode().iter_history_events(empty_ai_config))
+        events = list(VSCode().iter_history_events(empty_ai_config))
 
         assert events == []


### PR DESCRIPTION
## What it does

`discover_ai_configuration()` resolved the agents present on the machine only to fill the
reported `agents` list, and walked the configuration files of **every** known agent. The
two disagree whenever a file belongs to more than one agent: a project `.mcp.json` is read
by Claude Code and by Copilot, so a machine with Claude Code alone reports a `copilot`
configuration and no `copilot` agent. Copilot's hardcoded `github-mcp-server` entry is
worse: it touches no file, so it is emitted on every machine, Copilot installed or not.

The API attaches each configuration to an agent instance keyed by that name, so a
configuration naming an agent the payload never declared has nothing to attach to, and the
whole discovery is rejected. The fix resolves the installed agents once and runs the
discovery over that set only: project directories, configurations, hook status and
capabilities.

## VSCode's user directory

`is_present()` becomes load-bearing, and VSCode failed it off Linux: `config_folder`
hardcoded `~/.config/Code/User` while the activity source next to it already used
`get_editor_user_data_dir("Code")`. Filtering without this would have dropped the
`.vscode/mcp.json` files of every macOS and Windows user. VSCode now uses the same helper,
so its global MCP servers and its known workspaces are also discovered there.

## Notes

The discovery walk has no Rust counterpart. `ggshield-discovery` (#1405) reads the
inventory Python writes and resolves server names by search, so it needs no change and it
sees the corrected data once the cache is rewritten.

## Verification

`make unittest` (2669 passed, 4 skipped), `black --check`, `flake8` clean.
