### PR TITLE
fix(auth): report the scopes login did not get

### DIFF
--- a/changelog.d/20260904_140000_achille.mascia_login_reports_refused_scopes.md
+++ b/changelog.d/20260904_140000_achille.mascia_login_reports_refused_scopes.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `ggshield auth login` now reports the scopes it did not get, in two cases where it
+  stayed silent. A scope requested with `--scopes` and refused by the workspace is
+  named, instead of the login reporting nothing but success. And a still-valid token
+  that is reused is now checked too, so one minted before a scope joined the default
+  set no longer stays silently short until it expires; the message says the token lacks
+  the scope, rather than that it was refused, and names the command that requests it.

--- a/ggshield/cmd/auth/login.py
+++ b/ggshield/cmd/auth/login.py
@@ -20,22 +20,51 @@ from ggshield.core.url_utils import clean_url
 from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient
 
 
-def _warn_missing_scopes(client: GGClient) -> None:
+def _expected_scopes(extra_scopes: Optional[List[str]]) -> List[str]:
+    """The scopes this login asked for: the defaults plus anything from ``--scopes``.
+
+    The backend grants the subset the member is eligible for and drops the rest, so
+    what the user asked for is what we have to report against. Comparing against
+    ``DEFAULT_SCOPES`` alone leaves a refused ``--scopes`` entirely unmentioned. This is
+    also the set sent in the authorize URL.
+    """
+    return list(dict.fromkeys([*DEFAULT_SCOPES, *(extra_scopes or [])]))
+
+
+def _warn_missing_scopes(
+    client: GGClient, expected_scopes: List[str], *, reused_token: bool = False
+) -> None:
+    """Report the expected scopes the token does not carry.
+
+    ``reused_token`` distinguishes the two ways a scope can be absent, which need
+    different words and a different next step: after a login the server refused it,
+    while a kept token was simply never asked for it.
+    """
     # Best-effort warning: never fail an already-successful login when the scopes cannot
     # be read (non-JSON body, network blip, an error Detail that says nothing about them).
     granted = granted_scopes(client)
     if granted is None:
         return
-    missing = [s for s in DEFAULT_SCOPES if s not in granted]
-    if missing:
+    missing = [s for s in expected_scopes if s not in granted]
+    if not missing:
+        return
+    if reused_token:
         click.echo(
-            "Warning: the following scopes were not granted: "
+            "Warning: the current token does not have the following scopes: "
             + ", ".join(missing)
             + ".\n"
-            "Some features may require additional permissions at runtime.\n"
-            "Contact your workspace administrator if you need access.",
+            'Run "ggshield auth login --scopes '
+            + " ".join(missing)
+            + '" to get a token that does.',
             err=True,
         )
