### PR TITLE
fix(packaging): find Git for Windows bash wherever git sits

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -163,9 +163,11 @@ jobs:
             exit 1
           fi
           echo "Signing with $signtool_dir/signtool.exe"
-          echo "$signtool_dir" >> "$GITHUB_PATH"
+          # Windows-form on PATH: smctl is a native process and looks signtool up
+          # through %PATH%, where a `/c/...` entry means nothing.
+          cygpath -w "$signtool_dir" >> "$GITHUB_PATH"
           # The next step installs smctl, so do not look for it yet.
-          echo "/c/Program Files/DigiCert/DigiCert Keylocker Tools" >> "$GITHUB_PATH"
+          cygpath -w "/c/Program Files/DigiCert/DigiCert Keylocker Tools" >> "$GITHUB_PATH"
 
           # `cygpath -m`: a drive-letter path with forward slashes, which both bash
           # and smctl accept. $RUNNER_TEMP is backslashed here, and bash reads a

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -149,17 +149,31 @@ class RustDispatcherBuildHook(BuildHookInterface):
 
     @staticmethod
     def _git_bash() -> str:
-        """The bash that Git for Windows ships, found next to its own git.
+        """The bash that Git for Windows ships.
 
         Never a bare ``bash``: on PATH that is System32's WSL launcher, which
-        answers every invocation with "no installed distributions".
+        answers every invocation with "no installed distributions". Git for
+        Windows keeps its bash in ``bin``, but ships ``git`` in ``cmd``, ``bin``
+        and ``mingw64/bin`` alike, so which one PATH offers says nothing about
+        how far up the install root is. Try each depth, then the default
+        locations.
         """
+        roots = []
         git = shutil.which("git")
         if git:
-            bash = Path(git).resolve().parent.parent / "bin" / "bash.exe"
+            found = Path(git).resolve().parent
+            roots += [found, found.parent, found.parent.parent]
+        roots += [Path(r"C:\Program Files\Git"), Path(r"C:\Program Files (x86)\Git")]
+
+        tried = []
+        for root in roots:
+            bash = root / "bin" / "bash.exe"
+            tried.append(str(bash))
             if bash.is_file():
                 return str(bash)
-        raise SigningError("no Git for Windows bash alongside git, cannot sign")
+        raise SigningError(
+            "no Git for Windows bash to sign with, tried:\n  " + "\n  ".join(tried)
+        )
 
     def _run_signer(self, argv: list[str]) -> None:
         """Run a signing script, and say what it said when it fails.

--- a/scripts/build-os-packages/windows-sign-file
+++ b/scripts/build-os-packages/windows-sign-file
@@ -39,12 +39,14 @@ base="${file##*/}"
 tmp_path="$tmp_dir/${base//[^A-Za-z0-9._-]/_}"
 cp "$file" "$tmp_path"
 
+# A Windows path for a Windows tool: signtool reads `--input` itself, and only a
+# POSIX-looking argument gets translated on the way to a native process.
 smctl sign \
     --verbose \
     --exit-non-zero-on-fail \
     --fingerprint "$WINDOWS_CERT_FINGERPRINT" \
     --tool signtool \
-    --input "$tmp_path"
+    --input "$(cygpath -w "$tmp_path")"
 
 mv "$tmp_path" "$file"
 rm -rf "$tmp_dir"


### PR DESCRIPTION
Follow-up to #1429, which stopped the signer running under System32's WSL launcher but derived Git's bash from a single install layout:

```
hatch_build.py.SigningError: no Git for Windows bash alongside git, cannot sign
```

Git for Windows ships `git` in `cmd`, `bin` **and** `mingw64/bin`. From `mingw64/bin/git.exe`, `../bin/bash.exe` is `mingw64/bin/bash.exe`, which does not exist. So which git PATH offers says nothing about how far up the install root is.

This probes each depth above the git it found, then the two default install locations, and reports every candidate it tried when none of them holds a bash. Verified against all three layouts.

Signing runs only under `sign: true`, which no PR or push run sets, so this is reachable only from a tagged release or a `workflow_dispatch`.