### PR TITLE
fix(packaging): depend on a released py-gitguardian again

### DIFF
--- a/changelog.d/20260820_100000_achille.mascia_pygitguardian_1_34_0.md
+++ b/changelog.d/20260820_100000_achille.mascia_pygitguardian_1_34_0.md
@@ -1,0 +1,4 @@
+### Changed
+
+- ggshield now requires `py-gitguardian` 1.34.0, which carries the
+  `AgentInfo.subscription_email` field the AI discovery report sends.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,7 @@ dependencies = [
     "marshmallow-dataclass>=8.7.0,<9",
     "oauthlib>=3.2.1,<4",
     "packaging>=22.0",
-    # TODO: replace this with a real version number as soon as a new version of
-    # py-gitguardian is out (needs AgentInfo.subscription_email, PR #190).
-    "pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@0b9278889119f1535b072a997caa13a781e4cd59",
+    "pygitguardian~=1.34.0",
     "pyjwt>=2.13.0,<3",
     "python-dotenv>=0.21.0,<2",
     "pyyaml>=6.0.1,<7",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-16T14:06:49.447504Z"
+exclude-newer = "2026-08-16T16:55:27.612955Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1158,7 +1158,7 @@ requires-dist = [
     { name = "oauthlib", specifier = ">=3.2.1,<4" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pygitguardian", git = "https://github.com/GitGuardian/py-gitguardian.git?rev=0b9278889119f1535b072a997caa13a781e4cd59" },
+    { name = "pygitguardian", specifier = "~=1.34.0" },
     { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-dotenv", specifier = ">=0.21.0,<2" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
@@ -2929,8 +2929,8 @@ wheels = [
 
 [[package]]
 name = "pygitguardian"
-version = "1.33.1"
-source = { git = "https://github.com/GitGuardian/py-gitguardian.git?rev=0b9278889119f1535b072a997caa13a781e4cd59#0b9278889119f1535b072a997caa13a781e4cd59" }
+version = "1.34.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "marshmallow", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2939,6 +2939,10 @@ dependencies = [
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "setuptools" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/8f/5233d9261d1b4748343c6bd9f2514d4b0f322a70f9157e00599057bc2c47/pygitguardian-1.34.0.tar.gz", hash = "sha256:b0ea1d1ef76ed429ea16ad0f4deafe90f7d162715624b55b0e962c076baf2c57", size = 59612, upload-time = "2026-08-19T09:36:01.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/47/d04eb9a381ae2ca2969409ca812179355edd995ade448380b084b9bbb60a/pygitguardian-1.34.0-py3-none-any.whl", hash = "sha256:01a47294dc20b24279bf60f3418a652d480228a250bb8d531a5a390a8b999e1c", size = 25041, upload-time = "2026-08-19T09:36:00.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pyproject.toml` pinned py-gitguardian to a git rev, to get `AgentInfo.subscription_email` before it shipped. That reference reaches the built metadata verbatim:

```
Requires-Dist: pygitguardian @ git+https://github.com/GitGuardian/py-gitguardian.git@0b92788...
```

PyPI refuses a distribution whose metadata names a direct URL, so no release could be published while that pin stood, and it would have failed at the upload step after every artifact had been built and signed.

py-gitguardian 1.34.0 was released today and carries the field (`pygitguardian/models.py:1807`), so the pin goes back to a version specifier. Verified: `uv sync --locked` resolves 1.34.0 from PyPI, the full unit suite passes (2690 passed, 4 skipped), and a built wheel now declares `Requires-Dist: pygitguardian~=1.34.0` with no direct-URL requirements left.

`exclude-newer-package = { "pygitguardian" = false }` stays: the three-day quarantine would otherwise filter a release published this morning.