### PR TITLE
fix(packaging): make signed wheel builds actually work

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -165,7 +165,11 @@ jobs:
           # The next step installs smctl, so do not look for it yet.
           echo "/c/Program Files/DigiCert/DigiCert Keylocker Tools" >> "$GITHUB_PATH"
 
-          SECRETS_DIR=$RUNNER_TEMP/secrets
+          # `cygpath -m`: a drive-letter path with forward slashes, which both bash
+          # and smctl accept. $RUNNER_TEMP is backslashed here, and bash reads a
+          # backslash as an escape rather than a separator, so a path built from it
+          # raw names one file to `mkdir` and a different, missing one to `[ -f ]`.
+          SECRETS_DIR=$(cygpath -m "$RUNNER_TEMP")/secrets
           mkdir -p "$SECRETS_DIR"
           # The client certificate is base64-encoded because it is binary.
           echo "$SM_CLIENT_CERT_FILE" | base64 --decode > "$SECRETS_DIR/cert.p12"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,8 +49,10 @@ env:
   # Same rcodesign as build_release_assets.yml installs for the standalone
   # bundles; bump both together. The checksum is the aarch64 one -- the macOS
   # wheel is built on macos-14 and lipo'd, so there is no Intel runner here.
-  RCODESIGN_VERSION: 0.27.0
-  RCODESIGN_SHA256: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
+  # Not named RCODESIGN_*: rcodesign folds every variable carrying that prefix
+  # into its configuration and fails on the keys it does not recognise.
+  APPLE_CODESIGN_VERSION: 0.27.0
+  APPLE_CODESIGN_SHA256: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
 
 jobs:
   macos:
@@ -84,9 +86,9 @@ jobs:
           brew install coreutils
           # Unpacked outside the checkout: `python -m build` runs on it next.
           scripts/download \
-            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F$RCODESIGN_VERSION/apple-codesign-$RCODESIGN_VERSION-aarch64-apple-darwin.tar.gz" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F$APPLE_CODESIGN_VERSION/apple-codesign-$APPLE_CODESIGN_VERSION-aarch64-apple-darwin.tar.gz" \
             "$RUNNER_TEMP/rcodesign.tar.gz" \
-            "$RCODESIGN_SHA256"
+            "$APPLE_CODESIGN_SHA256"
           tar -C "$RUNNER_TEMP" --strip-components=1 -xzf "$RUNNER_TEMP/rcodesign.tar.gz"
           cp "$RUNNER_TEMP/rcodesign" /usr/local/bin
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -32,6 +32,10 @@ class WrongBinaryError(Exception):
     """The built binary does not match the platform tag we are about to write."""
 
 
+class SigningError(Exception):
+    """A signing script failed, with whatever it printed about why."""
+
+
 class RustDispatcherBuildHook(BuildHookInterface):
     PLUGIN_NAME = "ggshield-rust"
 
@@ -139,16 +143,17 @@ class RustDispatcherBuildHook(BuildHookInterface):
             )
 
     def _run_signer(self, argv: list[str]) -> None:
-        """Run a signing script, keeping whatever it said about a failure.
+        """Run a signing script, and say what it said when it fails.
 
