### PR TITLE
feat(ai-hook): add Amazon Kiro support

### DIFF
--- a/changelog.d/20260901_183452_achille.mascia_kiro_agent_support.md
+++ b/changelog.d/20260901_183452_achille.mascia_kiro_agent_support.md
@@ -1,0 +1,6 @@
+### Added
+
+- ggshield now supports Amazon Kiro, both the IDE and the CLI.
+  `ggshield machine setup` installs the secret-scanning hooks in
+  `~/.kiro/hooks/`, and MCP servers, tool calls and past usage are reported
+  like they are for every other assistant.

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -5,16 +5,19 @@ from .claude_code import Claude
 from .codex import Codex
 from .copilot import Copilot
 from .cursor import Cursor
+from .kiro import Kiro
 from .vibe import Vibe
 from .vscode import VSCode
 
 
 # Order matters: _detect_agent takes the first agent whose is_caller matches, so
 # exact matchers come before Claude's "claude" in transcript_path substring check.
+# Kiro comes last of all: it keys on event names the others share, so it is the
+# broadest matcher and every exact one gets first refusal.
 AGENTS: Dict[str, Agent] = {
     agent.name: agent
-    for agent in [Vibe(), Claude(), Codex(), Copilot(), Cursor(), VSCode()]
+    for agent in [Vibe(), Claude(), Codex(), Copilot(), Cursor(), VSCode(), Kiro()]
 }
 
 
-__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "Vibe", "VSCode"]
+__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "Kiro", "Vibe", "VSCode"]

