### PR TITLE
fix(ai): stop guessing the MCP server name VSCode leaves out

### DIFF
--- a/changelog.d/20260819_120000_achille.mascia_vscode_mcp_server_resolution.md
+++ b/changelog.d/20260819_120000_achille.mascia_vscode_mcp_server_resolution.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Report the raw `mcp_{server}_{tool}` name VSCode gives us when the server cannot
+  be identified from the local configuration, instead of guessing a server name that
+  the API cannot match. The API splits the name against the whole inventory.

--- a/ggshield/verticals/ai/agents/vscode.py
+++ b/ggshield/verticals/ai/agents/vscode.py
@@ -207,13 +207,16 @@ class VSCode(Agent):
         _, *parts = raw_tool_name.split("_")
 
         # At each separation point (starting from the biggest name possible), check if the mangled name is in the map.
-        for i in range(len(parts)):
+        for i in range(1, len(parts)):
             mangled_name = "_".join(parts[:-i])
             if mangled_name in mangled_to_server:
                 return mangled_to_server[mangled_name], "_".join(parts[-i:])
 
-        # If no match is found, fallback to use the first part as the server name.
-        return parts[0], "_".join(parts[1:])
+        # Nothing local matches, and VSCode leaves no delimiter between the mangled
+        # server name and the tool, so any cut here is a guess that resolves to no
+        # server at all. Report the raw name and let the API split it against the
+        # whole inventory, which is wider than what this machine can see.
+        return "", raw_tool_name
 
     def iter_history_events(
         self, ai_config: Optional[AIDiscovery]
@@ -291,10 +294,9 @@ class VSCode(Agent):
         tool_input = (invocation.get("toolSpecificData") or {}).get("rawInput") or {}
         if not isinstance(tool_input, dict):
             tool_input = {}
-        _, tool_name = self._lookup_server_name(tool_id, ai_config)
         return MCPActivityRequest(
             user=self._user_or_default(ai_config),
-            tool=tool_name,
+            tool=_strip_mangled_prefix(tool_id, server_cfg_name),
             server=self._resolve_server_name(server_cfg_name, ai_config),
             agent=self.name,
             model="",
@@ -349,3 +351,13 @@ MANGLING_PATTERN = re.compile(r"[^A-Za-z0-9-]+")
 def _mangle_name(name: str) -> str:
     """Mangle a name in the same way VSCode does."""
     return MANGLING_PATTERN.sub("_", name).lower()[:13]
+
+
+def _strip_mangled_prefix(tool_id: str, server_cfg_name: str) -> str:
+    """Remove the "mcp_{mangled server}_" prefix VSCode puts in front of a tool name.
+
+    History entries carry the server label next to the tool id, so the cut is known
+    here and needs no lookup.
+    """
+    prefix = f"mcp_{_mangle_name(server_cfg_name)}_"
+    return tool_id[len(prefix) :] if tool_id.startswith(prefix) else tool_id

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1632,7 +1632,8 @@ class TestVSCodeParseMcpActivity:
         assert req.tool == "tool_name"
         assert req.server == "server2"
 
-    def test_unknown_server_falls_back_to_cfg_name(self):
+    def test_unknown_server_reports_the_raw_tool_name(self):
+        """An unsplittable name is reported as-is, for the API to resolve."""
         vscode = VSCode()
         discovery = _ai_discovery(servers=[])
         payload = _payload(
@@ -1642,8 +1643,21 @@ class TestVSCodeParseMcpActivity:
 
         req = vscode.parse_mcp_activity(payload, discovery)
 
-        assert req.server == "unknown"
-        assert req.tool == "tool_name"
+        assert req.server == ""
+        assert req.tool == "mcp_unknown_tool_name"
+
+    def test_empty_tool_name_is_reported_without_a_server(self):
+        """A payload with no tool name must not break the hook."""
+        vscode = VSCode()
+        payload = _payload(
+            vscode,
+            raw={"tool_name": "", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        req = vscode.parse_mcp_activity(payload, _ai_discovery(servers=[]))
+
+        assert req.server == ""
+        assert req.tool == ""
 
 
 # ===========================================================================

--- a/tests/unit/verticals/ai/test_vscode_history.py
+++ b/tests/unit/verticals/ai/test_vscode_history.py
@@ -105,7 +105,7 @@ class TestVSCodeIterHistoryEvents:
 
         assert len(events) == 1
         ev = events[0]
-        assert ev.tool == "no_notion-search"
+        assert ev.tool == "notion-search"
         assert ev.server == "makenotion/notion-mcp-server"
         assert ev.agent == "vscode"
         assert ev.cwd == "/repo"


### PR DESCRIPTION
VSCode names an MCP tool call `mcp_{mangled server}_{tool}`, where the server name is lowercased, has its non-alphanumeric groups replaced by `_`, and is cut at 13 characters. No separator marks the end of the server name, so the split is only knowable against a list of known configuration names.

When no local configuration matches, the fallback cut the name at the first `_` and reported the result as the server. That name matches nothing on the API side, so the activity is dropped and the API logs an error. This is one of the causes behind the "Server not found for MCP activity" Sentry issue (NHI-1927). The raw name is now reported with an empty server, and the API splits it against the inventory of the whole account, which is wider than what one machine can see. The API side is in ward-runs-app!27641.

Two more fixes in the same path:

- The history walk gets the server label from VSCode next to the tool id, but still asked the same guesswork helper for the tool half. With no discovery cache it recorded `no_notion-search` for a tool named `notion-search`. It now cuts the tool with the mangled label, which needs no lookup and makes the live hook and the history agree.
- A payload with no tool name raised `IndexError` inside the hook, and the match loop tested the empty string on its first turn.

Note for reviewers: #1419 makes VSCode detectable on macOS and Windows, so the local configuration list is populated much more often there and this fallback becomes the exception it should be.