### PR TITLE
ci: pin all dependencies to fixed versions and add a 3-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,40 @@
 version: 2
+
+# Every ecosystem below shares the same cooldown: a release must have been
+# public for 3 days before Dependabot will open a PR for it. This is supply
+# chain hygiene, not conservatism about versions -- a compromised release is
+# usually yanked within hours of discovery, so waiting out that window keeps
+# the malicious-then-deleted versions from ever reaching a branch here.
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 3
+
+  # The root Dockerfile's base image. Scoped to '/' so the functional-test
+  # Dockerfiles under tests/ stay out of scope: their FROM is a build arg
+  # (TEST_DOCKER_IMAGE), not an image reference Dependabot could pin.
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3
+
+  # Python runtime + dev dependencies (pyproject.toml / uv.lock).
+  - package-ecosystem: 'uv'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3
+
+  # The Rust workspace backing the native pre-commit hook.
+  - package-ecosystem: 'cargo'
+    directory: '/rust'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,17 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+
+  # Lint/format hook revs in .pre-commit-config.yaml, which were updated by
+  # hand until now.
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3
+    ignore:
+      # This repo's own hook: `rev` there tracks ggshield's __version__ in the
+      # working tree, so a bump belongs to the release, not to Dependabot --
+      # otherwise the self-reference points at a version this tree isn't yet.
+      - dependency-name: 'https://github.com/gitguardian/ggshield'

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -57,7 +57,7 @@ jobs:
           /tmp/smoke/bin/ggshield --version
 
       - name: Upload packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
           path: |
@@ -73,14 +73,14 @@ jobs:
         include:
           - os: ubuntu-22.04
             # When building on Linux we use a container to build using an old enough version
-            container: rockylinux/rockylinux:8
+            container: rockylinux/rockylinux:8.10
             arch: x86_64
             nfpm_arch: x86_64
             sha256sum:
               python: d6254462d5fe066810a472d286861f6a18f66400008bfa9688e202a5672e88cb
               nfpm: 9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
           - os: ubuntu-24.04-arm
-            container: rockylinux/rockylinux:8
+            container: rockylinux/rockylinux:8.10
             arch: aarch64
             nfpm_arch: arm64
             sha256sum:
@@ -98,14 +98,14 @@ jobs:
               python: 1c7e8db27d1f5c029c232406103b7216baaa8a32a900a64f6dee20f8eaaca1af
               rcodesign: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Set up Python 3.14 (Windows 1/2)
         if: matrix.os == 'windows-2022'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.14'
 
