### PR TITLE
fix(config): read the credential store only when a token is needed

### DIFF
--- a/changelog.d/20260819_160000_achille.mascia_lazy_keyring_hydration.md
+++ b/changelog.d/20260819_160000_achille.mascia_lazy_keyring_hydration.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `ggshield` no longer reads the OS credential store on startup. The token is now
+  fetched when a command actually needs it, so commands that do not use one (such as
+  `ggshield config list`, `ggshield plugin list` and `ggshield install`) no longer
+  trigger a macOS Keychain password prompt.

--- a/ggshield/__main__.py
+++ b/ggshield/__main__.py
@@ -74,9 +74,7 @@ def cli(
     instance: Optional[str],
     **kwargs: Any,
 ) -> None:
-    # Load .env before Config so AuthConfig.load() can see GITGUARDIAN_API_KEY
-    # set via dotenv and skip keyring access when an env-provided token will be
-    # used instead.
+    # Load .env before Config so the config sees the variables it sets.
     dotenv_vars = load_dot_env()
 
     # Create ContextObj, load config

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -101,7 +101,7 @@ def revoke_token(config: Config, instance_url: str) -> None:
     instance = config.auth_config.get_instance(instance_url)
 
     assert instance.account is not None
-    token = instance.account.token
+    token = instance.token
 
     client = create_client(
         token,

--- a/ggshield/cmd/config/config_list.py
+++ b/ggshield/cmd/config/config_list.py
@@ -11,6 +11,7 @@ from ggshield.cmd.utils.common_options import (
 )
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.config.auth_config import InstanceConfig
+from ggshield.core.config.token_store import KEYRING_SENTINEL
 from ggshield.core.filter import censor_string
 
 from .constants import DATETIME_FORMAT, FIELDS
@@ -48,7 +49,13 @@ def get_instance_info(
 
     if account is not None:
         workspace_id = account.workspace_id
-        token = censor_string(account.token)
+        # Censoring the real token would mean reading the credential store, and
+        # listing the config is not worth a Keychain prompt.
+        token = (
+            "stored in keyring"
+            if account.token == KEYRING_SENTINEL
+            else censor_string(account.token)
+        )
         token_name = account.token_name
         expire_at = account.expire_at
         expiry = expire_at.strftime(DATETIME_FORMAT) if expire_at else "never"

--- a/ggshield/core/config/auth_config.py
+++ b/ggshield/core/config/auth_config.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -39,6 +38,38 @@ class AccountConfig:
     expire_at: Optional[datetime]
 
 
+def _token_from_store(instance_url: str) -> str:
+    """Read a sentinel-marked token from the credential store, "" if unavailable."""
+    store = get_token_store()
+    if not store.uses_external_storage:
+        logger.warning(
+            "Token for %s is stored in keyring but keyring is disabled. "
+            "Unset GGSHIELD_NO_KEYRING or re-authenticate with "
+            "'ggshield auth login'.",
+            instance_url,
+        )
+        return ""
+
+    try:
+        token = store.get_token(instance_url)
+    except Exception:
+        logger.warning(
+            "Failed to retrieve token from keyring for %s",
+            instance_url,
+            exc_info=True,
+        )
+        return ""
+
+    if token is None:
+        logger.warning(
+            "Token for %s was expected in keyring but not found. "
+            "Re-authenticate with 'ggshield auth login'.",
+            instance_url,
+        )
+        return ""
+    return token
+
+
 @dataclass
 class InstanceConfig:
     # Only handle 1 account per instance for the time being
@@ -55,6 +86,23 @@ class InstanceConfig:
             and self.account.expire_at is not None
             and self.account.expire_at <= datetime.now(timezone.utc)
         )
+
+    @property
+    def token(self) -> str:
+        """The account token, read from the credential store on first use.
+
+        Reading the store pops the macOS Keychain dialog, so it is deferred until
+        a caller actually needs the token. An unreadable token leaves the
+        sentinel in place, so a later save() keeps pointing at the stored one.
+        """
+        if self.account is None:
+            return ""
+        if self.account.token != KEYRING_SENTINEL:
+            return self.account.token
+        token = _token_from_store(self.url)
+        if token:
+            self.account.token = token
+        return token
 
     def init_account(self, token: str, token_data: Dict[str, Any]) -> None:
         """Initialize our account based on the token and the data received from the
@@ -148,37 +196,17 @@ class AuthConfig(FromDictMixin, ToDictMixin):
     def load(cls) -> "AuthConfig":
         """Load the auth config from the app config file.
 
-        If the active token store is a keyring backend, tokens marked with the
-        keyring sentinel are hydrated from the OS credential store.
-
-        When ``GITGUARDIAN_API_KEY`` is set in the environment it overrides any
-        stored token in :meth:`Config.get_api_key_and_source`, so we skip the
-        keyring access here to avoid prompting the user (e.g. for OS keychain
-        unlock) for a credential that will not be used. This matters for
-        global ggshield invocations like pre-commit hooks that already supply
-        a token via the environment.
+        Tokens marked with the keyring sentinel stay unresolved: the credential
+        store is only read by :attr:`InstanceConfig.token`, so a command that
+        needs no token never prompts for one.
         """
         config_path = get_auth_config_filepath()
 
         data = load_yaml_dict(config_path)
         if data:
             data = prepare_auth_config_dict_for_parse(data)
-            instance = cls.from_dict(data)
-        else:
-            instance = cls()
-
-        if os.environ.get("GITGUARDIAN_API_KEY"):
-            return instance
-
-        store = get_token_store()
-        if store.uses_external_storage:
-            for inst in instance.instances:
-                cls._hydrate_from_keyring(store, inst)
-        else:
-            for inst in instance.instances:
-                cls._warn_sentinel_without_keyring(inst)
-
-        return instance
+            return cls.from_dict(data)
+        return cls()
 
     def save(self) -> None:
         config_path = get_auth_config_filepath()
@@ -228,47 +256,10 @@ class AuthConfig(FromDictMixin, ToDictMixin):
         instance = self.get_instance(instance_name)
         if instance.expired:
             raise AuthExpiredError(instance=instance_name)
-        if instance.account is None or not instance.account.token:
+        token = instance.token
+        if not token:
             raise MissingTokenError(instance=instance_name)
-        return instance.account.token
-
-    @staticmethod
-    def _hydrate_from_keyring(store: TokenStore, inst: InstanceConfig) -> None:
-        if inst.account is None or inst.account.token != KEYRING_SENTINEL:
-            return
-        try:
-            token = store.get_token(inst.url)
-        except Exception:
-            logger.warning(
-                "Failed to retrieve token from keyring for %s",
-                inst.url,
-                exc_info=True,
-            )
-            token = None
-
-        if token is not None:
-            inst.account.token = token
-        else:
-            logger.warning(
-                "Token for %s was expected in keyring but not found. "
-                "Re-authenticate with 'ggshield auth login'.",
-                inst.url,
-            )
-            # Preserve account metadata; only clear the token so
-            # that a subsequent save() does not destroy the config.
-            inst.account.token = ""
-
-    @staticmethod
-    def _warn_sentinel_without_keyring(inst: InstanceConfig) -> None:
-        if inst.account is None or inst.account.token != KEYRING_SENTINEL:
-            return
-        logger.warning(
-            "Token for %s is stored in keyring but keyring is disabled. "
-            "Unset GGSHIELD_NO_KEYRING or re-authenticate with "
-            "'ggshield auth login'.",
-            inst.url,
-        )
-        inst.account.token = ""
+        return token
 
     @staticmethod
     def _persist_to_keyring(

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -419,7 +419,9 @@ class OAuthClient:
         Else return False
         """
         account = self.instance_config.account
-        if account is None or not account.token or self.instance_config.expired:
+        if account is None or self.instance_config.expired:
+            return False
+        if not self.instance_config.token:
             return False
 
         # Check our API key is valid, if not forget it

--- a/tests/unit/cmd/test_config.py
+++ b/tests/unit/cmd/test_config.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from typing import Tuple
+from unittest.mock import MagicMock, patch
 
 import jsonschema
 import pytest
@@ -10,6 +11,7 @@ from voluptuous.validators import All, Match
 
 from ggshield.__main__ import cli
 from ggshield.core.config import Config
+from ggshield.core.config.token_store import KeyringTokenStore
 from ggshield.core.config.user_config import UserConfig
 from ggshield.core.config.utils import find_global_config_path
 from ggshield.core.errors import ExitCode
@@ -122,6 +124,34 @@ class TestConfigList:
             )
             == dct
         )
