### PR TITLE
fix(codex): warn that Codex hooks need approval before they run

### DIFF
--- a/changelog.d/20260907_154500_achille.mascia_codex_hook_review_warning.md
+++ b/changelog.d/20260907_154500_achille.mascia_codex_hook_review_warning.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Installing the AI hook for Codex now says that Codex will not run the hook
+  until it is approved in the Codex hook review, so the install no longer looks
+  complete while nothing is being scanned.

--- a/ggshield/verticals/ai/agents/codex.py
+++ b/ggshield/verticals/ai/agents/codex.py
@@ -108,6 +108,17 @@ class Codex(Agent):
     def settings_path(self, mode: Literal["local", "global"]) -> Path:
         return Path(".codex") / "hooks.json"
 
+    def post_install_warning(self, mode: Literal["local", "global"]) -> Optional[str]:
+        # Codex trusts a hook by hashing its definition, recorded under
+        # [hooks.state] in ~/.codex/config.toml, and an untrusted hook does not
+        # run. Repinning the ggshield path re-hashes the entry back to
+        # untrusted, so the review is needed after a reinstall too.
+        return (
+            f"{self.display_name} runs a hook only once you approve it. Start "
+            "'codex' and accept the hook review, otherwise these hooks are "
+            "installed but scan nothing."
+        )
+
     def project_mcp_file(self, directory: Path) -> Path:
         return directory / ".codex" / "config.toml"
 

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -461,6 +461,12 @@ class TestFlavorSettingsProperties:
     def test_codex_settings_template(self):
         assert isinstance(Codex().settings_template, dict)
 
+    def test_codex_warns_about_the_hook_review(self):
+        """Codex does not run a hook until it is approved, in either scope."""
+        for mode in ("local", "global"):
+            warning = Codex().post_install_warning(mode)
+            assert warning is not None and "codex" in warning
+
     def test_vibe_settings_path_and_format(self, tmp_path: Path):
         with patch(
             "ggshield.verticals.ai.agents.vibe.os.getenv",


### PR DESCRIPTION
Installing the AI hook for Codex reports success even when nothing will be scanned. Codex records hook trust under `[hooks.state]` in `~/.codex/config.toml`, keyed by the hook's file path and event and holding a hash of the hook definition, and it does not run a hook that is not trusted. Until the user accepts the review in the Codex TUI, a freshly installed hook sits there inert. Verified against Codex CLI 0.147.0: a project hook fires only after the review, and a non-interactive `codex exec` with an unreviewed hook hangs waiting for it.

Because the trust is tied to a hash of the definition, this is not only a first-install concern. We pin the hook to the absolute path of the ggshield that ran the install, and repoint it when that binary moves, so an upgrade or reinstall re-hashes the entry and drops it back to untrusted.

The warning is unconditional rather than driven by `[hooks.state]`. After a repin the entry still exists and only the hash differs, so state-based silence would go quiet in exactly the case that matters, and matching Codex's own hashing would mean reimplementing it.