### PR TITLE
ci: document the cargo publish-age cooldown pending a 1.100 toolchain

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,39 @@
+# Cargo configuration for the ggshield Rust workspace.
+#
+# Cargo probes `.cargo/config.toml` in the invocation directory and every
+# parent, and hatch_build.py runs cargo with cwd=rust/, so settings here apply
+# to the hook builds.
+
+# --- Publish-age cooldown (not enabled yet: needs Rust >= 1.100) ------------
+#
+# This is cargo's equivalent of the 3-day cooldown Python dependencies already
+# get from `exclude-newer = "3 days"` in pyproject.toml's [tool.uv], and of the
+# `cooldown.default-days: 3` being added to .github/dependabot.yml for the
+# other ecosystems.
+#
+# A compromised release is usually yanked within hours of discovery, so
+# refusing anything published in the last 3 days keeps the
+# malicious-then-deleted versions out of a resolve entirely.
+#
+# Enforcement would already be strict without further config:
+# `resolver.incompatible-publish-age` defaults to "deny", which ignores
+# too-new versions *unless they are already in Cargo.lock*. So this holds back
+# new crates without churning the versions we have locked today.
+#
+# Why it stays commented: the key is only respected as of Rust 1.100 (RFC
+# 3923, stabilized there), and rust-toolchain.toml pins 1.96.0 to match the
+# cove workspace. Uncommenting it today does nothing except print
+#
+#   warning: ignoring `registry.global-min-publish-age` without `-Zmin-publish-age`
+#
+# on every cargo invocation. Uncomment when the pinned toolchain reaches
+# 1.100+; that bump is a cross-repo decision, not ggshield's alone.
+#
+# Note this is defense in depth rather than the primary control: Cargo.lock is
+# committed, so what actually reaches a build is whatever Dependabot proposes,
+# and its cargo updates already sit behind the same 3-day cooldown. This would
+# cover resolution that happens outside Dependabot, such as a local
+# `cargo update`.
+#
+# [registry]
+# global-min-publish-age = "3 days"


### PR DESCRIPTION
Adds `rust/.cargo/config.toml` documenting cargo's publish-age cooldown, with the setting present but commented out.

Cargo has a direct equivalent of the `exclude-newer = "3 days"` we use for Python (RFC 3923, stabilized in Rust 1.100):

```toml
[registry]
global-min-publish-age = "3 days"
```

Enforcement would already be strict without further config: `resolver.incompatible-publish-age` defaults to `"deny"`, which ignores too-new versions *unless they are already in `Cargo.lock`* -- so it holds back new crates without churning what we have locked today.

It stays commented because the key is only respected as of **Rust 1.100**, and `rust-toolchain.toml` pins 1.96.0 to match the cove workspace. Enabling it today only prints, on every cargo invocation:

```
warning: ignoring `registry.global-min-publish-age` without `-Zmin-publish-age`
```

Uncomment when the pinned toolchain reaches 1.100+; that bump is a cross-repo decision, not ggshield's alone. Note this is defense in depth rather than the primary control -- `Cargo.lock` is committed, so what reaches a build is whatever Dependabot proposes.

### Verified

- Cargo does read this path: with a deliberately wrong value type it errors with `error in /.../rust/.cargo/config.toml: registry.global-min-publish-age expected a string, but found a integer`, which confirms both discovery from `cwd=rust/` (where `hatch_build.py` runs cargo) and that the key is recognized.
- As committed it changes nothing: TOML parses with zero active keys, and `Cargo.lock` is byte-identical under `cargo metadata --locked`.
- The feature itself works, confirmed in a throwaway crate: with `"52 weeks"` and `-Zmin-publish-age` on a nightly-unlocked cargo, `serde_json` resolved to `1.0.143` instead of `1.0.151`.

`-Zmin-publish-age` is deliberately not used to enable this early. `-Z` is refused on stable, and the only way to force it is `RUSTC_BOOTSTRAP=1`, which unlocks *every* unstable feature process-wide -- a much wider blast radius than the 3-day cooldown it would buy, and upstream treats it as a compiler-development backdoor rather than a supported flag.

This is the Rust half of the dependency cooldown work; the Dependabot side (including `cargo`) is in #1454.