+
+    def test_list_keyring_token_not_read(self, cli_fs_runner, monkeypatch):
+        """
+        GIVEN an instance whose token lives in the credential store
+        WHEN calling `ggshield config list`
+        THEN the store is never read and the token is reported as stored there
+        """
+        add_instance_config()
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+        # The env key short-circuits token resolution, hiding what is tested here
+        monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock()
+        mock_store.store_token = MagicMock()
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            # Save once so the config file holds the sentinel instead of the token
+            Config().save()
+            exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        assert "token: stored in keyring" in output
+        mock_store.get_token.assert_not_called()
 
     @staticmethod
     def run_cmd(cli_fs_runner, json: bool = False) -> Tuple[bool, str]:

--- a/tests/unit/core/config/test_auth_config.py
+++ b/tests/unit/core/config/test_auth_config.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from ggshield.core.config import Config
 from ggshield.core.config.auth_config import (
@@ -175,6 +176,26 @@ def _reset_token_store():
     reset_token_store()
 
 
+def _sentinel_auth_config() -> dict:
+    """A copy of TEST_AUTH_CONFIG with every token replaced by the keyring sentinel."""
+    config = deepcopy(TEST_AUTH_CONFIG)
+    for instance in config["instances"]:
+        for account in instance["accounts"]:
+            account["token"] = KEYRING_SENTINEL
+    return config
+
+
+def _saved_tokens() -> list:
+    """The tokens as written to the auth config file."""
+    with open(get_auth_config_filepath()) as fp:
+        data = yaml.safe_load(fp)
+    return [
+        account["token"]
+        for instance in data["instances"]
+        for account in instance["accounts"]
+    ]
+
+
 @pytest.mark.usefixtures("isolated_fs", "_reset_token_store")
 class TestAuthConfigKeyring:
     """Tests for keyring integration in AuthConfig load/save."""
@@ -228,8 +249,8 @@ class TestAuthConfigKeyring:
     def test_load_with_keyring(self, monkeypatch):
         """
         GIVEN a YAML config with keyring sentinel tokens
-        WHEN loading with keyring enabled
-        THEN tokens are hydrated from keyring
+        WHEN loading the config, then reading the instance tokens
+        THEN the keyring is only read when a token is actually used
         """
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
 
@@ -250,15 +271,21 @@ class TestAuthConfigKeyring:
             return_value=mock_store,
         ):
             config = Config()
