### PR TITLE
fix(ai-hook): pin the hook to a stable ggshield launcher

### DIFF
--- a/changelog.d/20260819_140000_achille.mascia_ai_hook_stable_launcher.md
+++ b/changelog.d/20260819_140000_achille.mascia_ai_hook_stable_launcher.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The AI hook installed from the macOS standalone package now points at
+  `/usr/local/bin/ggshield` instead of the versioned `/opt/gitguardian/ggshield-<version>/`
+  directory an upgrade removes, so it keeps scanning after an upgrade.
+
+- `ggshield machine setup` now repoints an AI hook command whose ggshield binary is gone,
+  or is reachable through a more stable path, instead of leaving the broken command in
+  place.

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -45,6 +45,9 @@ class BuildConfigResult:
     stats: InstallationStats
 
 
+_HOOK_ARGS = "secret scan ai-hook"
+
+
 def build_hook_command() -> str:
     """Build the AI hook command line written into the agent's settings.
 
@@ -76,13 +79,14 @@ def build_hook_command() -> str:
     follow the final symlink, so a stable ``…/bin/ggshield`` launcher keeps
     working across upgrades.
 
-    Known limitation on the macOS standalone bundle: ``/usr/local/bin/ggshield``
-    is a symlink into a *versioned* ``/opt/gitguardian/ggshield-<version>/``
-    directory, but the frozen path comes from ``sys.executable``, which the OS
-    already resolved. The hook is therefore pinned to the versioned path and must
-    be reinstalled after an upgrade.
+    The frozen path is the one place where a symlink is already gone: the OS
+    resolves ``sys.executable`` for PyInstaller, and on the macOS bundle it
+    resolves into a *versioned* ``/opt/gitguardian/ggshield-<version>/``
+    directory that the next upgrade deletes. A stable launcher
+    (``/usr/local/bin/ggshield``, ``/usr/bin/ggshield``) is therefore preferred
+    when it resolves to that same binary, so the hook survives upgrades.
     """
-    return f"{_quote_executable(hook_executable())} secret scan ai-hook"
+    return f"{_quote_executable(hook_executable())} {_HOOK_ARGS}"
 
 
 def hook_executable() -> str:
@@ -97,6 +101,7 @@ def hook_executable() -> str:
             dispatcher, os.X_OK
         ):
             executable = dispatcher
+        executable = _stable_launcher(executable)
     else:
         argv0 = sys.argv[0]
         if os.path.dirname(argv0):
@@ -106,6 +111,58 @@ def hook_executable() -> str:
             # (the Python interpreter, not ggshield).
             executable = shutil.which(argv0) or os.path.abspath(argv0)
     return executable
+
+
+def _stable_launcher(executable: str) -> str:
+    """A version-independent launcher for `executable`, or `executable` itself.
+
+    Substitution requires the launcher to resolve to the very same file: on a
+    machine carrying several ggshield installs (Homebrew alongside the bundle),
+    the other one is a binary the user never authenticated. A launcher that does
+    not exist resolves to itself, so the comparison simply fails.
+    """
+    if os.name == "nt":
+        return executable
+    target = os.path.realpath(executable)
+    for launcher in ("/usr/local/bin/ggshield", "/usr/bin/ggshield"):
+        if os.path.realpath(launcher) == target:
+            return launcher
+    return executable
+
+
+def _hook_command_executable(command: str) -> Optional[str]:
+    """The ggshield path in a hook command, or None when the command is not ours.
+
+    Anything carrying extra arguments is the user's own command, not one we wrote.
+    """
+    suffix = f" {_HOOK_ARGS}"
+    if not command.endswith(suffix):
+        return None
+    path = command[: -len(suffix)]
+    if os.name == "nt":
+        return path.strip('"')
+    parts = shlex.split(path)
+    return parts[0] if len(parts) == 1 else None
+
+
+def _is_outdated_hook_command(existing: str, command: str) -> bool:
+    """Whether an installed hook command should be repointed at `command`.
+
+    True for a ggshield command whose binary is gone (a versioned bundle
+    directory an upgrade removed) or that reaches the same binary through a less
+    stable path. Anything else belongs to the user and is left alone.
+    """
+    if existing == command:
+        return False
+    installed = _hook_command_executable(existing)
+    new = _hook_command_executable(command)
+    if installed is None or new is None:
+        return False
+    if "ggshield" not in os.path.basename(installed):
+        return False
+    return not os.path.exists(installed) or os.path.realpath(
+        installed
+    ) == os.path.realpath(new)
 
 
 def _quote_executable(path: str) -> str:
