### PR TITLE
fix(ai): warm the credential store as the binary that runs the hook

### DIFF
--- a/changelog.d/20260819_150000_achille.mascia_hook_keychain_grant.md
+++ b/changelog.d/20260819_150000_achille.mascia_hook_keychain_grant.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- On macOS, `ggshield machine setup` now asks the Keychain for access as the binary
+  that actually runs the AI hook. Keychain grants are per binary, so the hook used to
+  raise its own authorization dialog inside an agent-spawned process, where the agent's
+  timeout could kill it before "Always Allow" was recorded and the dialog came back on
+  every prompt.

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -2,6 +2,7 @@ import json
 import os
 import shlex
 import shutil
+import subprocess
 import sys
 from collections.abc import MutableMapping
 from copy import deepcopy
@@ -452,3 +453,50 @@ def check_ai_hook_authentication(config: Config) -> None:
         )
     else:
         click.echo("ggshield successfully authenticated: the hook is ready to scan.")
+    _warm_hook_credential_store()
+
+
+# An event the hook answers by scanning the prompt and nothing else: no file is
+# named, so it reads its token, asks the API about this one line, and exits.
+_WARM_UP_EVENT = json.dumps(
+    {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "ggshield-machine-setup",
+        "transcript_path": "ggshield-machine-setup/claude-code.jsonl",
+        "prompt": "ggshield setup: checking the AI hook can read its token.",
+    }
+)
+
+
+def _warm_hook_credential_store() -> None:
+    """Have the hook binary itself read the token once, with the user present.
+
+    Keychain ACLs are per code identity, and in the standalone bundle the hook is
+    the Rust dispatcher, not the ``ggshield-py`` process running setup: the
+    authentication check grants nothing to the binary that does the reading. Its
+    own authorization dialog would first appear inside an agent-spawned hook,
+    where the agent's timeout can kill the process before an answered "Always
+    Allow" is recorded, so the dialog comes back on every turn.
+
+    Only macOS grants per binary, and only the bundle runs the hook from another
+    binary: everywhere else the token has already been read by the identity the
+    hook will use.
+    """
+    if sys.platform != "darwin" or not getattr(sys, "frozen", False):
+        return
+    executable = hook_executable()
+    if executable == sys.executable:
+        return
+    try:
+        subprocess.run(
+            [executable, "secret", "scan", "ai-hook"],
+            input=_WARM_UP_EVENT,
+            text=True,
+            capture_output=True,
+            # Room to answer a Keychain dialog, and a bound so setup cannot hang
+            # on one nobody answers.
+            timeout=60,
+            check=False,
+        )
+    except Exception:
+        pass

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -1,8 +1,11 @@
+import subprocess
+import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
+from pygitguardian.models import HealthCheckResponse
 
 from ggshield.__main__ import cli
 from ggshield.verticals.ai.installation import (
@@ -14,6 +17,10 @@ from tests.unit.conftest import assert_invoke_ok
 
 
 AGENTS_PATH = "ggshield.verticals.ai.installation.AGENTS"
+
+
+def _raise(error: Exception):
+    raise error
 
 
 class _FakeAgent:
@@ -142,6 +149,53 @@ class TestMachineSetupCommand:
 
         assert result.exit_code == 1
         mock_preflight.assert_not_called()
+
+    @patch("ggshield.cmd.machine.setup._warm_notifier")
+    @patch("ggshield.verticals.ai.installation.create_client_from_config")
+    @patch("ggshield.verticals.ai.installation._is_interactive", return_value=True)
+    @patch("ggshield.cmd.machine.setup.install_all_agent_hooks")
+    def test_a_broken_hook_binary_does_not_fail_setup(
+        self,
+        mock_install,
+        mock_interactive,
+        mock_client,
+        mock_notifier,
+        cli_fs_runner: CliRunner,
+        monkeypatch,
+    ):
+        """
+        GIVEN an interactive setup whose hook binary cannot be run at all
+        WHEN the credential-store warm-up spawns it
+        THEN setup still succeeds: the grant is best effort
+        """
+        mock_install.return_value = SetupSummary(configured=1, failed=0)
+        mock_client.return_value.health_check.return_value = Mock(
+            spec=HealthCheckResponse, status_code=200
+        )
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", "/opt/gitguardian/ggshield-py")
+        monkeypatch.setattr(
+            "ggshield.verticals.ai.installation.hook_executable",
+            lambda: "/opt/gitguardian/ggshield",
+        )
+        # Only the warm-up spawn fails; git and the rest of setup run for real.
+        real_run = subprocess.run
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda args, **kwargs: (
+                _raise(FileNotFoundError("no hook binary here"))
+                if args[0] == "/opt/gitguardian/ggshield"
+                else real_run(args, **kwargs)
+            ),
+        )
+
+        result = cli_fs_runner.invoke(
+            cli, ["machine", "setup", "--no-git-hooks", "--no-honeytokens"]
+        )
+
+        assert_invoke_ok(result)
 
     def test_agent_and_exclude_agent_are_mutually_exclusive(
         self, cli_fs_runner: CliRunner

--- a/tests/unit/cmd/test_install.py
+++ b/tests/unit/cmd/test_install.py
@@ -1,3 +1,4 @@
+import json
 import os
 import stat
 import subprocess
@@ -16,7 +17,10 @@ from ggshield.cmd.install import (
     install_local,
 )
 from ggshield.core.errors import ExitCode, MissingTokenError
-from ggshield.verticals.ai.installation import _is_interactive
+from ggshield.verticals.ai.installation import (
+    _is_interactive,
+    _warm_hook_credential_store,
+)
 from tests.repository import Repository
 from tests.unit.conftest import assert_invoke_exited_with, assert_invoke_ok
 
@@ -458,6 +462,131 @@ class TestInstallAIHook:
             assert _is_interactive() is True
             stdout.isatty.return_value = False
             assert _is_interactive() is False
+
+
+class TestHookCredentialStoreWarmUp:
+    """The hook binary must be the one that asks for credential-store access."""
+
+    @pytest.fixture()
+    def bundle(self, monkeypatch):
+        """A frozen macOS bundle whose hook is the Rust dispatcher."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", "/opt/gitguardian/ggshield-py")
+        monkeypatch.setattr(
+            "ggshield.verticals.ai.installation.hook_executable",
+            lambda: "/opt/gitguardian/ggshield",
+        )
+
+    @patch("ggshield.verticals.ai.installation._is_interactive", return_value=True)
+    @patch("ggshield.verticals.ai.installation.create_client_from_config")
+    @patch("ggshield.verticals.ai.installation._warm_hook_credential_store")
+    def test_warms_up_when_interactive(
+        self,
+        warm_up_mock: Mock,
+        create_client_mock: Mock,
+        interactive_mock: Mock,
+        cli_fs_runner: CliRunner,
+    ):
+        """
+        GIVEN an interactive install
+        WHEN the auth preflight runs
+        THEN the hook binary is warmed up too, while the user can answer a dialog
+        """
+        create_client_mock.return_value.health_check.return_value = Mock(
+            spec=HealthCheckResponse, status_code=200
+        )
+
+        result = cli_fs_runner.invoke(
+            cli, ["install", "-m", "local", "-t", "claude-code"]
+        )
+
+        assert_invoke_ok(result)
+        warm_up_mock.assert_called_once()
+
+    @patch("ggshield.verticals.ai.installation._is_interactive", return_value=False)
+    @patch("ggshield.verticals.ai.installation._warm_hook_credential_store")
+    def test_no_warm_up_when_non_interactive(
+        self, warm_up_mock: Mock, interactive_mock: Mock, cli_fs_runner: CliRunner
+    ):
+        """
+        GIVEN a non-interactive install (CI, MDM provisioning)
+        WHEN the hooks are installed
+        THEN nothing asks the credential store, so no dialog nobody can answer
+        """
+        result = cli_fs_runner.invoke(
+            cli, ["install", "-m", "local", "-t", "claude-code"]
+        )
+
+        assert_invoke_ok(result)
+        warm_up_mock.assert_not_called()
+
+    @patch("ggshield.verticals.ai.installation.subprocess.run")
+    def test_runs_the_hook_binary_on_a_hook_event(self, run_mock: Mock, bundle):
+        """
+        GIVEN a standalone bundle, where the hook is a distinct code identity
+        WHEN the warm-up runs
+        THEN that binary reads the token, on the hook's own code path
+        """
+        _warm_hook_credential_store()
+
+        run_mock.assert_called_once()
+        args, kwargs = run_mock.call_args
+        assert args[0] == ["/opt/gitguardian/ggshield", "secret", "scan", "ai-hook"]
+        assert json.loads(kwargs["input"])["hook_event_name"] == "UserPromptSubmit"
+        assert kwargs["timeout"] > 0
+
+    @pytest.mark.parametrize("platform", ["linux", "win32"])
+    @patch("ggshield.verticals.ai.installation.subprocess.run")
+    def test_no_warm_up_outside_macos(
+        self, run_mock: Mock, platform: str, bundle, monkeypatch
+    ):
+        """
+        GIVEN a platform whose credential store does not grant per binary
+        WHEN the warm-up runs
+        THEN nothing is spawned: the trip buys nothing there
+        """
+        monkeypatch.setattr(sys, "platform", platform)
+
+        _warm_hook_credential_store()
+
+        run_mock.assert_not_called()
+
+    @patch("ggshield.verticals.ai.installation.subprocess.run")
+    def test_no_warm_up_without_a_separate_hook_binary(
+        self, run_mock: Mock, monkeypatch
+    ):
+        """
+        GIVEN a pip/pipx/Homebrew install, where the hook is this interpreter
+        WHEN the warm-up runs
+        THEN nothing is spawned: the reading identity has already been granted
+        """
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delattr(sys, "frozen", raising=False)
+
+        _warm_hook_credential_store()
+
+        run_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            FileNotFoundError("no hook binary here"),
+            subprocess.TimeoutExpired(cmd="ggshield", timeout=60),
+        ],
+    )
+    @patch("ggshield.verticals.ai.installation.subprocess.run")
+    def test_a_broken_warm_up_is_swallowed(
+        self, run_mock: Mock, failure: Exception, bundle
+    ):
+        """
+        GIVEN a hook binary that is missing, or a dialog left unanswered
+        WHEN the warm-up runs
+        THEN the failure is swallowed: a best-effort grant must not fail setup
+        """
+        run_mock.side_effect = failure
+
+        _warm_hook_credential_store()
 
 
 @pytest.fixture()


### PR DESCRIPTION
`ggshield machine setup` checks the AI hook can authenticate, partly so the OS credentials store asks for access while the user is still at the terminal. That check runs inside `ggshield-py`, the Python bundle, but the binary that reads the keychain when the hook fires is the Rust dispatcher, a different code-signing identity. macOS Keychain ACLs are per identity, so the dispatcher's own dialog first appears in an agent-spawned hook process, where the agent's hook timeout can kill it before "Always Allow" is recorded, and it comes back on the next prompt. Upgrades from an older package inherit the pre-split grant and never see this; anyone migrating from pip, pipx or Homebrew does.

The preflight now also runs the hook binary once on a synthetic `UserPromptSubmit` event, discarding the result. That is the real code path down to `Config::token()`, so the dialog belongs to the identity that will do the reading. Best effort like `_warm_notifier()`: a missing or failing binary, or a denied dialog, never fails setup, and the 60s timeout bounds a dialog nobody answers.

Guarded to macOS and to the standalone bundle. The Windows credential manager and the Linux secret service do not grant per binary, and outside the bundle the hook runs the same interpreter that just read the token, so the trip buys nothing there. It costs one `/v1/metadata` request and one small `/v1/multiscan` of the synthetic prompt: reaching the token read at all means reaching a scan, since the token is read to build the verdict-cache key.

Independent of #1420, which also touches `installation.py` and will likely conflict textually in `hook_executable()`'s neighbourhood.