### PR TITLE
fix(ai-hook): report a Codex tool output as withheld, not leaked

### DIFF
--- a/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
+++ b/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
@@ -7,3 +7,6 @@
   disk, and the message no longer tells you to revoke a credential the assistant
   never read. Agents with no way to replace a tool output are unchanged and keep
   reporting the secret as leaked.
+- On Codex, a blocked tool output was already hidden from the assistant, but the
+  message still said the secret had been exposed and told you to revoke it. It
+  now reports the output as withheld.

--- a/rust/hook/src/message.rs
+++ b/rust/hook/src/message.rs
@@ -466,23 +466,15 @@ mod tests {
     fn the_wording_follows_the_agent_not_the_event() {
         use crate::payload::Agent;
         let secrets = [secret("AWS Keys", "valid", &["AKIAsomething"])];
+        // Codex on an MCP tool: a tool Claude could not redact, on an agent
+        // that replaces every tool result. The wording tracks the agent.
         let withheld = from_secrets(
             &secrets,
-            &payload_for(
-                Agent::Claude,
-                EventType::PostToolUse,
-                Some(Tool::Bash),
-                "id",
-            ),
+            &payload_for(Agent::Codex, EventType::PostToolUse, Some(Tool::Mcp), "id"),
         );
         let leaked = from_secrets(
             &secrets,
-            &payload_for(
-                Agent::VsCode,
-                EventType::PostToolUse,
-                Some(Tool::Bash),
-                "id",
-            ),
+            &payload_for(Agent::Cursor, EventType::PostToolUse, Some(Tool::Mcp), "id"),
         );
         assert!(withheld.contains("withheld from the agent"), "{withheld}");
         assert!(!withheld.contains("compromised"), "{withheld}");

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -110,17 +110,19 @@ pub fn can_redact_tool_output(payload: &Payload) -> bool {
             // `claude_capability_matches_the_shapes_it_can_build` locks the two
             // together.
             Agent::Claude => matches!(payload.tool, Some(Tool::Bash | Tool::Read)),
-            // Codex and Vibe are documented to replace a blocked tool result,
-            // and Cursor can for an MCP tool. None of that is established here
-            // against a real payload yet, and until it is they keep the leaked
-            // wording: telling someone to rotate a secret that never left is a
-            // nuisance, telling them not to rotate one that did is a breach.
-            Agent::Codex
-            | Agent::Copilot
-            | Agent::Cursor
-            | Agent::Kiro
-            | Agent::Vibe
-            | Agent::VsCode => false,
+            // `decision: "block"` already replaces the tool result, whatever
+            // the tool, so Codex needs no extra field in the response. Only the
+            // model is protected: Codex also records the raw output in a
+            // rollout file of its own, which no hook can reach, so the wording
+            // says the output never reached the agent and claims nothing about
+            // what is on disk.
+            Agent::Codex => true,
+            // Vibe is documented to replace a blocked tool result too, and
+            // Cursor can for an MCP tool. Neither is established here against a
+            // real payload yet, and until it is they keep the leaked wording:
+            // telling someone to rotate a secret that never left is a nuisance,
+            // telling them not to rotate one that did is a breach.
+            Agent::Copilot | Agent::Cursor | Agent::Kiro | Agent::Vibe | Agent::VsCode => false,
         }
 }
 
@@ -686,8 +688,16 @@ mod tests {
                 );
             }
         }
+        // Codex replaces the tool result whatever the tool, so it needs no
+        // shape of its own and every tool redacts.
+        for tool in [Some(Tool::Bash), Some(Tool::Read), Some(Tool::Mcp), None] {
+            assert!(can_redact_tool_output(&payload_with_tool(
+                Agent::Codex,
+                EventType::PostToolUse,
+                tool
+            )));
+        }
         for agent in [
-            Agent::Codex,
             Agent::Copilot,
             Agent::Cursor,
             Agent::Kiro,

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -2118,6 +2118,14 @@ def main():
         # to be justified here, so the gate keeps catching accidental drift in
         # the parsing, the request body and the other agents' contracts.
         known_divergences = {
+            "secret/codex/post_bash": (
+                "Codex already replaces a blocked tool result, so the secret "
+                "never reached the model on either side. Rust says so; Python "
+                "still tells the user the secret was exposed and to revoke it. "
+                "Remove with the Python ai-hook, which is being retired; Rust "
+                "is the reference implementation and this change is not "
+                "back-ported."
+            ),
             "secret/claude/post_bash": (
                 "Rust returns `hookSpecificOutput.updatedToolOutput`, so the "
                 "command output holding the secret is replaced before Claude reads "


### PR DESCRIPTION
Stacked on #1480, which introduces `can_redact_tool_output()`. Review that one first; this PR is the Codex arm of it.

Codex already hides a blocked tool output from the model, and we were telling users the opposite. A real `codex exec` run against a fixture with a fake AWS key confirms it: the model-visible `custom_tool_call_output` in the rollout carried the ggshield message with no trace of the secret, and the model answered that the output had been blocked. Codex documents this, `decision: "block"` replaces the tool result. But the message we put in that slot was the leaked-secret wording, telling the user the secret was compromised and to revoke it, which is a rotation they never needed.

Codex needs no extra field in the response, only the correct wording, so this is the capability flag plus its tests. It returns true for every tool, since `decision: "block"` replaces the result whatever the tool ran.

One caveat the wording is careful about: the model was protected, the disk was not. Codex records the raw output in a rollout file of its own under `~/.codex/sessions/`, in an `event_msg` record no hook can reach. The message therefore says the output never reached the agent and claims nothing about what is on disk. Vibe and Cursor are documented to support something similar and stay on the leaked wording until someone verifies them against a real payload.

NHI-2004