+            mock_store.get_token.assert_not_called()
 
-        assert config.auth_config.instances[0].account.token == real_token
-        assert config.auth_config.instances[1].account.token == real_token
+            assert config.auth_config.instances[0].token == real_token
+            assert config.auth_config.instances[1].token == real_token
+
+        assert mock_store.get_token.call_count == 2
+        # The resolved token is memoised, so a second read costs nothing
+        assert config.auth_config.instances[0].token == real_token
+        assert mock_store.get_token.call_count == 2
 
     def test_load_keyring_missing_token(self, monkeypatch):
         """
         GIVEN a YAML config with keyring sentinel
         WHEN the keyring returns None for a token
-        THEN the account metadata is preserved but the token is cleared
+        THEN the token reads as empty and the sentinel is kept in the config
         """
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
 
@@ -278,12 +305,14 @@ class TestAuthConfigKeyring:
         ):
             config = Config()
 
-        # Account metadata is preserved, only the token is cleared
+            assert config.auth_config.instances[0].token == ""
+            assert config.auth_config.instances[1].token == ""
+
+        # Account metadata and the sentinel are preserved, so a later save()
+        # keeps pointing at the stored token
         assert config.auth_config.instances[0].account is not None
-        assert config.auth_config.instances[0].account.token == ""
+        assert config.auth_config.instances[0].account.token == KEYRING_SENTINEL
         assert config.auth_config.instances[0].account.token_name == "my_token"
