### PR TITLE
fix(packages): prune empty .dist-info dirs left by rpm upgrades

### DIFF
--- a/changelog.d/20260831_122215_benjamin.rigaud_rpm_prune_empty_dist_info.md
+++ b/changelog.d/20260831_122215_benjamin.rigaud_rpm_prune_empty_dist_info.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The Linux rpm package could crash on startup after an in-place upgrade,
+  because empty `*.dist-info` directories were left behind. They are now
+  removed during the upgrade.

--- a/scripts/build-os-packages/nfpm.yaml
+++ b/scripts/build-os-packages/nfpm.yaml
@@ -51,3 +51,7 @@ overrides:
     depends:
       - libc6
       - git
+
+rpm:
+  scripts:
+    posttrans: scripts/build-os-packages/rpm-posttrans.sh

--- a/scripts/build-os-packages/rpm-posttrans.sh
+++ b/scripts/build-os-packages/rpm-posttrans.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# rpm doesn't own the bundle dirs, so upgrades leave empty *.dist-info behind;
+# an empty one crashes the frozen binary at import. Prune them post-transaction.
+find /usr/libexec/ggshield/_internal -type d -empty -delete 2>/dev/null || true


### PR DESCRIPTION
## TL;DR

rpm-only fix. An in-place ggshield rpm upgrade strands empty `*.dist-info` directories, which crash the frozen binary at import. This adds an rpm `%posttrans` hook that prunes them. `.deb` is unaffected.

## Problem

- The rpm owns the PyInstaller bundle **files but not their directories** (the 1.54.0 rpm manifest has 83 file entries and 0 directory entries).
- On upgrade, rpm deletes an old dependency's `*.dist-info` files but leaves the now-empty directory behind.
- An empty `*.dist-info` makes `importlib.metadata.version()` return `None`, and typeguard then runs `None.split()` at import (`typeguard/_importhook.py:36`) and raises `AttributeError`. `ggshield --version` and every command fail.

## Fix

- rpm `%posttrans` script prunes empty directories under `/usr/libexec/ggshield/_internal` after the transaction, so it also repairs already-broken hosts on their next upgrade.
- deb needs no change: dpkg owns the directories and removes them itself (verified: the deb `data.tar` carries directory entries; the rpm carries none).

## Verified

- The cleanup command on a mock bundle removes empty leftovers (including a nested emptied `licenses/`) and keeps the real dirs and `base_library.zip`.
- Reproduced the crash on the shipped 1.54.0 binary by injecting an empty `typeguard-*.dist-info` into `_internal`; removing it restores `ggshield --version`.

## Not covered here

- The current `linux_package_smoke_tests` do fresh installs, not upgrades, so they do not exercise the cleanup path (see QA-1465).
- Follow-ups: make the rpm own the bundle directories (parity with deb); add a build gate that rejects empty or duplicate `.dist-info` in the bundle.

Refs: END-944
