### PR TITLE
ci: pin the release build container, track Rocky majors in smoke tests

### DIFF
--- a/.github/workflows/build_release_assets.yml
+++ b/.github/workflows/build_release_assets.yml
@@ -76,14 +76,17 @@ jobs:
         include:
           - os: ubuntu-22.04
             # When building on Linux we use a container to build using an old enough version
-            container: rockylinux/rockylinux:8.10
+            # Pinned by digest rather than the floating `8`: this container
+            # compiles the released binaries, so a repushed tag would change
+            # what we ship. Bumped by Dependabot, behind the 3-day cooldown.
+            container: rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             arch: x86_64
             nfpm_arch: x86_64
             sha256sum:
               python: d6254462d5fe066810a472d286861f6a18f66400008bfa9688e202a5672e88cb
               nfpm: 9f8effa24bc6033b509611dbe68839542a63e825525b195672298c369051ef0b
           - os: ubuntu-24.04-arm
-            container: rockylinux/rockylinux:8.10
+            container: rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             arch: aarch64
             nfpm_arch: arm64
             sha256sum:
@@ -327,11 +330,17 @@ jobs:
         runner:
           - ubuntu-22.04
           - ubuntu-24.04-arm
+        # Deliberately unpinned, and tracking the major rather than a point
+        # release: enterprise distros only patch the newest point release, so
+        # `8.8` was a frozen 2023 snapshot that stopped getting updates when
+        # 8.9 shipped. These smoke tests check our packages against the distros
+        # users actually run and receive patches for, so following the tags is
+        # the signal.
         image:
           - debian:stable-20260824
           - ubuntu:26.04
-          - rockylinux/rockylinux:8.8
-          - rockylinux/rockylinux:9.8
+          - rockylinux/rockylinux:8
+          - rockylinux/rockylinux:9
           - opensuse/leap:16.0
     steps:
       - name: Install requirements


### PR DESCRIPTION
Two jobs pull container images for opposite reasons, so they get opposite strategies.

### Release builds: pinned

The build container compiles the released Linux binaries, so what it contains ends up in what we ship. It now carries a digest, because a tag can be repushed to different content:

```
rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
```

Same image as before -- this is the digest `8.10` resolves to today -- just no longer trusting a mutable tag. Updates come from Dependabot, behind the 3-day cooldown added in #1454.

### Smoke tests: floating

`linux_package_smoke_tests` installs our `.deb`/`.rpm` into a distro and checks it works. Nothing from those containers ships, so there is no supply-chain reason to pin them, and pinning would hide the thing the job exists to catch: a distro-side change breaking our packages.

They also now track the **major** rather than a point release. Enterprise distros only patch the newest point release, so `rockylinux:8.8` was a frozen May-2023 snapshot that stopped receiving updates the moment 8.9 shipped. `8` and `9` follow whatever is current and patched (8.10 and 9.8 today).

### Note for the reviewer

The comment above the build container is truncated on `main` ("an old enough version" -- of what is not stated). Left as-is rather than guessed at. The container is Rocky 8 with glibc 2.28, which is consistent with building portable binaries against an old libc, but that is not documented anywhere in the repo. Also worth a look: Rocky 8.10 is a June-2024 image whose full support ended 2024-05-31 (security-only until 2029), so whether it is still the intended floor is a separate question.

Verified: `rockylinux:8` and `:9` resolve to 8.10 / 9.8 and the job's `yum install -y git-core` step works on both; the pinned digest is a multi-arch index covering amd64 and arm64, as the two-runner matrix needs; the `case "${{ matrix.image }}"` branches still route every image the same way; `check-jsonschema` passes.
