### PR TITLE
fix(ai-hook): report a live hook command as installed

### DIFF
--- a/changelog.d/20260909_150000_achille.mascia_ai_hook_status_live_command.md
+++ b/changelog.d/20260909_150000_achille.mascia_ai_hook_status_live_command.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `ggshield machine doctor` and the AI discovery no longer report an assistant as
+  unprotected when its hook command points at a live binary that a next upgrade
+  would break. Only a missing or dead command now reads as not installed, and the
+  command found in the settings file is reported either way.

--- a/ggshield/verticals/ai/installation.py
+++ b/ggshield/verticals/ai/installation.py
@@ -35,6 +35,9 @@ from .agents import AGENTS, Agent
 class InstallationStats:
     added: int = 0
     already_present: int = 0
+    # Slots repointed away from a live binary. They count in `added`, yet the
+    # command they held scans every prompt: see `are_hooks_installed_globally`.
+    repointed_live: int = 0
     command: str = ""
 
 
@@ -405,6 +408,9 @@ def _fill_dict(
                 # then fails open: every prompt goes unscanned.
                 if _is_outdated_hook_command(cmd, command):
                     config[key] = "<COMMAND>"
+                    installed = _hook_command_executable(cmd)
+                    if installed and os.path.exists(installed):
+                        stats.repointed_live += 1
             # Update if needed
             if overwrite:
                 config[key] = value
@@ -416,12 +422,15 @@ def _fill_dict(
 
 
 def are_hooks_installed_globally(agent_name: str) -> Tuple[bool, Optional[str]]:
-    """Whether the ggshield AI hooks are installed in this agent's global settings file."""
-    result = build_hook_config(agent_name, "global")
-    return (
-        result.stats.added == 0,
-        result.stats.command if result.stats.added == 0 else None,
-    )
+    """Whether the ggshield AI hooks are installed in this agent's global settings file.
+
+    A slot repointed at a stabler path holds a hook that scans every prompt, so it
+    reads as installed; only a missing or dead command leaves the agent
+    unprotected. The command comes back either way, to tell a dead path from a
+    config that never had a hook.
+    """
+    stats = build_hook_config(agent_name, "global").stats
+    return stats.added == stats.repointed_live, stats.command or None
 
 
 @dataclass

--- a/tests/unit/verticals/ai/test_installation.py
+++ b/tests/unit/verticals/ai/test_installation.py
@@ -228,8 +228,9 @@ class TestFillDict:
         launcher = tmp_path / "ggshield"
         launcher.symlink_to(binary)
         command = f"{launcher} secret scan ai-hook"
-        config = {"hooks": [{"command": f"{binary} secret scan ai-hook"}]}
-        _fill_dict(
+        versioned = f"{binary} secret scan ai-hook"
+        config = {"hooks": [{"command": versioned}]}
+        stats = _fill_dict(
             config,
             {"hooks": [{"command": "<COMMAND>"}]},
             command,
@@ -238,6 +239,9 @@ class TestFillDict:
             locator=_locator,
         )
         assert config == {"hooks": [{"command": command}]}
+        assert stats == InstallationStats(
+            added=1, already_present=1, repointed_live=1, command=versioned
+        )
 
     def test_another_tool_command_is_left_alone(self, tmp_path: Path):
         """GIVEN a hook command running another tool, mentioning ggshield
@@ -794,6 +798,58 @@ class TestAreHooksInstalledGlobally:
         installed, command = are_hooks_installed_globally("claude-code")
         assert installed is True
         assert command == COMMAND
+
+    @pytest.mark.skipif(os.name == "nt", reason="creates a symlink")
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_live_command_through_a_launcher_stays_installed(
+        self, mock_home: Any, tmp_path: Path
+    ):
+        """GIVEN a hook pinned to a live binary that install would repoint
+        WHEN the status is read
+        THEN the agent counts as protected: that hook scans every prompt."""
+        mock_home.return_value = tmp_path
+        binary = tmp_path / "ggshield-1.53.0" / "ggshield"
+        binary.parent.mkdir()
+        binary.write_text("")
+        launcher = tmp_path / "ggshield"
+        launcher.symlink_to(binary)
+        versioned = f"{binary} secret scan ai-hook"
+
+        with patch(
+            "ggshield.verticals.ai.installation.build_hook_command",
+            return_value=versioned,
+        ):
+            install_hooks("claude-code", mode="global")
+
+        with patch(
+            "ggshield.verticals.ai.installation.build_hook_command",
+            return_value=f"{launcher} secret scan ai-hook",
+        ):
+            installed, command = are_hooks_installed_globally("claude-code")
+
+        assert installed is True
+        assert command == versioned
+
+    @patch("ggshield.verticals.ai.installation.get_user_home_dir")
+    def test_dead_command_is_reported_with_its_path(
+        self, mock_home: Any, tmp_path: Path
+    ):
+        """GIVEN a hook pinned to a binary an upgrade deleted
+        WHEN the status is read
+        THEN it is not installed, and the dead command says why."""
+        mock_home.return_value = tmp_path
+        stale = f"{tmp_path / 'ggshield-1.53.0' / 'ggshield'} secret scan ai-hook"
+
+        with patch(
+            "ggshield.verticals.ai.installation.build_hook_command",
+            return_value=stale,
+        ):
+            install_hooks("claude-code", mode="global")
+
+        installed, command = are_hooks_installed_globally("claude-code")
+
+        assert installed is False
+        assert command == stale
 
     @patch("ggshield.verticals.ai.installation.get_user_home_dir")
     def test_no_settings_file_returns_false(self, mock_home: Any, tmp_path: Path):


### PR DESCRIPTION
## Context

The AI hook status was derived from the install decision. `are_hooks_installed_globally` returned `stats.added == 0`, which answers "would `install` write anything?", and `install` also repoints a command that still runs but names a path the next upgrade deletes (a versioned bundle directory, when a stable launcher now resolves to the same binary).

Such an agent read as unprotected in `ggshield machine doctor` and in the AI discovery sent to GitGuardian, while its hook scanned every prompt and blocked secrets. The dashboard showed "Hooks: Not installed" next to a non-zero count of blocked secrets.

## What has been done

- `InstallationStats` counts the slots repointed away from a **live** binary (`repointed_live`).
- `are_hooks_installed_globally` reports the hooks as installed when those slots are the only reason `install` would write. A missing or dead command still reads as not installed, because that hook fails open.
- The command found in the settings file is returned in both cases, so a dead path can be told from a config that never had a hook. It was `None` for every uninstalled agent before.

`install` behavior does not change: it still repoints a dead path and a fragile one, and its output is untouched.

## Validation

- `pytest tests/unit/verticals/ai`
- Or by hand, on a machine with the hooks installed globally:
  - point the `command` entries of `~/.claude/settings.json` at a symlink target of your ggshield binary, for example `$(readlink -f "$(command -v ggshield)") secret scan ai-hook`
  - run `ggshield machine doctor`: the assistant reports the AI hook as installed, and `ggshield install -t claude-code -m global` still repoints the command at the stable launcher

## PR check list

- [x] As much as possible, the changes include tests (unit and/or functional)
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry (see doc/dev/getting-started.md). If the changes do not affect the end user, then the `skip-changelog` label has been added to the PR.