@@ -298,7 +298,7 @@ jobs:
           TEST_GG_VALID_TOKEN_IGNORE_SHA: ${{ secrets.TEST_GG_VALID_TOKEN_IGNORE_SHA }}
           TEST_UNKNOWN_SECRET: ${{ secrets.TEST_UNKNOWN_SECRET }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: os-packages-${{ matrix.os }}
           path: |
@@ -325,11 +325,11 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04-arm
         image:
-          - debian:stable
-          - ubuntu:latest
+          - debian:stable-20260824
+          - ubuntu:26.04
           - rockylinux/rockylinux:8.8
-          - rockylinux/rockylinux:9
-          - opensuse/leap
+          - rockylinux/rockylinux:9.8
+          - opensuse/leap:16.0
     steps:
       - name: Install requirements
         run: |
@@ -347,7 +347,7 @@ jobs:
           esac
 
       - name: Download OS packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: os-packages-${{ matrix.runner }}
           path: dist
@@ -391,14 +391,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           sparse-checkout: |
             scripts/vulnscan
             .grype.yaml
 
       - name: Download built packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: os-packages-*
           path: packages
@@ -408,7 +408,7 @@ jobs:
         run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Grype vulnerability database
-        uses: actions/cache@v6
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.cache/grype/db
           # The DB is refreshed daily upstream; keying on the date avoids

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -29,6 +29,9 @@ env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.14'
   GRYPE_VERSION: 0.116.1
+  # grype_${GRYPE_VERSION}_linux_amd64.tar.gz, from the release's
+  # grype_${GRYPE_VERSION}_checksums.txt. Update both together.
+  GRYPE_SHA256: 0122df7b655981abe547ad3d2190d65551dac6a2bfc80b4dc2a989b5d0587458
 
 jobs:
   build_wheel_sdist:
@@ -395,6 +398,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/vulnscan
+            scripts/download
             .grype.yaml
 
       - name: Download built packages
@@ -416,9 +420,17 @@ jobs:
           key: grype-db-${{ steps.date.outputs.date }}
 
       - name: Install Grype
+        # Not `curl .../main/install.sh | sh`: that fetches an unpinned script
+        # from a branch and pipes it into a shell, so upstream can change what
+        # runs here at any time. The release tarball is pinned and
+        # checksum-verified instead, like rustup-init in wheels.yml.
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
-            | sh -s -- -b /usr/local/bin "v${GRYPE_VERSION}"
+          scripts/download \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+            /tmp/grype.tar.gz \
+            "${GRYPE_SHA256}"
+          tar -xzf /tmp/grype.tar.gz -C /tmp grype
+          install -m 0755 /tmp/grype /usr/local/bin/grype
 
       - name: Scan and report
         # tee, not >>: the report is genuinely useful in the plain job log

--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -60,7 +60,7 @@ jobs:
           /tmp/smoke/bin/ggshield --version
 
       - name: Upload packages
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: |
@@ -101,14 +101,14 @@ jobs:
               python: 1c7e8db27d1f5c029c232406103b7216baaa8a32a900a64f6dee20f8eaaca1af
               rcodesign: 163520079cd6ad1427791c792735a6ddfcb8eca0187bbcf0cc0bebfa4a62153d
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Set up Python 3.14 (Windows 1/2)
         if: matrix.os == 'windows-2022'
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
 
@@ -301,7 +301,7 @@ jobs:
           TEST_GG_VALID_TOKEN_IGNORE_SHA: ${{ secrets.TEST_GG_VALID_TOKEN_IGNORE_SHA }}
           TEST_UNKNOWN_SECRET: ${{ secrets.TEST_UNKNOWN_SECRET }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: os-packages-${{ matrix.os }}
           path: |
@@ -350,7 +350,7 @@ jobs:
           esac
 
       - name: Download OS packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: os-packages-${{ matrix.runner }}
           path: dist
@@ -394,7 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             scripts/vulnscan
@@ -402,7 +402,7 @@ jobs:
             .grype.yaml
 
       - name: Download built packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: os-packages-*
           path: packages
@@ -412,7 +412,7 @@ jobs:
         run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Grype vulnerability database
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/grype/db
           # The DB is refreshed daily upstream; keying on the date avoids

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Check for changelog fragment'
-        uses: brettcannon/check-for-changed-files@v1.2.2
+        uses: brettcannon/check-for-changed-files@d85c64d17b3c1d0ac57c9cc46ea39399b0d6fa71 # v1.2.2
         with:
           file-pattern: |
             changelog.d/*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     name: Lint package
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -40,7 +40,7 @@ jobs:
         run: |
           uv sync --locked --group tests --group dev
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -81,13 +81,13 @@ jobs:
         os: [ubuntu-22.04, macos-15-intel, windows-2022]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
@@ -119,7 +119,7 @@ jobs:
           uv run coverage report --fail-under=80
           uv run coverage xml
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v4.6.0
         with:
           file: ./coverage.xml
           flags: unittests
@@ -140,13 +140,13 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -195,10 +195,10 @@ jobs:
     # A few minutes of CI is the cheaper side of that trade.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -207,7 +207,7 @@ jobs:
         run: |
           uv sync --locked --group dev --group tests
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -280,10 +280,10 @@ jobs:
       run:
         working-directory: rust
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Cache cargo
-        uses: actions/cache@v6
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: Scan commits for hardcoded secrets
@@ -331,26 +331,26 @@ jobs:
       - test_github_secret_scan_action
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v4.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.3.0
         with:
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     name: Lint package
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -40,7 +40,7 @@ jobs:
         run: |
           uv sync --locked --group tests --group dev
 
-      - uses: actions/cache@v6.1.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -81,13 +81,13 @@ jobs:
         os: [ubuntu-22.04, macos-15-intel, windows-2022]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}
@@ -119,7 +119,7 @@ jobs:
           uv run coverage report --fail-under=80
           uv run coverage xml
 
-      - uses: codecov/codecov-action@v4.6.0
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           file: ./coverage.xml
           flags: unittests
@@ -140,13 +140,13 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Get enough commits to run `ggshield secret scan commit-range` on ourselves
           fetch-depth: 10
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -195,10 +195,10 @@ jobs:
     # A few minutes of CI is the cheaper side of that trade.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -207,7 +207,7 @@ jobs:
         run: |
           uv sync --locked --group dev --group tests
 
-      - uses: actions/cache@v6.1.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -280,10 +280,10 @@ jobs:
       run:
         working-directory: rust
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache cargo
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Scan commits for hardcoded secrets
@@ -331,26 +331,26 @@ jobs:
       - test_github_secret_scan_action
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.3.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15-intel]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       # Ubuntu 22.04's `bats` apt package is 1.2.1 (2019), missing features
       # the test suite relies on (bats_require_minimum_version, `run !`).

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -25,12 +25,12 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15-intel]
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Ubuntu 22.04's `bats` apt package is 1.2.1 (2019), missing features
       # the test suite relies on (bats_require_minimum_version, `run !`).
       # Install a current bats-core instead of depending on distro packaging.
-      - uses: bats-core/bats-action@4.0.0
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           support-install: false

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -27,12 +27,12 @@ jobs:
       MAX_DELTA: 3
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ inputs.python_version || env.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -27,12 +27,12 @@ jobs:
       MAX_DELTA: 3
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ inputs.python_version || env.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -29,9 +29,9 @@ jobs:
     environment: release
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
 
@@ -39,20 +39,20 @@ jobs:
       # `ggshield-<version>-py3-none-any.whl`, so only `build_wheel_sdist`
       # builds one. See .github/workflows/wheels.yml.
       - name: Download the sdist and the pure-Python wheel
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: dist
           path: dist
 
       - name: Download the platform wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: wheel-*
           path: dist
           merge-multiple: true
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -93,14 +93,14 @@ jobs:
           echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Download OS packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: os-packages-*
           path: dist
           merge-multiple: true
 
       - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v2.4.0
         with:
           subject-path: |
             dist/ggshield-*.pkg
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v6.2.0
         with:
           images: |
             gitguardian/ggshield
@@ -155,26 +155,26 @@ jobs:
             type=ref,event=tag
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v4.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.3.0
         with:
           platforms: linux/amd64,linux/arm64
           push: true
@@ -190,10 +190,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: os-packages-*
           path: dist
@@ -216,10 +216,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: os-packages-windows-*
           path: dist

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -29,9 +29,9 @@ jobs:
     environment: release
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 
@@ -39,20 +39,20 @@ jobs:
       # `ggshield-<version>-py3-none-any.whl`, so only `build_wheel_sdist`
       # builds one. See .github/workflows/wheels.yml.
       - name: Download the sdist and the pure-Python wheel
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
 
       - name: Download the platform wheels
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: wheel-*
           path: dist
           merge-multiple: true
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -93,14 +93,14 @@ jobs:
           echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Download OS packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: os-packages-*
           path: dist
           merge-multiple: true
 
       - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v2.4.0
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: |
             dist/ggshield-*.pkg
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6.2.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             gitguardian/ggshield
@@ -155,26 +155,26 @@ jobs:
             type=ref,event=tag
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.3.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: linux/amd64,linux/arm64
           push: true
@@ -190,10 +190,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: os-packages-*
           path: dist
@@ -216,10 +216,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: os-packages-windows-*
           path: dist

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -39,7 +39,7 @@ jobs:
           echo "value=${VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout ${{ matrix.repository }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ matrix.repository }}
           token: ${{ secrets.PAT_GITHUB }}

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -39,7 +39,7 @@ jobs:
           echo "value=${VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout ${{ matrix.repository }}
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ matrix.repository }}
           token: ${{ secrets.PAT_GITHUB }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,11 +59,16 @@ jobs:
     name: wheel macos-universal2
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
+      # `v1` is the most specific ref upstream publishes: this action has no
+      # semver tags, only `v1` and per-version branches (`stable` is a branch
+      # too, and moves every rustup release). Which toolchain actually builds
+      # the binary is decided separately -- hatch_build.py runs cargo with
+      # cwd=rust/, so rust/rust-toolchain.toml pins that.
+      - uses: dtolnay/rust-toolchain@v1
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       # Only `sign: true` callers get here, and for them signing is not
@@ -112,7 +117,7 @@ jobs:
           python -m build --wheel --outdir dist
       - name: Smoke test the wheel
         run: scripts/smoke-test-wheel dist/*.whl
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheel-macos-universal2
           path: dist/*.whl
@@ -121,11 +126,16 @@ jobs:
     name: wheel windows-amd64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-      - uses: dtolnay/rust-toolchain@stable
+      # `v1` is the most specific ref upstream publishes: this action has no
+      # semver tags, only `v1` and per-version branches (`stable` is a branch
+      # too, and moves every rustup release). Which toolchain actually builds
+      # the binary is decided separately -- hatch_build.py runs cargo with
+      # cwd=rust/, so rust/rust-toolchain.toml pins that.
+      - uses: dtolnay/rust-toolchain@v1
       # Authenticode-signed like the .msi and the .zip. A signature binds no
       # stored credential here the way a macOS Keychain ACL does, but this is the
       # `ggshield` every invocation runs, and an unsigned native executable inside
@@ -202,7 +212,7 @@ jobs:
       - name: Smoke test the wheel
         shell: bash
         run: scripts/smoke-test-wheel dist/*.whl
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheel-windows-amd64
           path: dist/*.whl
@@ -251,7 +261,7 @@ jobs:
               rustup_sha256: 88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759,
             }
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Build, relabel and smoke test the wheel in ${{ matrix.tag }}
         run: |
           docker run --rm -v "$PWD:/io" -w /io -e GGSHIELD_BUILD_RUST=1 \
@@ -276,7 +286,7 @@ jobs:
 
               PYTHON="$PY" scripts/smoke-test-wheel dist/*.whl
             '
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheel-${{ matrix.tag }}
           path: dist/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,6 +70,10 @@ jobs:
       # rust/rust-toolchain.toml pins that.
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          # Required once pinned by SHA: the `stable` *branch* used to default
+          # this input, so `@stable` supplied the toolchain through the ref
+          # itself. Naming it here is what that ref meant.
+          toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       # Only `sign: true` callers get here, and for them signing is not
       # best-effort: an unsigned `ggshield` publishes fine and only shows up
@@ -136,6 +140,9 @@ jobs:
       # separately -- hatch_build.py runs cargo with cwd=rust/, so
       # rust/rust-toolchain.toml pins that.
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          # See the macOS job above: required once the action is SHA-pinned.
+          toolchain: stable
       # Authenticode-signed like the .msi and the .zip. A signature binds no
       # stored credential here the way a macOS Keychain ACL does, but this is the
       # `ggshield` every invocation runs, and an unsigned native executable inside

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,16 +59,16 @@ jobs:
     name: wheel macos-universal2
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-python@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-      # `v1` is the most specific ref upstream publishes: this action has no
-      # semver tags, only `v1` and per-version branches (`stable` is a branch
-      # too, and moves every rustup release). Which toolchain actually builds
-      # the binary is decided separately -- hatch_build.py runs cargo with
-      # cwd=rust/, so rust/rust-toolchain.toml pins that.
-      - uses: dtolnay/rust-toolchain@v1
+      # Commented `v1`, not a semver tag: this action publishes only `v1` and
+      # per-version branches (`stable` is a branch too, and moves every rustup
+      # release). Which toolchain actually builds the binary is decided
+      # separately -- hatch_build.py runs cargo with cwd=rust/, so
+      # rust/rust-toolchain.toml pins that.
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       # Only `sign: true` callers get here, and for them signing is not
@@ -117,7 +117,7 @@ jobs:
           python -m build --wheel --outdir dist
       - name: Smoke test the wheel
         run: scripts/smoke-test-wheel dist/*.whl
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-macos-universal2
           path: dist/*.whl
@@ -126,16 +126,16 @@ jobs:
     name: wheel windows-amd64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-python@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
-      # `v1` is the most specific ref upstream publishes: this action has no
-      # semver tags, only `v1` and per-version branches (`stable` is a branch
-      # too, and moves every rustup release). Which toolchain actually builds
-      # the binary is decided separately -- hatch_build.py runs cargo with
-      # cwd=rust/, so rust/rust-toolchain.toml pins that.
-      - uses: dtolnay/rust-toolchain@v1
+      # Commented `v1`, not a semver tag: this action publishes only `v1` and
+      # per-version branches (`stable` is a branch too, and moves every rustup
+      # release). Which toolchain actually builds the binary is decided
+      # separately -- hatch_build.py runs cargo with cwd=rust/, so
+      # rust/rust-toolchain.toml pins that.
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       # Authenticode-signed like the .msi and the .zip. A signature binds no
       # stored credential here the way a macOS Keychain ACL does, but this is the
       # `ggshield` every invocation runs, and an unsigned native executable inside
@@ -212,7 +212,7 @@ jobs:
       - name: Smoke test the wheel
         shell: bash
         run: scripts/smoke-test-wheel dist/*.whl
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-windows-amd64
           path: dist/*.whl
@@ -261,7 +261,7 @@ jobs:
               rustup_sha256: 88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759,
             }
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build, relabel and smoke test the wheel in ${{ matrix.tag }}
         run: |
           docker run --rm -v "$PWD:/io" -w /io -e GGSHIELD_BUILD_RUST=1 \
@@ -286,7 +286,7 @@ jobs:
 
               PYTHON="$PY" scripts/smoke-test-wheel dist/*.whl
             '
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.tag }}
           path: dist/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.10-slim AS build
+# Pinned to an exact patch release, not `3.10-slim`, so a rebuild resolves to
+# the same interpreter every time. Bumped by Dependabot (docker ecosystem).
+FROM python:3.10.21-slim AS build
 
 LABEL maintainer="GitGuardian SRE Team <support@gitguardian.com>"
 


### PR DESCRIPTION
Every dependency now resolves to a fixed version, and Dependabot waits 3 days before proposing a new one.

Split out of one larger branch; the Dockerfile lockfile change and the cargo cooldown note are separate PRs.

### 3-day cooldown

`cooldown.default-days: 3` on all five ecosystems. A compromised release is usually yanked within hours of discovery, so waiting out that window keeps malicious-then-deleted versions from ever reaching a branch here.

Dependabot only watched `github-actions` before, so `docker`, `uv`, `cargo` (rooted at `/rust`) and `pre-commit` are new. The `pre-commit` entry ignores this repo's own hook: its `rev` tracks `ggshield/__init__.py:__version__`, so bumping it belongs to the release, not to Dependabot.

### Fixed versions

Every pin resolves to whatever the floating ref pointed at when it was written, verified by comparing tag commit SHAs (actions) and registry digests (images). Nothing changes behaviour; it only freezes the current state so reruns are reproducible.

- **17 action refs** across 8 workflows, pinned to full commit SHAs with a trailing `# vX.Y.Z` comment, e.g. `actions/checkout@3d3c42e5... # v7.0.1`. Tags are mutable, so a SHA is the only immutable pin; this also covers `codecov/codecov-action`, which has been breached before. Dependabot handles this format natively -- its `github_actions` updater has a `VersionCommenter` whose job is keeping that comment in sync -- so updates keep working. Every SHA was independently re-resolved from its tag to confirm it matches its comment.
- **Container images**: `python:3.10-slim` -> `3.10.21-slim`; `rockylinux:8` -> `8.10`, `:9` -> `9.8`; `debian:stable` -> `stable-20260824`; `ubuntu:latest` -> `26.04`; `opensuse/leap` -> `16.0`.
- **Grype installer**: was `curl .../anchore/grype/main/install.sh | sh`. The binary version was pinned but the *script* was fetched from a branch and piped into a shell, so upstream could change what ran in a release job at any time. Now a checksum-verified release tarball via the existing `scripts/download` helper, matching how `rustup-init` is already handled.

### Notes for the reviewer

- `dtolnay/rust-toolchain` is SHA-pinned with a `# v1` comment rather than a semver one: upstream publishes only `v1` and per-version branches (`stable` is a branch too, and moves every rustup release). The toolchain that actually compiles the binary was never floating: `hatch_build.py` runs cargo with `cwd=rust/`, so `rust/rust-toolchain.toml` pins it to 1.96.0.
- `ubuntu:latest` was resolving to `26.04`, a non-LTS rolling release. Pinned as-is to avoid mixing a behaviour change into this PR, but if those smoke tests are meant to mirror what users run, `ubuntu:24.04` is probably the intent. Happy to switch.
- The `case "${{ matrix.image }}"` branches in `build_release_assets.yml` match on image name; all five renamed images still route to the same branch.
- Still floating, deliberately: `actions/secret/action.yml` uses `docker://gitguardian/ggshield:v1.53.0` and `.pre-commit-hooks.yaml` pulls `gitguardian/ggshield:latest`. Both are self-references whose bump belongs to the release process, and the `:latest` one is the contract consumers rely on.
- `scripts/install/install.sh` and `install.ps1` are deliberately left alone: they resolve *latest ggshield* for end users and enforce a mandatory sha256 from the GitHub API. Pinning them would defeat their purpose.

Verified with `check-jsonschema` (`vendor.github-workflows` + `vendor.dependabot`, the same hooks pre-commit runs). The grype step was dry-run locally, and its checksum confirmed to fail closed under GNU coreutils: correct hash passes, tampered hash exits nonzero.
