### PR TITLE
feat(ai-hook): add Junie CLI support

### DIFF
--- a/changelog.d/20260907_170500_achille.mascia_junie_cli_support.md
+++ b/changelog.d/20260907_170500_achille.mascia_junie_cli_support.md
@@ -1,0 +1,7 @@
+### Added
+
+- ggshield now supports Junie CLI, JetBrains' terminal coding agent.
+  `ggshield machine setup` installs the secret-scanning hooks in
+  `~/.junie/config.json`, and MCP servers and past usage are reported like they
+  are for every other assistant. Junie inside a JetBrains IDE is not covered:
+  it embeds Junie over ACP, which invokes no hooks.

--- a/ggshield/verticals/ai/agents/__init__.py
+++ b/ggshield/verticals/ai/agents/__init__.py
@@ -5,6 +5,7 @@ from .claude_code import Claude
 from .codex import Codex
 from .copilot import Copilot
 from .cursor import Cursor
+from .junie import Junie
 from .kiro import Kiro
 from .vibe import Vibe
 from .vscode import VSCode
@@ -16,8 +17,27 @@ from .vscode import VSCode
 # broadest matcher and every exact one gets first refusal.
 AGENTS: Dict[str, Agent] = {
     agent.name: agent
-    for agent in [Vibe(), Claude(), Codex(), Copilot(), Cursor(), VSCode(), Kiro()]
+    for agent in [
+        Vibe(),
+        Claude(),
+        Codex(),
+        Copilot(),
+        Cursor(),
+        VSCode(),
+        Junie(),
+        Kiro(),
+    ]
 }
 
 
-__all__ = ["AGENTS", "Claude", "Codex", "Copilot", "Cursor", "Kiro", "Vibe", "VSCode"]
+__all__ = [
+    "AGENTS",
+    "Claude",
+    "Codex",
+    "Copilot",
+    "Cursor",
+    "Junie",
+    "Kiro",
+    "Vibe",
+    "VSCode",
+]

