### PR TITLE
build(docker): install Python dependencies from uv.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,51 @@
-# Pinned to an exact patch release, not `3.10-slim`, so a rebuild resolves to
-# the same interpreter every time. Bumped by Dependabot (docker ecosystem).
-FROM python:3.10.21-slim AS build
+# Three stages:
+# - `uv` is just a pinned image to copy the binary out of (it builds nothing)
+# - `builder` installs the dependencies
+# - `build` is the image we publish.
+# The split exists because uv is a 44MB binary: copying only
+# the resulting virtualenv into a clean image keeps uv and the sources out of
+# what ships.
+# Pattern from uv's Docker integration guide:
+# https://docs.astral.sh/uv/guides/integration/docker/
+
+# uv, as its own stage rather than an inline `COPY --from=ghcr.io/...`:
+# Dependabot's docker ecosystem only parses `FROM` lines, so this is what lets
+# it keep the version below updated.
+# Pinned by digest as well as by tag, since a tag can be moved to a different commit.
+FROM ghcr.io/astral-sh/uv:0.10.8@sha256:88234bc9e09c2b2f6d176a3daf411419eb0370d450a08129257410de9cfafd2a AS uv
+
+# Pinned by digest, not just by tag: a tag is a mutable pointer that can be
+# repushed to different content, so the digest is what makes a rebuild resolve
+# to the same interpreter every time. Bumped by Dependabot (docker ecosystem).
+# `builder` and `build` stay on the same base image: see UV_PYTHON_DOWNLOADS
+# below.
+FROM python:3.10.21-slim@sha256:fd76ade0c607f27677bc04be3c60749f400eedc941d9e72967e19a4cedff80c2 AS builder
+
+COPY --from=uv /uv /usr/local/bin/uv
+
+# Use the base image's interpreter rather than one uv downloads: the venv
+# records an absolute interpreter path in pyvenv.cfg, so `builder` and `build`
+# have to agree on it.
+ENV UV_PYTHON_DOWNLOADS=0
+# Ship .pyc files: without them every `ggshield` invocation in a fresh
+# container recompiles, which measured ~0.2s slower on `--version` alone.
+ENV UV_COMPILE_BYTECODE=1
+
+# Must match the runtime path exactly -- console scripts get an absolute
+# shebang (`#!/app/.venv/bin/python3`), so a venv built elsewhere and copied
+# to /app/.venv would point at an interpreter that is not there.
+WORKDIR /app
+
+COPY . .
+
+# --locked installs exactly what the lock pins and fails if the lock is out of step
+# rather than silently re-resolving.
+# --no-dev keeps the test and dev groups out of a release image.
+# --no-editable so the venv holds a real copy rather than pointing back at
+# /app, which does not exist in the runtime stage.
+RUN uv sync --locked --no-dev --no-editable
+
+FROM python:3.10.21-slim@sha256:fd76ade0c607f27677bc04be3c60749f400eedc941d9e72967e19a4cedff80c2 AS build
 
 LABEL maintainer="GitGuardian SRE Team <support@gitguardian.com>"
 
@@ -19,9 +64,15 @@ RUN \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . .
+# The environment only. ggshield is installed inside it, so the sources are
+# not needed at runtime.
+COPY --from=builder /app/.venv /app/.venv
 
-RUN pip install .
+# actions/secret/action.yml runs /app/docker/actions-secret-entrypoint.sh, so
+# the image must carry it.
+COPY docker ./docker
+
+COPY LICENSE ./
 
 WORKDIR /data
 VOLUME [ "/data" ]

--- a/changelog.d/20260910_100000_gregoire.deveaux_docker_uv_lock.md
+++ b/changelog.d/20260910_100000_gregoire.deveaux_docker_uv_lock.md
@@ -1,0 +1,6 @@
+### Security
+
+- The Docker image now installs its Python dependencies from `uv.lock` instead
+  of re-resolving the version ranges in `pyproject.toml` at build time. The
+  image therefore gets the same hash-verified versions as CI, and the rolling
+  `exclude-newer = "3 days"` quarantine now applies to it too.


### PR DESCRIPTION
**Goal: pin the image's Python dependencies so a compromised release cannot reach it.**

`pip install .` read the version *ranges* from `pyproject.toml` and re-resolved them from PyPI at build time. `uv.lock` was copied into the image but never used, so the image was the one place our dependency hardening did not apply: no hash verification despite the 2140 `sha256` entries in the lock, and no 3-day `exclude-newer` cooldown, since pip does not read `[tool.uv]`. A package published minutes ago and matching `>=`/`~=` would land in the image, and two builds of the same commit could ship different versions.

`uv sync --locked` installs exactly what the lock pins and fails if the lock is out of step with `pyproject.toml` instead of silently re-resolving. Verified in the built image: all **69 installed packages match `uv.lock`**, zero divergence. `--no-dev` keeps the test and dev groups out, and `uv` is copied from `ghcr.io/astral-sh/uv` pinned by digest so nothing is fetched unpinned at build time.

### Cherry on the cake: 353MB -> 335MB (-18MB, -5%)

The build has three stages: `uv` is a pinned image to copy the binary out of, `builder` installs the dependencies into a virtualenv, and `build` is the published image, which receives only that virtualenv.

The dependencies themselves are not what shrinks -- they just move, from `site-packages` into `/app/.venv` (67.1MB -> 67.6MB). What goes away is everything else `pip install .` left in the final image:

| | |
| --- | --- |
| pip's download cache in `/root/.cache` | 20.2MB |
| `pip` and `wheel` themselves | 6.7MB |
| repo sources in `/app` | 1.7MB |

The cache is the big one: `pip install` ran without `--no-cache-dir`, so every wheel it downloaded stayed in the layer. `uv` has the same kind of cache, but it runs in `builder` and only the virtualenv is copied forward, so none of it reaches the published image.

(Those three are uncompressed sizes and do not sum to 18MB -- the install layer they live in compresses to 87.5MB, against 70.8MB for the virtualenv copy.)

Splitting `build` from `builder` is also what keeps `uv` itself (a 44MB binary, added by this PR) out of the published image.

### Notes for the reviewer

- `builder` and `build` must stay on the same base image and the same `/app/.venv` path: the venv records an absolute interpreter path in `pyvenv.cfg`, and console scripts get an absolute shebang (`#!/app/.venv/bin/python3`). `UV_PYTHON_DOWNLOADS=0` stops uv fetching its own interpreter for the same reason.
- `UV_COMPILE_BYTECODE=1` is needed because a `uv sync` venv otherwise ships no `.pyc` at all, where `pip install` generated them. It keeps startup where it is today and accounts for 17MB of the size above.
- `actions/secret/action.yml` runs `/app/docker/actions-secret-entrypoint.sh`, which the old `COPY . .` supplied, hence `COPY docker ./docker` in the runtime stage.
- Verified: that entrypoint runs, `git` still present for scans, a `linux/amd64` build from an arm64 host, and a desynced lock fails the build.

Dependabot cooldown and version pinning are in #1454, the cargo cooldown note in #1457.
