### PR TITLE
fix(packages): make the rpm own its bundle directories

### DIFF
--- a/changelog.d/20260831_140652_benjamin.rigaud_rpm_own_bundle_dirs.md
+++ b/changelog.d/20260831_140652_benjamin.rigaud_rpm_own_bundle_dirs.md
@@ -1,0 +1,4 @@
+### Changed
+
+- The Linux rpm now owns its bundle directories, so upgrades no longer leave
+  empty `*.dist-info` directories behind.

--- a/scripts/build-os-packages/nfpm.yaml
+++ b/scripts/build-os-packages/nfpm.yaml
@@ -21,13 +21,16 @@ umask: 0o022
 contents:
   # The Rust dispatcher, not the PyInstaller launcher: `ggshield` is the entry
   # point and `ggshield-py` (which it execs) sits next to it in
-  # /usr/libexec/ggshield, picked up by the `expand: true` entry below.
+  # /usr/libexec/ggshield, picked up by the bundle entry below.
   - src: ../libexec/ggshield/ggshield
     dst: /usr/bin/ggshield
     type: symlink
 
+  # type: tree so the rpm owns the bundle dirs and prunes stale *.dist-info on
+  # upgrade; expand: true is still required to expand ${PYINSTALLER_OUTPUT_DIR}.
   - src: ${PYINSTALLER_OUTPUT_DIR}
     dst: /usr/libexec/ggshield
+    type: tree
     expand: true
 
     # Required because our bundled Python binary still uses libcrypt.so.1, but


### PR DESCRIPTION
## TL;DR

Follow-up to #1443 (merged). Makes the rpm own its bundle directories so upgrades remove stale `*.dist-info` natively, matching what the deb already does.

## Why

#1443 added an rpm `%posttrans` that prunes empty `*.dist-info` on upgrade, repairing already-broken hosts. This is the structural half: the rpm now **owns** the bundle directories, so rpm removes a stale dependency's directory on upgrade instead of stranding an empty one.

## Change

`type: tree` (instead of `expand: true`) on the bundle content entry. nfpm then emits directory ownership in the rpm; the deb already had it.

## Verified (nfpm 2.36.1, mock bundle)

- `type: tree` produces the **same file set** as `expand: true`, plus directory entries: the rpm gains owned dirs (`_internal` and every `*.dist-info`) where `expand: true` owned **0**.
- Fedora upgrade test: install old rpm (owns dirs, ships `typeguard-4.3.0.dist-info`) then upgrade to a new rpm (ships `typeguard-4.5.2`, no 4.3.0) removes the stale `typeguard-4.3.0.dist-info`. With `expand: true` it persists.
- deb output unchanged (it already carried directory entries).

## Scope

The `%posttrans` from #1443 stays: it repairs hosts already on `expand: true` builds, which this change cannot retroactively clean (rpm only removes directories the installed package owned).

Refs: END-944
