### PR TITLE
fix(ai-hook): report a Vibe tool output as withheld, not leaked

### DIFF
--- a/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
+++ b/changelog.d/20260910_142900_achille.mascia_withhold_tool_output_secrets.md
@@ -10,3 +10,5 @@
 - On Codex, a blocked tool output was already hidden from the assistant, but the
   message still said the secret had been exposed and told you to revoke it. It
   now reports the output as withheld.
+- Mistral Vibe behaves the same way as Codex and now reports a blocked tool
+  output as withheld rather than leaked.

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -116,13 +116,17 @@ pub fn can_redact_tool_output(payload: &Payload) -> bool {
             // rollout file of its own, which no hook can reach, so the wording
             // says the output never reached the agent and claims nothing about
             // what is on disk.
-            Agent::Codex => true,
-            // Vibe is documented to replace a blocked tool result too, and
-            // Cursor can for an MCP tool. Neither is established here against a
-            // real payload yet, and until it is they keep the leaked wording:
-            // telling someone to rotate a secret that never left is a nuisance,
-            // telling them not to rotate one that did is a breach.
-            Agent::Copilot | Agent::Cursor | Agent::Kiro | Agent::Vibe | Agent::VsCode => false,
+            // `decision: "deny"` replaces `tool_output_text`, the field the
+            // model reads, so like Codex the reason we send is all it gets and
+            // the tool matters no more than it does there. Vibe also keeps the
+            // raw output in its own session log, out of a hook's reach.
+            Agent::Codex | Agent::Vibe => true,
+            // Cursor can replace an MCP tool's output only, and the rest cannot
+            // at all. Until each is established against a real payload they
+            // keep the leaked wording: telling someone to rotate a secret that
+            // never left is a nuisance, telling them not to rotate one that did
+            // is a breach.
+            Agent::Copilot | Agent::Cursor | Agent::Kiro | Agent::VsCode => false,
         }
 }
 
@@ -688,22 +692,17 @@ mod tests {
                 );
             }
         }
-        // Codex replaces the tool result whatever the tool, so it needs no
-        // shape of its own and every tool redacts.
-        for tool in [Some(Tool::Bash), Some(Tool::Read), Some(Tool::Mcp), None] {
-            assert!(can_redact_tool_output(&payload_with_tool(
-                Agent::Codex,
-                EventType::PostToolUse,
-                tool
-            )));
+        // Codex and Vibe replace the tool result whatever the tool, so neither
+        // needs a shape of its own and every tool redacts.
+        for agent in [Agent::Codex, Agent::Vibe] {
+            for tool in [Some(Tool::Bash), Some(Tool::Read), Some(Tool::Mcp), None] {
+                assert!(
+                    can_redact_tool_output(&payload_with_tool(agent, EventType::PostToolUse, tool)),
+                    "{agent:?}/{tool:?}"
+                );
+            }
         }
-        for agent in [
-            Agent::Copilot,
-            Agent::Cursor,
-            Agent::Kiro,
-            Agent::Vibe,
-            Agent::VsCode,
-        ] {
+        for agent in [Agent::Copilot, Agent::Cursor, Agent::Kiro, Agent::VsCode] {
             assert!(
                 !can_redact_tool_output(&payload(agent, EventType::PostToolUse)),
                 "{agent:?} has no verified way to replace an output"

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -2118,6 +2118,20 @@ def main():
         # to be justified here, so the gate keeps catching accidental drift in
         # the parsing, the request body and the other agents' contracts.
         known_divergences = {
+            "secret/vibe/post_bash": (
+                "Vibe already replaced `tool_output_text` with the reason, so the "
+                "secret reached the model on neither side. Rust says the output "
+                "was withheld; Python still tells the user to revoke. Remove with "
+                "the Python ai-hook, which is being retired; Rust is the reference "
+                "implementation and this change is not back-ported."
+            ),
+            "secret/vibe/post_bash_failed": (
+                "Vibe already replaced `tool_output_text` with the reason, so the "
+                "secret reached the model on neither side. Rust says the output "
+                "was withheld; Python still tells the user to revoke. Remove with "
+                "the Python ai-hook, which is being retired; Rust is the reference "
+                "implementation and this change is not back-ported."
+            ),
             "secret/codex/post_bash": (
                 "Codex already replaces a blocked tool result, so the secret "
                 "never reached the model on either side. Rust says so; Python "


### PR DESCRIPTION
Stacked on #1481, which is itself on #1480. Review those first; this is the Vibe arm of the same capability flag.

Vibe hides a blocked tool output from the model exactly as Codex does, so we were telling Vibe users to rotate a secret their agent never read. Confirmed against a real session on vibe 2.25.1: after the block, the model-facing `content` of the tool message holds our reason with the matches censored, and the raw command output appears only under `tool_result`, the metadata Vibe writes to its own session log. The assistant's reply named the detector and quoted no values. That matches the README, where `decision: "deny"` plus `reason` replaces `tool_output_text`.

It replaces the result whatever the tool ran, so like Codex this needs no output shape of its own, only the capability flag and its tests.

Same caveat as Codex, and the wording is careful about it: only the model is protected. The raw output stays in Vibe's session log under `~/.vibe/logs/session`, which no hook can reach, so the message says the output never reached the agent and claims nothing about what is on disk. Cursor stays on the leaked wording, since it can only replace an MCP tool's output and not a shell one.

NHI-2005