@@ -316,6 +373,10 @@ def _fill_dict(
             if value == "<COMMAND>" and isinstance(cmd, str) and "ggshield" in cmd:
                 stats.already_present += 1
                 stats.command = cmd
+                # An upgrade invalidates a versioned bundle path, and the hook
+                # then fails open: every prompt goes unscanned.
+                if _is_outdated_hook_command(cmd, command):
+                    config[key] = "<COMMAND>"
             # Update if needed
             if overwrite:
                 config[key] = value

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -138,11 +138,17 @@ def _hook_command_executable(command: str) -> Optional[str]:
     suffix = f" {_HOOK_ARGS}"
     if not command.endswith(suffix):
         return None
-    path = command[: -len(suffix)]
-    if os.name == "nt":
-        return path.strip('"')
-    parts = shlex.split(path)
-    return parts[0] if len(parts) == 1 else None
+    windows = os.name == "nt"
+    try:
+        # posix=False keeps Windows path separators, which posix mode would eat
+        # as escapes; it also keeps the quotes, hence the strip below.
+        parts = shlex.split(command[: -len(suffix)], posix=not windows)
+    except ValueError:
+        # Unbalanced quote in a hand-edited command: not one of ours.
+        return None
+    if len(parts) != 1:
+        return None
+    return parts[0].strip('"') if windows else parts[0]
 
 
 def _is_outdated_hook_command(existing: str, command: str) -> bool:

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -255,6 +255,23 @@ class TestFillDict:
         )
         assert config["hooks"] == [{"command": other}]
 
+    def test_another_tool_windows_command_is_left_alone(self):
+        """GIVEN a Windows hook command running another tool, mentioning ggshield
+        WHEN the hooks are installed again
+        THEN it is kept: arguments mark a command as not ours on Windows too."""
+        other = r"C:\Tools\other-scanner --ggshield-compat secret scan ai-hook"
+        config = {"hooks": [{"command": other}]}
+        with patch("ggshield.verticals.ai.installation.os.name", "nt"):
+            _fill_dict(
+                config,
+                {"hooks": [{"command": "<COMMAND>"}]},
+                COMMAND,
+                overwrite=False,
+                stats=InstallationStats(added=0, already_present=0),
+                locator=_locator,
+            )
+        assert config["hooks"] == [{"command": other}]
+
     def test_non_command_scalar_is_not_an_existing_install(self):
         """A template scalar other than the command may contain "ggshield" (a hook
         name, say). It must not be mistaken for an existing installation."""
@@ -795,23 +812,29 @@ class TestAreHooksInstalledGlobally:
 
 
 @contextlib.contextmanager
-def _simulate_platform(argv, *, windows):
+def _simulate_platform(argv=("ggshield", "install"), *, windows, frozen=None):
     """Run build_hook_command as if on a given OS, regardless of the test host.
 
-    Patches the path primitives the function uses (``os.name``,
-    ``os.path.abspath`` and ``os.path.dirname``) to the chosen flavor (ntpath or
-    posixpath) so the same assertions hold whether the runner is Linux or
-    Windows.
+    Patches the path primitives the function uses (``os.name`` and the
+    ``os.path`` functions) to the chosen flavor (ntpath or posixpath) so the
+    same assertions hold whether the runner is Linux or Windows. ``frozen``
+    names the ``sys.executable`` of a PyInstaller bundle; without it the
+    argv[0] code paths are exercised.
     """
     flavor = ntpath if windows else posixpath
     mod = "ggshield.verticals.ai.installation"
     with contextlib.ExitStack() as stack:
