### PR TITLE
feat(ai-hook): withhold a Claude Code tool output that holds a secret

### DIFF
--- a/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
+++ b/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
@@ -1,0 +1,9 @@
+### Changed
+
+- When the AI hook finds a secret in a tool output on Claude Code or Codex, the
+  output is now withheld from the assistant instead of being passed to it with a
+  warning attached. The assistant reads the block message in place of the output,
+  so the secret stays out of its context and out of the session transcript on
+  disk, and the message no longer tells you to revoke a credential the assistant
+  never read. Agents with no way to replace a tool output are unchanged and keep
+  reporting the secret as leaked.

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -207,8 +207,12 @@ fn scan(config: &config::Config, stdin_content: &str) -> Result<Emission, Error>
         );
         // `has_secret_already_leaked()`: on PostToolUse the secret is already in
         // the agent's context, so tell the user out-of-band. Best effort, and
-        // only for the invocation that scanned: one event, one banner.
-        if payload.event_type == EventType::PostToolUse {
+        // only for the invocation that scanned: one event, one banner. An agent
+        // that lets us replace the output leaked nothing, so a banner there
+        // would report a non-event.
+        if payload.event_type == EventType::PostToolUse
+            && !output::can_redact_tool_output(payload)
+        {
             notify(&result);
         }
         result

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -210,8 +210,7 @@ fn scan(config: &config::Config, stdin_content: &str) -> Result<Emission, Error>
         // only for the invocation that scanned: one event, one banner. An agent
         // that lets us replace the output leaked nothing, so a banner there
         // would report a non-event.
-        if payload.event_type == EventType::PostToolUse
-            && !output::can_redact_tool_output(payload)
+        if payload.event_type == EventType::PostToolUse && !output::can_redact_tool_output(payload)
         {
             notify(&result);
         }

--- a/rust/hook/src/message.rs
+++ b/rust/hook/src/message.rs
@@ -17,6 +17,11 @@ const PRE_OTHER_TEMPLATE: &str = include_str!("templates/pre_other.in");
 const POST_BASH_TEMPLATE: &str = include_str!("templates/post_bash.in");
 const POST_READ_TEMPLATE: &str = include_str!("templates/post_read.in");
 const POST_OTHER_TEMPLATE: &str = include_str!("templates/post_other.in");
+// Used when the agent lets us replace the output, so the secret never reached
+// the model and the leaked wording would send the user to rotate for nothing.
+const POST_BASH_REDACTED_TEMPLATE: &str = include_str!("templates/post_bash_redacted.in");
+const POST_READ_REDACTED_TEMPLATE: &str = include_str!("templates/post_read_redacted.in");
+const POST_OTHER_REDACTED_TEMPLATE: &str = include_str!("templates/post_other_redacted.in");
 const SECRET_LINE_TEMPLATE: &str = include_str!("templates/secret_line.in");
 const INCIDENT_URL_LINE_TEMPLATE: &str = include_str!("templates/incident_url_line.in");
 const REMEDIATION_STEPS_TEMPLATE: &str = include_str!("templates/remediation_steps.in");
@@ -133,12 +138,19 @@ fn secret_lines(secrets: &[Secret]) -> String {
 /// Called only with at least one secret, which is what lets the templates
 /// hard-break into the secret list.
 pub fn from_secrets(secrets: &[Secret], payload: &Payload) -> String {
+    // Whether the output was withheld from the model decides the whole second
+    // half of the message: what happened, and whether there is anything to
+    // revoke. See `output::can_redact_tool_output`.
+    let withheld = crate::output::can_redact_tool_output(payload);
     let template = match (payload.event_type, payload.tool) {
         // A UserPrompt event also carries a Tool::Read payload per file mentioned
         // in the prompt: the secret is in that file, not in the prompt, so the
         // prompt wording would name the wrong content.
         (EventType::UserPrompt, Some(Tool::Read)) => PRE_READ_TEMPLATE,
         (EventType::UserPrompt, _) => USER_PROMPT_TEMPLATE,
+        (EventType::PostToolUse, Some(Tool::Bash)) if withheld => POST_BASH_REDACTED_TEMPLATE,
+        (EventType::PostToolUse, Some(Tool::Read)) if withheld => POST_READ_REDACTED_TEMPLATE,
+        (EventType::PostToolUse, _) if withheld => POST_OTHER_REDACTED_TEMPLATE,
         (EventType::PostToolUse, Some(Tool::Bash)) => POST_BASH_TEMPLATE,
         (EventType::PostToolUse, Some(Tool::Read)) => POST_READ_TEMPLATE,
         (EventType::PostToolUse, _) => POST_OTHER_TEMPLATE,
@@ -246,12 +258,23 @@ mod tests {
     }
 
     fn payload(event_type: EventType, tool: Option<Tool>, identifier: &str) -> Payload {
+        payload_for(crate::payload::Agent::Claude, event_type, tool, identifier)
+    }
+
+    /// The agent decides whether a PostToolUse output was withheld from the
+    /// model, and so which half of the message the templates render.
+    fn payload_for(
+        agent: crate::payload::Agent,
+        event_type: EventType,
+        tool: Option<Tool>,
+        identifier: &str,
+    ) -> Payload {
         Payload {
             event_type,
             tool,
             content: String::new(),
             identifier: identifier.into(),
-            agent: crate::payload::Agent::Claude,
+            agent,
             cwd: String::new(),
             raw: Value::Object(Default::default()),
             read_range: None,
@@ -352,7 +375,14 @@ mod tests {
             secret("AWS Keys", "valid", &["AKIAsomethingXYZ"]),
             secret("Generic Password", "unknown", &["hunter2hunter2"]),
         ];
-        let p = payload(EventType::PostToolUse, Some(Tool::Read), "/tmp/creds.env");
+        // VS Code cannot replace a tool output, so the secret really did reach
+        // the model and this is the wording that must survive.
+        let p = payload_for(
+            crate::payload::Agent::VsCode,
+            EventType::PostToolUse,
+            Some(Tool::Read),
+            "/tmp/creds.env",
+        );
         let msg = from_secrets(&secrets, &p);
         assert!(
             msg.contains("Detected 2 secrets in /tmp/creds.env"),
@@ -372,7 +402,12 @@ mod tests {
         let mut s = secret("AWS Keys", "valid", &["AKIAsomethingXYZ"]);
         s.known_secret = true;
         s.incident_url = Some("https://dashboard.gitguardian.com/incidents/9".into());
-        let p = payload(EventType::PostToolUse, Some(Tool::Bash), "id");
+        let p = payload_for(
+            crate::payload::Agent::VsCode,
+            EventType::PostToolUse,
+            Some(Tool::Bash),
+            "id",
+        );
         let msg = from_secrets(&[s], &p);
         assert!(msg.contains("    Incident URL: https://dashboard.gitguardian.com/incidents/9"));
         assert!(
@@ -401,6 +436,57 @@ mod tests {
         assert!(msg.contains("in /tmp/config.py"));
         assert!(!msg.contains("in your prompt"));
         assert!(!msg.contains("remove the secret from your prompt"));
+    }
+
+    /// GIVEN a secret in an output the agent let us replace
+    /// WHEN the block message is built
+    /// THEN it says the output was withheld and never tells the user to revoke.
+    #[test]
+    fn a_withheld_output_never_advises_revoking() {
+        for (tool, expected) in [
+            (Tool::Bash, "The command ran, but its output was withheld"),
+            (Tool::Read, "The file content was withheld"),
+        ] {
+            let p = payload(EventType::PostToolUse, Some(tool), "/tmp/creds.env");
+            let msg = from_secrets(&[secret("AWS Keys", "valid", &["AKIAsomething"])], &p);
+            assert!(msg.contains(expected), "{tool:?}: {msg}");
+            assert!(msg.contains("not sent to the model"), "{tool:?}: {msg}");
+            assert!(!msg.contains("Consider it compromised"), "{tool:?}: {msg}");
+            assert!(!msg.contains("revoke"), "{tool:?}: {msg}");
+            // The false-positive escape hatch stays: a withheld output is still
+            // a blocked one, and the user may disagree with the finding.
+            assert!(msg.contains("ggshield secret ignore --last-found"), "{msg}");
+        }
+    }
+
+    /// GIVEN the same secret in the same tool output on two agents
+    /// WHEN one of them can replace the output and the other cannot
+    /// THEN only the agent that cannot is told the secret was compromised.
+    #[test]
+    fn the_wording_follows_the_agent_not_the_event() {
+        use crate::payload::Agent;
+        let secrets = [secret("AWS Keys", "valid", &["AKIAsomething"])];
+        let withheld = from_secrets(
+            &secrets,
+            &payload_for(
+                Agent::Claude,
+                EventType::PostToolUse,
+                Some(Tool::Bash),
+                "id",
+            ),
+        );
+        let leaked = from_secrets(
+            &secrets,
+            &payload_for(
+                Agent::VsCode,
+                EventType::PostToolUse,
+                Some(Tool::Bash),
+                "id",
+            ),
+        );
+        assert!(withheld.contains("withheld from the agent"), "{withheld}");
+        assert!(!withheld.contains("compromised"), "{withheld}");
+        assert!(leaked.contains("Consider it compromised."), "{leaked}");
     }
 
     /// GIVEN every (event, tool) pair the dispatch table has an arm for

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -8,7 +8,7 @@
 
 use serde_json::{Map, Value};
 
-use crate::payload::{Agent, EventType, Payload};
+use crate::payload::{Agent, EventType, Payload, Tool};
 
 pub struct HookResult<'a> {
     pub block: bool,
@@ -86,15 +86,106 @@ fn deny_pre_tool_use(message: &str) -> Value {
     )])
 }
 
-fn decision_block(message: &str, with_context: bool) -> Value {
-    let mut pairs = vec![
+fn decision_block(message: &str) -> Value {
+    obj(vec![
         ("decision", "block".into()),
         ("reason", Value::from(message)),
-    ];
-    if with_context {
-        pairs.push(("additionalContext", message.into()));
+    ])
+}
+
+/// Whether this agent lets the hook replace the tool's output before the model
+/// reads it, so a PostToolUse block withholds the secret rather than only
+/// warning about it after the fact.
+///
+/// Drives three things that must agree: the replacement `emission()` sends, the
+/// wording `message::from_secrets()` picks, and whether `lib.rs` raises the
+/// "already leaked" desktop notification.
+pub fn can_redact_tool_output(payload: &Payload) -> bool {
+    payload.event_type == EventType::PostToolUse
+        && match payload.agent {
+            // `updatedToolOutput` must match the tool's own output schema.
+            // Claude Code silently ignores a value that does not and shows the
+            // original, so only the shapes captured from a real payload count;
+            // `claude_updated_tool_output` builds exactly those, and
+            // `claude_capability_matches_the_shapes_it_can_build` locks the two
+            // together.
+            Agent::Claude => matches!(payload.tool, Some(Tool::Bash | Tool::Read)),
+            // Codex and Vibe are documented to replace a blocked tool result,
+            // and Cursor can for an MCP tool. None of that is established here
+            // against a real payload yet, and until it is they keep the leaked
+            // wording: telling someone to rotate a secret that never left is a
+            // nuisance, telling them not to rotate one that did is a breach.
+            Agent::Codex
+            | Agent::Copilot
+            | Agent::Cursor
+            | Agent::Kiro
+            | Agent::Vibe
+            | Agent::VsCode => false,
+        }
+}
+
+/// The output Claude Code hands the model in place of the one that held the
+/// secret, in that tool's own shape. `None` for a tool whose shape we have not
+/// captured, which falls back to warning about a leak that did happen.
+fn claude_updated_tool_output(payload: &Payload, message: &str) -> Option<Value> {
+    match payload.tool? {
+        Tool::Bash => Some(obj(vec![
+            ("stdout", message.into()),
+            ("stderr", "".into()),
+            ("interrupted", false.into()),
+            ("isImage", false.into()),
+        ])),
+        Tool::Read => {
+            let lines = message.lines().count().max(1);
+            Some(obj(vec![
+                ("type", "text".into()),
+                (
+                    "file",
+                    obj(vec![
+                        ("filePath", read_file_path(payload).into()),
+                        ("content", message.into()),
+                        ("numLines", lines.into()),
+                        ("startLine", 1.into()),
+                        ("totalLines", lines.into()),
+                    ]),
+                ),
+            ]))
+        }
+        Tool::Mcp | Tool::Other => None,
     }
-    obj(pairs)
+}
+
+/// The path Claude sent in `tool_input`, so the replacement names the file the
+/// agent asked for. Falls back to the payload identifier, which is that path
+/// resolved against the event's cwd.
+fn read_file_path(payload: &Payload) -> &str {
+    payload
+        .raw
+        .get("tool_input")
+        .and_then(|input| input.get("file_path"))
+        .and_then(Value::as_str)
+        .unwrap_or(&payload.identifier)
+}
+
+/// Claude's PostToolUse block. Carries `updatedToolOutput` when the tool's shape
+/// is one we can rebuild, which is what keeps the secret out of both the model's
+/// context and the session transcript on disk.
+fn claude_post_tool_use(result: &HookResult) -> Value {
+    let message = result.message.as_str();
+    let Some(replacement) = claude_updated_tool_output(result.payload, message) else {
+        return decision_block(message);
+    };
+    let mut value = decision_block(message);
+    if let Value::Object(map) = &mut value {
+        map.insert(
+            "hookSpecificOutput".into(),
+            obj(vec![
+                ("hookEventName", "PostToolUse".into()),
+                ("updatedToolOutput", replacement),
+            ]),
+        );
+    }
+    value
 }
 
 fn allow_with_optional_warning(warning: &str) -> Value {
@@ -136,7 +227,8 @@ pub fn emission(result: &HookResult) -> Emission {
                 allow_with_optional_warning(&result.warning)
             } else {
                 match event {
-                    EventType::UserPrompt | EventType::PostToolUse => decision_block(message, true),
+                    EventType::PostToolUse => claude_post_tool_use(result),
+                    EventType::UserPrompt => decision_block(message),
                     EventType::PreToolUse => deny_pre_tool_use(message),
                     // Should not happen; Claude's "universal" fields.
                     EventType::Other => obj(vec![
@@ -155,7 +247,7 @@ pub fn emission(result: &HookResult) -> Emission {
                 match event {
                     EventType::PreToolUse => Emission::Stdout(deny_pre_tool_use(message), 0),
                     EventType::UserPrompt | EventType::PostToolUse => {
-                        Emission::Stdout(decision_block(message, false), 0)
+                        Emission::Stdout(decision_block(message), 0)
                     }
                     EventType::Other => Emission::Stderr(message.to_string(), 2),
                 }
@@ -212,9 +304,9 @@ pub fn emission(result: &HookResult) -> Emission {
             } else {
                 match event {
                     EventType::PreToolUse => deny_pre_tool_use(message),
-                    EventType::PostToolUse => decision_block(message, false),
+                    EventType::PostToolUse => decision_block(message),
                     EventType::UserPrompt if result.payload.agent == Agent::Copilot => {
-                        decision_block(message, false)
+                        decision_block(message)
                     }
                     _ => obj(vec![
                         ("continue", false.into()),
@@ -280,9 +372,13 @@ mod tests {
     use crate::payload::Tool;
 
     fn payload(agent: Agent, event_type: EventType) -> Payload {
+        payload_with_tool(agent, event_type, Some(Tool::Bash))
+    }
+
+    fn payload_with_tool(agent: Agent, event_type: EventType, tool: Option<Tool>) -> Payload {
         Payload {
             event_type,
-            tool: Some(Tool::Bash),
+            tool,
             content: String::new(),
             identifier: "id".into(),
             agent,
@@ -303,6 +399,11 @@ mod tests {
 
     fn blocked(agent: Agent, event: EventType) -> Option<String> {
         let p = payload(agent, event);
+        emitted(&HookResult::block(&p, "nope".into(), 1))
+    }
+
+    fn blocked_tool(agent: Agent, event: EventType, tool: Option<Tool>) -> Option<String> {
+        let p = payload_with_tool(agent, event, tool);
         emitted(&HookResult::block(&p, "nope".into(), 1))
     }
 
@@ -366,14 +467,20 @@ mod tests {
             blocked(Agent::Claude, EventType::PreToolUse).as_deref(),
             Some(DENY)
         );
-        // Claude is the only adapter that also sets additionalContext.
+        // A Bash output is replaced, so the model reads the block message
+        // instead of the output that held the secret.
         assert_eq!(
             blocked(Agent::Claude, EventType::PostToolUse).as_deref(),
-            Some(r#"{"decision":"block","reason":"nope","additionalContext":"nope"}"#)
+            Some(
+                r#"{"decision":"block","reason":"nope","hookSpecificOutput":{"hookEventName":"PostToolUse","updatedToolOutput":{"stdout":"nope","stderr":"","interrupted":false,"isImage":false}}}"#
+            )
         );
+        // A blocked prompt carries no additionalContext: Claude Code reads that
+        // field only under hookSpecificOutput, and a blocked prompt is erased
+        // without a model turn, so nothing could be delivered anyway.
         assert_eq!(
             blocked(Agent::Claude, EventType::UserPrompt).as_deref(),
-            Some(r#"{"decision":"block","reason":"nope","additionalContext":"nope"}"#)
+            Some(r#"{"decision":"block","reason":"nope"}"#)
         );
         assert_eq!(
             blocked(Agent::Claude, EventType::Other).as_deref(),
@@ -497,6 +604,99 @@ mod tests {
             assert_eq!(
                 allowed(Agent::Copilot, event),
                 allowed(Agent::VsCode, event)
+            );
+        }
+    }
+
+    /// GIVEN a secret in a file Claude just read
+    /// WHEN the block is emitted
+    /// THEN the replacement is the Read tool's own output shape, naming the file
+    /// the agent asked for.
+    #[test]
+    fn a_replaced_read_uses_the_read_output_shape() {
+        let mut p = payload_with_tool(Agent::Claude, EventType::PostToolUse, Some(Tool::Read));
+        p.raw = serde_json::json!({"tool_input": {"file_path": "/tmp/creds.env"}});
+        let emitted = emitted(&HookResult::block(&p, "line one\nline two".into(), 1))
+            .expect("claude emits json");
+        let value: Value = serde_json::from_str(&emitted).expect("valid json");
+        let file = &value["hookSpecificOutput"]["updatedToolOutput"]["file"];
+        assert_eq!(
+            value["hookSpecificOutput"]["updatedToolOutput"]["type"],
+            "text"
+        );
+        assert_eq!(file["filePath"], "/tmp/creds.env");
+        assert_eq!(file["content"], "line one\nline two");
+        assert_eq!(file["numLines"], 2);
+        assert_eq!(file["startLine"], 1);
+        assert_eq!(file["totalLines"], 2);
+    }
+
+    /// GIVEN a Claude tool whose output shape we cannot rebuild
+    /// WHEN the block is emitted
+    /// THEN no replacement is sent, because Claude Code silently ignores a value
+    /// that does not match the schema and would show the original output.
+    #[test]
+    fn an_unknown_claude_tool_gets_no_replacement() {
+        for tool in [Some(Tool::Mcp), Some(Tool::Other), None] {
+            assert_eq!(
+                blocked_tool(Agent::Claude, EventType::PostToolUse, tool).as_deref(),
+                Some(r#"{"decision":"block","reason":"nope"}"#),
+                "{tool:?}"
+            );
+        }
+    }
+
+    /// GIVEN every tool
+    /// WHEN Claude's capability flag and the shape builder are compared
+    /// THEN they agree. They are two matches that must not drift: claiming a
+    /// redaction we do not send would tell the user a leaked secret was safe.
+    #[test]
+    fn claude_capability_matches_the_shapes_it_can_build() {
+        for tool in [
+            Some(Tool::Bash),
+            Some(Tool::Read),
+            Some(Tool::Mcp),
+            Some(Tool::Other),
+            None,
+        ] {
+            let p = payload_with_tool(Agent::Claude, EventType::PostToolUse, tool);
+            assert_eq!(
+                can_redact_tool_output(&p),
+                claude_updated_tool_output(&p, "nope").is_some(),
+                "{tool:?}"
+            );
+        }
+    }
+
+    /// GIVEN each agent and each event
+    /// WHEN the redaction capability is read
+    /// THEN only PostToolUse can redact, only on the agents proven to replace an
+    /// output, and Codex does so whatever the tool.
+    #[test]
+    fn only_proven_agents_report_that_they_can_withhold_an_output() {
+        for event in [
+            EventType::UserPrompt,
+            EventType::PreToolUse,
+            EventType::Other,
+        ] {
+            for agent in crate::payload::AGENTS {
+                assert!(
+                    !can_redact_tool_output(&payload(agent, event)),
+                    "{agent:?}/{event:?} is not a tool output"
+                );
+            }
+        }
+        for agent in [
+            Agent::Codex,
+            Agent::Copilot,
+            Agent::Cursor,
+            Agent::Kiro,
+            Agent::Vibe,
+            Agent::VsCode,
+        ] {
+            assert!(
+                !can_redact_tool_output(&payload(agent, EventType::PostToolUse)),
+                "{agent:?} has no verified way to replace an output"
             );
         }
     }

--- a/rust/hook/src/templates/post_bash_redacted.in
+++ b/rust/hook/src/templates/post_bash_redacted.in
@@ -1,0 +1,12 @@
+**🚨 Detected {count} {secrets} in the command output 🚨**  
+{secret_lines}
+
+The command ran, but its output was withheld from the agent, so the {secrets} {were} not sent to the model.
+
+> How to remediate
+
+  Since the {secrets} {were} caught before the output reached the agent:  
+  1. avoid printing the {secrets}: filter the sensitive lines, or redirect the output to a file.
+  2. consider moving the {secrets} to a secrets manager.
+
+{false_positive_instructions}

--- a/rust/hook/src/templates/post_other_redacted.in
+++ b/rust/hook/src/templates/post_other_redacted.in
@@ -1,0 +1,11 @@
+**🚨 Detected {count} {secrets} in the tool output 🚨**  
+{secret_lines}
+
+The tool call ran, but its output was withheld from the agent, so the {secrets} {were} not sent to the model.
+
+> How to remediate
+
+  Since the {secrets} {were} caught before the output reached the agent:  
+  1. consider moving the {secrets} to a secrets manager.
+
+{false_positive_instructions}

--- a/rust/hook/src/templates/post_read_redacted.in
+++ b/rust/hook/src/templates/post_read_redacted.in
@@ -1,0 +1,12 @@
+**🚨 Detected {count} {secrets} in {identifier} 🚨**  
+{secret_lines}
+
+The file content was withheld from the agent, so the {secrets} {were} not sent to the model.
+
+> How to remediate
+
+  Since the {secrets} {were} caught before the content reached the agent:  
+  1. avoid sharing this file with the agent.
+  2. if the agent needs other values from this file, share only the non-sensitive parts.
+
+{false_positive_instructions}

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -2107,9 +2107,90 @@ def main():
             n = int(sys.argv[sys.argv.index("--bench") + 1])
             bench(tmp, n)
         # Expected, tracked divergences: the gate stays green for these but
-        # still reddens on anything new. Keep this list empty in the steady
-        # state; every entry needs a reason and a removal condition.
+        # still reddens on anything new. Every entry needs a reason and a
+        # removal condition.
+        #
+        # Two kinds live here. The first two are Python bugs the Rust hook does
+        # not reproduce, and they go away when Python is fixed. The rest are
+        # deliberate Rust-side improvements that are not being back-ported,
+        # because the Python ai-hook is being retired: Rust is the reference
+        # implementation now. They all go away with it. Anything new still has
+        # to be justified here, so the gate keeps catching accidental drift in
+        # the parsing, the request body and the other agents' contracts.
         known_divergences = {
+            "secret/claude/post_bash": (
+                "Rust returns `hookSpecificOutput.updatedToolOutput`, so the "
+                "command output holding the secret is replaced before Claude reads "
+                "it, and the message says the output was withheld instead of "
+                "telling the user to revoke. Python passes the output through with "
+                "a warning beside it. Remove with the Python ai-hook, which is "
+                "being retired; Rust is the reference implementation and this "
+                "change is not back-ported."
+            ),
+            "secret/claude/user_prompt": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "mention/relative": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "mention/absolute": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "mention/dot_segments": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "mention/parent_segment": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "batch/many_mentions": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "cache/a_blocking_verdict_is_never_cached": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
+            "unreadable/mention": (
+                "Claude Code reads `additionalContext` only under "
+                "`hookSpecificOutput`, so the top-level copy Python still emits has "
+                "never reached the model. Rust drops it; `reason` already carries "
+                "the same text. Remove with the Python ai-hook, which is being "
+                "retired; Rust is the reference implementation and this change is "
+                "not back-ported."
+            ),
             "exclusion/vendor_ancestor": (
                 "the default wildcards are tested against the path relative to "
                 "the event cwd, not the absolute identifier. Python's hook "


### PR DESCRIPTION
A secret found in a tool output is caught after the tool ran. We answer `decision: "block"`, which on Claude Code only adds our warning next to the tool result: the agent reads the original output anyway, and the value is written in cleartext to the session transcript under `~/.claude/projects/`, kept 30 days by default and replayed into context on every `--resume`. Measured on a fixture with a fake AWS key, one `grep` through a subagent left 5 copies of it across the parent and subagent transcripts.

Claude Code accepts `hookSpecificOutput.updatedToolOutput`, which replaces the tool result before the model reads it. Same scan, same API call, different JSON answer, so no added latency. The replacement must match the tool's own output schema and Claude Code silently ignores one that does not, showing the original instead. Only the Bash and Read shapes captured from real payloads are claimed; any other tool falls back to reporting a leak that did happen, because a guessed shape would leak the secret while the message said it was safe.

`can_redact_tool_output()` is the single source of truth for whether an agent can withhold an output. It drives the emitted JSON, the message wording and the desktop notification together so those three cannot drift apart, and a test locks the capability flag to the shapes the builder can actually produce. Agents with no established way to replace an output keep the leaked wording, which is the safe direction to be wrong in. Codex, Vibe and Cursor are documented to support some form of this and get their own tickets.

This also drops the top-level `additionalContext` the Claude adapter emitted. Claude Code reads that field only under `hookSpecificOutput`, so it never had any effect; `reason` already carries the same text to the model. Verified end to end against Claude Code v2.1.267: the model reports the output was blocked, and the fake key appears 0 times in the transcript.

NHI-2003