+        return
+    click.echo(
+        "Warning: the following scopes were not granted: " + ", ".join(missing) + ".\n"
+        "Some features may require additional permissions at runtime.\n"
+        "Contact your workspace administrator if you need access.",
+        err=True,
+    )
 
 
 def validate_login_path(
@@ -261,7 +290,7 @@ def token_login(config: Config, instance: Optional[str]) -> None:
     click.echo("Authentication was successful.")
     print_default_instance_message(config)
 
-    _warn_missing_scopes(client)
+    _warn_missing_scopes(client, list(DEFAULT_SCOPES))
 
 
 def web_login(
@@ -283,7 +312,14 @@ def web_login(
     client = OAuthClient(config, defined_instance)
 
     if client.check_existing_token(required_scopes=extra_scopes):
-        # skip the process if a valid token is already saved
+        # skip the process if a valid token is already saved. Report what it lacks: a
+        # kept token is never re-checked otherwise, so one minted before a scope joined
+        # the defaults stays silently short until it expires.
+        _warn_missing_scopes(
+            create_client_from_config(config),
+            _expected_scopes(extra_scopes),
+            reused_token=True,
+        )
         return
 
     client.oauth_process(
@@ -293,5 +329,7 @@ def web_login(
         extra_scopes=extra_scopes,
         no_browser=no_browser,
     )
-    _warn_missing_scopes(create_client_from_config(config))
+    _warn_missing_scopes(
+        create_client_from_config(config), _expected_scopes(extra_scopes)
+    )
     print_default_instance_message(config)

--- a/tests/unit/cmd/auth/test_login.py
+++ b/tests/unit/cmd/auth/test_login.py
@@ -8,15 +8,15 @@ from unittest.mock import Mock, patch
 import pytest
 import requests.exceptions
 from pygitguardian import GGClient
-from pygitguardian.models import Detail
+from pygitguardian.models import APITokensResponse, Detail
 
 from ggshield.__main__ import cli
-from ggshield.cmd.auth.login import _warn_missing_scopes
+from ggshield.cmd.auth.login import _expected_scopes, _warn_missing_scopes
 from ggshield.core.config import Config
 from ggshield.core.constants import DEFAULT_INSTANCE_URL
 from ggshield.core.errors import ExitCode, UnexpectedError
 from ggshield.utils.datetime import get_pretty_date
-from ggshield.verticals.auth import OAuthClient, OAuthError
+from ggshield.verticals.auth import DEFAULT_SCOPES, OAuthClient, OAuthError
 from ggshield.verticals.auth.oauth import OOB_REDIRECT_URI
 from tests.unit.conftest import assert_invoke_ok
 from tests.unit.request_mock import (
@@ -455,12 +455,63 @@ class TestAuthLoginWeb:
         config = Config()
         assert len(config.auth_config.instances) == 0
 
+    def test_existing_token_missing_a_default_scope_is_reported(
+        self, cli_fs_runner, monkeypatch
+    ):
+        """
+        GIVEN a still-valid token that lacks one of the default scopes, e.g. one minted
+            before that scope joined the defaults
+        WHEN auth login reuses it
+        THEN the missing scope is reported instead of the token staying silently short
+        AND the wording says the token lacks it, not that the server refused it
+        AND the command that would request it is named
+        AND the token is kept: reporting must not trigger a login
+        """
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(
+            API_TOKENS_ENDPOINT,
+            create_json_response(
+                {**VALID_API_TOKENS_RESPONSE.json(), "scopes": ["scan"]}
+            ),
+        )
+        add_instance_config()
+
+        exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        self._webbrowser_open_mock.assert_not_called()
+        assert "already authenticated" in output
+        assert "the current token does not have the following scopes" in output
+        assert "ai-discover:send" in output
+        assert "ggshield auth login --scopes" in output
+        # Nothing was refused on this path, so the post-login wording must not appear.
+        assert "were not granted" not in output
+        self._request_mock.assert_all_requests_happened()
+
+    def test_existing_token_with_every_scope_stays_quiet(
+        self, cli_fs_runner, monkeypatch
+    ):
+        """
+        GIVEN a still-valid token carrying every default scope
+        WHEN auth login reuses it
+        THEN nothing is reported
+        """
+        self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
+        add_instance_config()
+
+        exit_code, output = self.run_cmd(cli_fs_runner)
+
+        assert exit_code == ExitCode.SUCCESS, output
+        assert "does not have the following scopes" not in output
+
     @pytest.mark.parametrize(
         "instance_url", [DEFAULT_INSTANCE_URL, "https://some_instance.com"]
     )
     def test_existing_token_no_expiry(self, instance_url, cli_fs_runner, monkeypatch):
         self._instance_url = instance_url
         self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
 
         add_instance_config(instance_url=instance_url)
 
@@ -493,6 +544,7 @@ class TestAuthLoginWeb:
 
         self._instance_url = instance_url
         self._request_mock.add_GET(METADATA_ENDPOINT, VALID_METADATA_RESPONSE)
+        self._request_mock.add_GET(API_TOKENS_ENDPOINT, VALID_API_TOKENS_RESPONSE)
 
         add_instance_config(instance_url=instance_url, expiry_date=dt)
 
@@ -1376,7 +1428,7 @@ def test_warn_missing_scopes_swallows_non_json_body(capsys):
         0,
     )
 
-    _warn_missing_scopes(client_mock)  # must not raise
+    _warn_missing_scopes(client_mock, ["scan"])  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
 
@@ -1391,9 +1443,73 @@ def test_warn_missing_scopes_silent_on_error_detail(capsys):
     client_mock.base_uri = "https://dashboard.example.com"
     client_mock.api_tokens.return_value = Detail("Unauthorized", 401)
 
-    _warn_missing_scopes(client_mock)
+    _warn_missing_scopes(client_mock, ["scan"])
 
     assert "scopes were not granted" not in capsys.readouterr().err
+
+
+class TestReportsRefusedScopes:
+    """The backend grants the subset the member is eligible for and drops the rest, so
+    ggshield has to report against what was asked for, not against the defaults."""
+
+    def _client(self, granted):
+        client = Mock(spec=GGClient)
+        client.base_uri = "https://dashboard.example.com"
+        client.api_tokens.return_value = Mock(
+            spec=APITokensResponse, scopes=list(granted)
+        )
+        return client
+
+    def test_expected_scopes_appends_requested_ones(self):
+        """
+        GIVEN scopes requested with --scopes
+        WHEN the expected set is built
+        THEN it is the defaults plus those, without duplicates
+        """
+        expected = _expected_scopes(["honeytokens:write", "scan"])
+        assert expected[: len(DEFAULT_SCOPES)] == list(DEFAULT_SCOPES)
+        assert "honeytokens:write" in expected
+        assert len(expected) == len(set(expected))
+
+    def test_expected_scopes_defaults_to_the_defaults(self):
+        assert _expected_scopes(None) == list(DEFAULT_SCOPES)
+
+    def test_a_refused_requested_scope_is_reported(self, capsys):
+        """
+        GIVEN a token granted everything except the scope asked for with --scopes
+        WHEN the login reports its scopes
+        THEN that scope is named, instead of the login looking entirely successful
+        """
+        client = self._client(DEFAULT_SCOPES)
+
+        _warn_missing_scopes(client, _expected_scopes(["honeytokens:write"]))
+
+        err = capsys.readouterr().err
+        assert "scopes were not granted" in err
+        assert "honeytokens:write" in err
+
+    def test_a_kept_token_is_told_what_to_run(self, capsys):
+        """
+        GIVEN a kept token that lacks an expected scope
+        WHEN the absence is reported
+        THEN the wording says the token lacks it, not that it was refused, and names the
+            command that requests it: nothing was refused on this path
+        """
+        client = self._client(["scan"])
+
+        _warn_missing_scopes(client, ["scan", "ai-discover:send"], reused_token=True)
+
+        err = capsys.readouterr().err
+        assert "the current token does not have the following scopes" in err
+        assert "were not granted" not in err
+        assert "ggshield auth login --scopes ai-discover:send" in err
+
+    def test_nothing_is_reported_when_everything_was_granted(self, capsys):
+        client = self._client([*DEFAULT_SCOPES, "honeytokens:write"])
+
+        _warn_missing_scopes(client, _expected_scopes(["honeytokens:write"]))
+
+        assert "scopes were not granted" not in capsys.readouterr().err
 
 
 def test_warn_missing_scopes_swallows_connection_error(capsys):
@@ -1406,7 +1522,7 @@ def test_warn_missing_scopes_swallows_connection_error(capsys):
     client_mock.base_uri = "https://dashboard.example.com"
     client_mock.api_tokens.side_effect = requests.exceptions.ConnectionError("boom")
 
-    _warn_missing_scopes(client_mock)  # must not raise
+    _warn_missing_scopes(client_mock, ["scan"])  # must not raise
 
     assert "scopes were not granted" not in capsys.readouterr().err
 


### PR DESCRIPTION
Closes NHI-1991. Based on #1441, which makes `--scopes` re-authenticate when the current
token lacks a requested scope; the two together are what close the loop, so this branch
is stacked on it rather than on `main`. Base retargets to `main` automatically once
#1441 merges.

### The problem

The backend grants the subset of requested scopes the member is eligible for and drops
the rest (END-587), so what a login actually obtained is only knowable from the token
afterwards. `_warn_missing_scopes` compared it against the hardcoded `DEFAULT_SCOPES`,
which left two cases silent.

**A refused `--scopes` was never mentioned.** `ggshield auth login --scopes
honeytokens:write` printed nothing but `Success! You are now authenticated.` while
`machine doctor` kept printing the same flag as the fix. Since ggshield only revokes on
`logout --revoke`, each retry left another token behind.

**A reused token was not looked at at all.** The early return in `web_login` skips the
report, so a token minted before a scope joined the defaults stayed short until it
expired, visible only in `machine doctor`.

### What changes

Compare the granted scopes against the effective requested set: the defaults plus
whatever `--scopes` added, which is also exactly the set sent in the authorize URL
(`oauth.py` dedupes the same way). Run that comparison on the reuse path too.

The two paths get different wording, because they are different problems with different
next steps. On the reuse path nothing was refused: the token was kept, so it was simply
never asked for the scope, and the useful answer is the command that asks.

Kept token:

```
$ ggshield auth login
ggshield is already authenticated without an expiry date
Warning: the current token does not have the following scopes: ai-discover:send.
Run "ggshield auth login --scopes ai-discover:send" to get a token that does.
```

After a login the server refused something:

```
Warning: the following scopes were not granted: honeytokens:write.
Some features may require additional permissions at runtime.
Contact your workspace administrator if you need access.
```

With #1441 underneath, the command suggested in the first message really does
re-authenticate, so following it either gets the scope or produces the second message.
One step, no loop.

Warning rather than re-authenticating by itself is deliberate: forcing a login whenever
a default scope is missing would mint a token on every run for any workspace whose plan
cannot grant one of them, which is the churn described above.

Cost is one `/v1/api_tokens/self` call on the reuse path, on an interactive and
infrequent command.

### What was verified how

The kept-token path is the output above, run against a real token that is missing
`ai-discover:send`: no browser, token untouched, exit 0.

The refused-scope path is covered by unit tests only. On this branch it performs a real
OAuth login, which would replace the tester's token, so I did not run it.

Full unit suite 2724 passed / 4 skipped; black, flake8 and ty clean.

### Notes for review

- The half of this that compares against the effective requested set was a DoD item on
  END-583, canceled once END-587 removed the self-hosted login failure that motivated
  the flag it shipped beside. Nothing was decided against the reporting itself, and
  END-526 asked for this behavior in general terms ("prompt the user to re-authenticate,
  give them the command to run").
- Unrelated to this PR, but noticed while rebasing onto it: **#1441 is 6 commits behind
  `main`** (the rpm packaging, README Keychain and pre-commit updates). Worth rebasing
  before it merges.