-        stack.enter_context(patch(f"{mod}.sys.argv", argv))
+        stack.enter_context(patch(f"{mod}.sys.argv", list(argv)))
         stack.enter_context(patch(f"{mod}.os.name", "nt" if windows else "posix"))
         stack.enter_context(patch(f"{mod}.os.path.abspath", flavor.abspath))
         stack.enter_context(patch(f"{mod}.os.path.dirname", flavor.dirname))
-        # Frozen detection must be off for the argv[0]-based paths.
-        stack.enter_context(patch.object(sys, "frozen", False, create=True))
+        stack.enter_context(patch(f"{mod}.os.path.join", flavor.join))
+        stack.enter_context(patch(f"{mod}.os.path.normpath", flavor.normpath))
+        stack.enter_context(
+            patch.object(sys, "frozen", frozen is not None, create=True)
+        )
+        if frozen is not None:
+            stack.enter_context(patch.object(sys, "executable", frozen, create=True))
         yield
 
 
@@ -957,27 +980,23 @@ class TestBuildHookCommand:
         ):
             assert build_hook_command() == f"{launcher} secret scan ai-hook"
 
-    def test_frozen_bundle_prefers_the_stable_launcher(self, tmp_path):
+    def test_frozen_bundle_prefers_the_stable_launcher(self):
         """GIVEN a frozen macOS bundle installed in a versioned directory
         WHEN /usr/local/bin/ggshield resolves to that very binary
         THEN the hook is pinned to the launcher, which survives an upgrade."""
