### PR TITLE
feat(machine): install the account's plugins during machine setup

### DIFF
--- a/changelog.d/20260827_120000_clement.tourriere_machine_setup_plugins.md
+++ b/changelog.d/20260827_120000_clement.tourriere_machine_setup_plugins.md
@@ -1,0 +1,10 @@
+### Added
+
+- `ggshield machine setup` now also installs the plugins the account is entitled
+  to — including `machine_scan`, which provides `ggshield machine scan` — instead
+  of leaving that to a manual `ggshield plugin install`. Entitlement comes from
+  the platform catalog, so an account with no plugins available (or a workspace
+  with the plugin system off) simply skips the step rather than failing the
+  setup. Signature verification stays strict, an already-installed plugin is left
+  untouched (upgrades remain `ggshield plugin update`), and a root run installs
+  machine-wide like the git hooks. Skip the step with `--no-plugins`.

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -17,6 +17,15 @@ from ggshield.cmd.install import (
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config
+from ggshield.core.config.enterprise_config import EnterpriseConfig
+from ggshield.core.plugin.client import (
+    PluginAPIClient,
+    PluginInfo,
+    PluginsNotEnabledError,
+)
+from ggshield.core.plugin.downloader import PluginDownloader
+from ggshield.core.plugin.installer import install_plugin_from_platform
 from ggshield.utils.os import is_root
 from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.installation import (
@@ -44,6 +53,11 @@ _GIT_HOOK_TYPES = ("pre-commit", "pre-push")
     "--no-honeytokens",
     is_flag=True,
     help="Do not plant a honeytoken on this machine.",
+)
+@click.option(
+    "--no-plugins",
+    is_flag=True,
+    help="Do not install the plugins available to this account.",
 )
 @click.option(
     "--agent",
@@ -76,6 +90,7 @@ def setup_cmd(
     no_ai_hooks: bool,
     no_git_hooks: bool,
     no_honeytokens: bool,
+    no_plugins: bool,
     agents: Tuple[str, ...],
     exclude_agents: Tuple[str, ...],
     system: bool,
@@ -86,13 +101,18 @@ def setup_cmd(
 
     Configures every protection in one idempotent run: the ggshield AI hook for
     each detected AI coding assistant, the global git pre-commit/pre-push hooks,
-    and a honeytoken to detect endpoint intrusion. Safe to re-run — it adds what
-    is missing and leaves existing entries untouched.
+    the plugins this account is entitled to (e.g. `machine_scan`, which provides
+    `ggshield machine scan`), and a honeytoken to detect endpoint intrusion. Safe
+    to re-run — it adds what is missing and leaves existing entries untouched.
 
     Each protection is on by default; drop one with `--no-ai-hooks`,
-    `--no-git-hooks`, or `--no-honeytokens`. `--agent` / `--exclude-agent`
-    narrow which assistants get the AI hook. When run as root (or with
-    `--system`), the git hooks are installed machine-wide for every user.
+    `--no-git-hooks`, `--no-plugins`, or `--no-honeytokens`. `--agent` /
+    `--exclude-agent` narrow which assistants get the AI hook. When run as root
+    (or with `--system`), the git hooks and the plugins are installed
+    machine-wide for every user.
+
+    Plugins are gated by the GitGuardian plan: an account with none available
+    simply skips that step, it is not a setup failure.
     """
     if agents and exclude_agents:
         raise click.UsageError("--agent and --exclude-agent cannot be used together.")
@@ -105,6 +125,10 @@ def setup_cmd(
 
     if not no_git_hooks:
         if not _setup_git_hooks(system):
+            failed = True
+
+    if not no_plugins:
+        if not _setup_plugins(ctx):
             failed = True
 
     if not no_honeytokens:
@@ -207,6 +231,84 @@ def _setup_git_hooks(system: bool) -> bool:
             "this per repo)."
         )
     return ok
+
+
+def _setup_plugins(ctx: click.Context) -> bool:
+    """Install every plugin this account is entitled to. Returns False on failure.
+
+    Entitlement is the platform's answer, not a guess: the catalog marks each
+    plugin `available`, with a `reason` when it is not. So there is nothing to
+    hardcode about plans here — install what comes back available.
+
+    Having no plugins available (free plan, or the plugin system off for the
+    workspace) is a normal outcome and must not fail the setup, no more than
+    having no AI assistant installed does. Only a plugin the account *is*
+    entitled to failing to install counts as a failure.
+
+    Under root this installs machine-wide, like the git hooks: `PluginDownloader`
+    lands the wheel in the system plugin dir so every user on the machine gets it.
+    """
+    click.echo(click.style("Plugins", bold=True))
+    config = ContextObj.get(ctx).config
+
+    try:
+        client = create_client_from_config(config)
+        plugin_api_client = PluginAPIClient(client)
+        catalog = plugin_api_client.get_available_plugins()
+    except PluginsNotEnabledError:
+        click.echo("  the plugin system is not enabled on this workspace; skipped")
+        return True
+    except Exception as exc:  # noqa: BLE001 - an unreachable catalog is not a failure
+        ui.display_warning(f"  could not fetch the plugin catalog: {exc}; skipped")
+        return True
+
+    available = [plugin for plugin in catalog.plugins if plugin.available]
+    if not available:
+        click.echo("  no plugins available for this account")
+        for plugin in catalog.plugins:
+            if plugin.reason:
+                click.echo(f"    {plugin.name}: {plugin.reason}")
+        return True
+
+    downloader = PluginDownloader()
+    enterprise_config = EnterpriseConfig.load()
+
+    ok = True
+    for plugin in available:
+        installed_version = downloader.get_installed_version(plugin.name)
+        if installed_version is not None:
+            click.echo(
+                f"  {plugin.name} already installed{_update_hint(plugin, installed_version)}"
+            )
+            continue
+        try:
+            installed = install_plugin_from_platform(
+                plugin_api_client,
+                plugin.name,
+                downloader=downloader,
+                enterprise_config=enterprise_config,
+            )
+        except Exception as exc:  # noqa: BLE001 - one plugin must not abort the rest
+            ui.display_warning(f"  could not install {plugin.name}: {exc}")
+            ok = False
+            continue
+        click.echo(f"  installed {installed.name} v{installed.version}")
+    return ok
+
+
+def _update_hint(plugin: PluginInfo, installed_version: str) -> str:
+    """Report the installed version, and point at `plugin update` if it is behind.
+
+    `setup` deliberately does not upgrade: it adds what is missing and leaves
+    what is there alone, so a re-run never swaps a working plugin out from under
+    a machine. Upgrading stays an explicit `ggshield plugin update`.
+    """
+    if plugin.latest_version and plugin.latest_version != installed_version:
+        return (
+            f" v{installed_version} (v{plugin.latest_version} available, "
+            "run `ggshield plugin update`)"
+        )
+    return f" v{installed_version}"
 
 
 def _setup_honeytokens(ctx: click.Context) -> bool:

--- a/ggshield/cmd/plugin/install.py
+++ b/ggshield/cmd/plugin/install.py
@@ -26,6 +26,7 @@ from ggshield.core.plugin.downloader import (
     InsecureSourceError,
     PluginDownloader,
 )
+from ggshield.core.plugin.installer import install_plugin_from_platform
 from ggshield.core.plugin.loader import enable_installed_plugin
 from ggshield.core.plugin.platform import get_platform_info
 from ggshield.core.plugin.signature import (
@@ -199,48 +200,20 @@ def _install_from_gitguardian(
 
     downloader = PluginDownloader()
     enterprise_config = EnterpriseConfig.load()
-    platform_info = get_platform_info()
 
     ui.display_info(f"Installing {plugin_name}...")
 
     try:
-        with plugin_api_client.download_plugin(
-            plugin_name, platform_info=platform_info, version=version
-        ) as (info, chunks):
-            bundle_bytes: Optional[bytes] = None
-            if info.signature_url:
-                try:
-                    bundle_bytes = plugin_api_client.download_signature_bundle(
-                        info.signature_url
-                    )
-                except PluginAPIError as bundle_err:
-                    # In STRICT mode, an unreachable bundle is a hard
-                    # failure — the user expects signature verification.
-                    # In WARN mode they have opted into accepting
-                    # unsigned plugins, so a bundle the proxy couldn't
-                    # serve is equivalent to "no signature available"
-                    # rather than a reason to abort an otherwise valid
-                    # wheel download.
-                    if signature_mode == SignatureVerificationMode.STRICT:
-                        raise
-                    ui.display_warning(
-                        f"Could not fetch signature bundle for {plugin_name}: "
-                        f"{bundle_err}. Continuing without verification "
-                        f"(--allow-unsigned)."
-                    )
-            wheel_path = downloader.download_and_install(
-                info,
-                chunks,
-                plugin_name,
-                signature_mode=signature_mode,
-                bundle_bytes=bundle_bytes,
-            )
-
-        installed_name = enable_installed_plugin(
-            enterprise_config, plugin_name, info.version, wheel_path
+        installed = install_plugin_from_platform(
+            plugin_api_client,
+            plugin_name,
+            version=version,
+            signature_mode=signature_mode,
+            downloader=downloader,
+            enterprise_config=enterprise_config,
+            platform_info=get_platform_info(),
         )
-        enterprise_config.save()
-        ui.display_info(f"Installed {installed_name} v{info.version}")
+        ui.display_info(f"Installed {installed.name} v{installed.version}")
 
     except SignatureVerificationError as e:
         ui.display_error(f"Signature verification failed for {plugin_name}: {e}")

--- a/ggshield/core/plugin/installer.py
+++ b/ggshield/core/plugin/installer.py
@@ -1,0 +1,95 @@
+"""
+Install a plugin from the GitGuardian platform.
+
+Shared by `ggshield plugin install <name>` and `ggshield machine setup`. The
+command turns every failure into a non-zero exit; setup keeps going and reports.
+Only the mechanics live here — download, verify, unpack, enable — so each caller
+decides what a failure means.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ggshield.core import ui
+from ggshield.core.config.enterprise_config import EnterpriseConfig
+from ggshield.core.plugin.client import PluginAPIClient, PluginAPIError
+from ggshield.core.plugin.downloader import PluginDownloader
+from ggshield.core.plugin.loader import enable_installed_plugin
+from ggshield.core.plugin.platform import PlatformInfo, get_platform_info
+from ggshield.core.plugin.signature import SignatureVerificationMode
+
+
+@dataclass
+class InstalledPlugin:
+    """A plugin that was just installed and enabled."""
+
+    name: str  # canonical config key it was enabled under, not the catalog reference
+    version: str
+
+
+def install_plugin_from_platform(
+    plugin_api_client: PluginAPIClient,
+    plugin_name: str,
+    *,
+    version: Optional[str] = None,
+    signature_mode: SignatureVerificationMode = SignatureVerificationMode.STRICT,
+    downloader: Optional[PluginDownloader] = None,
+    enterprise_config: Optional[EnterpriseConfig] = None,
+    platform_info: Optional[PlatformInfo] = None,
+) -> InstalledPlugin:
+    """Download, verify and enable ``plugin_name`` from the platform catalog.
+
+    The caller is expected to have checked the plugin is available for the
+    account; this goes straight to the download endpoint, which enforces
+    entitlement server-side anyway (403 -> ``PluginNotAvailableError``).
+
+    ``downloader`` and ``enterprise_config`` can be passed in so a caller
+    installing several plugins in a row reuses one of each.
+
+    Raises:
+        PluginNotAvailableError: The account cannot install this plugin.
+        PluginAPIError: The platform call failed.
+        SignatureVerificationError: STRICT mode and the signature is invalid.
+        DownloadError, ChecksumMismatchError: The wheel could not be installed.
+    """
+    downloader = downloader if downloader is not None else PluginDownloader()
+    if enterprise_config is None:
+        enterprise_config = EnterpriseConfig.load()
+    if platform_info is None:
+        platform_info = get_platform_info()
+
+    with plugin_api_client.download_plugin(
+        plugin_name, platform_info=platform_info, version=version
+    ) as (info, chunks):
+        bundle_bytes: Optional[bytes] = None
+        if info.signature_url:
+            try:
+                bundle_bytes = plugin_api_client.download_signature_bundle(
+                    info.signature_url
+                )
+            except PluginAPIError as bundle_err:
+                # In STRICT mode, an unreachable bundle is a hard failure — the
+                # caller expects signature verification. In WARN mode they have
+                # opted into accepting unsigned plugins, so a bundle the proxy
+                # couldn't serve is equivalent to "no signature available"
+                # rather than a reason to abort an otherwise valid download.
+                if signature_mode == SignatureVerificationMode.STRICT:
+                    raise
+                ui.display_warning(
+                    f"Could not fetch signature bundle for {plugin_name}: "
+                    f"{bundle_err}. Continuing without verification "
+                    f"(--allow-unsigned)."
+                )
+        wheel_path = downloader.download_and_install(
+            info,
+            chunks,
+            plugin_name,
+            signature_mode=signature_mode,
+            bundle_bytes=bundle_bytes,
+        )
+
+    installed_name = enable_installed_plugin(
+        enterprise_config, plugin_name, info.version, wheel_path
+    )
+    enterprise_config.save()
+    return InstalledPlugin(name=installed_name, version=info.version)

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -8,6 +9,13 @@ from click.testing import CliRunner
 from pygitguardian.models import HealthCheckResponse
 
 from ggshield.__main__ import cli
+from ggshield.core.plugin.client import (
+    PluginAPIError,
+    PluginCatalog,
+    PluginInfo,
+    PluginsNotEnabledError,
+)
+from ggshield.core.plugin.installer import InstalledPlugin
 from ggshield.verticals.ai.installation import (
     SetupSummary,
     install_all_agent_hooks,
@@ -214,56 +222,76 @@ class TestMachineSetupCommand:
 
 
 class TestMachineSetupOrchestration:
-    """`machine setup` runs all three protections by default; flags drop one."""
+    """`machine setup` runs all four protections by default; flags drop one."""
 
     AI = "ggshield.cmd.machine.setup._setup_ai_hooks"
     GIT = "ggshield.cmd.machine.setup._setup_git_hooks"
     HT = "ggshield.cmd.machine.setup._setup_honeytokens"
+    PLUGINS = "ggshield.cmd.machine.setup._setup_plugins"
 
-    def _run(self, cli_fs_runner, args, ai=True, git=True, ht=True):
+    def _run(self, cli_fs_runner, args, ai=True, git=True, ht=True, plugins=True):
         with patch(self.AI, return_value=ai) as m_ai, patch(
             self.GIT, return_value=git
-        ) as m_git, patch(self.HT, return_value=ht) as m_ht:
+        ) as m_git, patch(self.HT, return_value=ht) as m_ht, patch(
+            self.PLUGINS, return_value=plugins
+        ) as m_plugins:
             result = cli_fs_runner.invoke(cli, ["machine", "setup", *args])
-        return result, m_ai, m_git, m_ht
+        return result, m_ai, m_git, m_ht, m_plugins
 
     def test_runs_all_features_by_default(self, cli_fs_runner: CliRunner):
-        result, m_ai, m_git, m_ht = self._run(cli_fs_runner, [])
+        result, m_ai, m_git, m_ht, m_plugins = self._run(cli_fs_runner, [])
         assert_invoke_ok(result)
         m_ai.assert_called_once()
         m_git.assert_called_once()
         m_ht.assert_called_once()
+        m_plugins.assert_called_once()
 
     def test_no_ai_hooks_skips_ai(self, cli_fs_runner: CliRunner):
-        result, m_ai, m_git, m_ht = self._run(cli_fs_runner, ["--no-ai-hooks"])
+        result, m_ai, m_git, m_ht, _m_plugins = self._run(
+            cli_fs_runner, ["--no-ai-hooks"]
+        )
         assert_invoke_ok(result)
         m_ai.assert_not_called()
         m_git.assert_called_once()
         m_ht.assert_called_once()
 
     def test_no_git_hooks_skips_git(self, cli_fs_runner: CliRunner):
-        result, _m_ai, m_git, _m_ht = self._run(cli_fs_runner, ["--no-git-hooks"])
+        result, _m_ai, m_git, *_ = self._run(cli_fs_runner, ["--no-git-hooks"])
         assert_invoke_ok(result)
         m_git.assert_not_called()
 
     def test_no_honeytokens_skips_honeytokens(self, cli_fs_runner: CliRunner):
-        result, _m_ai, _m_git, m_ht = self._run(cli_fs_runner, ["--no-honeytokens"])
+        result, _m_ai, _m_git, m_ht, _m_plugins = self._run(
+            cli_fs_runner, ["--no-honeytokens"]
+        )
         assert_invoke_ok(result)
         m_ht.assert_not_called()
 
+    def test_no_plugins_skips_plugins(self, cli_fs_runner: CliRunner):
+        result, _m_ai, _m_git, m_ht, m_plugins = self._run(
+            cli_fs_runner, ["--no-plugins"]
+        )
+        assert_invoke_ok(result)
+        m_plugins.assert_not_called()
+        m_ht.assert_called_once()
+
     def test_failing_feature_returns_nonzero(self, cli_fs_runner: CliRunner):
-        result, _m_ai, _m_git, _m_ht = self._run(cli_fs_runner, [], git=False)
+        result, *_ = self._run(cli_fs_runner, [], git=False)
+        assert result.exit_code == 1
+
+    def test_failing_plugin_step_returns_nonzero(self, cli_fs_runner: CliRunner):
+        result, *_ = self._run(cli_fs_runner, [], plugins=False)
         assert result.exit_code == 1
 
     def test_system_flag_forwarded_to_git_hooks(self, cli_fs_runner: CliRunner):
-        result, _m_ai, m_git, _m_ht = self._run(
+        result, _m_ai, m_git, *_ = self._run(
             cli_fs_runner, ["--system", "--no-ai-hooks", "--no-honeytokens"]
         )
         assert_invoke_ok(result)
         m_git.assert_called_once_with(True)
 
     def test_git_hooks_default_to_non_system(self, cli_fs_runner: CliRunner):
-        result, _m_ai, m_git, _m_ht = self._run(
+        result, _m_ai, m_git, *_ = self._run(
             cli_fs_runner, ["--no-ai-hooks", "--no-honeytokens"]
         )
         assert_invoke_ok(result)
@@ -378,3 +406,142 @@ class TestHoneytokenPlant:
         """`honeytoken plant` stays a first-class command (not deprecated)."""
         result = cli_fs_runner.invoke(cli, ["honeytoken", "plant"])
         assert "deprecated" not in result.output.lower()
+
+
+class TestSetupPlugins:
+    """The plugin step installs what the account is entitled to, and only that.
+
+    Entitlement comes from the catalog (`available` / `reason`), so these tests
+    drive the catalog rather than any notion of a plan.
+    """
+
+    BASE = "ggshield.cmd.machine.setup"
+
+    def _plugin(self, name="machine_scan", available=True, latest="1.2.0", reason=None):
+        return PluginInfo(
+            name=name,
+            display_name=name.replace("_", " ").title(),
+            description="",
+            available=available,
+            latest_version=latest,
+            reason=reason,
+        )
+
+    @contextmanager
+    def _catalog(self, plugins=None, error=None, installed=None):
+        """Pin the catalog call and the installed-version lookup."""
+        api_client = Mock()
+        if error is not None:
+            api_client.get_available_plugins.side_effect = error
+        else:
+            api_client.get_available_plugins.return_value = PluginCatalog(
+                plugins=plugins or []
+            )
+        downloader = Mock()
+        downloader.get_installed_version.side_effect = lambda name: (
+            installed or {}
+        ).get(name)
+        with patch(f"{self.BASE}.create_client_from_config"), patch(
+            f"{self.BASE}.PluginAPIClient", return_value=api_client
+        ), patch(f"{self.BASE}.PluginDownloader", return_value=downloader), patch(
+            f"{self.BASE}.EnterpriseConfig"
+        ), patch(
+            f"{self.BASE}.install_plugin_from_platform"
+        ) as m_install:
+            yield m_install
+
+    def _run(self, cli_fs_runner):
+        return cli_fs_runner.invoke(
+            cli,
+            ["machine", "setup", "--no-ai-hooks", "--no-git-hooks", "--no-honeytokens"],
+        )
+
+    def test_installs_every_available_plugin(self, cli_fs_runner: CliRunner):
+        plugins = [self._plugin("machine_scan"), self._plugin("tokenscanner")]
+        with self._catalog(plugins) as m_install:
+            m_install.side_effect = lambda _client, name, **kwargs: InstalledPlugin(
+                name=name, version="1.2.0"
+            )
+            result = self._run(cli_fs_runner)
+        assert_invoke_ok(result)
+        assert [call.args[1] for call in m_install.call_args_list] == [
+            "machine_scan",
+            "tokenscanner",
+        ]
+        assert "installed machine_scan v1.2.0" in result.output
+
+    def test_skips_plugin_the_account_cannot_install(self, cli_fs_runner: CliRunner):
+        plugins = [
+            self._plugin(
+                "machine_scan",
+                available=False,
+                latest=None,
+                reason="Business or Enterprise plans only",
+            )
+        ]
+        with self._catalog(plugins) as m_install:
+            result = self._run(cli_fs_runner)
+        # Not entitled is a normal outcome, not a setup failure.
+        assert_invoke_ok(result)
+        m_install.assert_not_called()
+        assert "no plugins available for this account" in result.output
+        assert "Business or Enterprise plans only" in result.output
+
+    def test_plugin_system_disabled_is_not_a_failure(self, cli_fs_runner: CliRunner):
+        with self._catalog(error=PluginsNotEnabledError()) as m_install:
+            result = self._run(cli_fs_runner)
+        assert_invoke_ok(result)
+        m_install.assert_not_called()
+        assert "not enabled on this workspace" in result.output
+
+    def test_unreachable_catalog_is_not_a_failure(self, cli_fs_runner: CliRunner):
+        with self._catalog(error=PluginAPIError("boom")) as m_install:
+            result = self._run(cli_fs_runner)
+        assert_invoke_ok(result)
+        m_install.assert_not_called()
+        assert "could not fetch the plugin catalog" in result.output
+
+    def test_already_installed_plugin_is_left_alone(self, cli_fs_runner: CliRunner):
+        with self._catalog(
+            [self._plugin("machine_scan", latest="1.2.0")],
+            installed={"machine_scan": "1.2.0"},
+        ) as m_install:
+            result = self._run(cli_fs_runner)
+        assert_invoke_ok(result)
+        m_install.assert_not_called()
+        assert "machine_scan already installed v1.2.0" in result.output
+
+    def test_outdated_plugin_points_at_plugin_update(self, cli_fs_runner: CliRunner):
+        # `setup` adds what is missing; upgrading stays an explicit `plugin update`.
+        with self._catalog(
+            [self._plugin("machine_scan", latest="1.3.0")],
+            installed={"machine_scan": "1.2.0"},
+        ) as m_install:
+            result = self._run(cli_fs_runner)
+        assert_invoke_ok(result)
+        m_install.assert_not_called()
+        assert "v1.3.0 available" in result.output
+        assert "ggshield plugin update" in result.output
+
+    def test_failed_install_of_entitled_plugin_fails_setup(
+        self, cli_fs_runner: CliRunner
+    ):
+        with self._catalog([self._plugin("machine_scan")]) as m_install:
+            m_install.side_effect = PluginAPIError("download failed")
+            result = self._run(cli_fs_runner)
+        assert result.exit_code == 1
+        assert "could not install machine_scan" in result.output
+
+    def test_one_failing_plugin_does_not_stop_the_others(
+        self, cli_fs_runner: CliRunner
+    ):
+        plugins = [self._plugin("machine_scan"), self._plugin("tokenscanner")]
+        with self._catalog(plugins) as m_install:
+            m_install.side_effect = [
+                PluginAPIError("download failed"),
+                InstalledPlugin(name="tokenscanner", version="1.2.0"),
+            ]
+            result = self._run(cli_fs_runner)
+        assert result.exit_code == 1
+        assert "could not install machine_scan" in result.output
+        assert "installed tokenscanner v1.2.0" in result.output


### PR DESCRIPTION
Closes #1439.

`ggshield machine setup` configured the AI hooks, the git hooks and a honeytoken, then left `machine_scan` — the plugin that provides `ggshield machine scan`, and that `ggshield machine doctor` checks for — to a manual `ggshield plugin install`. So the command meant to set the machine up was the one that didn't install what doctor then asks for.

### Entitlement is asked, not guessed

The catalog (`GET /v1/endpoints/plugins`) already answers per account: `available: true` + `latest_version`, `available: false` + `reason`, or 404 when the plugin system is off for the workspace. Setup asks and installs what comes back available — nothing about plans is hardcoded, and no new endpoint was needed.

### What the step does

- Installs every `available: true` plugin in the catalog, with signature verification **STRICT** (no `--allow-unsigned` equivalent on `setup`).
- Nothing available, plugin system off, or an unreachable catalog → one line and **skip**. A free-plan account is a normal outcome, not a setup failure, no more than having no AI assistant installed is. Unavailable plugins print the server's `reason`.
- An *entitled* plugin failing to install → warning and non-zero exit, but the loop continues to the next plugin.
- Already installed → left untouched, with a `ggshield plugin update` pointer when the catalog has something newer. `setup` adds what is missing; it never swaps a working plugin out from under a machine.
- New `--no-plugins` opt-out, alongside `--no-ai-hooks` / `--no-git-hooks` / `--no-honeytokens`.
- A root run installs machine-wide for free: `PluginDownloader` already routes to the system plugin dir under `is_root()`, so one root `machine setup` provisions a fleet machine end to end.

### Refactor (first commit)

`_install_from_gitguardian` turned every failure into a `ctx.exit()`, so nothing else could reuse the download → verify → enable sequence. It moves to `ggshield/core/plugin/installer.py` as `install_plugin_from_platform()`, raising typed errors instead; `plugin install` keeps its exact exit-code behavior, and setup gets to keep going. The helper takes an optional `PluginDownloader` / `EnterpriseConfig` so a caller installing several plugins reuses one of each.

### Decisions worth a second opinion

Both were open questions on the issue; I picked and documented them in the code:

1. **Catalog-driven, not `machine_scan` by name** — future-proof and the same amount of code, but it does mean a plugin added to the catalog later starts installing itself on `setup`. Say the word if you'd rather it were a hardcoded allowlist.
2. **No upgrade on re-run** — upgrading stays `ggshield plugin update`.

### Testing

- 2715 unit tests pass, including 9 new `TestSetupPlugins` cases (installs all available, skips unentitled with reason, plugin system off, unreachable catalog, already installed, outdated → update hint, failed entitled install → exit 1, one failure doesn't stop the rest) and the updated orchestration harness.
- black / isort / flake8 clean, pyright 0 errors, import-linter both contracts KEPT — the new imports are all `cmd → core`, so no new layering exception was needed.
- Not exercised against a live instance: that installs a real wheel on a real machine, so it wants a reviewer with an entitled account.