-        The build backend does not forward a child's streams on Windows, so a
-        plain ``check=True`` leaves an unsigned build explained by an exit status
-        and nothing else.
+        The output goes in the exception rather than to stderr: the build backend
+        forwards neither of a child's streams, and the traceback is the only text
+        that reaches the log.
         """
         signer = subprocess.run(argv, capture_output=True, text=True)
-        sys.stderr.write(signer.stdout)
-        sys.stderr.write(signer.stderr)
-        signer.check_returncode()
+        if signer.returncode:
+            raise SigningError(
+                f"{argv[0]} exited {signer.returncode}\n{signer.stdout}{signer.stderr}"
+            )
 
     def _build(self, crate: Path, binary: Path) -> None:
         # --locked: build the dependency versions committed in rust/Cargo.lock,

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -127,15 +127,28 @@ class RustDispatcherBuildHook(BuildHookInterface):
         if sys.platform == "darwin":
             if not os.environ.get("MACOS_P12_FILE"):
                 return
-            subprocess.run([str(scripts / "macos-sign-file"), str(binary)], check=True)
+            self._run_signer([str(scripts / "macos-sign-file"), str(binary)])
         elif sys.platform == "win32":
             if not os.environ.get("SM_API_KEY"):
                 return
-            # Through bash explicitly: Windows honours no shebang, and Git Bash is
-            # already what drives this build on the runner.
-            subprocess.run(
-                ["bash", str(scripts / "windows-sign-file"), str(binary)], check=True
+            # Through bash explicitly, since Windows honours no shebang, and with a
+            # forward-slash path: bash reads the backslashes of a native path as
+            # escapes, so `dirname` sees no directory and `cp` no such file.
+            self._run_signer(
+                ["bash", str(scripts / "windows-sign-file"), binary.as_posix()]
             )
+
+    def _run_signer(self, argv: list[str]) -> None:
+        """Run a signing script, keeping whatever it said about a failure.
+
+        The build backend does not forward a child's streams on Windows, so a
+        plain ``check=True`` leaves an unsigned build explained by an exit status
+        and nothing else.
+        """
+        signer = subprocess.run(argv, capture_output=True, text=True)
+        sys.stderr.write(signer.stdout)
+        sys.stderr.write(signer.stderr)
+        signer.check_returncode()
 
     def _build(self, crate: Path, binary: Path) -> None:
         # --locked: build the dependency versions committed in rust/Cargo.lock,

--- a/scripts/build-os-packages/macos-sign-file
+++ b/scripts/build-os-packages/macos-sign-file
@@ -20,6 +20,14 @@ fi
 
 echo "- Signing $file${entitlements:+ (with entitlements)}"
 
+# rcodesign folds every RCODESIGN_* variable into its configuration and refuses
+# to run on a key it does not recognise, so a caller that keeps the tool's
+# version in RCODESIGN_VERSION breaks signing rather than configuring it.
+# Everything this script needs is passed on the command line.
+for name in $(env | sed -n 's/^\(RCODESIGN_[^=]*\)=.*/\1/p') ; do
+    unset "$name"
+done
+
 args=(
     --p12-file "$MACOS_P12_FILE"
     --p12-password-file "$MACOS_P12_PASSWORD_FILE"


### PR DESCRIPTION
Dispatching `wheels.yml` with `sign: true` (the only way to reach the signing code: no PR or push run sets that input) failed on both platforms. Two independent defects, neither reachable from CI:

**Windows.** `$RUNNER_TEMP` is backslashed (`D:\a\_temp`). Git Bash reads a backslash as an escape, not a separator, so `SECRETS_DIR=$RUNNER_TEMP/secrets` makes `mkdir -p` create a directory whose *name* contains the backslashes, while the `SM_CLIENT_CERT_FILE` handed to smctl names a file that is not there. The env dump in run 32274156447 shows `SM_CLIENT_CERT_FILE: D:\a\_temp/secrets/cert.p12`. Fixed with `cygpath -m`, which `build-os-packages` already uses for this class of problem.

**macOS.** rcodesign folds every `RCODESIGN_*` environment variable into its own configuration, so the workflow's `RCODESIGN_VERSION` and `RCODESIGN_SHA256` became config keys and it refused to start:

```
configuration file error
  in profile: default
  problem key: sha256
  problem: UnknownField("sha256", ["sign", "remote-sign"])
```

`build_release_assets.yml` escapes this only by accident: it keeps the version in a shell variable inside the step, so nothing exports it. The variables move out of the prefix here, and `macos-sign-file` now clears `RCODESIGN_*` itself so no caller can reintroduce it.

Both were verified locally against the pinned rcodesign 0.27.0: the error reproduces exactly from the env vars alone, and with the fix the script runs the full signing pipeline (certificate loaded, timestamp server reached), stopping only where a self-signed test certificate cannot satisfy `--for-notarization`.