### PR TITLE
feat(secret): ignore matches on configured regex patterns

### DIFF
--- a/.gitguardian.example.yml
+++ b/.gitguardian.example.yml
@@ -31,6 +31,11 @@ secret:
     - name: credentials
       match: MY_TEST_CREDENTIAL
 
+  # Ignore security incidents whose secret matches one of these regexes, for
+  # instance to skip values which are encrypted at rest
+  ignored_match_patterns: # default: []
+    - '^ENC\[AES256_GCM,data:'
+
   show_secrets: false # default: false
 
   # Detectors to ignore.

--- a/changelog.d/20260805_120000_adrai_ignore_match_pattern.md
+++ b/changelog.d/20260805_120000_adrai_ignore_match_pattern.md
@@ -1,0 +1,7 @@
+### Added
+
+- `ggshield secret scan` learned the `--ignore-match-pattern PATTERN` option. Secrets
+  whose value matches the given regex are ignored, which is handy to skip values
+  encrypted at rest, such as sops values starting with `ENC[AES256_GCM,data:`. The
+  option can be repeated, and is also available as the `ignored_match_patterns` setting
+  of the `secret` section in `.gitguardian.yaml`.

--- a/ggshield/cmd/secret/scan/secret_scan_common_options.py
+++ b/ggshield/cmd/secret/scan/secret_scan_common_options.py
@@ -18,7 +18,7 @@ from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.cmd.utils.output_format import OutputFormat
 from ggshield.core import ui
 from ggshield.core.config.user_config import SecretConfig