--- a/ggshield/verticals/ai/agents/kiro.py
+++ b/ggshield/verticals/ai/agents/kiro.py
@@ -1,0 +1,275 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple
+
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
+
+from ggshield.core.dirs import get_editor_user_data_dir, get_user_home_dir
+
+from ..agent_activity.sources import JSONLActivitySource
+from ..models import Agent, HookPayload, HookResult, MCPConfiguration, Scope
+
+
+#: Kiro compiles a hook's `matcher` as a regular expression and drops the hook
+#: when it does not compile. A bare "*" is not a valid regex ("nothing to
+#: repeat"), so it leaves a hook that exists, installs cleanly, and never runs.
+ALL_TOOLS = ".*"
+
+#: What the Kiro IDE prefixes an MCP tool call with. The CLI writes "@" instead.
+MCP_PREFIX = "mcp_"
+
+
+def _mangle_server_name(name: str) -> str:
+    """Mangle a server name the way the Kiro IDE does in a tool name."""
+    return "".join(char if char.isalnum() else "_" for char in name)
+
+
+def _is_mcp_tool_name(raw_tool_name: str) -> bool:
+    """Whether a tool name is one of Kiro's two MCP spellings."""
+    return raw_tool_name.startswith(("@", MCP_PREFIX))
+
+
+class KiroActivitySource(JSONLActivitySource):
+    """Every Kiro session transcript line, shipped raw.
+
+    Both surfaces append one JSON object per line to
+    ~/.kiro/sessions/<workspace-hash>/sess_<uuid>/messages.jsonl (prompts,
+    assistant turns, tool calls, tool results). The line is shipped verbatim;
+    GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "5_session_transcript"
+
+    def discover(self) -> Iterator[Path]:
+        return iter(
+            sorted(
+                (get_user_home_dir() / ".kiro").glob("sessions/*/sess_*/messages.jsonl")
+            )
+        )
+
+
+class Kiro(Agent):
+    """Behavior specific to Amazon Kiro, both the IDE and the CLI.
+
+    Installation, MCP discovery and activity only: the hook itself is served by
+    `rust/hook/`, so nothing here parses a payload or emits a verdict.
+
+    One adapter for two surfaces: they share the settings file and the session
+    store, and differ only in the spelling of a few tool names, which are
+    matched in both forms.
+    """
+
+    agent_activity_sources = [KiroActivitySource()]
+
+    @property
+    def name(self) -> str:
+        return "kiro"
+
+    @property
+    def display_name(self) -> str:
+        return "Kiro"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".kiro"
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        """Never: the Rust hook answers Kiro's payloads.
+
+        Detection, verdicts and read ranges all live in `rust/hook/`, which is
+        what `ggshield secret scan ai-hook` runs. This adapter carries only what
+        the Rust hook does not do: installation, MCP discovery and activity.
+        """
+        return False
+
+    def output_result(self, result: HookResult) -> int:
+        raise NotImplementedError("the Rust hook emits Kiro's verdicts")
+
+    def settings_path(self, mode: Literal["local", "global"]) -> Path:
+        # A directory of standalone files rather than one settings file, so
+        # ggshield owns a file of its own instead of merging into the user's.
+        return Path(".kiro") / "hooks" / "ggshield.json"
+
+    def post_install_warning(self, mode: Literal["local", "global"]) -> Optional[str]:
+        return (
+            "Kiro loads hooks when a session starts: restart Kiro, or open a new "
+            "chat, for these to take effect. The Kiro CLI reads this file in v3 "
+            "mode only (kiro-cli --v3); older sessions take their hooks from the "
+            "agent configuration instead."
+        )
+
+    @property
+    def settings_template(self) -> Dict[str, Any]:
+        def hook(name: str, trigger: str, **extra: Any) -> Dict[str, Any]:
+            return {
+                "name": name,
+                "trigger": trigger,
+                **extra,
+                "action": {"type": "command", "command": "<COMMAND>"},
+            }
+
+        return {
+            "version": "v1",
+            "hooks": [
+                # No matcher on the prompt trigger: there it filters on the
+                # prompt text, and every prompt has to be scanned.
+                hook("ggshield-prompt", "UserPromptSubmit"),
+                hook("ggshield-pre-tool", "PreToolUse", matcher=ALL_TOOLS),
+                hook("ggshield-post-tool", "PostToolUse", matcher=ALL_TOOLS),
+            ],
+        }
+
+    def settings_locate(
+        self, candidates: List[Dict[str, Any]], template: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        # One entry per trigger, and they all carry the same matcher, so the
+        # trigger is what tells them apart.
+        trigger = template.get("trigger")
+        return next(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.get("trigger") == trigger
+            ),
+            None,
+        )
+
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "settings" / "mcp.json"
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".kiro" / "settings" / "mcp.json"
+
+    def _get_user_mcp_configurations(self) -> Iterator[MCPConfiguration]:
+        """Yield user-scoped servers, including the ones a power contributed.
+
+        `kiro-cli mcp add` keeps the user's own servers under "mcpServers" and
+        the ones installed powers bring under "powers", in the same file and the
+        same shape. A power's server is as much a live MCP server as any other,
+        so it is reported too.
+        """
+        yield from super()._get_user_mcp_configurations()
+        if not (data := self._load_file(self.user_mcp_file)):
+            return
+        powers = data.get("powers")
+        if not isinstance(powers, dict):
+            return
+        # One block for all of them, which is the shape observed, or one block
+        # per power. A file that maps a power straight to a server definition,
+        # with no block of its own, is not read: telling that apart from the
+        # nested shape means guessing, and a guess here invents servers.
+        if configurations := list(self._parse_servers_block(powers, Scope.USER, None)):
+            yield from configurations
+            return
+        for entry in powers.values():
+            if isinstance(entry, dict):
+                yield from self._parse_servers_block(entry, Scope.USER, None)
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        # The IDE is a VS Code fork and keeps the same workspace records.
+        for file in get_editor_user_data_dir("Kiro").glob(
+            "workspaceStorage/*/workspace.json"
+        ):
+            if (data := self._load_file(file)) and "folder" in data:
+                path = Path(data["folder"].removeprefix("file://"))
+                if path.is_dir():
+                    yield path.resolve()
+
+    def _split_mcp_tool_name(
+        self, raw_tool_name: str, ai_config: Optional[AIDiscovery]
+    ) -> Tuple[str, str]:
+        """Split one of Kiro's two MCP tool-name spellings into server and tool.
+
+        The CLI sends "@{server}/{tool}", which is unambiguous. The IDE sends
+        "mcp_{server}_{tool}" with every non-alphanumeric character of the
+        server name replaced by "_", so only a configured name tells the server
+        apart from the tool; with none matching, the whole name is reported as
+        the tool rather than split at a guess.
+        """
+        if raw_tool_name.startswith("@"):
+            server_name, _, tool_name = raw_tool_name[1:].partition("/")
+            return server_name, tool_name
+
+        if raw_tool_name.startswith(MCP_PREFIX) and ai_config is not None:
+            remainder = raw_tool_name.removeprefix(MCP_PREFIX)
+            names = {
+                configuration.name
+                for server in ai_config.servers
+                for configuration in server.configurations
+                if configuration.agent == self.name
+            }
+            # Longest first: a server named "git" must not claim a call to one
+            # named "github", whose mangled name starts with it.
+            for name in sorted(names, key=len, reverse=True):
+                prefix = f"{_mangle_server_name(name)}_"
+                if remainder.startswith(prefix):
+                    return name, remainder.removeprefix(prefix)
+
+        return "", raw_tool_name
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        raw_tool_name = payload.raw.get("tool_name", "")
+        server_name, tool_name = self._split_mcp_tool_name(raw_tool_name, ai_config)
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool_name,
+            server=server_name,
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
+        )
+
+    def iter_history_events(
+        self, ai_config: Optional[AIDiscovery]
+    ) -> Iterator[MCPActivityRequest]:
+        """Walk every Kiro session transcript and yield its MCP tool calls.
+
+        Both surfaces write the same store, so one walk covers the IDE and the
+        CLI. The workspace is a hash in the path and the transcript names no
+        model, so neither is reported rather than invented.
+        """
+        for path in sorted(self.config_folder.glob("sessions/*/sess_*/messages.jsonl")):
+            for entry in self._load_jsonl_file(path):
+                if (event := self._parse_history_entry(entry, ai_config)) is not None:
+                    yield event
+
+    def _parse_history_entry(
+        self, entry: Dict[str, Any], ai_config: Optional[AIDiscovery]
+    ) -> Optional[MCPActivityRequest]:
+        """Turn one transcript line into an MCPActivityRequest, or None.
+
+        None for anything that is not an MCP tool call: the store records every
+        turn, prompt and first-party tool call too.
+        """
+        payload = entry.get("payload")
+        if not isinstance(payload, dict) or payload.get("type") != "tool_call":
+            return None
+
+        raw_tool_name = payload.get("toolName")
+        if not isinstance(raw_tool_name, str) or not _is_mcp_tool_name(raw_tool_name):
+            return None
+
+        try:
+            timestamp = datetime.fromisoformat(
+                entry["timestamp"].replace("Z", "+00:00")
+            )
+        except (KeyError, AttributeError, TypeError, ValueError):
+            return None
+
+        server_name, tool_name = self._split_mcp_tool_name(raw_tool_name, ai_config)
+        arguments = payload.get("args")
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=tool_name,
+            server=server_name,
+            agent=self.name,
+            model="",
+            cwd="",
+            input=arguments if isinstance(arguments, dict) else {},
+            timestamp=timestamp,
+        )

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -901,7 +901,9 @@ mod tests {
         let outcome = resolved.as_ref().map(|config| {
             scan(
                 config,
-                r#"{"unknown_agent": true, "hook_event_name": "PreToolUse"}"#,
+                // An event name no adapter answers to: "PreToolUse" alone, with
+                // no other agent's marker beside it, is Kiro's own signature.
+                r#"{"unknown_agent": true, "hook_event_name": "somethingElse"}"#,
             )
         });
         unsafe {

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -1,7 +1,7 @@
 //! The per-agent output contracts. One transcription of `output_result()` per
 //! adapter in `ggshield/verticals/ai/agents/`.
 //!
-//! The six schemas disagree about which key blocks, which events can block at
+//! The schemas disagree about which key blocks, which events can block at
 //! all, whether a warning is carried, whether anything is printed when the action
 //! is allowed, and what the exit code means. Getting one wrong produces a verdict
 //! the agent silently ignores, not an error.
@@ -220,6 +220,32 @@ pub fn emission(result: &HookResult) -> Emission {
             },
             0,
         ),
+
+        // Kiro, which this hook serves alone: its Python adapter declines every
+        // payload, so there is nothing to mirror here. There is no JSON verdict
+        // protocol on either surface: Kiro reads exit 2 as "blocked" and
+        // forwards the stderr text to the model.
+        Agent::Kiro => {
+            if result.block {
+                match event {
+                    // Constraint: the Kiro IDE does not honour a non-zero exit on
+                    // its prompt-submit trigger, so the prompt reaches the model
+                    // anyway and the verdict is advisory there. It blocks on the CLI.
+                    EventType::UserPrompt | EventType::PreToolUse => {
+                        Emission::Stderr(message.to_string(), 2)
+                    }
+                    // Nothing to block after the fact; lib.rs raises the desktop
+                    // notification for PostToolUse.
+                    EventType::PostToolUse | EventType::Other => Emission::Silent(0),
+                }
+            } else if !result.warning.is_empty() {
+                // A fail-open warning is text for the model, not a block, so the
+                // exit code stays 0.
+                Emission::Stderr(result.warning.clone(), 0)
+            } else {
+                Emission::Silent(0)
+            }
+        }
     }
 }
 
@@ -461,6 +487,58 @@ mod tests {
             assert_eq!(
                 allowed(Agent::Copilot, event),
                 allowed(Agent::VsCode, event)
+            );
+        }
+    }
+
+    /// `(stderr text, exit code)`, or `None` when the adapter emits nothing.
+    fn stderr_of(result: &HookResult) -> Option<(String, i32)> {
+        match emission(result) {
+            Emission::Stderr(message, code) => Some((message, code)),
+            Emission::Silent(..) => None,
+            Emission::Stdout(value, _) => panic!("unexpected stdout: {value}"),
+        }
+    }
+
+    /// GIVEN an allow, a fail-open warning and a block on each Kiro event
+    /// WHEN they are emitted
+    /// THEN nothing ever reaches stdout: a block on a prompt or a tool call is
+    /// stderr with exit 2, a warning is stderr with exit 0, and everything else is
+    /// silent.
+    #[test]
+    fn kiro_contract() {
+        for event in [
+            EventType::UserPrompt,
+            EventType::PreToolUse,
+            EventType::PostToolUse,
+            EventType::Other,
+        ] {
+            let p = payload(Agent::Kiro, event);
+            assert_eq!(stderr_of(&HookResult::allow(&p)), None, "{event:?}");
+            assert_eq!(
+                stderr_of(&HookResult::allow_with_warning(&p, "could not scan".into())),
+                Some(("could not scan".to_string(), 0)),
+                "{event:?}"
+            );
+        }
+
+        // Only the two events Kiro can still act on block, and exit 2 is what it
+        // reads as "blocked".
+        for event in [EventType::UserPrompt, EventType::PreToolUse] {
+            let p = payload(Agent::Kiro, event);
+            assert_eq!(
+                stderr_of(&HookResult::block(&p, "nope".into(), 1)),
+                Some(("nope".to_string(), 2)),
+                "{event:?}"
+            );
+        }
+        // Too late to block: lib.rs notifies instead.
+        for event in [EventType::PostToolUse, EventType::Other] {
+            let p = payload(Agent::Kiro, event);
+            assert_eq!(
+                stderr_of(&HookResult::block(&p, "nope".into(), 1)),
+                None,
+                "{event:?}"
             );
         }
     }

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -28,7 +28,7 @@ pub enum Tool {
     Other,
 }
 
-/// The six assistants ggshield supports, in the registry order of `AGENTS`
+/// The assistants ggshield supports, in the registry order of `AGENTS`
 /// (agents/__init__.py). Detection takes the FIRST match, so the order matters.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Agent {
@@ -38,15 +38,20 @@ pub enum Agent {
     Copilot,
     Cursor,
     VsCode,
+    Kiro,
 }
 
-pub const AGENTS: [Agent; 6] = [
+pub const AGENTS: [Agent; 7] = [
     Agent::Vibe,
     Agent::Claude,
     Agent::Codex,
     Agent::Copilot,
     Agent::Cursor,
     Agent::VsCode,
+    // Last: Kiro keys on event names other agents share (`PreToolUse` and
+    // friends), so it is the broadest matcher of the seven and every exact one
+    // gets first refusal.
+    Agent::Kiro,
 ];
 
 impl Agent {
@@ -59,6 +64,7 @@ impl Agent {
             Agent::Copilot => "copilot",
             Agent::Cursor => "cursor",
             Agent::VsCode => "vscode",
+            Agent::Kiro => "kiro",
         }
     }
 
@@ -72,6 +78,7 @@ impl Agent {
             Agent::Copilot => "Copilot CLI",
             Agent::Cursor => "Cursor",
             Agent::VsCode => "VSCode",
+            Agent::Kiro => "Kiro",
         }
     }
 
@@ -115,6 +122,44 @@ impl Agent {
             }
             Agent::Cursor => data.get("cursor_version").is_some(),
             Agent::VsCode => transcript.to_lowercase().contains("github.copilot-chat"),
+            // Kiro CLI spells its triggers in camelCase and the Kiro IDE in
+            // PascalCase; neither surface sends anything else identifying.
+            Agent::Kiro => {
+                const TRIGGERS: [&str; 15] = [
+                    "userPromptSubmit",
+                    "UserPromptSubmit",
+                    "preToolUse",
+                    "PreToolUse",
+                    "postToolUse",
+                    "PostToolUse",
+                    "agentSpawn",
+                    "SessionStart",
+                    "stop",
+                    "Stop",
+                    "PreTaskExec",
+                    "PostTaskExec",
+                    "PostFileCreate",
+                    "PostFileSave",
+                    "PostFileDelete",
+                ];
+                // Several of those spellings are shared with Claude, Cursor,
+                // Codex, Copilot CLI and Junie CLI, so the event name alone
+                // would let Kiro claim their payloads. These keys are what each
+                // of them sends and Kiro never does. `project_path` is Junie's,
+                // which mirrors Claude Code's wire protocol deliberately and so
+                // has no marker of its own either.
+                const FOREIGN_KEYS: [&str; 5] = [
+                    "transcript_path",
+                    "cursor_version",
+                    "turn_id",
+                    "timestamp",
+                    "project_path",
+                ];
+                let Some(name) = data.get("hook_event_name").and_then(Value::as_str) else {
+                    return false;
+                };
+                TRIGGERS.contains(&name) && FOREIGN_KEYS.iter().all(|key| data.get(key).is_none())
+            }
         }
     }
 
@@ -176,6 +221,22 @@ impl Agent {
                     None
                 } else {
                     Some((first, last))
+                }
+            }
+            // Kiro's `read_file` spells the same two parameters as Claude and
+            // counts `offset` from zero, not one: measured against a numbered
+            // file, `offset` 49 with `limit` 11 returns lines 50 to 60. A zero
+            // `offset` is a real read from the top, so it cannot go through
+            // `positive`, which reads 0 as absent. Its CLI `fs_read` names its
+            // files under `operations` and carries no bounds we have seen, so
+            // it arrives here with neither parameter and reads whole files.
+            Agent::Kiro => {
+                let offset = tool_input.get("offset").and_then(Value::as_u64);
+                let first = offset.unwrap_or(0).saturating_add(1);
+                match positive("limit") {
+                    Some(limit) => Some((first, Some(first.saturating_add(limit - 1)))),
+                    None if first == 1 => None,
+                    None => Some((first, None)),
                 }
             }
             // No range ever seen from these four: Copilot CLI's `view` carries
@@ -255,14 +316,25 @@ fn event_type_from_name(name: &str) -> EventType {
 
 fn parse_tool(data: &Value) -> Tool {
     let name = lookup_str(data, &["tool_name"]).to_lowercase();
-    if name.starts_with("mcp") {
+    // The Kiro IDE's `mcp_{server}_{tool}` already matches the prefix rule; the
+    // Kiro CLI writes the same call as `@{server}/{tool}`.
+    if name.starts_with("mcp") || name.starts_with('@') {
         return Tool::Mcp;
     }
     match name.as_str() {
         // `git_bash` and `powershell` are Vibe's other two shells; mapping them to
         // Bash is what gets their command parsed for file reads.
-        "shell" | "bash" | "git_bash" | "powershell" | "run_in_terminal" => Tool::Bash,
-        "read" | "read_file" | "view" => Tool::Read,
+        // `execute_bash`, its `execute_cmd` alias and `execute_pwsh` are Kiro's.
+        "shell" | "bash" | "git_bash" | "powershell" | "run_in_terminal" | "execute_bash"
+        | "execute_cmd" | "execute_pwsh" => Tool::Bash,
+        // `fs_read` is Kiro's CLI reader, `read_file` its IDE one. Its plural
+        // `read_files` is deliberately absent: it takes several paths in an
+        // unverified shape, and a Read payload whose path lookup finds nothing
+        // scans nothing. Left generic, the response it returns is still scanned.
+        "read" | "read_file" | "view" | "fs_read" => Tool::Read,
+        // Kiro's writers (`fs_write`, `str_replace`, `fs_append`) belong here on
+        // purpose: the generic branch scans their `tool_input`, which is what
+        // carries the content about to be written.
         _ => Tool::Other,
     }
 }
@@ -423,6 +495,12 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
                         &cwd,
                     );
                     read_range = agent.read_range(tool_input);
+                    // A reader that names its files somewhere else entirely, see
+                    // `read_operations`. The payload built here then carries no
+                    // identifier and no content, so it is scanned for nothing.
+                    if identifier.is_empty() {
+                        payloads.extend(read_operations(tool_input, agent, &cwd));
+                    }
                 }
                 // MCP and unrecognised tool arguments can carry secrets bound
                 // for external servers, so they are scanned as text.
@@ -462,6 +540,16 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
                     &cwd,
                 );
                 read_range = agent.read_range(tool_input);
+                if identifier.is_empty() {
+                    // A reader that names its file under `operations`. Recovering
+                    // it is what lets `secret.ignored_paths` and the verdict cache
+                    // see a path at all; the response body alone gives them a
+                    // hash. Only a single-file read has one path to answer with.
+                    let paths = read_operation_paths(tool_input);
+                    if let [path] = paths[..] {
+                        identifier = abs_read_path(path, &cwd);
+                    }
+                }
             }
         }
         EventType::Other => {}
@@ -506,6 +594,46 @@ pub fn parse(raw_content: &str) -> Result<Vec<Payload>, Error> {
         _ => {}
     }
     Ok(payloads)
+}
+
+/// The file paths a read tool names under `operations`, in order.
+fn read_operation_paths(tool_input: &Value) -> Vec<&str> {
+    tool_input
+        .get("operations")
+        .and_then(Value::as_array)
+        .map(|operations| {
+            operations
+                .iter()
+                .filter_map(|operation| operation.get("path").and_then(Value::as_str))
+                .filter(|path| !path.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The files a read tool names in an `operations` list rather than in a `path` of
+/// its own, one payload each.
+///
+/// Kiro's `fs_read` takes `{"operations": [{"mode": "Line", "path": "..."}, ...]}`,
+/// so a single call can expose several files and none of them is reachable through
+/// the usual `file_path`/`path` lookup. Every entry is a file about to reach the
+/// model, so every entry is scanned; a call whose paths cannot be read at all
+/// leaves nothing behind, which is what an unrecognised shape must not do
+/// silently.
+fn read_operations(tool_input: &Value, agent: Agent, cwd: &str) -> Vec<Payload> {
+    read_operation_paths(tool_input)
+        .into_iter()
+        .map(|path| Payload {
+            event_type: EventType::PreToolUse,
+            tool: Some(Tool::Read),
+            content: String::new(),
+            identifier: abs_read_path(path, cwd),
+            agent,
+            cwd: cwd.to_string(),
+            raw: Value::Object(Default::default()),
+            read_range: None,
+        })
+        .collect()
 }
 
 /// `_parse_command()`: agents sometimes read a file by shelling out.
@@ -557,7 +685,7 @@ mod tests {
     /// THEN each is identified from its own signature and the last two are refused.
     #[test]
     fn detects_each_agent_from_its_own_signature() {
-        let cases: [(&str, Value, Option<Agent>); 8] = [
+        let cases: [(&str, Value, Option<Agent>); 10] = [
             ("claude", claude(json!({})), Some(Agent::Claude)),
             (
                 "codex via turn_id",
@@ -585,6 +713,18 @@ mod tests {
                 json!({"session_id": "s",
                        "transcript_path": "/x/GitHub.Copilot-Chat/sess.json"}),
                 Some(Agent::VsCode),
+            ),
+            (
+                "kiro cli",
+                json!({"hook_event_name": "preToolUse", "cwd": "/p",
+                       "tool_name": "fs_write", "tool_input": {"command": "create"}}),
+                Some(Agent::Kiro),
+            ),
+            (
+                "kiro ide",
+                json!({"session_id": "sess_1", "hook_event_name": "PreToolUse",
+                       "cwd": "/p", "tool_name": "str_replace", "tool_input": {}}),
+                Some(Agent::Kiro),
             ),
             (
                 "codex sends transcript_path as null",
@@ -1234,5 +1374,303 @@ mod tests {
         });
         assert_eq!(Agent::Cursor.event_cwd(&cursor), "/home/user/foo");
         assert_eq!(Agent::Cursor.event_cwd(&json!({})), "");
+    }
+
+    /// GIVEN payloads carrying an event name Kiro shares with another agent, plus
+    /// one of that agent's own keys
+    /// WHEN the agent is detected
+    /// THEN the other agent wins: Kiro is registered last and refuses any payload
+    /// carrying a key it never sends.
+    #[test]
+    fn kiro_never_claims_another_agents_payload() {
+        let cases: [(&str, Value, Option<Agent>); 6] = [
+            (
+                "claude",
+                claude(json!({"hook_event_name": "PreToolUse"})),
+                Some(Agent::Claude),
+            ),
+            (
+                "cursor",
+                json!({"cursor_version": "2.5.25", "hook_event_name": "preToolUse",
+                       "tool_name": "Read"}),
+                Some(Agent::Cursor),
+            ),
+            (
+                "codex",
+                json!({"turn_id": "t1", "hook_event_name": "PreToolUse"}),
+                Some(Agent::Codex),
+            ),
+            (
+                "copilot",
+                json!({"hook_event_name": "PreToolUse", "session_id": "s",
+                       "timestamp": "t", "cwd": "/tmp"}),
+                Some(Agent::Copilot),
+            ),
+            // Junie CLI mirrors Claude Code's field names on purpose, so it
+            // reaches Kiro's matcher with a trigger name Kiro also uses.
+            (
+                "junie cli",
+                json!({"hook_event_name": "UserPromptSubmit", "session_id": "s",
+                       "cwd": "/p", "project_path": "/p", "prompt": "hello"}),
+                None,
+            ),
+            // Not one of Kiro's trigger spellings, and nothing else matches.
+            (
+                "unknown trigger",
+                json!({"hook_event_name": "beforeShellExecution", "cwd": "/p"}),
+                None,
+            ),
+        ];
+        for (label, data, expected) in cases {
+            assert_eq!(Agent::detect(&data), expected, "{label}");
+        }
+    }
+
+    /// GIVEN each Kiro trigger that carries nothing to scan
+    /// WHEN it is parsed
+    /// THEN Kiro is recognised and the event maps to no type.
+    #[test]
+    fn kiro_content_free_triggers_are_other_events() {
+        for event in [
+            "agentSpawn",
+            "SessionStart",
+            "stop",
+            "Stop",
+            "PreTaskExec",
+            "PostTaskExec",
+            "PostFileCreate",
+            "PostFileSave",
+            "PostFileDelete",
+        ] {
+            let raw = json!({"hook_event_name": event, "cwd": "/p"}).to_string();
+            let payloads = parse(&raw).expect("parses");
+            assert_eq!(payloads[0].agent, Agent::Kiro, "{event}");
+            assert_eq!(payloads[0].event_type, EventType::Other, "{event}");
+        }
+    }
+
+    /// GIVEN Kiro's tool names from both surfaces
+    /// WHEN each is classified
+    /// THEN the readers and the two shells are recognised, and both MCP spellings
+    /// (the CLI's `@server/tool` and the IDE's `mcp_server_tool`) are MCP.
+    #[test]
+    fn kiro_tool_names_map_to_their_tools() {
+        let cases = [
+            ("fs_read", Tool::Read),
+            ("read_file", Tool::Read),
+            // Several paths in a shape we have not verified: kept generic so no
+            // Read payload is built around a path lookup that finds nothing.
+            ("read_files", Tool::Other),
+            ("execute_bash", Tool::Bash),
+            ("execute_pwsh", Tool::Bash),
+            ("@github/create_issue", Tool::Mcp),
+            ("mcp_github_create_issue", Tool::Mcp),
+            // The writers stay generic so their tool_input is scanned as text.
+            ("fs_write", Tool::Other),
+            ("str_replace", Tool::Other),
+            ("fs_append", Tool::Other),
+        ];
+        for (tool_name, expected) in cases {
+            let data = json!({"tool_name": tool_name});
+            assert_eq!(parse_tool(&data), expected, "{tool_name}");
+        }
+    }
+
+    /// GIVEN a Kiro CLI `fs_write` and a Kiro IDE `str_replace`, the pre-write
+    /// blocking path
+    /// WHEN each is parsed
+    /// THEN the content about to be written is in the scanned text.
+    #[test]
+    fn kiro_write_tools_scan_the_content_being_written() {
+        let raw = json!({
+            "hook_event_name": "preToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "fs_write",
+            "tool_input": {"command": "create", "path": "/home/user/proj/.env",
+                           "file_text": "TOKEN=deadbeef"},
+        })
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert_eq!(payloads[0].agent, Agent::Kiro);
+        assert_eq!(payloads[0].event_type, EventType::PreToolUse);
+        assert_eq!(payloads[0].tool, Some(Tool::Other));
+        assert!(
+            payloads[0].content.contains("TOKEN=deadbeef"),
+            "{:?}",
+            payloads[0].content
+        );
+
+        let raw = json!({
+            "session_id": "sess_1",
+            "hook_event_name": "PreToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "str_replace",
+            "tool_input": {"path": "/home/user/proj/a.py", "oldStr": "hi",
+                           "newStr": "TOKEN=deadbeef", "replace_all": false},
+        })
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert!(
+            payloads[0].content.contains("TOKEN=deadbeef"),
+            "{:?}",
+            payloads[0].content
+        );
+    }
+
+    /// GIVEN the read ranges Kiro's `read_file` sends
+    /// WHEN they are resolved
+    /// THEN `offset` counts from zero, so the payload measured against a
+    /// numbered file (49, 11) covers lines 50 to 60, and a read with neither
+    /// parameter still covers the whole file.
+    #[test]
+    fn kiro_read_ranges_count_the_offset_from_zero() {
+        let cases = [
+            (
+                json!({"path": "f", "offset": 49, "limit": 11}),
+                Some((50, Some(60))),
+            ),
+            (
+                json!({"path": "f", "offset": 0, "limit": 10}),
+                Some((1, Some(10))),
+            ),
+            (json!({"path": "f", "offset": 49}), Some((50, None))),
+            (json!({"path": "f"}), None),
+            // The CLI reader names its files elsewhere and sends no bounds.
+            (json!({"operations": [{"mode": "Line", "path": "f"}]}), None),
+        ];
+        for (tool_input, expected) in cases {
+            assert_eq!(
+                Agent::Kiro.read_range(&tool_input),
+                expected,
+                "{tool_input}"
+            );
+        }
+    }
+
+    /// GIVEN a Kiro CLI `fs_read`, whose files are named in an `operations` list
+    /// WHEN it is parsed
+    /// THEN every path in the list becomes its own Read payload, resolved against
+    /// `cwd`, and the call's own payload carries nothing to scan.
+    #[test]
+    fn kiro_fs_read_operations_become_one_payload_per_file() {
+        let raw = json!({
+            "hook_event_name": "preToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "fs_read",
+            "tool_input": {"operations": [
+                {"mode": "Line", "path": "/home/user/proj/seed.txt"},
+                {"mode": "Line", "path": "creds.env"},
+                {"mode": "Directory"},
+            ]},
+        })
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        // The synthesised payloads come first, the call's own payload last.
+        let reads: Vec<_> = payloads[..payloads.len() - 1]
+            .iter()
+            .map(|p| (p.identifier.as_str(), p.event_type, p.read_range))
+            .collect();
+        assert_eq!(
+            reads,
+            vec![
+                (
+                    native("/home/user/proj/seed.txt").as_str(),
+                    EventType::PreToolUse,
+                    None
+                ),
+                (
+                    native("/home/user/proj/creds.env").as_str(),
+                    EventType::PreToolUse,
+                    None
+                ),
+            ]
+        );
+        // An operations list leaves the call's own payload with no text at all, so
+        // `scan_payloads` skips it instead of scanning the empty string. Its
+        // identifier is the hash of that empty content, not a path.
+        assert!(payloads.last().expect("non-empty").content.is_empty());
+    }
+
+    /// GIVEN the PostToolUse of a Kiro CLI `fs_read` of a single file
+    /// WHEN it is parsed
+    /// THEN the file is the identifier, so the exclusions and the verdict cache
+    /// still see a path rather than a hash of the response.
+    #[test]
+    fn kiro_fs_read_post_tool_use_keeps_the_path() {
+        let raw = json!({
+            "hook_event_name": "postToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "fs_read",
+            "tool_input": {"operations": [{"mode": "Line", "path": "creds.env"}]},
+            "tool_response": {"success": true, "result": ["password = hunter2"]},
+        })
+        .to_string();
+
+        let payloads = parse(&raw).expect("parses");
+
+        assert_eq!(payloads[0].tool, Some(Tool::Read));
+        assert_eq!(payloads[0].identifier, native("/home/user/proj/creds.env"));
+    }
+
+    /// GIVEN a read of several files at once, which no single path can name
+    /// WHEN its PostToolUse is parsed
+    /// THEN the response is scanned under a content hash rather than under one
+    /// of the files, which would answer for the others too.
+    #[test]
+    fn kiro_multi_file_read_post_tool_use_falls_back_to_a_hash() {
+        let raw = json!({
+            "hook_event_name": "postToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "fs_read",
+            "tool_input": {"operations": [
+                {"mode": "Line", "path": "a.env"},
+                {"mode": "Line", "path": "b.env"},
+            ]},
+            "tool_response": "password = hunter2",
+        })
+        .to_string();
+
+        let payloads = parse(&raw).expect("parses");
+
+        assert_eq!(payloads[0].identifier, sha256_hex("password = hunter2"));
+    }
+
+    /// GIVEN a Kiro prompt and a Kiro read, from either surface
+    /// WHEN they are parsed
+    /// THEN the prompt is scanned with its @-mentions resolved against `cwd`, and
+    /// the read covers the whole file.
+    #[test]
+    fn kiro_prompt_and_read_use_the_plain_cwd() {
+        let raw = json!({
+            "hook_event_name": "userPromptSubmit",
+            "cwd": "/home/user/proj",
+            "prompt": "check @src/creds.env",
+        })
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        let ids: Vec<_> = payloads.iter().map(|p| p.identifier.as_str()).collect();
+        assert!(
+            ids.contains(&native("/home/user/proj/src/creds.env").as_str()),
+            "{ids:?}"
+        );
+        assert_eq!(
+            payloads.last().expect("non-empty").content,
+            "check @src/creds.env"
+        );
+
+        let raw = json!({
+            "session_id": "sess_1",
+            "hook_event_name": "PostToolUse",
+            "cwd": "/home/user/proj",
+            "tool_name": "read_file",
+            "tool_input": {"path": "creds.env"},
+            "tool_response": "TOKEN=deadbeef",
+        })
+        .to_string();
+        let payloads = parse(&raw).expect("parses");
+        assert_eq!(payloads[0].tool, Some(Tool::Read));
+        assert_eq!(payloads[0].identifier, native("/home/user/proj/creds.env"));
+        assert_eq!(payloads[0].content, "TOKEN=deadbeef");
+        assert_eq!(payloads[0].read_range, None);
     }
 }

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -14,7 +14,7 @@ sides must produce but whose value is allowed to differ (see `same_request`).
   python3 tests/equivalence.py            # equivalence only
   python3 tests/equivalence.py --bench N  # also time both, N iterations/side
 
-Ten matrices:
+Eleven matrices:
   agents   6 assistants x their own payload shapes x {clean, secret}
   config   .gitguardian.yaml cases: discovery, precedence, and every key that
            changes the verdict or the request
@@ -31,6 +31,8 @@ Ten matrices:
   exclude  the default ignored-path wildcards: which files a vendored *name*
            may and may not swallow
   extra    fail-open, and the unrecognized-agent case
+  kiro     Kiro, which the Rust hook serves alone: asserted against its
+           output contract instead of diffed, there being no Python side
 
 Every payload fixture is copied from tests/unit/verticals/ai/test_hooks.py, so
 the shapes are the ones ggshield's own tests consider realistic.
@@ -1876,6 +1878,121 @@ def extra_cases(tmp):
     return failures
 
 
+def kiro_payloads():
+    """Kiro's own shapes, one per surface: the CLI in camelCase, the IDE in
+    PascalCase, `fs_read`/`operations` against `read_file`/`offset`.
+
+    Shapes are copied from the adapter's own research; Kiro has no Python
+    implementation to lift fixtures from, which is the point of `check_kiro`.
+    """
+    cli = {"hook_event_name": "preToolUse", "cwd": "/tmp"}
+    ide = {"session_id": "sess_1", "cwd": "/tmp"}
+    command = (
+        f"aws configure set aws_access_key_id {CLIENT_ID} --secret {CLIENT_SECRET}"
+    )
+    return {
+        # (payload, whether it carries something to scan)
+        "cli/user_prompt": (
+            {
+                "hook_event_name": "userPromptSubmit",
+                "cwd": "/tmp",
+                "prompt": f"deploy with key {CLIENT_ID} please",
+            },
+            True,
+        ),
+        "cli/pre_bash": (
+            {**cli, "tool_name": "execute_bash", "tool_input": {"command": command}},
+            True,
+        ),
+        "cli/pre_fs_read": (
+            {
+                **cli,
+                "tool_name": "fs_read",
+                "tool_input": {"operations": [{"mode": "Line", "path": READ_FILE}]},
+            },
+            True,
+        ),
+        "cli/pre_fs_write": (
+            {
+                **cli,
+                "tool_name": "fs_write",
+                "tool_input": {"command": "create", "file_text": f"KEY={CLIENT_ID}"},
+            },
+            True,
+        ),
+        "cli/post_bash": (
+            {
+                "hook_event_name": "postToolUse",
+                "cwd": "/tmp",
+                "tool_name": "execute_bash",
+                "tool_input": {"command": "printenv"},
+                "tool_response": {"success": True, "result": [f"KEY={CLIENT_ID}"]},
+            },
+            True,
+        ),
+        "ide/pre_read_file": (
+            {
+                **ide,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "read_file",
+                "tool_input": {"path": READ_FILE, "offset": 0, "limit": 20},
+            },
+            True,
+        ),
+        # No tool and no prompt: recognised, parsed, and scanned for nothing.
+        "ide/session_start": (
+            {**ide, "hook_event_name": "SessionStart"},
+            False,
+        ),
+    }
+
+
+def check_kiro(tmp):
+    """Kiro, asserted rather than diffed: the Rust hook is its only
+    implementation, so there is no Python side to compare against.
+
+    The contract is `Agent::Kiro` in output.rs: nothing ever reaches stdout, a
+    block on a prompt or a pre-tool call is stderr with exit 2, and everything
+    else exits 0. A payload that carries something to scan must also reach the
+    API, otherwise a silent parse failure would read as a clean allow.
+    """
+    failures = []
+    print("\nKiro (Rust-only, asserted): exit codes, stderr, and what was sent")
+    for mode in ("clean", "secret"):
+        log = tmp / f"requests-kiro-{mode}.jsonl"
+        mock, port = start_mock(mode, log)
+        try:
+            for name, (payload, scannable) in kiro_payloads().items():
+                workdir = make_workdir(tmp, f"kiro-{mode}-{name.replace('/', '-')}")
+                write_read_file()
+                before = len(read_requests(log))
+                proc, _ = run(RS_CMD, payload, port, workdir)
+                sent = len(read_requests(log)) > before
+                blocks = mode == "secret" and payload["hook_event_name"] in (
+                    "userPromptSubmit",
+                    "preToolUse",
+                    "PreToolUse",
+                )
+                expected_code = 2 if blocks else 0
+                ok = (
+                    proc.returncode == expected_code
+                    and proc.stdout == b""
+                    and bool(proc.stderr) == blocks
+                    and sent == scannable
+                )
+                print(f"  [{'OK  ' if ok else 'FAIL'}] {mode}/{name}")
+                if not ok:
+                    failures.append(f"kiro/{mode}/{name}")
+                    print(
+                        f"        exit={proc.returncode} (want {expected_code}) "
+                        f"stdout={proc.stdout[:120]!r} "
+                        f"stderr={proc.stderr[:120]!r} sent={sent} (want {scannable})"
+                    )
+        finally:
+            mock.kill()
+    return failures
+
+
 def bench(tmp, iterations):
     """Latency, alternating sides so machine load hits both equally.
 
