### PR TITLE
build(deps): pin the hatchling build backend to an exact version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,13 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/GitGuardian/ggshield"
 
+# Pinned: uv.lock does not cover the build backend, and hatchling runs
+# hatch_build.py / hatch_meta.py. Split because 1.28.0 dropped Python 3.9.
 [build-system]
-requires = ["hatchling"]
+requires = [
+    "hatchling==1.32.0; python_version >= '3.10'",
+    "hatchling==1.27.0; python_version < '3.10'",
+]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
**Goal: close the last unpinned fetch in a ggshield build.**

`uv.lock` pins and hash-verifies the 68 runtime dependencies, but it does not
record the build backend. `[build-system] requires = ["hatchling"]` was
unbounded, so every wheel, sdist and Docker image build resolved `hatchling`
fresh from PyPI. hatchling is not passive: it loads `hatch_build.py` and
`hatch_meta.py` and runs them, so a compromised release executes inside the
build, with no lock entry to check it against.

The 3-day `exclude-newer` cooldown does cover it (uv applies `exclude-newer` to
build-dependency resolution, not just to the lock), so the exposure was a
malicious release that survives more than three days undetected. An exact pin
removes that window: PyPI files are immutable, so a fixed version can only be
attacked by publishing a new one, which the pin excludes.

### Why two entries instead of one

hatchling 1.28.0 raised its floor to Python 3.10, and `requires-python` here is
still `>=3.9`. A single `hatchling==1.32.0` fails on the 3.9 leg:

```
ERROR: Ignored the following versions that require a different python version:
1.28.0 Requires-Python >=3.10; ... 1.32.0 Requires-Python >=3.10
```

1.27.0 is the last release supporting 3.9, hence the marker split.

### Notes for the reviewer

- `uv.lock` is untouched and stays in sync: `[build-system] requires` is not
  part of what `--locked` compares, verified with `uv lock --check` and with
  `uv sync --locked` in the image.
- Verified that both frontends honour the markers, on both interpreters:
  `pip install .` and `uv build --wheel` succeed on `python:3.9-slim` and
  `python:3.10.21-slim`, and the build environment gets hatchling 1.27.0 on 3.9,
  1.32.0 on 3.10.
- The pin does not appear to be something Dependabot's `uv` ecosystem bumps, so
  it will need moving by hand. That is cheap to live with: hatchling never
  ships in an artifact, so a stale pin carries no runtime exposure, only missed
  build-backend fixes.
- Deliberately pinned in `[build-system]` rather than in
  `[tool.uv] build-constraint-dependencies`, so the guarantee also holds for
  `pip install .` (what the Docker image does on `main` today) and does not
  depend on the frontend.
- No changelog fragment: nothing here is observable to a user of ggshield.

Found while reviewing #1456, which is what makes the gap visible: with the
runtime dependencies locked, the backend is the only thing left resolving at
build time. The two are independent and can land in either order.