--- a/ggshield/verticals/ai/agents/junie.py
+++ b/ggshield/verticals/ai/agents/junie.py
@@ -1,0 +1,177 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Literal, Optional
+
+from pygitguardian.models import AIDiscovery, MCPActivityRequest
+
+from ggshield.core.dirs import get_user_home_dir
+
+from ..agent_activity.sources import JSONLActivitySource
+from ..models import Agent, HookPayload, HookResult
+
+
+#: The events Junie fires that carry something to scan. It also fires
+#: SessionStart, Stop, StopFailure, SessionEnd and PermissionRequest, none of
+#: which carries a prompt or a tool input, and it has no PostToolUse at all.
+SCANNED_EVENTS = ("UserPromptSubmit", "PreToolUse")
+
+
+class JunieActivitySource(JSONLActivitySource):
+    """Every Junie CLI session event line, shipped raw.
+
+    One JSON object per line under
+    ~/.junie/sessions/<sessionId>/events.jsonl. The line is shipped verbatim;
+    GitGuardian scans and strips secrets server-side before storing it.
+    """
+
+    kind = "5_session_events"
+
+    def discover(self) -> Iterator[Path]:
+        return iter(
+            sorted((get_user_home_dir() / ".junie").glob("sessions/*/events.jsonl"))
+        )
+
+
+class Junie(Agent):
+    """Behavior specific to Junie CLI, JetBrains' standalone terminal agent.
+
+    Installation, MCP discovery and activity only: the hook itself is served by
+    `rust/hook/`, so nothing here parses a payload or emits a verdict.
+
+    Junie inside a JetBrains IDE is a different surface and not covered: hooks
+    are dispatched by the interactive TUI and batch hosts only, and the IDE
+    embeds Junie over ACP, which invokes none.
+    """
+
+    agent_activity_sources = [JunieActivitySource()]
+
+    @property
+    def name(self) -> str:
+        return "junie"
+
+    @property
+    def display_name(self) -> str:
+        return "Junie CLI"
+
+    @property
+    def config_folder(self) -> Path:
+        return get_user_home_dir() / ".junie"
+
+    def is_caller(self, hook_payload: Dict[str, Any]) -> bool:
+        """Never: the Rust hook answers Junie's payloads.
+
+        Detection and verdicts live in `rust/hook/`, which is what
+        `ggshield secret scan ai-hook` runs. This adapter carries only what the
+        Rust hook does not do: installation, MCP discovery and activity.
+        """
+        return False
+
+    def output_result(self, result: HookResult) -> int:
+        raise NotImplementedError("the Rust hook emits Junie's verdicts")
+
+    def settings_path(self, mode: Literal["local", "global"]) -> Path:
+        return Path(".junie") / "config.json"
+
+    def post_install_warning(self, mode: Literal["local", "global"]) -> Optional[str]:
+        if mode == "local":
+            return (
+                "Junie ignores `hooks` in a project's .junie/config.json: a "
+                "repository must not be able to run shell commands on checkout. "
+                "Install for the user instead (`ggshield machine setup`), or "
+                "pass this file explicitly with `junie --config-location`."
+            )
+        return (
+            "Junie loads hooks when a session starts, so restart it for these to "
+            "take effect. Two gaps to know about: hooks are an Early Access "
+            "feature, so a stable build may ignore this file entirely, and the "
+            "prompt event fires in the interactive TUI only, so prompts "
+            "submitted in batch (-p) or ACP mode are not scanned. Tool calls are "
+            "scanned in both TUI and batch."
+        )
+
+    @property
+    def settings_template(self) -> Dict[str, Any]:
+        # No matcher on either entry: Junie matches it against the tool name and
+        # refuses to load an entry whose matcher matches nothing, and every tool
+        # call has to be scanned anyway. The prompt event takes no matcher at all.
+        command = {"hooks": [{"type": "command", "command": "<COMMAND>"}]}
+        return {"hooks": {event: [command] for event in SCANNED_EVENTS}}
+
+    def settings_locate(
+        self, candidates: List[Dict[str, Any]], template: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Locate the matcher entry that already carries a ggshield command.
+
+        Junie nests one list inside another: an event maps to matcher entries,
+        and each entry holds its own list of commands. The entries carry no
+        matcher of ours to recognise, so the ggshield command one list down is
+        what identifies the entry to update rather than duplicate.
+        """
+        if "hooks" not in template:
+            return super().settings_locate(candidates, template)
+        for candidate in candidates:
+            commands = candidate.get("hooks")
+            if not isinstance(commands, list):
+                continue
+            if any(
+                isinstance(command, dict)
+                and isinstance(command.get("command"), str)
+                and (
+                    "ggshield" in command["command"]
+                    or command["command"] == "<COMMAND>"
+                )
+                for command in commands
+            ):
+                return candidate
+        return None
+
+    @property
+    def user_mcp_file(self) -> Path:
+        return self.config_folder / "mcp" / "mcp.json"
+
+    def project_mcp_file(self, directory: Path) -> Path:
+        return directory / ".junie" / "mcp" / "mcp.json"
+
+    def discover_project_directories(self) -> Iterator[Path]:
+        """The projects Junie has opened a session for.
+
+        ~/.junie/sessions/index.jsonl holds one session summary per line, each
+        naming its own `projectDir`. A malformed line is skipped rather than
+        taken down the whole walk: the file is appended to by a running CLI, so
+        a half-written last line is expected.
+        """
+        index = self.config_folder / "sessions" / "index.jsonl"
+        try:
+            lines = index.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return
+        seen = set()
+        for line in lines:
+            try:
+                summary = json.loads(line)
+            except ValueError:
+                continue
+            directory = summary.get("projectDir") if isinstance(summary, dict) else None
+            if not isinstance(directory, str) or directory in seen:
+                continue
+            seen.add(directory)
+            path = Path(directory)
+            if path.is_dir():
+                yield path.resolve()
+
+    def parse_mcp_activity(
+        self, payload: HookPayload, ai_config: AIDiscovery
+    ) -> MCPActivityRequest:
+        # How Junie spells an MCP tool in a hook payload is unverified: the
+        # permission matcher documents "an MCP tool name" and no prefix scheme.
+        # The whole name is reported as the tool rather than split at a guess.
+        return MCPActivityRequest(
+            user=self._user_or_default(ai_config),
+            tool=payload.raw.get("tool_name", ""),
+            server="",
+            agent=self.name,
+            model="",
+            cwd=payload.raw.get("cwd", ""),
+            input=payload.raw.get("tool_input", {}),
+            timestamp=payload.timestamp,
+        )

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -148,6 +148,29 @@ pub fn emission(result: &HookResult) -> Emission {
             0,
         ),
 
+        // Junie CLI, which this hook serves alone. Its hook API is Claude
+        // Code's, so the verdict schema is too, except that Junie has no
+        // PostToolUse event at all: nothing it fires can carry a tool result,
+        // so that arm is unreachable rather than shared.
+        Agent::Junie => Emission::Stdout(
+            if !result.block {
+                allow_with_optional_warning(&result.warning)
+            } else {
+                match event {
+                    EventType::UserPrompt => decision_block(message, true),
+                    EventType::PreToolUse => deny_pre_tool_use(message),
+                    // SessionStart, Stop, StopFailure, SessionEnd and
+                    // PermissionRequest land here; `continue: false` is the one
+                    // key every Junie event honours.
+                    EventType::PostToolUse | EventType::Other => obj(vec![
+                        ("continue", false.into()),
+                        ("stopReason", message.into()),
+                    ]),
+                }
+            },
+            0,
+        ),
+
         // codex.py. No `additionalContext` (Codex shows the decision reason in
         // the transcript), and the unknown-event branch goes to stderr with exit 2.
         Agent::Codex => {
@@ -497,6 +520,47 @@ mod tests {
             assert_eq!(
                 allowed(Agent::Copilot, event),
                 allowed(Agent::VsCode, event)
+            );
+        }
+    }
+
+    /// GIVEN each Junie event, allowed, warned and blocked
+    /// WHEN it is emitted
+    /// THEN the schema is Claude Code's, which is what Junie's hook API
+    /// deliberately copies: `permissionDecision` denies a tool call, `decision`
+    /// blocks a prompt, and an allow always prints `continue: true`.
+    #[test]
+    fn junie_contract() {
+        assert_eq!(
+            blocked(Agent::Junie, EventType::PreToolUse).as_deref(),
+            Some(
+                r#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"nope"}}"#
+            )
+        );
+        assert_eq!(
+            blocked(Agent::Junie, EventType::UserPrompt).as_deref(),
+            Some(r#"{"decision":"block","reason":"nope","additionalContext":"nope"}"#)
+        );
+        // No PostToolUse event exists, so this arm is only ever reached by the
+        // events that carry nothing to scan.
+        assert_eq!(
+            blocked(Agent::Junie, EventType::Other).as_deref(),
+            Some(r#"{"continue":false,"stopReason":"nope"}"#)
+        );
+        for event in [
+            EventType::UserPrompt,
+            EventType::PreToolUse,
+            EventType::Other,
+        ] {
+            assert_eq!(
+                allowed(Agent::Junie, event).as_deref(),
+                Some(r#"{"continue":true}"#),
+                "{event:?}"
+            );
+            assert_eq!(
+                warned(Agent::Junie, event).as_deref(),
+                Some(r#"{"continue":true,"systemMessage":"could not scan"}"#),
+                "{event:?}"
             );
         }
     }

--- a/rust/hook/src/payload.rs
+++ b/rust/hook/src/payload.rs
@@ -38,14 +38,16 @@ pub enum Agent {
     Copilot,
     Cursor,
     VsCode,
+    Junie,
     Kiro,
 }
 
-pub const AGENTS: [Agent; 7] = [
+pub const AGENTS: [Agent; 8] = [
     Agent::Vibe,
     Agent::Cursor,
     Agent::Codex,
     Agent::VsCode,
+    Agent::Junie,
     // Kiro keys on event names other agents share (`PreToolUse` and friends),
     // so every agent carrying a marker of its own gets first refusal.
     Agent::Kiro,
@@ -53,7 +55,7 @@ pub const AGENTS: [Agent; 7] = [
     // broader than Kiro and comes after it.
     Agent::Copilot,
     // Last: Claude Code has no marker of its own, so it answers for whatever
-    // the six above refuse. See its arm of `is_caller`.
+    // the seven above refuse. See its arm of `is_caller`.
     Agent::Claude,
 ];
 
@@ -67,6 +69,7 @@ impl Agent {
             Agent::Copilot => "copilot",
             Agent::Cursor => "cursor",
             Agent::VsCode => "vscode",
+            Agent::Junie => "junie",
             Agent::Kiro => "kiro",
         }
     }
@@ -81,6 +84,7 @@ impl Agent {
             Agent::Copilot => "Copilot CLI",
             Agent::Cursor => "Cursor",
             Agent::VsCode => "VSCode",
+            Agent::Junie => "Junie CLI",
             Agent::Kiro => "Kiro",
         }
     }
@@ -138,6 +142,14 @@ impl Agent {
             }
             Agent::Cursor => data.get("cursor_version").is_some(),
             Agent::VsCode => transcript.to_lowercase().contains("github.copilot-chat"),
+            // Junie CLI mirrors Claude Code's wire protocol on purpose, down to
+            // the field names, so `project_path` is the only thing that tells
+            // the two apart: Junie always sends it and Claude never does. The
+            // absent `transcript_path` is what keeps this off a future
+            // assistant that borrows the same protocol *and* ships a transcript.
+            Agent::Junie => {
+                data.get("project_path").is_some() && data.get("transcript_path").is_none()
+            }
             // Kiro CLI spells its triggers in camelCase and the Kiro IDE in
             // PascalCase; neither surface sends anything else identifying.
             Agent::Kiro => {
@@ -199,6 +211,19 @@ impl Agent {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string(),
+            // Junie runs a hook from its own home directory and reports that as
+            // `cwd`, so the workspace it names in `project_path` is what a
+            // relative read path has to resolve against. Observed on the wire:
+            // the docs say only that `project_path` is sent "when the session
+            // provides it".
+            Agent::Junie => {
+                let project = lookup_str(data, &["project_path"]);
+                if project.is_empty() {
+                    lookup_str(data, &["cwd"])
+                } else {
+                    project
+                }
+            }
             _ => lookup_str(data, &["cwd"]),
         }
     }
@@ -258,7 +283,14 @@ impl Agent {
             // No range ever seen from these four: Copilot CLI's `view` carries
             // only `path`, Cursor's Read has no range keys, Codex shells out, and
             // Vibe's `read_file` carries only `path`.
-            Agent::Codex | Agent::Copilot | Agent::Cursor | Agent::Vibe => None,
+            //
+            // Junie is here for a different reason: its ranged reader `open`
+            // reaches a hook as Claude's `Read` and carries `file_path` with an
+            // `offset`, but never a `limit`, so a range would run to the end of
+            // the file anyway. Constraint: whole-file means a read of a file over
+            // `maximum_document_size` is skipped by the scanner entirely, which
+            // the `offset` alone cannot narrow.
+            Agent::Codex | Agent::Copilot | Agent::Cursor | Agent::Vibe | Agent::Junie => None,
         }
     }
 }
@@ -347,7 +379,12 @@ fn parse_tool(data: &Value) -> Tool {
         // `read_files` is deliberately absent: it takes several paths in an
         // unverified shape, and a Read payload whose path lookup finds nothing
         // scans nothing. Left generic, the response it returns is still scanned.
-        "read" | "read_file" | "view" | "fs_read" => Tool::Read,
+        //
+        // `open_entire_file` is Junie's whole-file reader, and the one tool of
+        // its own it does not rename to Claude's spelling: its ranged sibling
+        // `open` reaches a hook as `Read`, this one keeps its name and would
+        // otherwise read a file with nothing scanned first.
+        "read" | "read_file" | "view" | "fs_read" | "open_entire_file" => Tool::Read,
         // Kiro's writers (`fs_write`, `str_replace`, `fs_append`) belong here on
         // purpose: the generic branch scans their `tool_input`, which is what
         // carries the content about to be written.
@@ -1513,6 +1550,119 @@ mod tests {
         assert_eq!(Agent::Cursor.event_cwd(&json!({})), "");
     }
 
+    /// GIVEN the two readers a real Junie CLI dispatched to a PreToolUse hook
+    /// WHEN each is classified and parsed
+    /// THEN both build a Read payload around the path they name, under the two
+    /// different spellings Junie sends them as.
+    #[test]
+    fn both_junie_readers_are_read_tools() {
+        for (tool_name, tool_input) in [
+            ("Read", json!({"file_path": "creds.txt", "offset": 1})),
+            ("open_entire_file", json!({"path": "creds.txt"})),
+        ] {
+            assert_eq!(parse_tool(&json!({"tool_name": tool_name})), Tool::Read);
+            let raw = json!({
+                "hook_event_name": "PreToolUse",
+                "cwd": "/home/someone/.junie",
+                "project_path": "/p",
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+            })
+            .to_string();
+            let payloads = parse(&raw).expect("parses");
+            assert_eq!(payloads[0].agent, Agent::Junie, "{tool_name}");
+            assert_eq!(payloads[0].tool, Some(Tool::Read), "{tool_name}");
+            // Resolved against the project, not the `cwd` Junie reports.
+            assert_eq!(
+                payloads[0].identifier,
+                native("/p/creds.txt"),
+                "{tool_name}"
+            );
+            // Whole file: Junie sends no `limit`, so no range narrows the scan.
+            assert_eq!(payloads[0].read_range, None, "{tool_name}");
+        }
+    }
+
+    /// GIVEN the SessionStart payload a real Junie CLI 26.8.31 sent
+    /// WHEN its working directory is resolved
+    /// THEN the project wins over `cwd`, which is Junie's own home directory
+    /// rather than the workspace.
+    #[test]
+    fn junie_resolves_the_project_not_its_own_home() {
+        let payload = json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "session-260908-103926-173d",
+            "cwd": "/Users/someone/.junie",
+            "project_path": "/Users/someone/work/project",
+            "source": "startup",
+        });
+
+        assert_eq!(Agent::detect(&payload), Some(Agent::Junie));
+        assert_eq!(
+            Agent::Junie.event_cwd(&payload),
+            "/Users/someone/work/project"
+        );
+        // A payload that names no project falls back rather than resolving
+        // against nothing.
+        assert_eq!(
+            Agent::Junie.event_cwd(&json!({"cwd": "/fallback"})),
+            "/fallback"
+        );
+    }
+
+    /// GIVEN Junie CLI payloads, and the payloads of the two agents whose wire
+    /// protocol Junie borrows
+    /// WHEN the agent is detected
+    /// THEN `project_path` is what tells Junie from Claude, and Claude's
+    /// `transcript_path` is what keeps Junie off a Claude payload.
+    #[test]
+    fn junie_is_detected_by_its_project_path() {
+        let cases: [(&str, Value, Option<Agent>); 5] = [
+            (
+                "prompt",
+                json!({"hook_event_name": "UserPromptSubmit", "session_id": "s",
+                       "cwd": "/p", "project_path": "/p", "prompt": "hello"}),
+                Some(Agent::Junie),
+            ),
+            (
+                "pre tool",
+                json!({"hook_event_name": "PreToolUse", "cwd": "/p",
+                       "project_path": "/p", "tool_name": "Bash",
+                       "tool_input": {"command": "ls"}}),
+                Some(Agent::Junie),
+            ),
+            // Every other Junie event reaches the hook too, and none of them
+            // carries anything to scan.
+            (
+                "session start",
+                json!({"hook_event_name": "SessionStart", "session_id": "s",
+                       "cwd": "/p", "project_path": "/p", "source": "startup"}),
+                Some(Agent::Junie),
+            ),
+            // Claude wins: it is registered first, and it is the transcript
+            // path that separates the two protocols.
+            (
+                "claude keeps its own payload",
+                claude(json!({"hook_event_name": "UserPromptSubmit", "project_path": "/p"})),
+                Some(Agent::Claude),
+            ),
+            // Constraint: `project_path` is sent only "when the session
+            // provides it", so a session without a project falls through to
+            // Kiro, whose contract also blocks on exit 2 but reports the wrong
+            // agent. Every Junie CLI run has a project, so this is the shape we
+            // have never seen rather than one we tolerate.
+            (
+                "no project path",
+                json!({"hook_event_name": "PreToolUse", "cwd": "/p",
+                       "tool_name": "Bash", "tool_input": {"command": "ls"}}),
+                Some(Agent::Kiro),
+            ),
+        ];
+        for (label, payload, expected) in cases {
+            assert_eq!(Agent::detect(&payload), expected, "{label}");
+        }
+    }
+
     /// GIVEN payloads carrying an event name Kiro shares with another agent, plus
     /// one of that agent's own keys
     /// WHEN the agent is detected
@@ -1544,12 +1694,13 @@ mod tests {
                 Some(Agent::Copilot),
             ),
             // Junie CLI mirrors Claude Code's field names on purpose, so it
-            // reaches Kiro's matcher with a trigger name Kiro also uses.
+            // reaches Kiro's matcher with a trigger name Kiro also uses. Its
+            // own `project_path` is what settles it, in both directions.
             (
                 "junie cli",
                 json!({"hook_event_name": "UserPromptSubmit", "session_id": "s",
                        "cwd": "/p", "project_path": "/p", "prompt": "hello"}),
-                None,
+                Some(Agent::Junie),
             ),
             // Not one of Kiro's trigger spellings, and nothing else matches.
             (

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -14,7 +14,7 @@ sides must produce but whose value is allowed to differ (see `same_request`).
   python3 tests/equivalence.py            # equivalence only
   python3 tests/equivalence.py --bench N  # also time both, N iterations/side
 
-Eleven matrices:
+Twelve matrices:
   agents   6 assistants x their own payload shapes x {clean, secret}
   config   .gitguardian.yaml cases: discovery, precedence, and every key that
            changes the verdict or the request
@@ -33,6 +33,8 @@ Eleven matrices:
   extra    fail-open, and the unrecognized-agent case
   kiro     Kiro, which the Rust hook serves alone: asserted against its
            output contract instead of diffed, there being no Python side
+  junie    Junie CLI, likewise Rust-only: Claude Code's verdict schema, its
+           own `project_path`, and no PostToolUse event at all
 
 Every payload fixture is copied from tests/unit/verticals/ai/test_hooks.py, so
 the shapes are the ones ggshield's own tests consider realistic.
@@ -1994,6 +1996,151 @@ def check_kiro(tmp):
     return failures
 
 
+def junie_payloads():
+    """Junie CLI's shapes: Claude Code's wire protocol plus `project_path`.
+
+    Field names copied from the hook payload builder in Junie's own jar
+    (`DefaultExternalHookRuntime.buildStdinJson`): `hook_event_name` and `cwd`
+    always, `session_id` and `project_path` when the session provides them.
+    """
+    base = {"session_id": "sess-1", "cwd": "/tmp", "project_path": "/tmp"}
+    command = (
+        f"aws configure set aws_access_key_id {CLIENT_ID} --secret {CLIENT_SECRET}"
+    )
+    return {
+        # (payload, whether it carries something to scan)
+        "user_prompt": (
+            {
+                **base,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": f"deploy with key {CLIENT_ID} please",
+            },
+            True,
+        ),
+        "pre_bash": (
+            {
+                **base,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command, "run_in_background": False},
+            },
+            True,
+        ),
+        "pre_read": (
+            {
+                **base,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": READ_FILE},
+            },
+            True,
+        ),
+        "pre_write": (
+            {
+                **base,
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/tmp/out.env",
+                    "content": f"K={CLIENT_ID}",
+                },
+            },
+            True,
+        ),
+        # Junie has no PostToolUse event at all. These four carry nothing to
+        # scan, and must still parse rather than be refused as another agent's.
+        # `cwd` is Junie's own home, not the workspace: the project is what a
+        # relative read path resolves against. Captured from a real session.
+        "session_start": (
+            {
+                **base,
+                "cwd": "/Users/someone/.junie",
+                "hook_event_name": "SessionStart",
+                "source": "startup",
+            },
+            False,
+        ),
+        "stop": (
+            {
+                **base,
+                "hook_event_name": "Stop",
+                "stop_hook_active": False,
+                "last_assistant_message": "done",
+            },
+            False,
+        ),
+        "stop_failure": (
+            {
+                **base,
+                "hook_event_name": "StopFailure",
+                "error": "rate_limit",
+                "error_details": "429 Too Many Requests",
+            },
+            False,
+        ),
+        # The real SessionEnd envelope, captured from Junie 26.8.31: two keys
+        # and nothing else, so `buildStdinJson`'s "cwd always" does not hold
+        # here. With no `project_path` no adapter answers to it, which is the
+        # unrecognized-agent exit rather than a verdict. Harmless because
+        # ggshield installs no SessionEnd hook: the event carries nothing to
+        # scan, and hooking it would only add an exit ggshield logs a warning for.
+        "session_end": (
+            {"hook_event_name": "SessionEnd", "reason": "prompt_input_exit"},
+            False,
+            1,
+        ),
+    }
+
+
+def check_junie(tmp):
+    """Junie, asserted rather than diffed: the Rust hook is its only
+    implementation, so there is no Python side to compare against.
+
+    The contract is `Agent::Junie` in output.rs, which is Claude Code's: JSON on
+    stdout and exit 0 always, a block spelled `permissionDecision` on a tool
+    call and `decision` on a prompt. A payload that carries something to scan
+    must also reach the API, otherwise a silent parse failure would read as a
+    clean allow.
+    """
+    failures = []
+    print("\nJunie (Rust-only, asserted): verdict schema, exit code, and what was sent")
+    for mode in ("clean", "secret"):
+        log = tmp / f"requests-junie-{mode}.jsonl"
+        mock, port = start_mock(mode, log)
+        try:
+            for name, case in junie_payloads().items():
+                payload, scannable = case[0], case[1]
+                expected_code = case[2] if len(case) > 2 else 0
+                workdir = make_workdir(tmp, f"junie-{mode}-{name}")
+                write_read_file()
+                before = len(read_requests(log))
+                proc, _ = run(RS_CMD, payload, port, workdir)
+                sent = len(read_requests(log)) > before
+                blocks = mode == "secret" and scannable
+                if expected_code:
+                    # No agent answers to it, so there is no verdict to read.
+                    ok = proc.returncode == expected_code and proc.stdout == b""
+                else:
+                    ok = (
+                        proc.returncode == 0
+                        and verdict_of(proc.stdout) == ("block" if blocks else "allow")
+                        and sent == scannable
+                    )
+                print(f"  [{'OK  ' if ok else 'FAIL'}] {mode}/{name}")
+                if not ok:
+                    failures.append(f"junie/{mode}/{name}")
+                    print(
+                        f"        exit={proc.returncode} (want {expected_code}) "
+                        f"verdict={verdict_of(proc.stdout)} "
+                        f"(want {'block' if blocks else 'allow'}) "
+                        f"sent={sent} (want {scannable}) "
+                        f"stdout={proc.stdout[:160]!r}"
+                    )
+        finally:
+            mock.kill()
+    return failures
+
+
 def bench(tmp, iterations):
     """Latency, alternating sides so machine load hits both equally.
 
@@ -2103,6 +2250,7 @@ def main():
         failures += compare_exclusions(tmp)
         failures += extra_cases(tmp)
         failures += check_kiro(tmp)
+        failures += check_junie(tmp)
         if "--bench" in sys.argv:
             n = int(sys.argv[sys.argv.index("--bench") + 1])
             bench(tmp, n)

--- a/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
+++ b/tests/unit/verticals/ai/agent_activity/test_agent_sources.py
@@ -188,3 +188,25 @@ def test_kiro_agent_ships_raw_transcript_lines(fake_home: Path) -> None:
     # The workspace hash and the session id stay in the path, so an event can be
     # traced back to the session it came from.
     assert all(event.source_path.startswith("sessions/a1b2/sess_") for event in events)
+
+
+def test_junie_agent_ships_raw_session_events(fake_home: Path) -> None:
+    """Junie writes one event stream per session, keyed by session id."""
+    from ggshield.verticals.ai.agents.junie import Junie
+
+    for session_id in ("sess-1", "sess-2"):
+        session = fake_home / ".junie" / "sessions" / session_id
+        session.mkdir(parents=True)
+        (session / "events.jsonl").write_text(
+            json.dumps({"id": session_id, "type": "user_prompt"}) + "\n"
+        )
+
+    events = list(Junie().iter_agent_activity_events())
+
+    assert len(events) == 2
+    assert {event.agent_name for event in events} == {"junie"}
+    assert {event.source_kind for event in events} == {"5_session_events"}
+    assert {event.source_path for event in events} == {
+        "sessions/sess-1/events.jsonl",
+        "sessions/sess-2/events.jsonl",
+    }

--- a/tests/unit/verticals/ai/test_agents.py
+++ b/tests/unit/verticals/ai/test_agents.py
@@ -14,6 +14,7 @@ from ggshield.verticals.ai.agents.claude_code import Claude, _mangle_server_name
 from ggshield.verticals.ai.agents.codex import Codex
 from ggshield.verticals.ai.agents.copilot import Copilot
 from ggshield.verticals.ai.agents.cursor import Cursor, _parse_tool_arguments
+from ggshield.verticals.ai.agents.junie import Junie
 from ggshield.verticals.ai.agents.kiro import Kiro
 from ggshield.verticals.ai.agents.vibe import Vibe
 from ggshield.verticals.ai.agents.vscode import VSCode
@@ -2174,3 +2175,116 @@ class TestKiro:
             assert request.server == "probe-time"
             assert request.tool == "get_current_time"
             assert request.agent == "kiro"
+
+
+# ===========================================================================
+# Junie CLI
+# ===========================================================================
+
+
+class TestJunie:
+    def test_config_folder_and_mcp_files(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.junie.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            junie = Junie()
+            assert junie.config_folder == tmp_path / ".junie"
+            assert junie.user_mcp_file == tmp_path / ".junie" / "mcp" / "mcp.json"
+        assert Junie().project_mcp_file(Path("/tmp/project")) == (
+            Path("/tmp/project") / ".junie" / "mcp" / "mcp.json"
+        )
+
+    def test_settings_template_covers_the_two_scannable_events(self):
+        """GIVEN the installed hook file
+        WHEN its events are read
+        THEN it hooks the prompt and the tool call, and carries no matcher:
+        Junie matches one against the tool name and refuses an entry whose
+        matcher matches nothing."""
+        hooks = Junie().settings_template["hooks"]
+
+        assert sorted(hooks) == ["PreToolUse", "UserPromptSubmit"]
+        for entries in hooks.values():
+            assert entries == [{"hooks": [{"type": "command", "command": "<COMMAND>"}]}]
+
+    def test_settings_locate_finds_the_entry_by_its_nested_command(self):
+        """GIVEN matcher entries that carry no matcher of ours
+        WHEN one is located for an update
+        THEN the ggshield command one list down identifies it, so a second
+        install updates the entry instead of appending a duplicate."""
+        junie = Junie()
+        candidates = [
+            {"hooks": [{"type": "command", "command": "somebody-elses-hook"}]},
+            {
+                "hooks": [
+                    {"type": "command", "command": "/usr/bin/ggshield secret scan"}
+                ]
+            },
+        ]
+
+        template = {"hooks": [{"type": "command", "command": "<COMMAND>"}]}
+
+        assert junie.settings_locate(candidates, template) is candidates[1]
+        assert junie.settings_locate(candidates[:1], template) is None
+
+    def test_local_install_warns_that_junie_ignores_it(self):
+        """GIVEN a project-scoped install
+        WHEN the post-install warning is read
+        THEN it says Junie will not load it: a repository must not be able to
+        run shell commands on checkout."""
+        assert "ignores" in (Junie().post_install_warning("local") or "")
+        assert "Early Access" in (Junie().post_install_warning("global") or "")
+
+    def test_discover_project_directories_reads_the_session_index(self, tmp_path: Path):
+        """GIVEN a session index naming one project twice and one broken line
+        WHEN the project directories are discovered
+        THEN each existing project is yielded once and the broken line is
+        skipped: a running CLI appends to this file, so a half-written last
+        line is expected."""
+        project = tmp_path / "project"
+        project.mkdir()
+        sessions = tmp_path / ".junie" / "sessions"
+        sessions.mkdir(parents=True)
+        (sessions / "index.jsonl").write_text(
+            "\n".join(
+                [
+                    json.dumps({"sessionId": "a", "projectDir": str(project)}),
+                    json.dumps({"sessionId": "b", "projectDir": str(project)}),
+                    json.dumps(
+                        {"sessionId": "c", "projectDir": str(tmp_path / "gone")}
+                    ),
+                    '{"sessionId": "d", "projectDir": "/half-writt',
+                ]
+            )
+        )
+
+        with patch(
+            "ggshield.verticals.ai.agents.junie.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            assert list(Junie().discover_project_directories()) == [project.resolve()]
+
+    def test_discover_project_directories_survives_no_index(self, tmp_path: Path):
+        with patch(
+            "ggshield.verticals.ai.agents.junie.get_user_home_dir",
+            return_value=tmp_path,
+        ):
+            assert list(Junie().discover_project_directories()) == []
+
+    def test_parse_mcp_activity_reports_the_whole_tool_name(self):
+        """GIVEN an MCP tool call
+        WHEN the activity is parsed
+        THEN the whole name is the tool and no server is claimed: how Junie
+        spells an MCP tool in a hook payload is unverified, and a split would
+        be a guess."""
+        junie = Junie()
+        payload = _payload(
+            junie,
+            raw={"tool_name": "github/create_issue", "cwd": "/tmp", "tool_input": {}},
+        )
+
+        request = junie.parse_mcp_activity(payload, _ai_discovery(servers=[]))
+
+        assert request.server == ""
+        assert request.tool == "github/create_issue"
+        assert request.agent == "junie"

--- a/tests/unit/verticals/ai/test_cmd_ai.py
+++ b/tests/unit/verticals/ai/test_cmd_ai.py
@@ -240,8 +240,8 @@ class TestAiHookCmd:
         result = runner.invoke(
             cli,
             ["secret", "scan", "ai-hook"],
-            # An event name no adapter answers to: "PreToolUse" with no other
-            # agent's marker beside it is Kiro's own signature.
+            # An event name no adapter answers to. A bare "PreToolUse" would
+            # not do: the Rust hook reads that as Kiro's signature.
             input='{"hook_event_name": "somethingElse"}',
         )
 


### PR DESCRIPTION
Junie CLI, JetBrains' standalone terminal agent, gets the AI hook. Its hook API is a deliberate copy of Claude Code's, so the verdict schema is Claude's too; `project_path` is what tells the two apart, since Junie sends it and Claude never does. Junie has no PostToolUse event at all, so a secret that reaches the model through a tool result is out of scope for this assistant in a way it is not for the others.

The hook path is served by the Rust hook alone, following Kiro. The Python adapter carries what the Rust hook does not do: installing into `~/.junie/config.json`, MCP discovery, and shipping session events. A project-scoped install is refused by Junie itself, a repository not being allowed to run shell commands on checkout, so the post-install warning says so rather than leaving a file that never loads.

One thing only a real session shows: Junie runs a hook from its own home directory and reports *that* as `cwd`, naming the workspace in `project_path` instead. Reads resolve against `project_path` for that reason. Taking `cwd` at face value sends them to `~/.junie`, which means the wrong verdict-cache key and the default `ignored_paths` tested against the wrong root. Payload shapes otherwise come from the hook runtime in Junie's own jar, the docs abbreviating the envelope: `SessionEnd` carries only its event name and reason.

Verified against a real Junie 26.8.31 session: a prompt carrying an AWS key pair is refused and never reaches the model. `PreToolUse` is unverified live, needing a working model subscription. Only Junie CLI is covered; the IDE embeds Junie over ACP, which invokes no hooks.

Closes NHI-1971