### PR TITLE
fix(ai-hook): never fail an event open over an unusable read path

### DIFF
--- a/changelog.d/20260820_120000_achille.mascia_ai_hook_unreadable_candidate.md
+++ b/changelog.d/20260820_120000_achille.mascia_ai_hook_unreadable_candidate.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `ggshield secret scan ai-hook` no longer leaves a whole event unscanned when the file path
+  it guessed from a Bash command or an `@`-mention cannot be read. Such a candidate is
+  dropped instead of being sent to the scanner, where the read error aborted the event and
+  allowed the action with a "could not scan" warning, so the command or prompt text of that
+  same event is now always scanned. A candidate longer than the filesystem's limits (a
+  heredoc mistaken for a file name) is also recognized as text without a filesystem call.

--- a/ggshield/verticals/ai/hooks.py
+++ b/ggshield/verticals/ai/hooks.py
@@ -695,9 +695,15 @@ class AIHookScanner:
                     if scannable.is_longer_than(DOCUMENT_SIZE_THRESHOLD_BYTES)
                     else scannable.content
                 )
+            except OSError:
+                # A candidate path that stats but cannot be opened is not a
+                # document: SecretScanner only skips a missing file, so batching
+                # it raises there and fails the whole event open, leaving the
+                # command or prompt text of that same event unscanned.
+                continue
             except Exception:
-                # Unreadable or undecodable: no cache key, and it still goes to the
-                # scanner, which decides how to skip it and says so.
+                # Undecodable: no cache key, and it still goes to the scanner,
+                # which decides how to skip it and says so.
                 content = ""
 
             key = (

--- a/ggshield/verticals/ai/models.py
+++ b/ggshield/verticals/ai/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
@@ -128,6 +129,24 @@ class HookResult:
         )
 
 
+#: NAME_MAX and PATH_MAX. Nothing over them can name an existing file.
+_NAME_MAX = 255
+_PATH_MAX = 4096
+
+
+def _cannot_be_a_path(identifier: str) -> bool:
+    """Whether `identifier` is too long for the filesystem to hold such a file.
+
+    A candidate read path can be a whole shell command (a heredoc, a pipeline),
+    which no filesystem can name. Answering from the length keeps that off the
+    syscall, whose failure is platform-dependent: `stat` reports ENAMETOOLONG,
+    which `Path.is_file()` raises before Python 3.13 and swallows after.
+    """
+    return len(identifier) > _PATH_MAX or any(
+        len(component) > _NAME_MAX for component in re.split(r"[\\/]", identifier)
+    )
+
+
 @dataclass
 class HookPayload:
     event_type: EventType
