### PR TITLE
fix(ai-hook): strip a UTF-8 BOM from the hook payload

### DIFF
--- a/changelog.d/20260903_120000_achille.mascia_cursor_windows_hook_bom.md
+++ b/changelog.d/20260903_120000_achille.mascia_cursor_windows_hook_bom.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The AI hook no longer rejects a hook event whose payload starts with a UTF-8
+  BOM, which Cursor on Windows prepends. Prompts and tool calls were reaching
+  the agent unscanned.

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -49,6 +49,17 @@ pub enum Outcome {
     },
 }
 
+/// Decode the hook event an agent wrote to our stdin.
+///
+/// U+FEFF is not White_Space, so `trim` leaves a BOM in place and the parser
+/// then rejects the whole event. Agents on Windows can prefix one.
+fn decode_payload(buffer: &[u8]) -> String {
+    String::from_utf8_lossy(buffer)
+        .trim_start_matches('\u{feff}')
+        .trim()
+        .to_string()
+}
+
 /// Run the hook end to end; the dispatcher acts on the outcome.
 pub fn run_hook() -> Outcome {
     let mut buffer = Vec::new();
@@ -56,7 +67,7 @@ pub fn run_hook() -> Outcome {
         .lock()
         .take(MAX_READ_SIZE)
         .read_to_end(&mut buffer);
-    let stdin_content = String::from_utf8_lossy(&buffer).trim().to_string();
+    let stdin_content = decode_payload(&buffer);
 
     // An agent reads a non-zero exit with no JSON as "the hook is broken", so a
     // panic is treated as any other internal failure.
@@ -528,6 +539,17 @@ mod tests {
 
     /// Recognised by the mock below as "this document holds a secret".
     const SECRET: &str = "AKIAsomething";
+
+    #[test]
+    fn decode_payload_survives_a_bom() {
+        let event =
+            br#"{"hook_event_name":"beforeSubmitPrompt","cursor_version":"3.17.8","prompt":"hi"}"#;
+        let mut with_bom = vec![0xEF, 0xBB, 0xBF];
+        with_bom.extend_from_slice(event);
+
+        assert_eq!(decode_payload(&with_bom), decode_payload(event));
+        assert!(payload::parse(&decode_payload(&with_bom)).is_ok());
+    }
 
     /// What the mock reports on `/v1/metadata`, plus which multiscan it refuses.
     #[derive(Clone, Copy)]


### PR DESCRIPTION
A Cursor user on Windows reported that the hook stopped blocking secrets in the
chat while the same setup worked on Linux. Cursor was invoking the hook, but the
JSON on stdin began with a byte the parser rejected, so every prompt and tool
call reached the agent unscanned.

Rust's `trim` follows the White_Space property, which excludes U+FEFF, so a BOM
survived into `serde_json` and failed on the first character. The hook then
exited non-zero, and an agent reads that as a non-blocking error rather than a
verdict, which is why the failure was silent.

Reading stdin already goes through raw bytes decoded as UTF-8, so the codepage
half of this class of bug cannot occur here; only the BOM needed handling. The
equivalent Python path in `ai_hook.py` has the same weakness and is untouched:
the customer is on 1.53 and moving to 1.54.x, so the fix is only useful in the
native hook.

One thing left unproven: we know the payload starts with a byte that is not
valid JSON, and a BOM matches, but we have not captured the actual bytes from
the reporter's machine.
