### PR TITLE
fix(machine): report unavailable protections instead of failing

### DIFF
--- a/changelog.d/20260817_120000_achille.mascia_plant_forbidden_message.md
+++ b/changelog.d/20260817_120000_achille.mascia_plant_forbidden_message.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `ggshield honeytoken plant` explains a `403` (honeytoken module disabled, insufficient
+  user permissions, or a token without `honeytokens:write`) instead of printing the raw
+  API response body.

--- a/changelog.d/20260817_121000_achille.mascia_login_honors_requested_scopes.md
+++ b/changelog.d/20260817_121000_achille.mascia_login_honors_requested_scopes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `ggshield auth login --scopes` no longer reports "already authenticated" when the
+  configured token lacks one of the requested scopes: it authenticates again to get a
+  token that carries them.

--- a/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
+++ b/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
@@ -1,0 +1,11 @@
+### Changed
+
+- `ggshield machine setup` skips honeytoken planting when the token has no
+  `honeytokens:write` scope, instead of failing the run on a workspace that cannot be
+  granted it.
+
+- `ggshield machine doctor` reports the plan-gated scopes it cannot require
+  (`honeytokens:write`, `ai-discover:send`) as unavailable (`!`) instead of failing, so
+  it no longer exits non-zero on a workspace whose plan does not offer them. The
+  `endpoints:send` scope stays required, since installing the `machine_scan` plugin is
+  an explicit opt-in.

--- a/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
+++ b/changelog.d/20260817_122000_achille.mascia_machine_unavailable_protections.md
@@ -2,10 +2,12 @@
 
 - `ggshield machine setup` skips honeytoken planting when the token has no
   `honeytokens:write` scope, instead of failing the run on a workspace that cannot be
-  granted it.
+  granted it. The message says who can get the scope (a Manager on a Business or
+  Enterprise plan) rather than sending every member through `auth login --scopes`.
 
 - `ggshield machine doctor` reports the plan-gated scopes it cannot require
   (`honeytokens:write`, `ai-discover:send`) as unavailable (`!`) instead of failing, so
-  it no longer exits non-zero on a workspace whose plan does not offer them. The
+  it no longer exits non-zero on a workspace whose plan does not offer them. Their
+  fix lines say who can get the scope instead of pointing everyone at `--scopes`. The
   `endpoints:send` scope stays required, since installing the `machine_scan` plugin is
   an explicit opt-in.

--- a/changelog.d/20260904_140000_achille.mascia_login_reports_refused_scopes.md
+++ b/changelog.d/20260904_140000_achille.mascia_login_reports_refused_scopes.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `ggshield auth login` now reports the scopes it did not get, in two cases where it
+  stayed silent. A scope requested with `--scopes` and refused by the workspace is
+  named, instead of the login reporting nothing but success. And a still-valid token
+  that is reused is now checked too, so one minted before a scope joined the default
+  set no longer stays silently short until it expires; the message says the token lacks
+  the scope, rather than that it was refused, and names the command that requests it.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -20,22 +20,51 @@ from ggshield.core.url_utils import clean_url
 from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
-def _warn_missing_scopes(client: GGClient) -> None:
+def _expected_scopes(extra_scopes: Optional[List[str]]) -> List[str]:
+    """The scopes this login asked for: the defaults plus anything from ``--scopes``.
+
+    The backend grants the subset the member is eligible for and drops the rest, so
+    what the user asked for is what we have to report against. Comparing against
+    ``DEFAULT_SCOPES`` alone leaves a refused ``--scopes`` entirely unmentioned. This is
+    also the set sent in the authorize URL.
+    """
+    return list(dict.fromkeys([*DEFAULT_SCOPES, *(extra_scopes or [])]))
+
+
+def _warn_missing_scopes(
+    client: GGClient, expected_scopes: List[str], *, reused_token: bool = False
+) -> None:
+    """Report the expected scopes the token does not carry.
+
+    ``reused_token`` distinguishes the two ways a scope can be absent, which need
+    different words and a different next step: after a login the server refused it,
+    while a kept token was simply never asked for it.
+    """
     # Best-effort warning: never fail an already-successful login when the scopes cannot
     # be read (non-JSON body, network blip, an error Detail that says nothing about them).
     granted = granted_scopes(client)
     if granted is None:
         return
-    missing = [s for s in DEFAULT_SCOPES if s not in granted]
-    if missing:
+    missing = [s for s in expected_scopes if s not in granted]
+    if not missing:
+        return
+    if reused_token:
         click.echo(
-            "Warning: the following scopes were not granted: "
+            "Warning: the current token does not have the following scopes: "
             + ", ".join(missing)
             + ".\n"
-            "Some features may require additional permissions at runtime.\n"
-            "Contact your workspace administrator if you need access.",
+            'Run "ggshield auth login --scopes '
+            + " ".join(missing)
+            + '" to get a token that does.',
             err=True,
         )