-from ggshield.core.filter import init_exclusion_regexes
+from ggshield.core.filter import init_exclusion_regexes, validate_ignored_match_patterns
 from ggshield.utils.click import RealPath
 from ggshield.verticals.secret.output import (
     SecretJSONOutputHandler,
@@ -128,6 +128,30 @@ _banlist_detectors_option = click.option(
 )
 
 
+def _ignored_match_patterns_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[List[str]]
+) -> Optional[List[str]]:
+    ignored_match_patterns = _get_secret_config(ctx).ignored_match_patterns
+    if value is not None:
+        ignored_match_patterns.update(value)
+
+    validate_ignored_match_patterns(ignored_match_patterns)
+    return value
+
+
+_ignored_match_patterns_option = click.option(
+    "--ignore-match-pattern",
+    default=None,
+    help="""
+    Ignore secrets whose value matches the specified regex. The regex is searched
+    anywhere in the value: anchor it with ^ to only match a prefix.
+    """,
+    multiple=True,
+    callback=_ignored_match_patterns_callback,
+    metavar="PATTERN",
+)
+
+
 _with_incident_details_option = click.option(
     "--with-incident-details",
     is_flag=True,
@@ -195,6 +219,7 @@ def add_secret_scan_common_options() -> Callable[[AnyFunction], AnyFunction]:
         _exclude_option(cmd)
         _ignore_known_secrets_option(cmd)
         _banlist_detectors_option(cmd)
+        _ignored_match_patterns_option(cmd)
         _with_incident_details_option(cmd)
         instance_option(cmd)
         _all_secrets(cmd)

--- a/ggshield/core/config/user_config.py
+++ b/ggshield/core/config/user_config.py
@@ -39,6 +39,7 @@ class SecretConfig(FilteredConfig):
     show_secrets: bool = False
     ignored_detectors: Set[str] = field(default_factory=set)
     ignored_matches: List[IgnoredMatch] = field(default_factory=list)
+    ignored_match_patterns: Set[str] = field(default_factory=set)
     ignored_paths: Set[str] = field(default_factory=set)
     ignore_known_secrets: bool = False
     with_incident_details: bool = False
@@ -73,6 +74,7 @@ class SecretConfig(FilteredConfig):
                 "show_secrets": self.show_secrets,
                 "ignored_detectors_count": len(self.ignored_detectors),
                 "ignored_matches_count": len(self.ignored_matches),
+                "ignored_match_patterns_count": len(self.ignored_match_patterns),
                 "ignored_paths_count": len(self.ignored_paths),
                 "ignore_known_secrets": self.ignore_known_secrets,
                 "with_incident_details": self.with_incident_details,

--- a/ggshield/core/filter.py
+++ b/ggshield/core/filter.py
@@ -47,6 +47,26 @@ def is_in_ignored_matches(
     return False
 
 
+def is_in_ignored_match_patterns(
+    policy_break: PolicyBreak,
+    ignored_match_patterns: Iterable[str],
+) -> bool:
+    """
+    is_in_ignored_match_patterns checks if any of the occurrence matches is ignored,
+    by searching each pattern in the match value.
+
+    :param policy_break: Policy Break occurrence to judge
+    :param ignored_match_patterns: Iterable of regexes to search for
+    :return: True if ignored
+    """
+
+    return any(
+        re.search(pattern, match.match)
+        for pattern in ignored_match_patterns
+        for match in policy_break.matches
+    )
+
+
 def get_ignore_sha(policy_break: PolicyBreak) -> str:
     hashable = "".join(
         [
@@ -104,6 +124,22 @@ def init_exclusion_regexes(paths_ignore: Iterable[str]) -> Set[Pattern[str]]:
             raise UsageError(f"{path} is not a valid exclude pattern.")
         res.add(re.compile(translate_user_pattern(path)))
     return res
+
+
+def validate_ignored_match_patterns(patterns: Iterable[str]) -> None:
+    """
+    Check the patterns secret values are searched for, so that an unusable one is
+    reported when the command starts rather than silently affecting the scan.
+    """
+    for pattern in patterns:
+        if not pattern:
+            raise UsageError("An ignored match pattern should not be empty.")
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise UsageError(
+                f"{pattern} could not be compiled as a regex: {exc}"
+            ) from exc
 
 
 def censor_string(text: str) -> str:

--- a/ggshield/verticals/secret/secret_scan_collection.py
+++ b/ggshield/verticals/secret/secret_scan_collection.py
@@ -17,7 +17,7 @@ from pygitguardian.models import (
 
 from ggshield.core.config.user_config import SecretConfig
 from ggshield.core.errors import handle_api_error
-from ggshield.core.filter import is_in_ignored_matches
+from ggshield.core.filter import is_in_ignored_match_patterns, is_in_ignored_matches
 from ggshield.core.lines import get_lines_from_content
 from ggshield.core.scan import Scannable
 from ggshield.utils.git_shell import Filemode
@@ -26,6 +26,9 @@ from ggshield.verticals.secret.extended_match import ExtendedMatch
 
 class IgnoreKind(str, Enum):
     IGNORED_MATCH = "Match ignored via local .gitguardian yaml"
+    IGNORED_MATCH_PATTERN = (
+        "Match ignored via --ignore-match-pattern or local .gitguardian yaml"
+    )
     IGNORED_DETECTOR = "Detector ignored via local .gitguardian yaml"
     KNOWN_SECRET = "Secret is known in dashboard and --ignore-known-secrets is used"
     NOT_INTRODUCED = "Secret was not in added in commit"
@@ -60,6 +63,10 @@ def compute_ignore_reason(
         )
     elif is_in_ignored_matches(policy_break, secret_config.ignored_matches or []):
         ignore_reason = IgnoreReason(IgnoreKind.IGNORED_MATCH)
+    elif is_in_ignored_match_patterns(
+        policy_break, secret_config.ignored_match_patterns
+    ):
+        ignore_reason = IgnoreReason(IgnoreKind.IGNORED_MATCH_PATTERN)
     elif policy_break.break_type in secret_config.ignored_detectors:
         ignore_reason = IgnoreReason(IgnoreKind.IGNORED_DETECTOR)
     elif secret_config.ignore_known_secrets and policy_break.known_secret:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,4 +1,5 @@
 import random
+from typing import List
 
 import factory
 import factory.fuzzy
@@ -7,7 +8,7 @@ from pygitguardian.models import Match, PolicyBreak, ScanResult
 from ggshield.core.scan.scannable import StringScannable
 from ggshield.utils.git_shell import Filemode
 from ggshield.verticals.secret.secret_scan_collection import Secret
-from tests.factory_constants import DETECTOR_NAMES, MATCH_NAMES
+from tests.factory_constants import DETECTOR_NAMES, MATCH_NAMES, MATCH_SEPARATOR
 
 
 def get_line_index(content, index):
@@ -119,3 +120,23 @@ class SecretFactory(factory.Factory):
     vault_name = None
     vault_path = None
     vault_path_count = None
+
+
+def build_policy_break(*match_values: str) -> PolicyBreak:
+    content = MATCH_SEPARATOR.join(match_values)
+    matches: List[Match] = []
+    index_start = 0
+    for index, value in enumerate(match_values):
+        matches.append(
+            MatchFactory(
+                content=content,
+                match=value,
+                match_type=f"password_{index}",
+                index_start=index_start,
+                index_end=index_start + len(value),
+            )
+        )
+        index_start += len(value) + len(MATCH_SEPARATOR)
+
+    policy_break: PolicyBreak = PolicyBreakFactory(content=content, matches=matches)
+    return policy_break

--- a/tests/factory_constants.py
+++ b/tests/factory_constants.py
@@ -90,3 +90,13 @@ MATCH_NAMES = [
     "client_key",
     "config_value",
 ]
+
+SOPS_ENCRYPTED_VALUE = (
+    "ENC[AES256_GCM,data:Zm9vYmFyYmF6,iv:9Xk1Nw==,tag:Qk5tZw==,type:str]"
+)
+
+SOPS_PATTERN = r"^ENC\[AES256_GCM,data:"
+
+INVALID_REGEX_PATTERN = "^ENC["
+
+MATCH_SEPARATOR = "\n"

--- a/tests/functional/secret/test_scan_path.py
+++ b/tests/functional/secret/test_scan_path.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -160,3 +161,25 @@ def test_scan_path_works_if_git_not_found(monkeypatch, tmp_path: Path) -> None:
     # WHEN ggshield scans the test file
     # THEN it does not fail
     run_ggshield_scan("path", "--debug", str(test_file), cwd=tmp_path, expected_code=0)
+
+
+def test_scan_path_ignore_match_pattern(tmp_path: Path) -> None:
+    # GIVEN a secret
+    test_file = tmp_path / "config.py"
+    test_file.write_text(f"SECRET='{GG_VALID_TOKEN}'")
+
+    # WHEN ggshield scans it, ignoring matches looking like the secret
+    result = run_ggshield_scan(
+        "--json",
+        "--ignore-match-pattern",
+        re.escape(GG_VALID_TOKEN),
+        "path",
+        str(test_file),
+        cwd=tmp_path,
+        expected_code=0,
+    )
+
+    # THEN no incident is reported
+    parsed_result = json.loads(result.stdout)
+    assert parsed_result["total_incidents"] == 0
+    assert parsed_result["total_occurrences"] == 0

--- a/tests/unit/cmd/scan/test_path.py
+++ b/tests/unit/cmd/scan/test_path.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +11,12 @@ from pygitguardian.models import MultiScanResult
 
 from ggshield.__main__ import cli
 from ggshield.core.errors import ExitCode
+from tests.factories import ScanResultFactory, build_policy_break
+from tests.factory_constants import (
+    INVALID_REGEX_PATTERN,
+    SOPS_ENCRYPTED_VALUE,
+    SOPS_PATTERN,
+)
 from tests.repository import Repository
 from tests.unit.conftest import (
     _ONE_LINE_AND_MULTILINE_PATCH,
@@ -20,6 +27,15 @@ from tests.unit.conftest import (
     my_vcr,
     write_text,
 )
+
+
+def assert_secrets_ignored(output: str, nb_ignored: int) -> None:
+    if nb_ignored > 0:
+        assert (
+            f"{nb_ignored} secret{'s' if nb_ignored != 1 else ''} ignored"
+        ) in output
+    else:
+        assert "ignored" not in output
 
 
 def create_normally_ignored_file() -> Path:
@@ -509,10 +525,186 @@ class TestScanDirectory:
                 assert (
                     f": {nb_secret} secret{'s' if nb_secret != 1 else ''} detected"
                 ) in result.output
-                if nb_ignored > 0:
-                    assert (
-                        f"{nb_ignored} secret{'s' if nb_ignored != 1 else ''} ignored"
-                    ) in result.output
+                assert_secrets_ignored(result.output, nb_ignored)
+
+    @pytest.mark.parametrize(
+        ("ignored_match_patterns", "nb_secret", "nb_ignored"),
+        [
+            ([], 2, 0),
+            (["--ignore-match-pattern", "^-----BEGIN RSA PRIVATE KEY-----"], 1, 1),
+            (["--ignore-match-pattern", r"^SG\."], 1, 1),
+            (["--ignore-match-pattern", SOPS_PATTERN], 2, 0),
+            (
+                [
+                    "--ignore-match-pattern",
+                    r"^SG\.",
+                    "--ignore-match-pattern",
+                    "^-----BEGIN RSA",
+                ],
+                0,
+                2,
+            ),
+        ],
+    )
+    def test_ignore_match_patterns(
+        self,
+        cli_fs_runner: CliRunner,
+        ignored_match_patterns: List[str],
+        nb_secret: int,
+        nb_ignored: int,
+    ) -> None:
+        """
+        GIVEN a file holding a RSA private key and a SendGrid key
+        WHEN scanning it while ignoring matches by pattern
+        THEN only the secrets whose match is searched by a pattern should be ignored
+        """
+        write_text(Path("file_secret"), _ONE_LINE_AND_MULTILINE_PATCH)
+        with my_vcr.use_cassette("test_scan_path_file_one_line_and_multiline_patch"):
+            result = cli_fs_runner.invoke(
+                cli,
+                [
+                    "secret",
+                    "scan",
+                    "-v",
+                    *ignored_match_patterns,
+                    "path",
+                    "file_secret",
+                    "--exit-zero",
+                ],
+            )
+
+            assert result.exit_code == ExitCode.SUCCESS, result.output
+            assert (
+                f": {nb_secret} secret{'s' if nb_secret != 1 else ''} detected"
+            ) in result.output
+            assert_secrets_ignored(result.output, nb_ignored)
+
+    def test_ignore_match_patterns_from_both_cli_and_config(
+        self, cli_fs_runner: CliRunner
+    ) -> None:
+        """
+        GIVEN a config file ignoring the SendGrid key by pattern
+        WHEN scanning with a pattern ignoring the RSA private key on the command line
+        THEN both secrets should be ignored
+        """
+        write_text(Path("file_secret"), _ONE_LINE_AND_MULTILINE_PATCH)
+        write_text(
+            Path(".gitguardian.yaml"),
+            "version: 2\nsecret:\n  ignored_match_patterns:\n    - '^SG\\.'\n",
+        )
+
+        with my_vcr.use_cassette("test_scan_path_file_one_line_and_multiline_patch"):
+            result = cli_fs_runner.invoke(
+                cli,
+                [
+                    "secret",
+                    "scan",
+                    "-v",
+                    "--ignore-match-pattern",
+                    "^-----BEGIN RSA",
+                    "path",
+                    "file_secret",
+                    "--exit-zero",
+                ],
+            )
+
+            assert result.exit_code == ExitCode.SUCCESS, result.output
+            assert ": 0 secrets detected" in result.output
+            assert_secrets_ignored(result.output, 2)
+
+    @pytest.mark.parametrize(
+        ("ignore_options", "nb_secret", "nb_ignored"),
+        [
+            ([], 1, 0),
+            (["--ignore-match-pattern", SOPS_PATTERN], 0, 1),
+        ],
+    )
+    @patch("pygitguardian.GGClient.multi_content_scan")
+    @my_vcr.use_cassette("test_scan_context_repository.yaml")
+    def test_ignore_sops_encrypted_match(
+        self,
+        scan_mock: Mock,
+        cli_fs_runner: CliRunner,
+        ignore_options: List[str],
+        nb_secret: int,
+        nb_ignored: int,
+    ) -> None:
+        """
+        GIVEN a file holding a sops-encrypted value reported as a secret
+        WHEN scanning it while ignoring matches looking sops-encrypted
+        THEN the secret should be ignored, and detected without the pattern
+        """
+        write_text(Path("secrets.yaml"), SOPS_ENCRYPTED_VALUE)
+        scan_result = MultiScanResult(
+            [
+                ScanResultFactory(
+                    policy_breaks=[build_policy_break(SOPS_ENCRYPTED_VALUE)]
+                )
+            ]
+        )
+        scan_result.status_code = 200
+        scan_mock.return_value = scan_result
+
+        result = cli_fs_runner.invoke(
+            cli,
+            [
+                "secret",
+                "scan",
+                "-v",
+                *ignore_options,
+                "path",
+                "secrets.yaml",
+                "--exit-zero",
+            ],
+        )
+
+        assert result.exit_code == ExitCode.SUCCESS, result.output
+        assert (
+            f": {nb_secret} secret{'s' if nb_secret != 1 else ''} detected"
+        ) in result.output
+        assert_secrets_ignored(result.output, nb_ignored)
+
+    def test_invalid_ignore_match_pattern(self, cli_fs_runner: CliRunner) -> None:
+        """
+        GIVEN an ignore pattern which is not a valid regex
+        WHEN scanning
+        THEN it should fail with a usage error naming the pattern
+        """
+        write_text(Path("file_secret"), _ONE_LINE_AND_MULTILINE_PATCH)
+
+        result = cli_fs_runner.invoke(
+            cli,
+            [
+                "secret",
+                "scan",
+                "--ignore-match-pattern",
+                INVALID_REGEX_PATTERN,
+                "path",
+                "file_secret",
+            ],
+        )
+
+        assert result.exit_code == ExitCode.USAGE_ERROR, result.output
+        assert INVALID_REGEX_PATTERN in result.output
+
+    def test_invalid_ignore_match_pattern_from_config(
+        self, cli_fs_runner: CliRunner
+    ) -> None:
+        """
+        GIVEN a config file holding an ignore pattern which is not a valid regex
+        WHEN scanning
+        THEN it should fail with a usage error naming the pattern
+        """
+        write_text(Path("file_secret"), _ONE_LINE_AND_MULTILINE_PATCH)
+        write_text(
+            Path(".gitguardian.yaml"),
+            f"version: 2\nsecret:\n  ignored_match_patterns:\n    - '{INVALID_REGEX_PATTERN}'\n",
+        )
+
+        result = cli_fs_runner.invoke(cli, ["secret", "scan", "path", "file_secret"])
+
+        assert result.exit_code == ExitCode.USAGE_ERROR, result.output
+        assert INVALID_REGEX_PATTERN in result.output
 
     @patch("pygitguardian.GGClient.multi_content_scan")
     @my_vcr.use_cassette("test_scan_context_repository.yaml")

--- a/tests/unit/core/config/test_user_config.py
+++ b/tests/unit/core/config/test_user_config.py
@@ -13,6 +13,7 @@ from ggshield.core.config.user_config import (
 )
 from ggshield.core.errors import ParseError, UnexpectedError
 from ggshield.core.types import IgnoredMatch
+from tests.factory_constants import SOPS_PATTERN
 from tests.unit.conftest import write_text, write_yaml
 
 
@@ -345,6 +346,33 @@ class TestUserConfig:
         result = json.loads(config.dump_for_monitoring())
         assert isinstance(result["source_uuid"], str)
         assert result["source_uuid"] == str(uid)
+
+    def test_ignored_match_patterns_from_config_file(self, local_config_path):
+        """
+        GIVEN a config file holding ignore patterns
+        WHEN loading the configuration
+        THEN the patterns should be read
+        """
+        write_yaml(
+            local_config_path,
+            {"version": 2, "secret": {"ignored_match_patterns": [SOPS_PATTERN]}},
+        )
+
+        config = Config()
+
+        assert config.user_config.secret.ignored_match_patterns == {SOPS_PATTERN}
+
+    def test_dump_for_monitoring_counts_ignored_match_patterns(self):
+        """
+        GIVEN a SecretConfig with ignored match patterns
+        WHEN dump_for_monitoring() is called
+        THEN it should report how many patterns are configured
+        """
+        config = SecretConfig(ignored_match_patterns={"^ENC\\[", "^vault:"})
+
+        result = json.loads(config.dump_for_monitoring())
+
+        assert result["ignored_match_patterns_count"] == 2
 
     def test_bad_local_config(self, local_config_path, global_config_path):
         """

--- a/tests/unit/core/test_filter.py
+++ b/tests/unit/core/test_filter.py
@@ -1,11 +1,25 @@
 import copy
 import random
+import re
 from typing import List, Set
 
 import pytest
+from click import UsageError
 from pygitguardian.models import Match, PolicyBreak
 
-from ggshield.core.filter import censor_match, censor_string, get_ignore_sha
+from ggshield.core.filter import (
+    censor_match,
+    censor_string,
+    get_ignore_sha,
+    is_in_ignored_match_patterns,
+    validate_ignored_match_patterns,
+)
+from tests.factories import build_policy_break
+from tests.factory_constants import (
+    INVALID_REGEX_PATTERN,
+    SOPS_ENCRYPTED_VALUE,
+    SOPS_PATTERN,
+)
 from tests.unit.conftest import (
     _MULTILINE_SECRET,
     _MULTIPLE_SECRETS_SCAN_RESULT,
@@ -129,3 +143,96 @@ def test_censor_match(input_match: Match, expected_value: str) -> None:
 def test_censor_string(text: str, expected: str) -> None:
     censored = censor_string(text)
     assert censored == expected
+
+
+class TestIsInIgnoredMatchPatterns:
+    def test_without_pattern(self) -> None:
+        """
+        GIVEN a policy break and no ignore pattern
+        WHEN checking whether it is ignored
+        THEN it should not be
+        """
+        policy_break = build_policy_break(SOPS_ENCRYPTED_VALUE)
+
+        assert is_in_ignored_match_patterns(policy_break, []) is False
+
+    def test_matching_pattern(self) -> None:
+        """
+        GIVEN a policy break whose match is a sops-encrypted value
+        WHEN checking it against a pattern for sops-encrypted values
+        THEN it should be ignored
+        """
+        policy_break = build_policy_break(SOPS_ENCRYPTED_VALUE)
+
+        assert is_in_ignored_match_patterns(policy_break, [SOPS_PATTERN]) is True
+
+    def test_non_matching_pattern(self) -> None:
+        """
+        GIVEN a policy break whose match is a plaintext secret
+        WHEN checking it against a pattern for sops-encrypted values
+        THEN it should not be ignored
+        """
+        policy_break = build_policy_break("hunter2")
+
+        assert is_in_ignored_match_patterns(policy_break, [SOPS_PATTERN]) is False
+
+    def test_one_matching_pattern_among_several(self) -> None:
+        """
+        GIVEN a policy break whose match is a sops-encrypted value
+        WHEN checking it against several patterns, one of which matches
+        THEN it should be ignored
+        """
+        policy_break = build_policy_break(SOPS_ENCRYPTED_VALUE)
+
+        assert (
+            is_in_ignored_match_patterns(policy_break, ["^vault:", SOPS_PATTERN])
+            is True
+        )
+
+    def test_one_matching_match_among_several(self) -> None:
+        """
+        GIVEN a policy break carrying several matches, one of which is sops-encrypted
+        WHEN checking it against a pattern for sops-encrypted values
+        THEN it should be ignored
+        """
+        policy_break = build_policy_break("admin", SOPS_ENCRYPTED_VALUE)
+
+        assert is_in_ignored_match_patterns(policy_break, [SOPS_PATTERN]) is True
+
+    def test_unanchored_pattern(self) -> None:
+        """
+        GIVEN a policy break whose match contains a sops algorithm name
+        WHEN checking it against an unanchored pattern
+        THEN it should be ignored, the pattern being searched anywhere in the match
+        """
+        policy_break = build_policy_break(SOPS_ENCRYPTED_VALUE)
+
+        assert is_in_ignored_match_patterns(policy_break, ["AES256_GCM"]) is True
+
+
+class TestValidateIgnoredMatchPatterns:
+    def test_valid_patterns(self) -> None:
+        """
+        GIVEN patterns which are valid regexes
+        WHEN validating them
+        THEN it should be accepted
+        """
+        validate_ignored_match_patterns([SOPS_PATTERN, "^vault:"])
+
+    def test_invalid_pattern(self) -> None:
+        """
+        GIVEN a pattern which is not a valid regex
+        WHEN validating it
+        THEN it should raise a usage error naming the pattern
+        """
+        with pytest.raises(UsageError, match=re.escape(INVALID_REGEX_PATTERN)):
+            validate_ignored_match_patterns([INVALID_REGEX_PATTERN])
+
+    def test_empty_pattern(self) -> None:
+        """
+        GIVEN an empty pattern, which would match every secret
+        WHEN validating it
+        THEN it should raise a usage error instead of silencing all detection
+        """
+        with pytest.raises(UsageError, match="should not be empty"):
+            validate_ignored_match_patterns([SOPS_PATTERN, ""])

--- a/tests/unit/verticals/secret/test_secret_scan_collection.py
+++ b/tests/unit/verticals/secret/test_secret_scan_collection.py
@@ -14,7 +14,13 @@ from ggshield.verticals.secret.secret_scan_collection import (
     Result,
     compute_ignore_reason,
 )
-from tests.factories import PolicyBreakFactory, ScannableFactory, ScanResultFactory
+from tests.factories import (
+    PolicyBreakFactory,
+    ScannableFactory,
+    ScanResultFactory,
+    build_policy_break,
+)
+from tests.factory_constants import SOPS_ENCRYPTED_VALUE, SOPS_PATTERN
 from tests.unit.conftest import (
     _ONE_LINE_AND_MULTILINE_PATCH_CONTENT,
     _ONE_LINE_AND_MULTILINE_PATCH_SCAN_RESULT,
@@ -202,6 +208,30 @@ class TestComputeIgnoreReason:
             ignored_detectors=[policy_break.break_type],
         )
         assert compute_ignore_reason(policy_break, config) is not None
+
+    def test_ignore_ignored_match_pattern(self):
+        """
+        GIVEN a policy break whose match is a sops-encrypted value
+        WHEN computing the ignore reason with a matching pattern in config
+        THEN it should be ignored as a match pattern
+        """
+        policy_break = build_policy_break(SOPS_ENCRYPTED_VALUE)
+        config = SecretConfig(ignored_match_patterns={SOPS_PATTERN})
+
+        assert compute_ignore_reason(policy_break, config) == IgnoreReason(
+            IgnoreKind.IGNORED_MATCH_PATTERN
+        )
+
+    def test_non_matching_ignored_match_pattern(self):
+        """
+        GIVEN a policy break whose match is a plaintext secret
+        WHEN computing the ignore reason with a pattern matching nothing
+        THEN it should not be ignored
+        """
+        policy_break = build_policy_break("hunter2")
+        config = SecretConfig(ignored_match_patterns={SOPS_PATTERN})
+
+        assert compute_ignore_reason(policy_break, config) is None
 
     @pytest.mark.parametrize("ignore_known", (True, False))
     def test_known_secret(self, ignore_known):


### PR DESCRIPTION
## Context

Closes #1394

Secrets encrypted at rest trigger detection on the ciphertext. A sops value is routinely reported as a `Generic Password`:

```
$ ggshield secret scan path secrets.yaml --json
... "occurrences": [{"match": "ENC[AES256_GCM,data****...", ...}], "type": "Generic Password", ... "total_incidents": 1 ...
```

Ignoring matches based on regexes would solve a real-world problem and make ggshield even more usable.

No existing mechanism fits a whole family of values like this one: `ignored_matches` needs each secret listed and goes stale on re-encryption, `ignored_paths` hides real secrets alongside, `--banlist-detector` loses the detector everywhere.

I don't know how to say it better than it's already been said on [GitGuardian's own website](https://www.gitguardian.com/comparisons/trufflehog-v3#comparison:~:text=The%20ability%20to%20reduce%20the%20number%20of%20incidents) (talking about filepath exclusions):

> The ability to reduce the number of incidents and concentrate solely on those that matter most is critical to scaling your secrets detection and remediation program.

This feature goes further, definitely in the same correct direction, by proposing filtering out false positives based on regex patterns -- ignoring more noise to let the real signals get noticed better.

## What has been done

This implements the API described in the issue.

- **`--ignore-match-pattern PATTERN` on `ggshield secret scan`**, repeatable, on every subcommand. A finding is ignored when one of its match values is matched by a pattern, searched anywhere in the value
- **`secret.ignored_match_patterns` in `../.gitguardian.yaml`**, so a team commits the rule once instead of everyone typing the flag. CLI and config patterns add up
- **Ignored findings stay visible** under `--all-secrets`, with a new `IGNORED_MATCH_PATTERN` reason
- **Bad patterns fail the command, not the scan.** Validated at startup: an uncompilable regex (or an empty one, which would match every value and silently switch detection off) exits with a usage error naming it

## Validation

Set up a "secret" to trigger a false positive

```sh
mkdir tmp_1394_ggsops && cd tmp_1394_ggsops
printf 'password: ENC[AES256_GCM,data:Zm9vYmFyYmF6,iv:9Xk1Nw==,tag:Qk5tZw==,type:str]\n' > secrets.yaml

#Reproduce: the ciphertext is reported
ggshield secret scan path secrets.yaml

#Validate: nothing is reported
ggshield secret scan path secrets.yaml --ignore-match-pattern '^ENC\[AES256_GCM,data:'

#Still auditable, with its ignore reason
ggshield secret scan path secrets.yaml -v --all-secrets --ignore-match-pattern '^ENC\[AES256_GCM,data:'

#Usage error naming the pattern, before any scan
ggshield secret scan path secrets.yaml --ignore-match-pattern '^ENC['

#Refuses, rather than quietly ignoring every secret
ggshield secret scan path secrets.yaml --ignore-match-pattern ''
```

And you can check that you get the same result from setting it in `../.gitguardian.yaml` instead of using the command flag:

```yaml
secret:
  ignored_match_patterns:
    - '^ENC\[AES256_GCM,data:'
```

## PR check list

- [x] All tests pass
- [x] Linters are happy
- [x] Changes include tests
- [x] PR has a changelog entry
