### PR TITLE
fix(packaging): sign through Git for Windows bash, not the WSL launcher

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -8,6 +8,7 @@ expects to exec its sibling from.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -135,12 +136,30 @@ class RustDispatcherBuildHook(BuildHookInterface):
         elif sys.platform == "win32":
             if not os.environ.get("SM_API_KEY"):
                 return
-            # Through bash explicitly, since Windows honours no shebang, and with a
+            # Through bash, since Windows honours no shebang, and with a
             # forward-slash path: bash reads the backslashes of a native path as
             # escapes, so `dirname` sees no directory and `cp` no such file.
             self._run_signer(
-                ["bash", str(scripts / "windows-sign-file"), binary.as_posix()]
+                [
+                    self._git_bash(),
+                    str(scripts / "windows-sign-file"),
+                    binary.as_posix(),
+                ]
             )
+
+    @staticmethod
+    def _git_bash() -> str:
+        """The bash that Git for Windows ships, found next to its own git.
+
+        Never a bare ``bash``: on PATH that is System32's WSL launcher, which
+        answers every invocation with "no installed distributions".
+        """
+        git = shutil.which("git")
+        if git:
+            bash = Path(git).resolve().parent.parent / "bin" / "bash.exe"
+            if bash.is_file():
+                return str(bash)
+        raise SigningError("no Git for Windows bash alongside git, cannot sign")
 
     def _run_signer(self, argv: list[str]) -> None:
         """Run a signing script, and say what it said when it fails.


### PR DESCRIPTION
Signed Windows wheel builds failed with an empty-looking error. The output was UTF-16, which is why it read as a stray `W` and blank lines. Decoded:

```
Windows Subsystem for Linux has no installed distributions.
Use 'wsl.exe --list --online' to list available distributions
```

`subprocess.run(["bash", ...])` resolves `bash` on PATH to `C:\\Windows\\System32\\bash.exe`, the WSL launcher. The workflow's own `shell: bash` steps use `C:\\Program Files\\Git\\bin\\bash.EXE`, but nothing made the build hook use the same one. So `windows-sign-file` never ran at all, which is also why the earlier failures carried no message from it.

The hook now takes the bash Git for Windows ships, located next to the `git` already on PATH (both `Git\\cmd\\git.exe` and `Git\\bin\\git.exe` layouts resolve to `Git\\bin\\bash.exe`), and fails with a clear message if it is not there.

Signing runs only under `sign: true`, which no PR or push run sets, so this is reachable only by a tagged release or a `workflow_dispatch`.