@@ -147,12 +166,13 @@ class HookPayload:
         Cached: a ranged read builds the slice by reading the file, and callers
         ask for the scannable more than once (`empty`, then the scan itself).
         """
-        if self.tool == Tool.READ:
+        if self.tool == Tool.READ and not _cannot_be_a_path(self.identifier):
             # The identifier is not always a real path: it can be a whole shell
             # command (a heredoc, a pipeline...) that a caller guessed was a
             # file name. Path.is_file() only swallows "not found" errors, so it
-            # still raises on such identifiers (ENAMETOOLONG, embedded NULs...).
-            # Never let that abort the scan: fall back to scanning the content.
+            # still raises on such identifiers (embedded NULs, a too-long name on
+            # Python < 3.13...). Never let that abort the scan: fall back to
+            # scanning the content.
             try:
                 path = Path(self.identifier)
                 if path.is_file() and not is_path_binary(path):

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -359,7 +359,7 @@ const UTF8_TO_WORSE_OTHER_ENCODING_RATIO: u64 = 4;
 /// `None` means "nothing to scan here": the file is too large to be scanned at
 /// all, so reading it would only cost the memory.
 fn scannable(config: &config::Config, payload: &mut Payload) -> Option<(String, String)> {
-    if payload.tool == Some(Tool::Read) {
+    if payload.tool == Some(Tool::Read) && !cannot_be_a_path(&payload.identifier) {
         let path = Path::new(&payload.identifier);
         if path.is_file() && !is_path_binary(path) {
             // Reading first and measuring after is how `@big.log` on a multi-GB
@@ -383,6 +383,20 @@ fn scannable(config: &config::Config, payload: &mut Payload) -> Option<(String, 
         std::mem::take(&mut payload.content),
         payload.identifier.clone(),
     ))
+}
+
+/// NAME_MAX and PATH_MAX. Nothing over them can name an existing file.
+const NAME_MAX: usize = 255;
+const PATH_MAX: usize = 4096;
+
+/// `_cannot_be_a_path()`: a candidate read path can be a whole shell command (a
+/// heredoc, a pipeline), which no filesystem can name. Counted in characters, as
+/// Python's `len()`, so both implementations answer alike.
+fn cannot_be_a_path(identifier: &str) -> bool {
+    identifier.chars().count() > PATH_MAX
+        || identifier
+            .split(['\\', '/'])
+            .any(|component| component.chars().count() > NAME_MAX)
 }
 
 fn is_over_any_encoding_of_the_ceiling(config: &config::Config, path: &Path) -> bool {
@@ -916,6 +930,23 @@ mod tests {
         assert!(is_path_binary(Path::new("/tmp/a.zip")));
         assert!(!is_path_binary(Path::new("/tmp/a.env")));
         assert!(!is_path_binary(Path::new("/tmp/a")));
+    }
+
+    /// GIVEN a candidate read path holding a whole heredoc command, and one whose
+    /// components are each short but whose total is over PATH_MAX
+    /// WHEN it is measured against the filesystem's limits
+    /// THEN neither can name a file, while an ordinary path still can.
+    #[test]
+    fn an_over_long_candidate_cannot_be_a_path() {
+        let heredoc = format!(
+            "> /tmp/probe.py <<'PYEOF'\n{}\nPYEOF",
+            "x = 1\n".repeat(500)
+        );
+        assert!(cannot_be_a_path(&heredoc));
+        assert!(cannot_be_a_path(&format!("/tmp/{}.env", "a".repeat(300))));
+        assert!(cannot_be_a_path(&"/dir".repeat(2000)));
+        assert!(!cannot_be_a_path("/tmp/creds.env"));
+        assert!(!cannot_be_a_path(r"C:\Users\me\creds.env"));
     }
 
     /// GIVEN a Read payload pointing at a path that is not a file

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -1225,6 +1225,9 @@ def run(cmd, payload, port, workdir, env_extra=None):
         "GG_USER_HOME_DIR": str(workdir / "home"),
         # Keep the Python side off the OS keychain entirely.
         "GGSHIELD_NO_KEYRING": "1",
+        # Most of these payloads carry a secret, and a PostToolUse verdict raises
+        # a desktop banner per side per case.
+        "GGSHIELD_NO_NOTIFICATION": "1",
         "GITGUARDIAN_DONT_LOAD_ENV": "1",
         "PYTHONPATH": str(PY_SOURCES),
     }
@@ -1684,7 +1687,40 @@ def extra_cases(tmp):
         finally:
             mock.kill()
 
-    # 4. A payload from no known agent: no verdict at all, exit 1.
+    # 4. A candidate read path that stats but cannot be opened. It is not a
+    #    document, and it must not take the rest of the event down with it: the
+    #    prompt holds the secret, so both sides have to block.
+    print("\nUnreadable candidate (the secret in the same event must still block):")
+    unreadable = tmp / "unreadable" / "locked.env"
+    mention_payload = {
+        **agent_bases()["claude"],
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": f"compare @{unreadable} with AWS_KEY={CLIENT_ID}",
+    }
+
+    def lock_file():
+        # Runs once per side, and the previous run left it unwritable.
+        unreadable.parent.mkdir(parents=True, exist_ok=True)
+        unreadable.unlink(missing_ok=True)
+        unreadable.write_text(f"AWS_KEY={CLIENT_ID}\n")
+        unreadable.chmod(0o000)
+
+    log = tmp / "requests-unreadable.jsonl"
+    mock, port = start_mock("secret", log)
+    try:
+        verdict_ok, request_ok, py, rs, _ = compare_one(
+            tmp, log, port, "unreadable", mention_payload, setup=lock_file
+        )
+        report(failures, "unreadable/mention", verdict_ok, request_ok, py, rs)
+        for side, proc in (("python", py), ("rust", rs)):
+            if verdict_of(proc.stdout) != "block":
+                failures.append(f"unreadable/mention ({side} did not block)")
+                print(f"        ^ {side}: {proc.stdout[:120]!r}")
+    finally:
+        mock.kill()
+        unreadable.chmod(0o600)
+
+    # 5. A payload from no known agent: no verdict at all, exit 1.
     print("\nUnrecognized agent (both sides): no stdout, exit 1")
     for side, cmd in (("python", PY_CMD), ("rust", RS_CMD)):
         workdir = make_workdir(tmp, f"unknown-{side}")

--- a/tests/unit/verticals/ai/test_hooks.py
+++ b/tests/unit/verticals/ai/test_hooks.py
@@ -603,6 +603,45 @@ class TestBatchedPayloadScan:
         mock_scanner.scan.assert_called_once()
         assert _scanned_urls(mock_scanner) == ["full"]
 
+    def test_an_unreadable_file_does_not_stop_the_rest_of_the_event(
+        self, tmp_path: Path
+    ):
+        """GIVEN an event holding a secret plus a read of a file that stats but
+        cannot be opened
+        WHEN the event is scanned
+        THEN the unreadable document is dropped and the secret still reaches the
+        API, where the read error used to abort the whole event and allow it."""
+        locked = tmp_path / "locked.env"
+        locked.write_text("TOKEN=abc")
+        scanner = _real_secret_scanner()
+        scanner.client.base_uri = INSTANCE
+        scanner.client.api_key = API_KEY
+
+        def multi_content_scan(documents, *args, **kwargs):
+            result = MultiScanResult(
+                [
+                    ApiScanResult(policy_break_count=0, policy_breaks=[], policies=[])
+                    for _ in documents
+                ]
+            )
+            result.status_code = 200
+            return result
+
+        scanner.client.multi_content_scan.side_effect = multi_content_scan
+        payloads = [self._read_payload(locked), self._payload("prompt")]
+        error = PermissionError(errno.EACCES, "Permission denied")
+
+        with patch.object(File, "is_longer_than", side_effect=error):
+            results = AIHookScanner(scanner)._scan_contents(payloads)
+
+        assert [result.block for result in results] == [False, False]
+        sent = [
+            document["filename"]
+            for call in scanner.client.multi_content_scan.call_args_list
+            for document in call.args[0]
+        ]
+        assert sent == ["prompt"]
+
     def test_no_payload_to_scan_makes_no_api_call(self):
         """All payloads empty means nothing to send at all."""
         mock_scanner = _scanner_per_document()

--- a/tests/unit/verticals/ai/test_models.py
+++ b/tests/unit/verticals/ai/test_models.py
@@ -88,6 +88,31 @@ class TestHookPayloadScannable:
         with patch.object(Path, "is_file", side_effect=error):
             assert isinstance(payload.scannable, StringScannable)
 
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            pytest.param(
+                "> /tmp/probe.py <<'PYEOF'\n" + "x = 1\n" * 500 + "PYEOF",
+                id="heredoc-command",
+            ),
+            pytest.param("/tmp/" + "a" * 300 + ".env", id="component-over-name-max"),
+            pytest.param("/dir" * 2000, id="path-over-path-max"),
+        ],
+    )
+    def test_read_tool_over_long_identifier_is_not_a_path(self, identifier: str):
+        """An identifier too long to name a file is text, and costs no syscall."""
+        payload = HookPayload(
+            event_type=EventType.PRE_TOOL_USE,
+            tool=Tool.READ,
+            content="some content",
+            identifier=identifier,
+            agent=Cursor(),
+            raw={},
+        )
+        with patch.object(Path, "is_file") as is_file:
+            assert isinstance(payload.scannable, StringScannable)
+        is_file.assert_not_called()
+
     def test_non_read_tool_returns_string_scannable(self):
         payload = HookPayload(
             event_type=EventType.PRE_TOOL_USE,


### PR DESCRIPTION
## The report

A `PreToolUse:Bash` call was allowed with:

```
ggshield could not scan ([Errno 63] File name too long: "> /private/.../scratchpad/probe.py <<'PYEOF'\nimport socket, ssl, sys, re\n...") - this action was NOT scanned for secrets.
```

The command was a `cat > file <<'PYEOF' ... PYEOF` heredoc writing a few thousand characters of generated Python. The action was allowed **without being scanned at all**, which is the actual bug: a long generated inline script is exactly the shape most likely to carry a secret.

## Reproduction

Both implementations were run against the reported payload shape (a Claude `Bash` event whose command is a 4.3 KB heredoc carrying an AWS key pair), through a localhost mock API.

The errno-63 shape itself no longer reproduces on `main`: `HookPayload.scannable` has guarded the stat since "don't abandon the scan when a `cat` argument isn't a path", and both sides block. What does still reproduce is the same fail-open one step later, when the candidate stats but cannot be *opened*. A prompt carrying a secret that also `@`-mentions an unreadable file:

```
python: {"continue": true, "systemMessage": "ggshield could not scan ([Errno 13] Permission denied: '.../locked.env') - this action was NOT scanned for secrets. ..."}
        0 documents posted: the prompt holding the secret was never scanned
rust:   {"decision":"block", ...}  1 document posted
```

The Bash equivalent, `cat <unreadable file>`, behaves the same way: Python posts nothing and allows, the native hook scans the command text.

## Root cause

An unusable path candidate is treated as "the scan failed" instead of "this is not a path", and because every payload of an event is scanned in one batch, one unusable document fails the whole event open.

- Python: `ggshield/verticals/ai/models.py:150` returns a `File` after a bare `Path.is_file()`, and `ggshield/verticals/ai/hooks.py:695-698` keeps that document in the batch when reading it raises. `SecretScanner._start_scans` (`ggshield/verticals/secret/secret_scanner.py:172-180`) only skips `DecodeError`, `NonSeekableFileError` and `FileNotFoundError`, so a `PermissionError` propagates out of the hook and `ai_hook.py` fails open.
- Rust: `rust/hook/src/lib.rs:361-369` does not have the bug. `Path::is_file()` answers `false` instead of raising, and `std::fs::read(path).ok()?` drops an unreadable candidate, leaving the rest of the event scanned. Verified, not assumed: the native hook blocks on both payloads above.

## The change

Python drops an unreadable candidate from the batch instead of sending it, matching the native hook, so the command or prompt text of the same event is still scanned. Both implementations also answer the length question before the syscall: a component over `NAME_MAX` (255) or a path over `PATH_MAX` cannot name an existing file, and `stat`'s failure for one is platform-dependent (`Path.is_file()` raises `ENAMETOOLONG` before Python 3.13 and swallows it after, Rust returns `false`).

The equivalence gate gains the unreadable-candidate case, and now sets `GGSHIELD_NO_NOTIFICATION`: most of its payloads carry a secret, and each PostToolUse verdict was raising a real desktop banner per side.

## Checks

`cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` 155 passed (154 on `main`, +1 for the new length-check test), `pytest tests/unit` 2702 passed / 4 skipped (2698 on `main`, +4 cases), `equivalence.py` ends with `RESULT: EQUIVALENT`.

Both new tests fail without the fix: `test_an_unreadable_file_does_not_stop_the_rest_of_the_event` errors with the `PermissionError` that used to escape the hook, and the gate reports `unreadable/mention (python did not block)`.