+        return
+    click.echo(
+        "Warning: the following scopes were not granted: " + ", ".join(missing) + ".\n"
+        "Some features may require additional permissions at runtime.\n"
+        "Contact your workspace administrator if you need access.",
+        err=True,
+    )
 
 
 def validate_login_path(
@@ -261,7 +290,7 @@ def token_login(config: Config, instance: Optional[str]) -> None:
     click.echo("Authentication was successful.")
     print_default_instance_message(config)
 
-    _warn_missing_scopes(client)
+    _warn_missing_scopes(client, list(DEFAULT_SCOPES))
 
 
 def web_login(
@@ -283,7 +312,14 @@ def web_login(
     client = OAuthClient(config, defined_instance)
 
     if client.check_existing_token(required_scopes=extra_scopes):
-        # skip the process if a valid token is already saved
+        # skip the process if a valid token is already saved. Report what it lacks: a
+        # kept token is never re-checked otherwise, so one minted before a scope joined
+        # the defaults stays silently short until it expires.
+        _warn_missing_scopes(
+            create_client_from_config(config),
+            _expected_scopes(extra_scopes),
+            reused_token=True,
+        )
         return
 
     client.oauth_process(
@@ -293,5 +329,7 @@ def web_login(
         extra_scopes=extra_scopes,
         no_browser=no_browser,
     )
-    _warn_missing_scopes(create_client_from_config(config))
+    _warn_missing_scopes(
+        create_client_from_config(config), _expected_scopes(extra_scopes)
+    )
     print_default_instance_message(config)

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -4,14 +4,13 @@ from typing import Any, List, Optional, Tuple
 import click
 import requests
 from pygitguardian import GGClient
-from pygitguardian.models import APITokensResponse
 
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core.client import (
     create_client,
     create_client_from_config,
-    safe_api_tokens,
+    granted_scopes,
     safe_response_json,
 )
 from ggshield.core.config import Config
@@ -22,17 +21,11 @@ from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
 def _warn_missing_scopes(client: GGClient) -> None:
-    try:
-        token_info = safe_api_tokens(client)
-    except (UnexpectedError, requests.exceptions.RequestException):
-        # Best-effort warning: never fail an already-successful login if the
-        # token-info fetch errors out (non-JSON body, network blip, timeout...).
+    # Best-effort warning: never fail an already-successful login when the scopes cannot
+    # be read (non-JSON body, network blip, an error Detail that says nothing about them).
+    granted = granted_scopes(client)
+    if granted is None:
         return
-    if not isinstance(token_info, APITokensResponse):
-        # An error Detail (e.g. 401/500) tells us nothing about scopes; don't
-        # warn that scopes are "missing" when we never managed to read them.
-        return
-    granted = token_info.scopes or []
     missing = [s for s in DEFAULT_SCOPES if s not in granted]
     if missing:
         click.echo(
@@ -122,7 +115,9 @@ def print_default_instance_message(config: Config) -> None:
     type=str,
     help=(
         "Space-separated list of extra scopes to request in addition to the default"
-        " scopes (scan, honeytokens:check, endpoints:send, ai-discover:send)."
+        " scopes (scan, honeytokens:check, endpoints:send, ai-discover:send). If the"
+        " current token lacks one of them, ggshield authenticates again instead of"
+        " reusing it."
     ),
     metavar="SCOPES",
 )
@@ -182,7 +177,9 @@ def login_cmd(
     available scopes in [GitGuardian API documentation][1].
 
     If a valid personal access token is already configured, this command simply displays
-    a success message indicating that ggshield is already ready to use.
+    a success message indicating that ggshield is already ready to use — unless
+    `--scopes` asks for a scope that token does not carry, in which case ggshield
+    authenticates again to get one that does.
 
     [1]: https://docs.gitguardian.com/api-docs/authentication#scopes
     """
@@ -285,7 +282,7 @@ def web_login(
 
     client = OAuthClient(config, defined_instance)
 
-    if client.check_existing_token():
+    if client.check_existing_token(required_scopes=extra_scopes):
         # skip the process if a valid token is already saved
         return
 

--- a/ggshield/cmd/honeytoken/plant.py
+++ b/ggshield/cmd/honeytoken/plant.py
@@ -32,6 +32,18 @@ from ggshield.verticals.honeytoken.targets import (
 )
 
 
+# A 403 on reconcile is an entitlement problem, not a broken machine, and the raw API
+# body does not say which of the three prerequisites is missing.
+_FORBIDDEN_HELP = """ggshield is not allowed to plant honeytokens on your workspace. Make sure that:
+
+- the honeytoken module is enabled for your GitGuardian workspace,
+- you have the necessary permissions as a user (Manager access level),
+- the token used by ggshield has the `honeytokens:write` scope
+  (run `ggshield auth login --scopes honeytokens:write`).
+
+To learn more, visit https://docs.gitguardian.com/honeytoken/getting-started."""
+
+
 @dataclass
 class _Outcome:
     """Per-target reconciliation result, aggregated into the final exit code."""
@@ -202,7 +214,10 @@ def _reconcile_for_user(
                 profile_name=profile_name,
             )
     except EndpointDeploymentsError as exc:
-        click.echo(f"[{target.username}] {exc}", err=True)
+        if exc.status_code == 403:
+            click.echo(f"[{target.username}] {_FORBIDDEN_HELP}", err=True)
+        else:
+            click.echo(f"[{target.username}] {exc}", err=True)
         outcome.api_failure = True
         outcome.api_auth_failure = exc.is_auth
         return outcome

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -28,7 +28,7 @@ _GIT_HOOK_TYPES = ("pre-commit", "pre-push")
 
 # Scopes the configured protections need.
 _SCAN_SCOPE = "scan"  # the AI and git hooks run `ggshield secret scan`
-_HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
+HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
 _ENDPOINT_SCOPE = "endpoints:send"  # the machine_scan plugin uploads endpoint data
 _AI_DISCOVER_SCOPE = "ai-discover:send"  # `ai discover` uploads AI agent discovery
 
@@ -46,6 +46,10 @@ class Check:
     ok: bool
     detail: str = ""
     fix: str = ""
+    # An optional check reports a protection that is unavailable rather than a machine
+    # that is misconfigured, so a failure is a warning: it is printed with its fix but
+    # does not fail the run. Nothing the user can do on this machine would turn it green.
+    optional: bool = False
 
 
 @click.command(name="doctor")
@@ -68,7 +72,8 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     shadowing `core.hooksPath`, which git precedence means must be integrated into
     that hook manager or unset; scopes via a token that carries them; the plugin via
     `ggshield plugin install`). Exits non-zero if any check fails, so it can gate an
-    MDM rollout.
+    MDM rollout — except checks marked `!`, which report a protection the workspace
+    does not offer (honeytokens on a plan without them) rather than a machine to fix.
     """
     config = ContextObj.get(ctx).config
 
@@ -84,7 +89,7 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
         checks.append(_check_plugin_native())
 
     _render(checks)
-    return 0 if all(check.ok for check in checks) else 1
+    return 0 if all(check.ok or check.optional for check in checks) else 1
 
 
 def _check_auth_and_scopes(config: Any) -> "tuple[Optional[List[str]], Check]":
@@ -192,9 +197,12 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
     # server-side on a paid plan (Business or Enterprise).
     def _scope_fix(scope: str, *, paid_plan: bool = False) -> str:
         account = " from a Business or Enterprise account" if paid_plan else ""
+        # `--scopes` matters: plain `auth login` reuses a still-valid token and would
+        # report "already authenticated" without ever asking for the missing scope.
         return (
             f"use a token{account} that has the `{scope}` scope "
-            f"(re-run `ggshield auth login` or create a service-account token)"
+            f"(run `ggshield auth login --scopes {scope}` or create a "
+            "service-account token)"
         )
 
     checks = [
@@ -204,17 +212,24 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
             "required by the AI and git hooks",
             fix=_scope_fix(_SCAN_SCOPE),
         ),
+        # Both plan-gated: a workspace whose plan does not offer them can never be
+        # granted them, so failing the run would gate an MDM rollout on something out
+        # of the fleet's reach. Neither is needed by a `machine setup` protection that
+        # is already in place — honeytoken planting skips without its scope, and
+        # `ai discover` is a separate command.
         Check(
-            f"Scope `{_HONEYTOKEN_SCOPE}`",
-            _HONEYTOKEN_SCOPE in scopes,
+            f"Scope `{HONEYTOKEN_SCOPE}`",
+            HONEYTOKEN_SCOPE in scopes,
             "honeytoken protection — Business or Enterprise plans only",
-            fix=_scope_fix(_HONEYTOKEN_SCOPE, paid_plan=True),
+            fix=_scope_fix(HONEYTOKEN_SCOPE, paid_plan=True),
+            optional=True,
         ),
         Check(
             f"Scope `{_AI_DISCOVER_SCOPE}`",
             _AI_DISCOVER_SCOPE in scopes,
             "AI agent discovery upload — Business or Enterprise plans only",
             fix=_scope_fix(_AI_DISCOVER_SCOPE, paid_plan=True),
+            optional=True,
         ),
     ]
     if plugin_installed:
@@ -262,12 +277,18 @@ def _check_plugin_native() -> Check:
 
 def _render(checks: List[Check]) -> None:
     for check in checks:
-        mark = click.style("✓", fg="green") if check.ok else click.style("✗", fg="red")
+        if check.ok:
+            mark = click.style("✓", fg="green")
+        elif check.optional:
+            mark = click.style("!", fg="yellow")
+        else:
+            mark = click.style("✗", fg="red")
         detail = f" — {check.detail}" if check.detail else ""
         click.echo(f"  {mark} {check.name}{detail}")
         if not check.ok and check.fix:
             click.echo(f"      {click.style('↳ fix:', fg='yellow')} {check.fix}")
-    failed = [check for check in checks if not check.ok]
+    failed = [check for check in checks if not check.ok and not check.optional]
+    unavailable = [check for check in checks if not check.ok and check.optional]
     click.echo()
     if failed:
         click.echo(
@@ -278,6 +299,10 @@ def _render(checks: List[Check]) -> None:
             )
         )
     else:
-        click.echo(
-            click.style("This machine is correctly set up.", fg="green", bold=True)
-        )
+        message = "This machine is correctly set up."
+        if unavailable:
+            message += (
+                f" {len(unavailable)} optional protection(s) unavailable on this"
+                " workspace (marked !)."
+            )
+        click.echo(click.style(message, fg="green", bold=True))

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -28,7 +28,7 @@ _GIT_HOOK_TYPES = ("pre-commit", "pre-push")
 
 # Scopes the configured protections need.
 _SCAN_SCOPE = "scan"  # the AI and git hooks run `ggshield secret scan`
-HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (granted only to Business)
+HONEYTOKEN_SCOPE = "honeytokens:write"  # plant honeytokens (Managers, paid plans only)
 _ENDPOINT_SCOPE = "endpoints:send"  # the machine_scan plugin uploads endpoint data
 _AI_DISCOVER_SCOPE = "ai-discover:send"  # `ai discover` uploads AI agent discovery
 
@@ -205,6 +205,18 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
             "service-account token)"
         )
 
+    def _unavailable_fix(scope: str, granted_to: str) -> str:
+        # The server grants what the plan and role allow and silently drops the rest,
+        # so pointing everyone at `--scopes` sends an ineligible member into a loop
+        # that mints a token per attempt. Lead with who can get the scope, and say
+        # what it means when that is not the reader.
+        return (
+            f"only {granted_to} can get the `{scope}` scope. If that is you, run "
+            f"`ggshield auth login --scopes {scope}` (or use a service-account "
+            "token); otherwise your plan or role cannot grant it, and there is "
+            "nothing to fix on this machine"
+        )
+
     checks = [
         Check(
             f"Scope `{_SCAN_SCOPE}`",
@@ -220,15 +232,19 @@ def _check_scopes(scopes: Optional[List[str]], plugin_installed: bool) -> List[C
         Check(
             f"Scope `{HONEYTOKEN_SCOPE}`",
             HONEYTOKEN_SCOPE in scopes,
-            "honeytoken protection — Business or Enterprise plans only",
-            fix=_scope_fix(HONEYTOKEN_SCOPE, paid_plan=True),
+            "honeytoken protection — Managers on Business or Enterprise plans only",
+            fix=_unavailable_fix(
+                HONEYTOKEN_SCOPE, "a Manager on a Business or Enterprise plan"
+            ),
             optional=True,
         ),
         Check(
             f"Scope `{_AI_DISCOVER_SCOPE}`",
             _AI_DISCOVER_SCOPE in scopes,
             "AI agent discovery upload — Business or Enterprise plans only",
-            fix=_scope_fix(_AI_DISCOVER_SCOPE, paid_plan=True),
+            fix=_unavailable_fix(
+                _AI_DISCOVER_SCOPE, "members of a Business or Enterprise workspace"
+            ),
             optional=True,
         ),
     ]

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -14,9 +14,11 @@ from ggshield.cmd.install import (
     install_global,
     install_system,
 )
+from ggshield.cmd.machine.doctor import HONEYTOKEN_SCOPE
 from ggshield.cmd.utils.common_options import add_common_options
 from ggshield.cmd.utils.context_obj import ContextObj
 from ggshield.core import ui
+from ggshield.core.client import create_client_from_config, granted_scopes
 from ggshield.utils.os import is_root
 from ggshield.verticals.ai.agents import AGENTS
 from ggshield.verticals.ai.installation import (
@@ -210,6 +212,20 @@ def _setup_git_hooks(system: bool) -> bool:
 
 
 def _setup_honeytokens(ctx: click.Context) -> bool:
-    """Plant a honeytoken on this machine (idempotent reconcile via `plant`)."""
+    """Plant a honeytoken on this machine (idempotent reconcile via `plant`).
+
+    Planting needs `honeytokens:write`, which only a plan offering honeytokens grants,
+    and only to a Manager. Without it this is a skip, not a failure: the machine is not
+    misconfigured, the feature is unavailable — and failing here would gate the whole
+    setup on something the workspace cannot have.
+    """
     click.echo(click.style("Honeytoken", bold=True))
+    scopes = granted_scopes(create_client_from_config(ContextObj.get(ctx).config))
+    if scopes is not None and HONEYTOKEN_SCOPE not in scopes:
+        ui.display_warning(
+            f"  skipped: the token does not have the `{HONEYTOKEN_SCOPE}` scope "
+            "(Business or Enterprise plan, Manager access level). Run "
+            f"`ggshield auth login --scopes {HONEYTOKEN_SCOPE}` to request it."
+        )
+        return True
     return ctx.invoke(plant_cmd) == 0

--- a/ggshield/cmd/machine/setup.py
+++ b/ggshield/cmd/machine/setup.py
@@ -223,9 +223,11 @@ def _setup_honeytokens(ctx: click.Context) -> bool:
     scopes = granted_scopes(create_client_from_config(ContextObj.get(ctx).config))
     if scopes is not None and HONEYTOKEN_SCOPE not in scopes:
         ui.display_warning(
-            f"  skipped: the token does not have the `{HONEYTOKEN_SCOPE}` scope "
-            "(Business or Enterprise plan, Manager access level). Run "
-            f"`ggshield auth login --scopes {HONEYTOKEN_SCOPE}` to request it."
+            f"  skipped: the token does not have the `{HONEYTOKEN_SCOPE}` scope, "
+            "which only a Manager on a Business or Enterprise plan can get. If that "
+            f"is you, run `ggshield auth login --scopes {HONEYTOKEN_SCOPE}`; "
+            "otherwise your plan or role cannot grant it, and honeytoken protection "
+            "is unavailable here."
         )
         return True
     return ctx.invoke(plant_cmd) == 0

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -194,6 +194,24 @@ def safe_api_tokens(client: GGClient) -> Union[APITokensResponse, Detail]:
         raise _non_json_error(client.base_uri, exc) from exc
 
 
+def granted_scopes(client: GGClient) -> Optional[set[str]]:
+    """The scopes the client's token carries, or None when they could not be read.
+
+    Scopes are raw strings, not ``TokenScope``: a scope newer than pygitguardian's enum
+    (e.g. ``endpoints:send``) must still count as granted. ``None`` means "unknown",
+    never "none granted" — a caller must not report a scope as missing because the
+    lookup itself failed.
+    """
+    try:
+        token_info = safe_api_tokens(client)
+    except (UnexpectedError, requests.exceptions.RequestException):
+        return None
+    if not isinstance(token_info, APITokensResponse):
+        # An error Detail (401/500...) tells us nothing about the scopes.
+        return None
+    return set(token_info.scopes or [])
+
+
 def safe_response_json(response: requests.Response) -> Any:
     """Parse a JSON response body, raising a clean UnexpectedError that names the
     instance URL instead of letting a raw JSONDecodeError escape when the body is

--- a/ggshield/verticals/auth/oauth.py
+++ b/ggshield/verticals/auth/oauth.py
@@ -18,10 +18,12 @@ from ggshield.core.client import (
     create_client,
     create_client_from_config,
     create_session,
+    granted_scopes,
     safe_response_json,
 )
 from ggshield.core.config import Config, InstanceConfig
 from ggshield.core.errors import APIKeyCheckError, UnexpectedError
+from ggshield.core.text_utils import pluralize
 from ggshield.core.url_utils import urljoin
 from ggshield.utils.datetime import get_pretty_date
 
@@ -411,12 +413,16 @@ class OAuthClient:
             )
         return self._state
 
-    def check_existing_token(self) -> bool:
+    def check_existing_token(self, required_scopes: Optional[List[str]] = None) -> bool:
         """
         Check if the config already has a non expired token.
         If one could be found, outputs a message including the expiry date
         and return True.
         Else return False
+
+        ``required_scopes`` holds the scopes asked for explicitly with ``--scopes``: a
+        token lacking one cannot do what the user just asked for, so fall through to a
+        fresh login instead of reporting "already authenticated" and doing nothing.
         """
         account = self.instance_config.account
         if account is None or self.instance_config.expired:
@@ -434,6 +440,24 @@ class OAuthClient:
                 "Account had an API key recorded but it's no longer valid, removing it"
             )
             self.instance_config.account = None
+            return False
+
+        # Only when `--scopes` asked for something: with nothing to check there is
+        # nothing to learn, and the lookup would cost a round trip on every login.
+        scopes = granted_scopes(client) if required_scopes else None
+        missing = (
+            []
+            if scopes is None
+            else [s for s in required_scopes or [] if s not in scopes]
+        )
+        if missing:
+            # Keep the account: the new login overwrites it on success, and dropping it
+            # first would leave an aborted login with no token at all.
+            click.echo(
+                "The current token is missing the requested "
+                f"{pluralize('scope', len(missing))} {', '.join(missing)}. "
+                "Authenticating again to get a new token."
+            )
             return False
 
         # Trigger a save to migrate cleartext tokens to keyring if needed

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -3,7 +3,7 @@ import urllib.parse as urlparse
 from datetime import datetime, timedelta, timezone
 from enum import IntEnum, auto
 from typing import Optional, Set
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import requests.exceptions
@@ -1409,3 +1409,63 @@ def test_warn_missing_scopes_swallows_connection_error(capsys):
     _warn_missing_scopes(client_mock)  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
+
+
+class TestCheckExistingTokenScopes:
+    """A valid token is only reusable if it carries the scopes `--scopes` asked for."""
+
+    OAUTH = "ggshield.verticals.auth.oauth"
+
+    def _client(self, cli_fs_runner) -> OAuthClient:
+        add_instance_config(instance_url=DEFAULT_INSTANCE_URL)
+        return OAuthClient(Config(), DEFAULT_INSTANCE_URL)
+
+    def _check(self, cli_fs_runner, granted, required):
+        client = self._client(cli_fs_runner)
+        with patch(f"{self.OAUTH}.create_client_from_config"), patch(
+            f"{self.OAUTH}.check_client_api_key"
+        ), patch(f"{self.OAUTH}.granted_scopes", return_value=granted) as m_scopes:
+            return client.check_existing_token(required_scopes=required), m_scopes
+
+    def test_reuses_token_that_has_the_requested_scope(self, cli_fs_runner, capsys):
+        """
+        GIVEN a valid token that carries the scope asked for with --scopes
+        WHEN auth login checks it
+        THEN the token is reused
+        """
+        reused, _ = self._check(
+            cli_fs_runner, {"scan", "honeytokens:write"}, ["honeytokens:write"]
+        )
+        assert reused is True
+
+    def test_reauthenticates_when_the_requested_scope_is_missing(
+        self, cli_fs_runner, capsys
+    ):
+        """
+        GIVEN a valid token that lacks the scope asked for with --scopes
+        WHEN auth login checks it
+        THEN the token is not reused, so the login flow runs and can grant the scope
+        """
+        reused, _ = self._check(cli_fs_runner, {"scan"}, ["honeytokens:write"])
+        assert reused is False
+        assert "honeytokens:write" in capsys.readouterr().out
+
+    def test_no_scope_lookup_without_requested_scopes(self, cli_fs_runner):
+        """
+        GIVEN a plain `auth login` (no --scopes)
+        WHEN the existing token is checked
+        THEN no scope lookup happens: there is nothing to check and it would cost a
+        round trip on every login
+        """
+        reused, m_scopes = self._check(cli_fs_runner, {"scan"}, None)
+        assert reused is True
+        m_scopes.assert_not_called()
+
+    def test_unreadable_scopes_keep_the_token(self, cli_fs_runner):
+        """
+        GIVEN a token whose scopes cannot be read (network blip, error Detail)
+        WHEN the existing token is checked against --scopes
+        THEN the token is kept: a failed lookup must not force a needless re-login
+        """
+        reused, _ = self._check(cli_fs_runner, None, ["honeytokens:write"])
+        assert reused is True

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -8,15 +8,15 @@ from unittest.mock import Mock, patch
 import pytest
 import requests.exceptions
 from pygitguardian import GGClient
-from pygitguardian.models import Detail
+from pygitguardian.models import APITokensResponse, Detail
 
 from ggshield.__main__ import cli
-from ggshield.cmd.auth.login import _warn_missing_scopes
+from ggshield.cmd.auth.login import _expected_scopes, _warn_missing_scopes
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
 from ggshield.utils.datetime import get_pretty_date
-from ggshield.verticals.auth import OAuthClient, OAuthError
+from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient, OAuthError
 from ggshield.verticals.auth.oauth import OOB_REDIRECT_URI
 from tests.unit.conftest import assert_invoke_ok
 from tests.unit.request_mock import (
@@ -455,12 +455,63 @@ class TestAuthLoginWeb:
         config = Config()
         assert len(config.auth_config.instances) == 0
 
+    def test_existing_token_missing_a_default_scope_is_reported(
+        self, cli_fs_runner, monkeypatch
+    ):
+        """
+        GIVEN a still-valid token that lacks one of the default scopes, e.g. one minted
+            before that scope joined the defaults
+        WHEN auth login reuses it
+        THEN the missing scope is reported instead of the token staying silently short
+        AND the wording says the token lacks it, not that the server refused it
+        AND the command that would request it is named
+        AND the token is kept: reporting must not trigger a login
+        """
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(
+            API_TOKENS_ENDPOINT,
+            create_json_response(
+                {**VALID_API_TOKENS_RESPONSE.json(), "scopes": ["scan"]}
+            ),
+        )
+        add_instance_config()
+
+        exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        self._webbrowser_open_mock.assert_not_called()
+        assert "already authenticated" in output
+        assert "the current token does not have the following scopes" in output
+        assert "ai-discover:send" in output
+        assert "ggshield auth login --scopes" in output
+        # Nothing was refused on this path, so the post-login wording must not appear.
+        assert "were not granted" not in output
+        self._request_mock.assert_all_requests_happened()
+
+    def test_existing_token_with_every_scope_stays_quiet(
+        self, cli_fs_runner, monkeypatch
+    ):
+        """
+        GIVEN a still-valid token carrying every default scope
+        WHEN auth login reuses it
+        THEN nothing is reported
+        """
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
+        add_instance_config()
+
+        exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        assert "does not have the following scopes" not in output
+
     @pytest.mark.parametrize(
         "instance_url", [DEFAULT_INSTANCE_URL, "https://some_instance.com"]
     )
     def test_existing_token_no_expiry(self, instance_url, cli_fs_runner, monkeypatch):
         self._instance_url = instance_url
         self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
 
         add_instance_config(instance_url=instance_url)
 
@@ -493,6 +544,7 @@ class TestAuthLoginWeb:
 
         self._instance_url = instance_url
         self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
 
         add_instance_config(instance_url=instance_url, expiry_date=dt)
 
@@ -1376,7 +1428,7 @@ def test_warn_missing_scopes_swallows_non_json_body(capsys):
         0,
     )
 
-    _warn_missing_scopes(client_mock)  # must not raise
+    _warn_missing_scopes(client_mock, ["scan"])  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
 
@@ -1391,9 +1443,73 @@ def test_warn_missing_scopes_silent_on_error_detail(capsys):
     client_mock.base_uri = "https://dashboard.example.com"
     client_mock.api_tokens.return_value = Detail("Unauthorized", 401)
 
-    _warn_missing_scopes(client_mock)
+    _warn_missing_scopes(client_mock, ["scan"])
 
     assert "scopes were not granted" not in capsys.readouterr().err
+
+
+class TestReportsRefusedScopes:
+    """The backend grants the subset the member is eligible for and drops the rest, so
+    ggshield has to report against what was asked for, not against the defaults."""
+
+    def _client(self, granted):
+        client = Mock(spec=GGClient)
+        client.base_uri = "https://dashboard.example.com"
+        client.api_tokens.return_value = Mock(
+            spec=APITokensResponse, scopes=list(granted)
+        )
+        return client
+
+    def test_expected_scopes_appends_requested_ones(self):
+        """
+        GIVEN scopes requested with --scopes
+        WHEN the expected set is built
+        THEN it is the defaults plus those, without duplicates
+        """
+        expected = _expected_scopes(["honeytokens:write", "scan"])
+        assert expected[: len(DEFAULT_SCOPES)] == list(DEFAULT_SCOPES)
+        assert "honeytokens:write" in expected
+        assert len(expected) == len(set(expected))
+
+    def test_expected_scopes_defaults_to_the_defaults(self):
+        assert _expected_scopes(None) == list(DEFAULT_SCOPES)
+
+    def test_a_refused_requested_scope_is_reported(self, capsys):
+        """
+        GIVEN a token granted everything except the scope asked for with --scopes
+        WHEN the login reports its scopes
+        THEN that scope is named, instead of the login looking entirely successful
+        """
+        client = self._client(DEFAULT_SCOPES)
+
+        _warn_missing_scopes(client, _expected_scopes(["honeytokens:write"]))
+
+        err = capsys.readouterr().err
+        assert "scopes were not granted" in err
+        assert "honeytokens:write" in err
+
+    def test_a_kept_token_is_told_what_to_run(self, capsys):
+        """
+        GIVEN a kept token that lacks an expected scope
+        WHEN the absence is reported
+        THEN the wording says the token lacks it, not that it was refused, and names the
+            command that requests it: nothing was refused on this path
+        """
+        client = self._client(["scan"])
+
+        _warn_missing_scopes(client, ["scan", "ai-discover:send"], reused_token=True)
+
+        err = capsys.readouterr().err
+        assert "the current token does not have the following scopes" in err
+        assert "were not granted" not in err
+        assert "ggshield auth login --scopes ai-discover:send" in err
+
+    def test_nothing_is_reported_when_everything_was_granted(self, capsys):
+        client = self._client([*DEFAULT_SCOPES, "honeytokens:write"])
+
+        _warn_missing_scopes(client, _expected_scopes(["honeytokens:write"]))
+
+        assert "scopes were not granted" not in capsys.readouterr().err
 
 
 def test_warn_missing_scopes_swallows_connection_error(capsys):
@@ -1406,7 +1522,7 @@ def test_warn_missing_scopes_swallows_connection_error(capsys):
     client_mock.base_uri = "https://dashboard.example.com"
     client_mock.api_tokens.side_effect = requests.exceptions.ConnectionError("boom")
 
-    _warn_missing_scopes(client_mock)  # must not raise
+    _warn_missing_scopes(client_mock, ["scan"])  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
 

--- a/tests/unit/cmd/honeytoken/test_plant.py
+++ b/tests/unit/cmd/honeytoken/test_plant.py
@@ -352,6 +352,9 @@ def test_api_auth_error_exits_authentication(
     result = cli_fs_runner.invoke(cli, ["honeytoken", "plant", "--user-dir", "home"])
     assert_invoke_exited_with(result, ExitCode.AUTHENTICATION_ERROR)
     assert not Path("home/.aws/credentials").exists()
+    # The raw API body never says which prerequisite is missing — name all three.
+    assert "honeytokens:write" in result.output
+    assert "honeytoken module is enabled" in result.output
 
 
 def test_remove_only_foreign_profile_is_kept(

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -65,6 +65,31 @@ class TestDoctorCommand:
         assert result.exit_code == 1
         assert "failed" in result.output
 
+    def test_optional_check_warns_without_failing(self, cli_fs_runner: CliRunner):
+        """An unavailable protection is reported with `!` and its fix, but must not fail
+        the run — it would gate an MDM rollout on a scope the workspace cannot have."""
+        optional = Check(
+            "Scope `honeytokens:write`", False, fix="use a token", optional=True
+        )
+        with patch(
+            f"{BASE}._check_auth_and_scopes",
+            return_value=(["scan"], Check("Authentication", True)),
+        ), patch(f"{BASE}._is_plugin_installed", return_value=False), patch(
+            f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks", return_value=Check("Git hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks_precedence",
+            return_value=Check("Git hook precedence", True),
+        ), patch(
+            f"{BASE}._check_scopes", return_value=[optional]
+        ):
+            result = cli_fs_runner.invoke(cli, ["machine", "doctor"])
+        assert result.exit_code == 0
+        assert "correctly set up" in result.output
+        assert "unavailable" in result.output
+        assert "use a token" in result.output
+
     def test_plugin_check_skipped_without_plugin(self, cli_fs_runner: CliRunner):
         _result, m_plugin = self._run(
             cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=False
@@ -193,6 +218,28 @@ class TestCheckScopes:
         by_name = {c.name: c.ok for c in checks}
         assert by_name["Scope `scan`"] is True
         assert by_name["Scope `honeytokens:write`"] is False
+
+    def test_plan_gated_scopes_are_optional_but_scan_is_not(self):
+        """A workspace whose plan does not offer them can never be granted the
+        plan-gated scopes, so missing them must not fail the run the way a missing
+        `scan` does."""
+        by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
+        assert by_name["Scope `honeytokens:write`"].optional is True
+        assert by_name["Scope `ai-discover:send`"].optional is True
+        assert by_name["Scope `scan`"].optional is False
+
+    def test_endpoint_scope_stays_required_with_the_plugin(self):
+        """Installing the plugin is an explicit opt-in, so a token that cannot upload
+        endpoint data is a real misconfiguration, not an unavailable feature."""
+        with_plugin = _check_scopes(["scan"], plugin_installed=True)
+        endpoint = [c for c in with_plugin if "endpoints:send" in c.name]
+        assert endpoint and endpoint[0].optional is False
+
+    def test_scope_fix_names_the_scopes_flag(self):
+        """Plain `auth login` reuses a valid token and would never ask for the missing
+        scope, so the fix has to spell out `--scopes`."""
+        by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
+        assert "--scopes honeytokens:write" in by_name["Scope `honeytokens:write`"].fix
 
     def test_ai_discover_scope_reported(self):
         checks = _check_scopes(["scan"], plugin_installed=False)

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -241,6 +241,21 @@ class TestCheckScopes:
         by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
         assert "--scopes honeytokens:write" in by_name["Scope `honeytokens:write`"].fix
 
+    def test_plan_gated_fix_leads_with_who_can_get_the_scope(self):
+        """The server silently drops a scope the plan or role does not allow, so
+        pointing everyone at `--scopes` would send an ineligible member into a
+        re-login loop. The fix has to say who can get the scope and what it means
+        when that is not the reader."""
+        by_name = {c.name: c for c in _check_scopes(["scan"], plugin_installed=False)}
+        honeytoken_fix = by_name["Scope `honeytokens:write`"].fix
+        assert "Manager" in honeytoken_fix
+        assert "nothing to fix" in honeytoken_fix
+        # Only honeytokens are Manager-gated.
+        assert "Manager" not in by_name["Scope `ai-discover:send`"].fix
+        assert "nothing to fix" in by_name["Scope `ai-discover:send`"].fix
+        # A required scope keeps its unconditional fix: missing it is a real break.
+        assert "nothing to fix" not in by_name["Scope `scan`"].fix
+
     def test_ai_discover_scope_reported(self):
         checks = _check_scopes(["scan"], plugin_installed=False)
         by_name = {c.name: c.ok for c in checks}

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -378,3 +378,41 @@ class TestHoneytokenPlant:
         """`honeytoken plant` stays a first-class command (not deprecated)."""
         result = cli_fs_runner.invoke(cli, ["honeytoken", "plant"])
         assert "deprecated" not in result.output.lower()
+
+
+class TestSetupHoneytokens:
+    """Planting is skipped, not failed, when the workspace cannot grant the scope."""
+
+    BASE = "ggshield.cmd.machine.setup"
+
+    def _run(self, scopes, plant_exit_code=0):
+        from ggshield.cmd.machine.setup import _setup_honeytokens
+
+        ctx = MagicMock()
+        ctx.invoke.return_value = plant_exit_code
+        with patch(f"{self.BASE}.create_client_from_config"), patch(
+            f"{self.BASE}.granted_scopes", return_value=scopes
+        ):
+            return _setup_honeytokens(ctx), ctx.invoke
+
+    def test_plants_when_the_scope_is_granted(self):
+        ok, invoke = self._run({"scan", "honeytokens:write"})
+        invoke.assert_called_once()
+        assert ok is True
+
+    def test_reports_a_failing_plant(self):
+        ok, _invoke = self._run({"scan", "honeytokens:write"}, plant_exit_code=1)
+        assert ok is False
+
+    def test_skips_without_the_scope_and_does_not_fail(self, capsys):
+        ok, invoke = self._run({"scan"})
+        assert ok is True
+        invoke.assert_not_called()
+        output = capsys.readouterr()
+        assert "honeytokens:write" in output.out + output.err
+
+    def test_plants_when_scopes_are_unreadable(self):
+        """An unreadable token must not silently disable the protection: try to plant
+        and let the API be the judge."""
+        _ok, invoke = self._run(None)
+        invoke.assert_called_once()

--- a/tests/unit/cmd/machine/test_setup.py
+++ b/tests/unit/cmd/machine/test_setup.py
@@ -408,8 +408,13 @@ class TestSetupHoneytokens:
         ok, invoke = self._run({"scan"})
         assert ok is True
         invoke.assert_not_called()
-        output = capsys.readouterr()
-        assert "honeytokens:write" in output.out + output.err
+        text = "".join(capsys.readouterr())
+        assert "honeytokens:write" in text
+        # Say who can get the scope: sending every member through `--scopes` would
+        # loop the ineligible through a re-login that mints a token per attempt.
+        assert "Manager" in text
+        assert "--scopes honeytokens:write" in text
+        assert "cannot grant it" in text
 
     def test_plants_when_scopes_are_unreadable(self):
         """An unreadable token must not silently disable the protection: try to plant


### PR DESCRIPTION
Splits out the three uncontested commits of #1410 (@amascia-gg, authorship preserved) and rebases them onto current main. **Nothing here changes `DEFAULT_SCOPES`** — the `feat(auth): request the honeytokens:write scope by default` commit stays on #1410, where the design question raised in review is still open.

### The problem

`ggshield auth login` requests `scan`, `honeytokens:check`, `endpoints:send`, `ai-discover:send` — **not** `honeytokens:write`. So a token from a plain login can never plant a honeytoken, and `ggshield machine setup` ends its run with a raw `endpoint-deployments API error (403): …` per target and exit code 1. `ggshield machine doctor` fails the same way on the missing scope.

Neither is a broken machine. `honeytokens:write` is granted only on a plan that offers honeytokens, and only to a Manager; `ai-discover:send` is likewise plan-gated. A member's laptop is correctly set up and still reports red — and under MDM that gates a rollout on something no machine can fix.

### What changes

- **`machine setup`** checks the token's scopes before planting. Without `honeytokens:write` it reports the protection as unavailable and moves on, instead of running a doomed API call and failing the whole setup. Scopes it cannot read still go through `plant`, which surfaces the real error.
- **`machine doctor`** grows an `optional` check: printed with its fix and a yellow `!`, excluded from the exit code. Applied to `honeytokens:write` and `ai-discover:send` — both plan-gated, and neither is needed by a protection that is already in place (honeytoken planting skips without its scope, and `ai discover` is a separate command). `scan` stays fatal, and `endpoints:send` stays fatal when the `machine_scan` plugin is installed: installed-but-cannot-upload *is* a real break.
- **`honeytoken plant`** answers a 403 with the three prerequisites (honeytoken module enabled, Manager access level, `honeytokens:write` on the token) instead of the raw API body, which never said which one was missing.
- **`auth login --scopes`** now falls through to a fresh login when the current token lacks a requested scope. Before, it reused the still-valid token and reported "already authenticated" without ever asking for it — which made every `↳ fix:` line in doctor that says "re-run auth login" a no-op. The doctor fixes now say `auth login --scopes <scope>`.

### Testing

- Full unit suite: 2717 passed, 4 skipped. black / isort / flake8 clean, import-linter both contracts KEPT.
- The only conflict from the rebase was a test import line (`Mock` vs `MagicMock`).

### Notes for review

- Lightly conflicts with #1440 (both touch `setup.py` imports and the area around `_setup_honeytokens`); whichever lands second needs a two-line resolution.
- The remaining question on #1410 — whether `honeytokens:write` belongs in `DEFAULT_SCOPES`, or whether honeytoken planting needs a scope/feature redesign first, given it is Manager-only and mostly run via MDM — is deliberately untouched here.