@@ -1984,6 +2101,7 @@ def main():
         failures += compare_dotenv(tmp)
         failures += compare_exclusions(tmp)
         failures += extra_cases(tmp)
+        failures += check_kiro(tmp)
         if "--bench" in sys.argv:
             n = int(sys.argv[sys.argv.index("--bench") + 1])
             bench(tmp, n)

--- a/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
+++ b/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
@@ -166,3 +166,25 @@ def test_copilot_does_not_inherit_vscode_source(fake_home: Path) -> None:
 
     [source] = Copilot().agent_activity_sources
     assert isinstance(source, CopilotActivitySource)
+
+
+def test_kiro_agent_ships_raw_transcript_lines(fake_home: Path) -> None:
+    """Both Kiro surfaces write the same session store, so one source covers
+    the IDE and the CLI."""
+    from ggshield.verticals.ai.agents.kiro import Kiro
+
+    for session_id in ("sess_1", "sess_2"):
+        session = fake_home / ".kiro" / "sessions" / "a1b2" / session_id
+        session.mkdir(parents=True)
+        (session / "messages.jsonl").write_text(
+            json.dumps({"id": session_id, "payload": {"type": "user"}}) + "\n"
+        )
+
+    events = list(Kiro().iter_agent_activity_events())
+
+    assert len(events) == 2
+    assert {event.agent_name for event in events} == {"kiro"}
+    assert {event.source_kind for event in events} == {"5_session_transcript"}
+    # The workspace hash and the session id stay in the path, so an event can be
+    # traced back to the session it came from.
+    assert all(event.source_path.startswith("sessions/a1b2/sess_") for event in events)

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
@@ -13,6 +14,7 @@ from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.codex import Codex
 from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