-        assert config.auth_config.instances[1].account is not None
-        assert config.auth_config.instances[1].account.token == ""
 
     def test_migration_cleartext_to_keyring(self, monkeypatch):
         """
@@ -370,7 +399,7 @@ class TestAuthConfigKeyring:
         """
         GIVEN a YAML config with keyring sentinel
         WHEN get_token raises an exception
-        THEN the account metadata is preserved and the token is cleared
+        THEN the token reads as empty and the sentinel is kept in the config
         """
         monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
 
@@ -390,15 +419,17 @@ class TestAuthConfigKeyring:
         ):
             config = Config()
 
+            assert config.auth_config.instances[0].token == ""
+
         assert config.auth_config.instances[0].account is not None
-        assert config.auth_config.instances[0].account.token == ""
+        assert config.auth_config.instances[0].account.token == KEYRING_SENTINEL
         assert config.auth_config.instances[0].account.token_name == "my_token"
 
     def test_load_sentinel_without_keyring(self, monkeypatch):
         """
         GIVEN a YAML config with keyring sentinel tokens
-        WHEN loading with GGSHIELD_NO_KEYRING=1 (keyring disabled)
-        THEN the token is cleared and a warning is logged
+        WHEN reading a token with GGSHIELD_NO_KEYRING=1 (keyring disabled)
+        THEN the token reads as empty and the sentinel is kept in the config
         """
         monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
 
@@ -410,11 +441,11 @@ class TestAuthConfigKeyring:
 
         config = Config()
 
-        # Sentinel is detected and cleared rather than sent as an API token
+        # Sentinel is detected rather than sent as an API token
+        assert config.auth_config.instances[0].token == ""
+        assert config.auth_config.instances[1].token == ""
         assert config.auth_config.instances[0].account is not None
-        assert config.auth_config.instances[0].account.token == ""
-        assert config.auth_config.instances[1].account is not None
-        assert config.auth_config.instances[1].account.token == ""
+        assert config.auth_config.instances[0].account.token == KEYRING_SENTINEL
 
     def test_load_skips_keyring_when_env_api_key_set(self, monkeypatch):
         """
@@ -445,6 +476,124 @@ class TestAuthConfigKeyring:
         mock_get_store.assert_not_called()
         mock_store.is_available.assert_not_called()
         mock_store.get_token.assert_not_called()
