### PR TITLE
ci: group Dependabot's minor bumps and stop superseded runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ version: 2
 # chain hygiene, not conservatism about versions -- a compromised release is
 # usually yanked within hours of discovery, so waiting out that window keeps
 # the malicious-then-deleted versions from ever reaching a branch here.
+#
+# Each also groups minor and patch bumps only: a major can need a code change,
+# and grouped, one broken major blocks every safe bump beside it.
+#
+# `labels` replaces the set Dependabot applies itself, so its two are repeated.
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -12,6 +17,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+    labels: ['dependencies', 'github_actions', 'skip-changelog']
+    groups:
+      github-actions-minor-patch:
+        applies-to: version-updates
+        patterns: ['*']
+        update-types: ['minor', 'patch']
 
   # The root Dockerfile's base image. Scoped to '/' so the functional-test
   # Dockerfiles under tests/ stay out of scope: their FROM is a build arg
@@ -22,6 +33,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+    labels: ['dependencies', 'docker', 'skip-changelog']
+    groups:
+      docker-minor-patch:
+        applies-to: version-updates
+        patterns: ['*']
+        update-types: ['minor', 'patch']
 
   # Python runtime + dev dependencies (pyproject.toml / uv.lock).
   - package-ecosystem: 'uv'
@@ -30,6 +47,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+    labels: ['dependencies', 'python:uv', 'skip-changelog']
+    groups:
+      uv-minor-patch:
+        applies-to: version-updates
+        patterns: ['*']
+        update-types: ['minor', 'patch']
 
   # The Rust workspace backing the native pre-commit hook.
   - package-ecosystem: 'cargo'
@@ -38,6 +61,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+    labels: ['dependencies', 'rust', 'skip-changelog']
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        patterns: ['*']
+        update-types: ['minor', 'patch']
 
   # Lint/format hook revs in .pre-commit-config.yaml, which were updated by
   # hand until now.
@@ -47,6 +76,12 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 3
+    labels: ['dependencies', 'pre_commit', 'skip-changelog']
+    groups:
+      pre-commit-minor-patch:
+        applies-to: version-updates
+        patterns: ['*']
+        update-types: ['minor', 'patch']
     ignore:
       # This repo's own hook: `rev` there tracks ggshield's __version__ in the
       # working tree, so a bump belongs to the release, not to Dependabot --

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,6 +13,11 @@ on:
       - 'labeled'
       - 'unlabeled'
 
+# Fires once per label change, and only the last run sees the final label set.
+concurrency:
+  group: changelog-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-changelog:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ on:
       - 'doc/**'
       - 'README.md'
 
+# Never cancel on main: push_docker_images-unstable gates on that run, so
+# cancelling it would skip the unstable image for that commit.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.9'

--- a/.github/workflows/perfbench.yml
+++ b/.github/workflows/perfbench.yml
@@ -10,6 +10,10 @@ on:
         description: 'Python version to use (use https://github.com/actions/setup-python#supported-version-syntax)'
         default: '3.10'
 
+concurrency:
+  group: perfbench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   UV_VERSION: 0.10.8
   DEFAULT_PYTHON_VERSION: '3.10'


### PR DESCRIPTION
**Goal: stop a week of dependency bumps from taking the runner pool down with it.**

Dependabot on five ecosystems opened 20 PRs at once, every one failing the changelog gate, together queuing 120 workflow runs — 105 of them Dependabot's. That saturated the pool and rate-limited the functional tests repo-wide: scans came back with zero incidents, so unrelated PRs went red with `Expected returncode 1, got 0`.

| Fix | Effect |
|---|---|
| `groups` | Minor and patch batched per ecosystem, majors still one per PR. On last week's batch: uv 1 PR instead of 5, cargo and pre-commit 3 each instead of 5, github-actions unchanged at 4 (all majors). |
| `labels` | 66 of the 120 runs were `Changelog check`, all red. Dependabot never applies `skip-changelog`, and setting `labels` replaces its default set, so all three are listed per ecosystem. |
| `concurrency` | Only `wheels` had a block, so pushes stacked full runs — one branch had 2 CI runs and 2 benchmarks live at once. `main` stays uncancellable, since `push_docker_images-unstable` gates on it. |

Majors staying separate is deliberate: `sha2 0.11` does not compile, `black 26` fights isort's `lines_after_imports`, `ty 0.0.78` fails the lint gate, while every minor and patch last week was clean. Grouped, any one of those blocks the rest.

`concurrency` is unrelated to Dependabot and helps every branch.

**Dependency, already done:** `TEST_KNOWN_SECRET` added to the Dependabot secret scope. Without it `functest_api` and all five `build_os_packages` legs fail on every Dependabot PR for want of a fixture, at ~16 min of runner each. The other three `TEST_*` vars have working defaults in `tests/conftest.py`.

**Testing:** Dependabot config is not locally verifiable. `check-jsonschema` 0.38.0 validates the new file clean; 0.31.0 flags `uv` and `pre-commit` as unknown ecosystems against unmodified `main` too. Real check is Insights → Dependency graph → Dependabot → "Check for updates": confirm the groups form before closing the 20 open PRs.
