### PR TITLE
ci: stop grouping Dockerfile bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@ version: 2
 # usually yanked within hours of discovery, so waiting out that window keeps
 # the malicious-then-deleted versions from ever reaching a branch here.
 #
-# Each also groups minor and patch bumps only: a major can need a code change,
-# and grouped, one broken major blocks every safe bump beside it.
+# Most also group minor and patch bumps only: a major can need a code change,
+# and grouped, one broken major blocks every safe bump beside it. Docker is the
+# exception: a 3.10 -> 3.14 interpreter jump counts as minor there, so a group
+# would batch the riskiest bump in the file behind a "minor and patch" label.
 #
 # `labels` replaces the set Dependabot applies itself, so its two are repeated.
 updates:
@@ -34,11 +36,6 @@ updates:
     cooldown:
       default-days: 3
     labels: ['dependencies', 'docker', 'skip-changelog']
-    groups:
-      docker-minor-patch:
-        applies-to: version-updates
-        patterns: ['*']
-        update-types: ['minor', 'patch']
 
   # Python runtime + dev dependencies (pyproject.toml / uv.lock).
   - package-ecosystem: 'uv'


### PR DESCRIPTION
`docker` is the one ecosystem where the minor/patch group has no upside and a
real cost.

Dependabot classifies a base-image bump by semver, so `python:3.10.21-slim` ->
`python:3.14.7-slim` reads as *minor*. #1489 is the result: a four-release
interpreter jump, batched with `ghcr.io/astral-sh/uv` 0.10.8 -> 0.12.13, behind
a title that says `the docker-minor-patch group`. The riskiest bump currently
open arrives labelled routine, and cannot be merged apart from the bump that
actually is routine.

Ungrouped, the two `FROM` images come as their own PRs and the interpreter is
reviewed on its own. The other four ecosystems keep their groups: there the
minor/patch line does track risk.

Once this lands, #1489 can be closed and Dependabot will reopen both bumps
separately.