-        versioned = str(tmp_path / "ggshield-1.53.0" / "ggshield")
-        with patch.object(sys, "frozen", True, create=True), patch.object(
-            sys, "executable", versioned, create=True
-        ), patch(
+        versioned = "/opt/gitguardian/ggshield-1.53.0/ggshield"
+        with _simulate_platform(windows=False, frozen=versioned), patch(
             "ggshield.verticals.ai.installation.os.path.realpath",
             lambda path: versioned if path == "/usr/local/bin/ggshield" else path,
         ):
             assert build_hook_command() == "/usr/local/bin/ggshield secret scan ai-hook"
 
-    def test_frozen_bundle_ignores_a_launcher_to_another_binary(self, tmp_path):
+    def test_frozen_bundle_ignores_a_launcher_to_another_binary(self):
         """GIVEN a frozen bundle on a machine that also has a Homebrew ggshield
         WHEN /usr/local/bin/ggshield resolves to that other install
         THEN the bundle path is kept: the other binary holds no credentials."""
-        versioned = str(tmp_path / "ggshield-1.53.0" / "ggshield")
-        with patch.object(sys, "frozen", True, create=True), patch.object(
-            sys, "executable", versioned, create=True
-        ), patch(
+        versioned = "/opt/gitguardian/ggshield-1.53.0/ggshield"
+        with _simulate_platform(windows=False, frozen=versioned), patch(
             "ggshield.verticals.ai.installation.os.path.realpath",
             lambda path: (
                 "/opt/homebrew/bin/ggshield"
@@ -1006,13 +1025,8 @@ class TestBuildHookCommand:
         WHEN the POSIX launcher paths would match
         THEN they are ignored: they mean nothing on Windows."""
         exe = r"C:\Program Files\GitGuardian\ggshield\ggshield.exe"
-        mod = "ggshield.verticals.ai.installation"
-        with patch.object(sys, "frozen", True, create=True), patch.object(
-            sys, "executable", exe, create=True
-        ), patch(f"{mod}.os.name", "nt"), patch(
-            f"{mod}.os.path.dirname", ntpath.dirname
-        ), patch(
-            f"{mod}.os.path.realpath", lambda path: exe
+        with _simulate_platform(windows=True, frozen=exe), patch(
+            "ggshield.verticals.ai.installation.os.path.realpath", lambda path: exe
         ):
             assert build_hook_command() == f'"{exe}" secret scan ai-hook'
 

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -200,6 +200,61 @@ class TestFillDict:
             added=2, already_present=1, command="ggshield already"
         )
 
+    def test_vanished_ggshield_command_is_repointed(self, tmp_path: Path):
+        """GIVEN a hook pinned to a versioned bundle path an upgrade deleted
+        WHEN the hooks are installed again
+        THEN the command is repointed, instead of failing open on every prompt."""
+        stale = f"{tmp_path / 'ggshield-1.53.0' / 'ggshield'} secret scan ai-hook"
+        config = {"hooks": [{"command": stale}]}
+        stats = _fill_dict(
+            config,
+            {"hooks": [{"command": "<COMMAND>"}]},
+            COMMAND,
+            overwrite=False,
+            stats=InstallationStats(added=0, already_present=0),
+            locator=_locator,
+        )
+        assert config == {"hooks": [{"command": COMMAND}]}
+        assert stats == InstallationStats(added=1, already_present=1, command=stale)
+
+    @pytest.mark.skipif(os.name == "nt", reason="creates a symlink")
+    def test_versioned_path_to_the_same_binary_is_repointed(self, tmp_path: Path):
+        """GIVEN a hook pinned to a still-valid versioned path
+        WHEN the new command reaches that same binary through a launcher
+        THEN the hook is migrated to the launcher before the next upgrade."""
+        binary = tmp_path / "ggshield-1.53.0" / "ggshield"
+        binary.parent.mkdir()
+        binary.write_text("")
+        launcher = tmp_path / "ggshield"
+        launcher.symlink_to(binary)
+        command = f"{launcher} secret scan ai-hook"
+        config = {"hooks": [{"command": f"{binary} secret scan ai-hook"}]}
+        _fill_dict(
+            config,
+            {"hooks": [{"command": "<COMMAND>"}]},
+            command,
+            overwrite=False,
+            stats=InstallationStats(added=0, already_present=0),
+            locator=_locator,
+        )
+        assert config == {"hooks": [{"command": command}]}
+
+    def test_another_tool_command_is_left_alone(self, tmp_path: Path):
+        """GIVEN a hook command running another tool, mentioning ggshield
+        WHEN the hooks are installed again
+        THEN it is kept: only the commands we wrote are ever repointed."""
+        other = f"{tmp_path / 'other-scanner'} --ggshield-compat secret scan ai-hook"
+        config = {"hooks": [{"command": other}]}
+        _fill_dict(
+            config,
+            {"hooks": [{"command": "<COMMAND>"}]},
+            COMMAND,
+            overwrite=False,
+            stats=InstallationStats(added=0, already_present=0),
+            locator=_locator,
+        )
+        assert config["hooks"] == [{"command": other}]
+
     def test_non_command_scalar_is_not_an_existing_install(self):
         """A template scalar other than the command may contain "ggshield" (a hook
         name, say). It must not be mistaken for an existing installation."""
@@ -901,6 +956,65 @@ class TestBuildHookCommand:
             sys, "executable", str(launcher), create=True
         ):
             assert build_hook_command() == f"{launcher} secret scan ai-hook"
+
+    def test_frozen_bundle_prefers_the_stable_launcher(self, tmp_path):
+        """GIVEN a frozen macOS bundle installed in a versioned directory
+        WHEN /usr/local/bin/ggshield resolves to that very binary
+        THEN the hook is pinned to the launcher, which survives an upgrade."""
+        versioned = str(tmp_path / "ggshield-1.53.0" / "ggshield")
+        with patch.object(sys, "frozen", True, create=True), patch.object(
+            sys, "executable", versioned, create=True
+        ), patch(
+            "ggshield.verticals.ai.installation.os.path.realpath",
+            lambda path: versioned if path == "/usr/local/bin/ggshield" else path,
+        ):
+            assert build_hook_command() == "/usr/local/bin/ggshield secret scan ai-hook"
+
+    def test_frozen_bundle_ignores_a_launcher_to_another_binary(self, tmp_path):
+        """GIVEN a frozen bundle on a machine that also has a Homebrew ggshield
+        WHEN /usr/local/bin/ggshield resolves to that other install
+        THEN the bundle path is kept: the other binary holds no credentials."""
+        versioned = str(tmp_path / "ggshield-1.53.0" / "ggshield")
+        with patch.object(sys, "frozen", True, create=True), patch.object(
+            sys, "executable", versioned, create=True
+        ), patch(
+            "ggshield.verticals.ai.installation.os.path.realpath",
+            lambda path: (
+                "/opt/homebrew/bin/ggshield"
+                if path == "/usr/local/bin/ggshield"
+                else path
+            ),
+        ):
+            assert build_hook_command() == f"{versioned} secret scan ai-hook"
+
+    def test_stable_launcher_is_not_used_outside_a_frozen_bundle(self):
+        """GIVEN a pip/Homebrew install (not frozen)
+        WHEN a launcher would resolve to the same file
+        THEN argv[0] is still used verbatim, symlinks unresolved."""
+        with _simulate_platform(
+            ["/opt/homebrew/bin/ggshield", "install"], windows=False
+        ), patch(
+            "ggshield.verticals.ai.installation.os.path.realpath",
+            lambda path: "/opt/homebrew/bin/ggshield",
+        ):
+            assert (
+                build_hook_command() == "/opt/homebrew/bin/ggshield secret scan ai-hook"
+            )
+
+    def test_frozen_bundle_on_windows_ignores_posix_launchers(self):
+        """GIVEN a frozen Windows install
+        WHEN the POSIX launcher paths would match
+        THEN they are ignored: they mean nothing on Windows."""
+        exe = r"C:\Program Files\GitGuardian\ggshield\ggshield.exe"
+        mod = "ggshield.verticals.ai.installation"
+        with patch.object(sys, "frozen", True, create=True), patch.object(
+            sys, "executable", exe, create=True
+        ), patch(f"{mod}.os.name", "nt"), patch(
+            f"{mod}.os.path.dirname", ntpath.dirname
+        ), patch(
+            f"{mod}.os.path.realpath", lambda path: exe
+        ):
+            assert build_hook_command() == f'"{exe}" secret scan ai-hook'
 
 
 class _FakeAgent:


### PR DESCRIPTION
The macOS `.pkg` installs into `/opt/gitguardian/ggshield-<version>/` and every version shares the package id `com.gitguardian.ggshield`, so installing a new one removes the old tree. `hook_executable()` reads `sys.executable`, which the OS has already resolved through the `/usr/local/bin/ggshield` symlink, so the hook command written into `~/.claude/settings.json` names the versioned directory. The next upgrade deletes it and the hook fails open: the agent keeps working with no secret scanning, printing only `Failed with non-blocking status code: /bin/sh: /opt/gitguardian/ggshield-1.53.0/ggshield: No such file or directory`.

When frozen, the hook now prefers `/usr/local/bin/ggshield` or `/usr/bin/ggshield`, but only when the launcher resolves to the same file as the bundle path: a machine with Homebrew's ggshield next to the package would otherwise get its hook aimed at a binary that was never authenticated. `os.path.realpath` on a missing launcher returns the path itself, so an absent launcher simply fails the comparison. Linux and Windows install unversioned paths and are unaffected; `/usr/bin/ggshield` is in the list for symmetry.

Installing the hooks previously left any existing ggshield command alone unless `--force`, so an already-broken versioned path stayed broken. `_fill_dict` now repoints a command whose ggshield binary is gone, or that reaches the same binary through a less stable path. Detection requires the command to be one we wrote (the exact `secret scan ai-hook` tail, a single-token path, `ggshield` in its basename), so a hand-customized command or another tool is never rewritten.

```
71 passed, 2 warnings in 0.22s
```
(`pytest tests/unit/verticals/ai/test_installation.py`; the wider `tests/unit/verticals/ai tests/unit/cmd/machine` run gives `667 passed`.)

https://claude.ai/code/session_01GWfFkmQG2UbLUSinipaqf8