### PR TITLE
feat(ai-hook): let GGSHIELD_NO_NOTIFICATION withhold the banner

### DIFF
--- a/changelog.d/20260820_120000_achille.mascia_no_notification_switch.md
+++ b/changelog.d/20260820_120000_achille.mascia_no_notification_switch.md
@@ -1,0 +1,5 @@
+### Added
+
+- `GGSHIELD_NO_NOTIFICATION` suppresses the AI hook's desktop notification. The
+  secret is still detected and the tool call still blocked; only the banner is
+  withheld.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -20,6 +20,7 @@ from ggshield.core.scan import Scannable, ScannerProtocol
 from ggshield.core.scan import SecretProtocol as Secret
 from ggshield.core.scanner_ui import create_message_only_scanner_ui
 from ggshield.core.text_utils import pluralize, translate_validity
+from ggshield.utils.os import getenv_bool
 from ggshield.verticals.ai.mcp import is_mcp_activity_payload, send_mcp_activity
 
 from .agents import AGENTS
@@ -388,6 +389,8 @@ def _send_desktop_notification(title: str, message: str) -> None:
     paths, emoji, tabs...). ``stdin`` is detached and a timeout enforced so a
     misbehaving notifier can't stall the hook. Other platforms use notifypy.
     """
+    if getenv_bool("GGSHIELD_NO_NOTIFICATION", default=False):
+        return
     if sys.platform == "darwin":
         subprocess.run(
             [

--- a/rust/config/src/config.rs
+++ b/rust/config/src/config.rs
@@ -552,7 +552,7 @@ pub fn resolve() -> Result<Config, Error> {
 
 /// `getenv_bool()` (utils/os.py): set to anything other than `false` or `0`,
 /// case-insensitively, counts as true — including the empty string.
-fn getenv_bool(key: &str) -> bool {
+pub fn getenv_bool(key: &str) -> bool {
     std::env::var(key).is_ok_and(|v| !matches!(v.to_lowercase().as_str(), "false" | "0"))
 }
 

--- a/rust/hook/src/notify.rs
+++ b/rust/hook/src/notify.rs
@@ -6,7 +6,14 @@
 //! each backend treats it as data an interpreter never parses.
 
 /// Raise a desktop notification. Never panics, never blocks for long.
+///
+/// `GGSHIELD_NO_NOTIFICATION` builds the message and delivers nothing: a banner
+/// lands on whoever is at the keyboard, and the equivalence gate runs both hooks
+/// against payloads carrying secrets.
 pub fn send(title: &str, body: &str) {
+    if ggshield_config::config::getenv_bool("GGSHIELD_NO_NOTIFICATION") {
+        return;
+    }
     imp::send(title, body);
 }
 
@@ -466,5 +473,38 @@ mod tests {
             "ggshield - Secrets Detected",
             "Cursor got access to 1 secret by running the command `printenv \"café\" ❤`",
         );
+    }
+
+    /// Serialises the environment this test owns.
+    static NOTIFY_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// GIVEN `GGSHIELD_NO_NOTIFICATION` is set
+    /// WHEN a notification is sent
+    /// THEN nothing is delivered and nothing is built to deliver it with, for
+    /// every value the switch reads as true.
+    #[test]
+    fn the_no_notification_switch_delivers_nothing() {
+        let _guard = NOTIFY_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        for value in ["1", "true", "TRUE", "yes", ""] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            // SAFETY: single-threaded section, serialised by the guard above.
+            unsafe {
+                std::env::set_var("GGSHIELD_NO_NOTIFICATION", value);
+                std::env::set_var("GG_CACHE_DIR", dir.path());
+            }
+            super::send("ggshield - Secrets Detected", "nothing should appear");
+            unsafe {
+                std::env::remove_var("GGSHIELD_NO_NOTIFICATION");
+                std::env::remove_var("GG_CACHE_DIR");
+            }
+            let left: Vec<_> = std::fs::read_dir(dir.path())
+                .expect("read")
+                .filter_map(|e| e.ok().map(|e| e.file_name()))
+                .collect();
+            assert!(
+                left.is_empty(),
+                "{value:?} suppresses delivery, yet left {left:?}"
+            );
+        }
     }
 }

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -33,6 +33,7 @@ from ggshield.verticals.ai.cache import (
 )
 from ggshield.verticals.ai.hooks import (
     AIHookScanner,
+    _send_desktop_notification,
     build_agent_headers,
     find_filepaths,
     has_already_been_seen,
@@ -2848,3 +2849,22 @@ class TestReadRange:
         assert isinstance(read_payload.agent, Codex)
         assert read_payload.read_range is None
         assert read_payload.scannable.content == file.read_bytes().decode()
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", ""])
+@patch("ggshield.verticals.ai.hooks.subprocess.run")
+def test_no_notification_switch_delivers_nothing(mock_run, monkeypatch, value):
+    """GGSHIELD_NO_NOTIFICATION withholds the banner without reaching a backend."""
+    monkeypatch.setenv("GGSHIELD_NO_NOTIFICATION", value)
+    _send_desktop_notification("ggshield - Secrets Detected", "nothing appears")
+    mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False"])
+@patch("ggshield.verticals.ai.hooks.sys.platform", "darwin")
+@patch("ggshield.verticals.ai.hooks.subprocess.run")
+def test_a_falsy_no_notification_switch_still_notifies(mock_run, monkeypatch, value):
+    """The switch reads like every other ggshield boolean: 0 and false are off."""
+    monkeypatch.setenv("GGSHIELD_NO_NOTIFICATION", value)
+    _send_desktop_notification("ggshield - Secrets Detected", "a banner appears")
+    mock_run.assert_called_once()


### PR DESCRIPTION
`rust/tests/equivalence.py` exercises both hook implementations against payloads that carry secrets, and a blocking `PostToolUse` case notifies for real. A local run therefore raises dozens of desktop banners, two per case (one from each implementation), all titled `ggshield - Secrets Detected`.

That is worse than noise: it trains whoever runs the gate to dismiss the exact banner that means a secret reached an agent, and it looks indistinguishable from a product bug from the outside.

`GGSHIELD_NO_NOTIFICATION` withholds delivery in both implementations, read where the message is handed to a backend so the message is still built and the verdict is untouched. It follows `GGSHIELD_NO_KEYRING`'s convention exactly, via the same `getenv_bool` in each language (unset or `0`/`false` is off, anything else is on), and the gate sets it.

Verified: the new Rust test fails with the guard removed (it asserts nothing is even built in the cache dir), 143 Rust tests pass, 2698 Python tests pass, and `RESULT: EQUIVALENT` with the gate now running silently.