+
+    def test_load_does_not_touch_the_store(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens
+        WHEN loading the config without asking for a token
+        THEN the credential store is never reached
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), _sentinel_auth_config())
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store"
+        ) as mock_get_store:
+            config = Config()
+            # Everything a token-free command reads stays local
+            assert config.auth_config.default_token_lifetime == 2
+            assert config.auth_config.instances[0].account.token_name == "my_token"
+
+        mock_get_store.assert_not_called()
+
+    def test_get_instance_token_reads_the_store(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens
+        WHEN asking for an instance token
+        THEN the token comes from the credential store
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        raw_config = _sentinel_auth_config()
+        raw_config["instances"][0]["accounts"][0]["expire_at"] = None
+        write_yaml(get_auth_config_filepath(), raw_config)
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock(return_value="real-token-from-keyring")
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            token = Config().auth_config.get_instance_token(
+                "https://dashboard.gitguardian.com"
+            )
+
+        assert token == "real-token-from-keyring"
+        mock_store.get_token.assert_called_once_with(
+            "https://dashboard.gitguardian.com"
+        )
+
+    def test_save_keeps_unresolved_token(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens, never resolved
+        WHEN saving the config, as `config set` or `secret ignore` do
+        THEN the sentinel survives and the stored token is left alone
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), _sentinel_auth_config())
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock()
+        mock_store.store_token = MagicMock()
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+            config.auth_config.default_token_lifetime = 42
+            config.auth_config.save()
+
+        mock_store.get_token.assert_not_called()
+        mock_store.store_token.assert_not_called()
+        assert _saved_tokens() == [KEYRING_SENTINEL, KEYRING_SENTINEL]
+
+    def test_save_keeps_sentinel_when_keyring_read_fails(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens the keyring cannot read
+        WHEN a failed token resolution is followed by a save
+        THEN the sentinel survives, so a working keyring recovers the token
+        """
+        monkeypatch.delenv("GGSHIELD_NO_KEYRING", raising=False)
+
+        write_yaml(get_auth_config_filepath(), _sentinel_auth_config())
+
+        mock_store = KeyringTokenStore()
+        mock_store.get_token = MagicMock(side_effect=RuntimeError("keyring locked"))
+        mock_store.store_token = MagicMock()
+        mock_store.is_available = MagicMock(return_value=True)
+
+        with patch(
+            "ggshield.core.config.auth_config.get_token_store",
+            return_value=mock_store,
+        ):
+            config = Config()
+            assert config.auth_config.instances[0].token == ""
+            config.auth_config.save()
+
+        mock_store.store_token.assert_not_called()
+        assert _saved_tokens() == [KEYRING_SENTINEL, KEYRING_SENTINEL]
+
+    def test_save_keeps_sentinel_without_keyring(self, monkeypatch):
+        """
+        GIVEN a YAML config with keyring sentinel tokens and GGSHIELD_NO_KEYRING=1
+        WHEN saving the config
+        THEN the sentinel survives, so re-enabling the keyring recovers the token
+        """
+        monkeypatch.setenv("GGSHIELD_NO_KEYRING", "1")
+
+        write_yaml(get_auth_config_filepath(), _sentinel_auth_config())
+
+        config = Config()
+        assert config.auth_config.instances[0].token == ""
+        config.auth_config.save()
+
+        assert _saved_tokens() == [KEYRING_SENTINEL, KEYRING_SENTINEL]
 
     def test_file_store_preserves_cleartext(self, monkeypatch):
         """


### PR DESCRIPTION
Loading the config hydrated every keyring-stored token, so any `ggshield` command popped a macOS Keychain password prompt, including the ones that never authenticate. A colleague running a managed fleet hit this: background MDM scripts running `ggshield plugin list` and `ggshield install -t <target>` each raised a password dialog at an arbitrary moment, with nothing tying it to ggshield.

The keyring sentinel now stays in the config until `InstanceConfig.token` is read, which happens when an API client is built, when `auth logout` revokes a token, and when `auth login` checks an existing one. `--version`, `plugin list`, `config list` and `install` never reach the store. The Rust side already resolves the token lazily for the same reason, so the two now behave the same way.

The care went into `save()`. A failed or skipped read leaves the sentinel in the config instead of blanking the token, so a `config set`, `auth logout` or `secret ignore` round trip cannot write an empty token over a credential that is still in the store (which the eager path did whenever the keyring was momentarily unreadable). `_persist_to_keyring` already skips the sentinel, so an unresolved instance is written back untouched. `config list` reports those tokens as `stored in keyring` rather than reading the store to censor them.

https://claude.ai/code/session_01GWfFkmQG2UbLUSinipaqf8