### PR TITLE
feat(machine): add doctor --strict to fail on unavailable protections

### DIFF
--- a/changelog.d/20260904_120000_achille.mascia_doctor_strict.md
+++ b/changelog.d/20260904_120000_achille.mascia_doctor_strict.md
@@ -1,0 +1,8 @@
+### Added
+
+- `ggshield machine doctor --strict` fails on protections reported as unavailable
+  (`!`) instead of only on a misconfigured machine. The API exposes a token's scopes,
+  not the workspace's entitlements, so ggshield cannot tell "this plan cannot grant the
+  scope" from "this token is missing it"; `--strict` is how a caller that knows the
+  workspace offers the protection gates on it, for instance an MDM rollout on a
+  Business plan.

--- a/ggshield/cmd/machine/doctor.py
+++ b/ggshield/cmd/machine/doctor.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import import_module
 from typing import Any, List, Optional
 
@@ -53,9 +53,16 @@ class Check:
 
 
 @click.command(name="doctor")
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Fail on protections reported as unavailable, instead of only on a machine "
+    "that is misconfigured. Use it where the workspace is known to offer them, e.g. "
+    "an MDM rollout on a Business plan.",
+)
 @add_common_options()
 @click.pass_context
-def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
+def doctor_cmd(ctx: click.Context, strict: bool, **kwargs: Any) -> int:
     """
     Check that this machine's ggshield protections are correctly set up.
 
@@ -74,6 +81,12 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     `ggshield plugin install`). Exits non-zero if any check fails, so it can gate an
     MDM rollout — except checks marked `!`, which report a protection the workspace
     does not offer (honeytokens on a plan without them) rather than a machine to fix.
+
+    A missing scope is indistinguishable from a plan that does not grant it: the API
+    exposes a token's scopes, not the workspace's entitlements or the member's access
+    level. `--strict` is how a caller who knows better says so, turning those `!` into
+    failures: a fleet whose plan does offer honeytokens wants a token that cannot
+    plant one to fail the gate.
     """
     config = ContextObj.get(ctx).config
 
@@ -87,6 +100,10 @@ def doctor_cmd(ctx: click.Context, **kwargs: Any) -> int:
     checks.extend(_check_scopes(scopes, plugin_installed))
     if plugin_installed:
         checks.append(_check_plugin_native())
+
+    if strict:
+        # Drop the exemption rather than teach _render and the exit code about it.
+        checks = [replace(check, optional=False) for check in checks]
 
     _render(checks)
     return 0 if all(check.ok or check.optional for check in checks) else 1

--- a/tests/unit/cmd/machine/test_doctor.py
+++ b/tests/unit/cmd/machine/test_doctor.py
@@ -90,6 +90,59 @@ class TestDoctorCommand:
         assert "unavailable" in result.output
         assert "use a token" in result.output
 
+    def _run_with_optional_failure(self, cli_fs_runner, args):
+        optional = Check(
+            "Scope `honeytokens:write`", False, fix="use a token", optional=True
+        )
+        with patch(
+            f"{BASE}._check_auth_and_scopes",
+            return_value=(["scan"], Check("Authentication", True)),
+        ), patch(f"{BASE}._is_plugin_installed", return_value=False), patch(
+            f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks", return_value=Check("Git hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks_precedence",
+            return_value=Check("Git hook precedence", True),
+        ), patch(
+            f"{BASE}._check_scopes", return_value=[optional]
+        ):
+            return cli_fs_runner.invoke(cli, ["machine", "doctor", *args])
+
+    def test_strict_fails_on_an_unavailable_protection(self, cli_fs_runner: CliRunner):
+        """A caller who knows the workspace offers the protection wants a token that
+        cannot use it to fail the gate, not to be told the machine is fine."""
+        result = self._run_with_optional_failure(cli_fs_runner, ["--strict"])
+        assert result.exit_code == 1
+        assert "1 check(s) failed" in result.output
+        assert "correctly set up" not in result.output
+        assert "use a token" in result.output
+
+    def test_strict_keeps_a_healthy_machine_passing(self, cli_fs_runner: CliRunner):
+        """--strict only drops the exemption; it invents no new failures."""
+        with patch(
+            f"{BASE}._check_auth_and_scopes",
+            return_value=(["scan"], Check("Authentication", True)),
+        ), patch(f"{BASE}._is_plugin_installed", return_value=False), patch(
+            f"{BASE}._check_ai_hooks", return_value=Check("AI hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks", return_value=Check("Git hooks", True)
+        ), patch(
+            f"{BASE}._check_git_hooks_precedence",
+            return_value=Check("Git hook precedence", True),
+        ), patch(
+            f"{BASE}._check_scopes", return_value=[Check("Scope `scan`", True)]
+        ):
+            result = cli_fs_runner.invoke(cli, ["machine", "doctor", "--strict"])
+        assert result.exit_code == 0
+        assert "correctly set up" in result.output
+
+    def test_default_stays_lenient(self, cli_fs_runner: CliRunner):
+        """Without --strict the exemption holds, so an MDM rollout is not gated on a
+        scope the workspace may be unable to grant."""
+        result = self._run_with_optional_failure(cli_fs_runner, [])
+        assert result.exit_code == 0
+
     def test_plugin_check_skipped_without_plugin(self, cli_fs_runner: CliRunner):
         _result, m_plugin = self._run(
             cli_fs_runner, auth_ok=True, ai_ok=True, git_ok=True, plugin_installed=False


### PR DESCRIPTION
Stacked on #1441, which introduces the `optional` check state this builds on. Base will
retarget to `main` once that merges. #1441 itself is untouched.

### The problem

#1441 exempts the plan-gated scopes from doctor's exit code, because a workspace whose
plan does not offer honeytokens can never be granted `honeytokens:write`, and failing
there would gate an MDM rollout on something no machine can fix.

That exemption is unconditional, so the opposite case is now silent: a fleet on a plan
that *does* offer the protection, whose service-account token is simply missing the
scope, gets `This machine is correctly set up` and exit 0. That is the case the scope
check was added for.

### Why a flag

ggshield cannot tell the two apart. `/v1/api_tokens/self` returns a token's scopes,
`member_id`, `workspace_id` and type; `/v1/metadata` returns scan preferences. Neither
exposes the workspace's entitlements or the member's access level, so no client-side
inference is available.

I looked at inferring it from `honeytokens:check` (whose only gate is the workspace
flag, with no role check) combined with the token type, but it breaks exactly in the
MDM case: a service-account token is minted with hand-picked scopes, so a missing
`honeytokens:check` says nothing about the workspace. So the caller declares intent
instead.

### What changes

`--strict` clears `optional` on every check, which leaves `_render` and the exit-code
expression unaware of the distinction.

| | default | `--strict` |
| --- | --- | --- |
| plan-gated scope missing | `!` yellow, excluded from exit code | `✗` red, counted |
| summary | `correctly set up. 2 optional protection(s) unavailable` | `2 check(s) failed` |
| exit code | 0 | 1 |

Verified on a laptop whose token lacks both `honeytokens:write` and `ai-discover:send`:
exit 0 by default, exit 1 with `--strict`, and a healthy machine still exits 0 either
way. Full unit suite 2720 passed / 4 skipped; black, flake8 and ty clean.