### PR TITLE
ci: pin the Cloudsmith CLI used by the release job

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  UV_VERSION: 0.10.8
+
 jobs:
   build_release_assets:
     uses: ./.github/workflows/build_release_assets.yml
@@ -199,8 +202,18 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      # Pinned, and cooled with an explicit flag since `uv tool install` reads
+      # no `[tool.uv]`: this job holds CLOUDSMITH_API_KEY, and the bare `pip
+      # install` it replaces resolved 65 packages fresh from PyPI at each release.
       - name: Install Cloudsmith CLI
-        run: pip install cloudsmith-cli
+        run: |
+          uv tool install --exclude-newer '3 days' cloudsmith-cli==1.26.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Push to Cloudsmith
         run: |


### PR DESCRIPTION
**Goal: stop the release job from installing 65 unpinned packages next to a publishing credential.**

`push_to_cloudsmith` ran `pip install cloudsmith-cli` with no bound. That
resolves fresh from PyPI on every release: verified, **65 packages** (pydantic,
cryptography, keyring, uvicorn, starlette, mcp and the rest of the tree). The
next step hands `CLOUDSMITH_API_KEY` to `scripts/push-to-cloudsmith`, so any of
those 65 runs in a job that can publish as us. pip also reads no `[tool.uv]`,
so the 3-day cooldown the rest of the tree relies on never applied here.

`uv tool install` with an exact version and an explicit `--exclude-newer`
brings the step to the same standard as everything else: the top level cannot
move, and the transitive tree cannot pick up a release younger than three days.
The flag has to be spelled out because `uv tool install` is not project-scoped
and so does not read `pyproject.toml`.

1.26.0 rather than the current 1.27.0: 1.27.0 was published on 2026-09-09, so
it is still inside its own cooldown window and `--exclude-newer` would refuse
it.

### Notes for the reviewer

- Verified end to end against the uv version this workflow pins: with
  `uv tool install --exclude-newer '3 days' cloudsmith-cli==1.26.0`,
  `cloudsmith --version` reports 1.26.0, and both subcommands the script calls
  (`push deb`, `push rpm`) resolve.
- `echo "$HOME/.local/bin" >> "$GITHUB_PATH"` because `uv tool install` puts
  the executable there. It happens to be on PATH already on the ubuntu runners,
  but a silent miss here would only show up mid-release.
- `UV_VERSION` moves to a workflow-level `env`, matching ci.yml,
  build_release_assets.yml and perfbench.yml.
- Nothing bumps this pin automatically. Dependabot's `uv` ecosystem reads
  pyproject.toml/uv.lock and `github-actions` reads `uses:` refs, so a pip pin
  inside a `run:` block is invisible to both and 1.26.0 will sit here until
  someone looks. Tracked as a follow-up rather than solved here: giving the CLI
  its own small uv project (`scripts/release-tools/` with a committed
  `uv.lock`) plus a `uv` entry in dependabot.yml for that directory would pin
  and hash all 65 *and* get bumps. Verified it works, but it overlaps the
  in-flight dependabot.yml rewrite in #1483.
- Stronger option if you want it: a `--require-hashes` requirements file
  generated by `uv pip compile --universal --generate-hashes`, which would pin
  and hash all 65 rather than only cooling them. It costs a generated file plus
  a `pip` entry in dependabot.yml, so I kept this PR to the cooldown standard
  the repo already settled on. Say the word and I will swap it.

Same class as #1478 (the unpinned `hatchling` build backend), found in the same
sweep. Independent of it.