+from ggshield.verticals.ai.agents.kiro import Kiro
 from ggshield.verticals.ai.agents.vibe import Vibe
 from ggshield.verticals.ai.agents.vscode import VSCode
 from ggshield.verticals.ai.models import (
@@ -1924,3 +1926,237 @@ class TestSubscriptionEmail:
         WHEN subscription_email is read
         THEN None is returned, never a stand-in from git config"""
         assert agent.subscription_email() is None
+
+
+# ===========================================================================
+# Kiro
+# ===========================================================================
+
+
+class TestKiro:
+    def test_config_folder(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.kiro.get_user_home_dir", return_value=tmp_path
+        ):
+            assert Kiro().config_folder == tmp_path / ".kiro"
+
+    def test_mcp_files(self):
+        kiro = Kiro()
+        assert kiro.project_mcp_file(Path("/tmp/project")) == (
+            Path("/tmp/project") / ".kiro" / "settings" / "mcp.json"
+        )
+        assert kiro.user_mcp_file.parts[-3:] == (".kiro", "settings", "mcp.json")
+
+    def test_settings_template_matcher_is_a_regex(self):
+        """GIVEN the installed hook file
+        WHEN its matchers are read
+        THEN they are regexes: Kiro drops a hook whose matcher does not compile,
+        and a bare "*" does not, so it would install a hook that never runs."""
+        hooks = Kiro().settings_template["hooks"]
+        matchers = {hook["trigger"]: hook.get("matcher") for hook in hooks}
+
+        assert matchers == {
+            "UserPromptSubmit": None,
+            "PreToolUse": ".*",
+            "PostToolUse": ".*",
+        }
+
+    def test_settings_locate_matches_on_the_trigger(self):
+        """GIVEN hooks that all carry the same matcher
+        WHEN one is located for an update
+        THEN the trigger is what tells them apart."""
+        kiro = Kiro()
+        candidates = [
+            {"trigger": "PreToolUse", "name": "ggshield-pre-tool"},
+            {"trigger": "PostToolUse", "name": "ggshield-post-tool"},
+        ]
+
+        found = kiro.settings_locate(candidates, {"trigger": "PostToolUse"})
+
+        assert found is candidates[1]
+        assert kiro.settings_locate(candidates, {"trigger": "SessionStart"}) is None
+
+    def test_user_mcp_configurations_include_powers(self, tmp_path: Path):
+        """GIVEN an mcp.json holding the user's own servers and a power's
+        WHEN the user-scoped configurations are discovered
+        THEN both are reported: a power's server is a live server too."""
+        settings = tmp_path / ".kiro" / "settings"
+        settings.mkdir(parents=True)
+        (settings / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"mine": {"command": "uvx", "args": ["mine"]}},
+                    "powers": {
+                        "mcpServers": {
+                            "from-power": {"url": "https://example.test/mcp"}
+                        }
+                    },
+                }
+            )
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.kiro.get_user_home_dir", return_value=tmp_path
+        ):
+            configurations = list(Kiro()._get_user_mcp_configurations())
+
+        assert {c.name for c in configurations} == {"mine", "from-power"}
+        assert all(c.scope == Scope.USER and c.agent == "kiro" for c in configurations)
+
+    def test_user_mcp_configurations_read_powers_nested_per_power(self, tmp_path: Path):
+        """GIVEN an mcp.json that keys the powers block by power
+        WHEN the user-scoped configurations are discovered
+        THEN their servers are still reported."""
+        settings = tmp_path / ".kiro" / "settings"
+        settings.mkdir(parents=True)
+        (settings / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "powers": {
+                        "aws-docs": {"mcpServers": {"docs": {"command": "uvx"}}},
+                        "notes": {"mcpServers": {"notes": {"command": "notes-mcp"}}},
+                    }
+                }
+            )
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.kiro.get_user_home_dir", return_value=tmp_path
+        ):
+            configurations = list(Kiro()._get_user_mcp_configurations())
+
+        assert {c.name for c in configurations} == {"docs", "notes"}
+
+    def test_project_mcp_configurations(self, tmp_path: Path):
+        """GIVEN a workspace holding .kiro/settings/mcp.json
+        WHEN its configurations are discovered
+        THEN the servers are reported against that project."""
+        settings = tmp_path / ".kiro" / "settings"
+        settings.mkdir(parents=True)
+        (settings / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"pg": {"command": "postgres-mcp"}}})
+        )
+
+        configurations = list(Kiro()._get_project_mcp_configurations(tmp_path))
+
+        assert [c.name for c in configurations] == ["pg"]
+        assert configurations[0].scope == Scope.PROJECT
+        assert configurations[0].project == str(tmp_path)
+
+    def test_iter_history_events_yields_only_mcp_tool_calls(self, tmp_path: Path):
+        """GIVEN a session transcript holding first-party and MCP tool calls
+        WHEN its history is walked
+        THEN only the MCP calls are reported, in either spelling, with their
+        arguments and the time they were made."""
+        session = tmp_path / ".kiro" / "sessions" / "a1b2" / "sess_1"
+        session.mkdir(parents=True)
+        lines = [
+            {
+                "id": "1",
+                "timestamp": "2026-09-01T14:29:42.409Z",
+                "payload": {"type": "user"},
+            },
+            {
+                "id": "2",
+                "timestamp": "2026-09-01T14:29:43.000Z",
+                "payload": {
+                    "type": "tool_call",
+                    "toolName": "read_file",
+                    "args": {"path": "/p/a.py"},
+                },
+            },
+            {
+                "id": "3",
+                "timestamp": "2026-09-01T14:29:44.000Z",
+                "payload": {
+                    "type": "tool_call",
+                    "toolName": "@probe-time/get_current_time",
+                    "args": {"timezone": "UTC"},
+                },
+            },
+            {
+                "id": "4",
+                "timestamp": "2026-09-01T14:29:45.000Z",
+                "payload": {
+                    "type": "tool_call",
+                    "toolName": "mcp_probe_time_get_current_time",
+                    "args": {},
+                },
+            },
+        ]
+        (session / "messages.jsonl").write_text(
+            "\n".join(json.dumps(line) for line in lines)
+        )
+        cfg = _cfg(name="probe-time", agent="kiro")
+        discovery = _ai_discovery(
+            servers=[MCPServer(name="probe-time", configurations=[cfg], tools=[])]
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.kiro.get_user_home_dir", return_value=tmp_path
+        ):
+            events = list(Kiro().iter_history_events(discovery))
+
+        assert [(e.server, e.tool) for e in events] == [
+            ("probe-time", "get_current_time"),
+            ("probe-time", "get_current_time"),
+        ]
+        assert events[0].input == {"timezone": "UTC"}
+        assert events[0].timestamp == datetime(
+            2026, 9, 1, 14, 29, 44, tzinfo=timezone.utc
+        )
+        assert all(e.agent == "kiro" for e in events)
+
+    def test_iter_history_events_survives_a_broken_transcript(self, tmp_path: Path):
+        """GIVEN a transcript holding a truncated line and an undated tool call
+        WHEN its history is walked
+        THEN the unusable lines are skipped rather than aborting the walk."""
+        session = tmp_path / ".kiro" / "sessions" / "a1b2" / "sess_1"
+        session.mkdir(parents=True)
+        (session / "messages.jsonl").write_text(
+            "{not json\n"
+            + json.dumps(
+                {"payload": {"type": "tool_call", "toolName": "@srv/tool", "args": {}}}
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "timestamp": "2026-09-01T14:29:44.000Z",
+                    "payload": {
+                        "type": "tool_call",
+                        "toolName": "@srv/tool",
+                        "args": {},
+                    },
+                }
+            )
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.kiro.get_user_home_dir", return_value=tmp_path
+        ):
+            events = list(Kiro().iter_history_events(None))
+
+        assert [(e.server, e.tool) for e in events] == [("srv", "tool")]
+
+    def test_parse_mcp_activity_splits_both_spellings(self):
+        """GIVEN the CLI's "@server/tool" and the IDE's "mcp_server_tool"
+        WHEN the MCP activity is parsed
+        THEN both resolve to the same server and tool."""
+        kiro = Kiro()
+        cfg = _cfg(name="probe-time", agent="kiro")
+        discovery = _ai_discovery(
+            servers=[MCPServer(name="probe-time", configurations=[cfg], tools=[])]
+        )
+
+        cli = kiro.parse_mcp_activity(
+            _payload(kiro, raw={"tool_name": "@probe-time/get_current_time"}), discovery
+        )
+        ide = kiro.parse_mcp_activity(
+            _payload(kiro, raw={"tool_name": "mcp_probe_time_get_current_time"}),
+            discovery,
+        )
+
+        for request in (cli, ide):
+            assert request.server == "probe-time"
+            assert request.tool == "get_current_time"
+            assert request.agent == "kiro"

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -240,7 +240,9 @@ class TestAiHookCmd:
         result = runner.invoke(
             cli,
             ["secret", "scan", "ai-hook"],
-            input='{"hook_event_name": "PreToolUse"}',
+            # An event name no adapter answers to: "PreToolUse" with no other
+            # agent's marker beside it is Kiro's own signature.
+            input='{"hook_event_name": "somethingElse"}',
         )
 
         assert result.exit_code == 1


