### PR TITLE
docs(readme): warn about the macOS Keychain prompt after upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/GitGuardian/ggshield/main.yml?branch=main&style=for-the-badge)](https://github.com/GitGuardian/ggshield/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/GitGuardian/ggshield?style=for-the-badge)](https://codecov.io/gh/GitGuardian/ggshield/)
 
+> [!IMPORTANT]
+> **macOS: upgrading to 1.54.0 triggers a Keychain prompt for `ggshield-py`**, a second binary that now reads your saved token. Click **Always Allow**; it won't ask again.
+
 `ggshield` is a CLI application that runs in your local environment or in a CI environment to help you detect more than 500+ types of secrets.
 
 `ggshield` uses our [public API](https://api.gitguardian.com/docs) through [py-gitguardian](https://github.com/GitGuardian/py-gitguardian) to scan and detect potential vulnerabilities in files and other text content.
@@ -34,7 +37,6 @@ Only metadata such as call time, request size and scan mode is stored from scans
     - [Using pip](#using-pip)
 - [Initial setup](#initial-setup)
   - [Using `ggshield auth login`](#using-ggshield-auth-login)
-  - [macOS: Keychain prompt after upgrading](#macos-keychain-prompt-after-upgrading)
   - [Manual setup](#manual-setup)
 - [Getting started](#getting-started)
   - [Secrets](#secrets)
@@ -189,17 +191,6 @@ pip install --user --upgrade ggshield
 To use `ggshield` you need to authenticate against GitGuardian servers. To do so, use the `ggshield auth login` command. This command automates the provisioning of a personal access token and its configuration on the local workstation.
 
 You can learn more about it from [`ggshield auth login` documentation](https://docs.gitguardian.com/internal-repositories-monitoring/ggshield/reference/auth/login).
-
-## macOS: Keychain prompt after upgrading
-
-> [!IMPORTANT]
-> **Upgrading to 1.54.0 triggers a macOS Keychain prompt.**
->
-> Since 1.54.0, `ggshield` is a fast native launcher that hands most commands to a second binary, `ggshield-py`. Both read your token from the Keychain, and the entry you already have trusts only the old single binary — so macOS asks before letting `ggshield-py` read it.
->
-> Click **Always Allow**, or run `ggshield auth login` again to rewrite the entry so it trusts both. Either way the prompt does not come back.
->
-> Deploying with an MDM? Set `GITGUARDIAN_API_KEY` instead (see below): nothing then touches the Keychain.
 
 ## Manual setup
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/GitGuardian/ggshield?style=for-the-badge)](https://codecov.io/gh/GitGuardian/ggshield/)
 
 > [!IMPORTANT]
-> **macOS: upgrading to 1.54.0 triggers a Keychain prompt for `ggshield-py`**, a second binary that now reads your saved token. Click **Always Allow**; it won't ask again.
+> **macOS: upgrading to 1.54.0 triggers a Keychain prompt for `ggshield-py`**, a second binary that now reads your saved token as part of our performance improvements. Click **Always Allow**; it won't ask again.
 
 `ggshield` is a CLI application that runs in your local environment or in a CI environment to help you detect more than 500+ types of secrets.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Only metadata such as call time, request size and scan mode is stored from scans
     - [Using pip](#using-pip)
 - [Initial setup](#initial-setup)
   - [Using `ggshield auth login`](#using-ggshield-auth-login)
+  - [macOS: Keychain prompt after upgrading](#macos-keychain-prompt-after-upgrading)
   - [Manual setup](#manual-setup)
 - [Getting started](#getting-started)
   - [Secrets](#secrets)
@@ -188,6 +189,17 @@ pip install --user --upgrade ggshield
 To use `ggshield` you need to authenticate against GitGuardian servers. To do so, use the `ggshield auth login` command. This command automates the provisioning of a personal access token and its configuration on the local workstation.
 
 You can learn more about it from [`ggshield auth login` documentation](https://docs.gitguardian.com/internal-repositories-monitoring/ggshield/reference/auth/login).
+
+## macOS: Keychain prompt after upgrading
+
+> [!IMPORTANT]
+> **Upgrading to 1.54.0 triggers a macOS Keychain prompt.**
+>
+> Since 1.54.0, `ggshield` is a fast native launcher that hands most commands to a second binary, `ggshield-py`. Both read your token from the Keychain, and the entry you already have trusts only the old single binary — so macOS asks before letting `ggshield-py` read it.
+>
+> Click **Always Allow**, or run `ggshield auth login` again to rewrite the entry so it trusts both. Either way the prompt does not come back.
+>
+> Deploying with an MDM? Set `GITGUARDIAN_API_KEY` instead (see below): nothing then touches the Keychain.
 
 ## Manual setup
 

--- a/changelog.d/20260827_123000_henri.hubert_macos_keychain_prompt_doc.md
+++ b/changelog.d/20260827_123000_henri.hubert_macos_keychain_prompt_doc.md
@@ -1,0 +1,8 @@
+### Changed
+
+- The README's "Initial setup" section now documents the macOS Keychain prompt
+  that appears on the first run after upgrading from a version before 1.54.0:
+  `ggshield` and `ggshield-py` both read the token, while the existing Keychain
+  entry trusts only the previous single binary. Clicking **Always Allow**, or
+  running `ggshield auth login` again, settles it for good, and an MDM
+  deployment can set `GITGUARDIAN_API_KEY` to bypass the Keychain entirely.

--- a/changelog.d/20260827_123000_henri.hubert_macos_keychain_prompt_doc.md
+++ b/changelog.d/20260827_123000_henri.hubert_macos_keychain_prompt_doc.md
@@ -1,8 +1,5 @@
 ### Changed
 
-- The README's "Initial setup" section now documents the macOS Keychain prompt
-  that appears on the first run after upgrading from a version before 1.54.0:
-  `ggshield` and `ggshield-py` both read the token, while the existing Keychain
-  entry trusts only the previous single binary. Clicking **Always Allow**, or
-  running `ggshield auth login` again, settles it for good, and an MDM
-  deployment can set `GITGUARDIAN_API_KEY` to bypass the Keychain entirely.
+- The README now warns, at the top, that upgrading to 1.54.0 on macOS triggers
+  a Keychain prompt for `ggshield-py`, the second binary that reads the saved
+  token, and that clicking **Always Allow** settles it for good.


### PR DESCRIPTION
## Context

[END-934](https://linear.app/gitguardian/issue/END-934/vs-code-extension-installation-triggers-unexpected-keychain-access): a user upgraded to 1.54.0, ran `ggshield`, and got a macOS Keychain dialog asking to let `ggshield-py` read their API key. 
Nothing documented this.

## What has been done

A two-line `> [!IMPORTANT]` banner immediately after the badge row:

Placed at the very top, and kept that short, because the note is temporary — it stops being useful once everyone has upgraded past 1.54.0, and it can then be removed in one edit. The top of the file is also outside `# Installation`, whose leading comment requires any change there to be mirrored into the public documentation.

"Always Allow" does persist: it adds `ggshield-py` to the item's ACL, and a later `ggshield auth login` rewrites the entry to trust both binaries anyway (`_MACOS_TRUSTED_BINARY_NAMES` in `ggshield/core/config/token_store.py`).

Plus a changelog fragment.