### PR DESCRIPTION
Adds Amazon Kiro to the assistants ggshield supports, covering both surfaces
(the IDE and the CLI) with one adapter. They share the payload schema, the hook
settings file, the session store and the exit-code contract, and differ only in
the spelling of a few trigger and tool names, which are matched in both forms.
Hooks scan prompts and tool calls, and MCP servers, live tool calls and past
usage are reported like they are for Cursor, Claude and Copilot.

Kiro has no JSON verdict protocol: exit 2 blocks and hands stderr to the model,
while anything written to stdout becomes model context instead. The adapter
therefore answers with an exit code alone. Prompt-submit verdicts are advisory
on the IDE, which forwards the prompt whatever the hook returns
(kirodotdev/Kiro#11050); the CLI honours them.

Two payload shapes are worth flagging for review. `fs_read` lists the files it
is about to read under `operations` rather than in a path of its own, so each
entry becomes its own payload; without that, a read of a secret-bearing file
reached the model unscanned. And Kiro compiles a hook `matcher` as a regular
expression and drops the hook when it fails to compile, so the installed
matcher is `.*`: a bare `*` installs cleanly, never runs, and scans nothing.

Identifying Kiro from a payload is the one part with no clean answer. The other
six assistants each carry a marker to key on: `cursor_version`, `turn_id`, a
`transcript_path` naming the tool, or Copilot CLI's exact key set. Kiro carries
none, and the trigger names it sends (`PreToolUse`, `UserPromptSubmit`) are
strings Claude and Codex send too. So it is identified by what it lacks: one of
Kiro's trigger names, and none of `transcript_path`, `cursor_version`,
`turn_id` or `timestamp`. It is registered last so that all six exact matchers
get first refusal.

The cost is that another assistant sending only those generic fields is
attributed to Kiro until it gets a marker of its own, and Junie CLI is a live
example rather than a hypothetical one: it mirrors Claude Code's wire protocol
deliberately, so it carries no marker either. `project_path`, which Junie sends
and Kiro does not, is therefore among the keys that make Kiro refuse a payload,
and an unrecognized event fails loudly rather than being answered in a contract
that assistant may not read.

Three existing tests met the same edge from the other side: they used a bare
`{"hook_event_name": "PreToolUse"}` to mean "no recognizable agent", which is
now a Kiro-shaped payload, so they name an event no adapter answers to instead,
as `rust/tests/equivalence.py` already did.

Verified against Kiro CLI 2.20.2 and Kiro IDE 1.0.411: pre-write and pre-read
blocking, prompt scanning, MCP activity reporting with a real MCP server, and
history backfill from the session transcripts. Two limitations worth knowing
before this is announced. Installing into `~/.kiro/hooks/` covers the IDE and
the CLI in v3 mode; the CLI in its current default mode only reads hooks from
agent configuration files, which this deliberately does not patch. And live MCP
activity reporting runs in the Python hook only, since `send_mcp_activity` has
no native implementation, for any assistant.


Refs NHI-1608, NHI-1609.


