### PR TITLE
test(scan-pypi): swap tensorflow for numba in the functional test

### DIFF
--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -23,10 +23,15 @@ from ggshield.core.scan.file import create_files_from_paths
 from ggshield.core.scanner_ui import create_scanner_ui
 from ggshield.utils.archive import safe_unpack
 from ggshield.utils.files import ListFilesMode
+from ggshield.utils.os import getenv_int
 from ggshield.verticals.secret import SecretScanCollection, SecretScanner
 
 
 PYPI_DOWNLOAD_TIMEOUT = 30
+# Anything past an hour is a typo, and a big enough number overflows the float
+# the deadline is built from.
+MAX_PYPI_DOWNLOAD_TIMEOUT = 3600
+TIMEOUT_ENV_VAR = "GG_PYPI_DOWNLOAD_TIMEOUT"
 DEFAULT_INDEX_URL = "https://pypi.org/simple/"
 
 
@@ -40,20 +45,28 @@ def _get_index_urls() -> List[str]:
 
 def _download_timeout() -> int:
     """Seconds allowed for the whole download. `GG_PYPI_DOWNLOAD_TIMEOUT` raises
-    it for the functional test, whose package is 454 MB; a malformed value falls
-    back rather than failing the scan."""
-    raw = os.getenv("GG_PYPI_DOWNLOAD_TIMEOUT", "")
-    return int(raw) if raw.isdigit() else PYPI_DOWNLOAD_TIMEOUT
+    it for the functional test, whose package is 454 MB. A bad value is refused
+    rather than ignored: falling back silently would just time out later."""
+    try:
+        timeout = getenv_int(TIMEOUT_ENV_VAR, PYPI_DOWNLOAD_TIMEOUT)
+    except ValueError:
+        raise UnexpectedError(f"{TIMEOUT_ENV_VAR} must be a whole number of seconds.")
+    if not 1 <= timeout <= MAX_PYPI_DOWNLOAD_TIMEOUT:
+        raise UnexpectedError(
+            f"{TIMEOUT_ENV_VAR} must be between 1"
+            f" and {MAX_PYPI_DOWNLOAD_TIMEOUT} seconds."
+        )
+    return timeout
 
 
-def _enforce_deadline(deadline: float) -> None:  # pragma: no cover
+def _enforce_deadline(deadline: float, timeout: int) -> None:  # pragma: no cover
     """Give up once the download budget is spent."""
     if time.monotonic() > deadline:
-        raise TimeoutError(f"timed out after {_download_timeout()}s")
+        raise TimeoutError(f"timed out after {timeout}s")
 
 
 def _download_link(
-    finder: PackageFinder, link: Link, dest: Path, deadline: float
+    finder: PackageFinder, link: Link, dest: Path, deadline: float, timeout: int
 ) -> None:
     """Stream the distribution at `link` into `dest`, giving up once `deadline`
     is reached."""
@@ -61,14 +74,15 @@ def _download_link(
         response.raise_for_status()
         with dest.open("wb") as f:
             for chunk in response.iter_bytes():
-                _enforce_deadline(deadline)
+                _enforce_deadline(deadline, timeout)
                 f.write(chunk)
 
 
 def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     ui.display_heading("Downloading package")
 
-    deadline = time.monotonic() + _download_timeout()
+    timeout = _download_timeout()
+    deadline = time.monotonic() + timeout
 
     finder = PackageFinder(
         index_urls=_get_index_urls(),
@@ -89,12 +103,13 @@ def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
 
     archive_path = temp_dir / best_match.link.filename
     try:
-        _enforce_deadline(deadline)
+        _enforce_deadline(deadline, timeout)
         _download_link(
             finder=finder,
             link=best_match.link,
             dest=archive_path,
             deadline=deadline,
+            timeout=timeout,
         )
     except Exception as exc:
         raise UnexpectedError(f'Failed to download "{package_name}": {exc}')

--- a/ggshield/cmd/secret/scan/pypi.py
+++ b/ggshield/cmd/secret/scan/pypi.py
@@ -38,10 +38,18 @@ def _get_index_urls() -> List[str]:
     return index_urls
 
 
+def _download_timeout() -> int:
+    """Seconds allowed for the whole download. `GG_PYPI_DOWNLOAD_TIMEOUT` raises
+    it for the functional test, whose package is 454 MB; a malformed value falls
+    back rather than failing the scan."""
+    raw = os.getenv("GG_PYPI_DOWNLOAD_TIMEOUT", "")
+    return int(raw) if raw.isdigit() else PYPI_DOWNLOAD_TIMEOUT
+
+
 def _enforce_deadline(deadline: float) -> None:  # pragma: no cover
-    """Give up once the PYPI_DOWNLOAD_TIMEOUT budget is spent."""
+    """Give up once the download budget is spent."""
     if time.monotonic() > deadline:
-        raise TimeoutError(f"timed out after {PYPI_DOWNLOAD_TIMEOUT}s")
+        raise TimeoutError(f"timed out after {_download_timeout()}s")
 
 
 def _download_link(
@@ -60,7 +68,7 @@ def _download_link(
 def save_package_to_tmp(temp_dir: Path, package_name: str) -> None:
     ui.display_heading("Downloading package")
 
-    deadline = time.monotonic() + PYPI_DOWNLOAD_TIMEOUT
+    deadline = time.monotonic() + _download_timeout()
 
     finder = PackageFinder(
         index_urls=_get_index_urls(),

--- a/tests/functional/secret/test_scan_pypi.py
+++ b/tests/functional/secret/test_scan_pypi.py
@@ -24,4 +24,12 @@ def test_scan_pypi(tmp_path: Path, package: str, expected_code: int) -> None:
     # .gitguardian.yaml stored at the root of ggshield repo.
     # If we did then we would not find secrets in ggshield package because the
     # test secrets would be ignored.
-    run_ggshield_scan("pypi", package, expected_code=expected_code, cwd=tmp_path)
+    run_ggshield_scan(
+        "pypi",
+        package,
+        expected_code=expected_code,
+        cwd=tmp_path,
+        # tensorflow's wheel is 454 MB, which the 30s default cannot fetch on a
+        # runner that gets less than ~15 MB/s.
+        env={"GG_PYPI_DOWNLOAD_TIMEOUT": "300"},
+    )

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -9,6 +9,8 @@ from packaging.requirements import InvalidRequirement
 
 from ggshield.cmd.secret.scan.pypi import (
     DEFAULT_INDEX_URL,
+    PYPI_DOWNLOAD_TIMEOUT,
+    _download_timeout,
     _get_index_urls,
     get_files_from_package,
     save_package_to_tmp,
@@ -51,6 +53,27 @@ class TestGetIndexUrls:
             "https://extra1.test/simple/",
             "https://extra2.test/simple/",
         ]
+
+
+class TestDownloadTimeout:
+    def test_defaults_to_the_builtin_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GG_PYPI_DOWNLOAD_TIMEOUT", raising=False)
+
+        assert _download_timeout() == PYPI_DOWNLOAD_TIMEOUT
+
+    def test_honors_the_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GG_PYPI_DOWNLOAD_TIMEOUT", "300")
+
+        assert _download_timeout() == 300
+
+    def test_falls_back_on_a_malformed_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GG_PYPI_DOWNLOAD_TIMEOUT", "five minutes")
+
+        assert _download_timeout() == PYPI_DOWNLOAD_TIMEOUT
 
 
 @patch("ggshield.cmd.secret.scan.pypi.PackageFinder")

--- a/tests/unit/cmd/scan/test_pypi.py
+++ b/tests/unit/cmd/scan/test_pypi.py
@@ -9,7 +9,9 @@ from packaging.requirements import InvalidRequirement
 
 from ggshield.cmd.secret.scan.pypi import (
     DEFAULT_INDEX_URL,
+    MAX_PYPI_DOWNLOAD_TIMEOUT,
     PYPI_DOWNLOAD_TIMEOUT,
+    TIMEOUT_ENV_VAR,
     _download_timeout,
     _get_index_urls,
     get_files_from_package,
@@ -59,21 +61,42 @@ class TestDownloadTimeout:
     def test_defaults_to_the_builtin_budget(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv("GG_PYPI_DOWNLOAD_TIMEOUT", raising=False)
+        monkeypatch.delenv(TIMEOUT_ENV_VAR, raising=False)
 
         assert _download_timeout() == PYPI_DOWNLOAD_TIMEOUT
 
-    def test_honors_the_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("GG_PYPI_DOWNLOAD_TIMEOUT", "300")
-
-        assert _download_timeout() == 300
-
-    def test_falls_back_on_a_malformed_value(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("value, expected", (("300", 300), ("300 ", 300)))
+    def test_honors_the_env_override(
+        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: int
     ) -> None:
-        monkeypatch.setenv("GG_PYPI_DOWNLOAD_TIMEOUT", "five minutes")
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, value)
 
-        assert _download_timeout() == PYPI_DOWNLOAD_TIMEOUT
+        assert _download_timeout() == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "five minutes",
+            # isdigit() accepts this, int() does not.
+            "\N{SUPERSCRIPT TWO}",
+            "0",
+            "-1",
+            # Large enough to overflow the float the deadline is built from.
+            "1" + "0" * 309,
+        ),
+    )
+    def test_refuses_a_value_it_cannot_honor(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, value)
+
+        with pytest.raises(UnexpectedError, match=TIMEOUT_ENV_VAR):
+            _download_timeout()
+
+    def test_accepts_the_upper_bound(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, str(MAX_PYPI_DOWNLOAD_TIMEOUT))
+
+        assert _download_timeout() == MAX_PYPI_DOWNLOAD_TIMEOUT
 
 
 @patch("ggshield.cmd.secret.scan.pypi.PackageFinder")


### PR DESCRIPTION
`test_scan_pypi[tensorflow==2.5.0]` has been failing on main with
`Failed to download "tensorflow==2.5.0": timed out after 30s`. The first
version of this PR raised the download budget. The review pointed at the
test subject instead, and that holds on both counts.

**It is too big.** With compatibility ignored, unearth picks the 433 MiB
cp39 manylinux wheel on the Linux runner. Finishing in 30 s needs 15 MB/s
sustained, and successful runs took 49 s to 118 s wall clock.

**It does not test what its comment says.** tensorflow 2.5.0 declares no
`Requires-Python` and is the first release to ship cp39 wheels. The API
functests run on Python 3.9 (`DEFAULT_PYTHON_VERSION`), where it is fully
pip-compatible, so the case passes with or without the #458 fix.

`numba==0.52.0`, the subject #1346 started with, declares
`Requires-Python >=3.6,<3.9`: refused by every supported interpreter under
the old pip lookup, about 2 MB, exit code 0 (exit code 1 stays covered by
`ggshield==1.14.2`). Checked with unearth's compatibility check on: Python
3.9 and 3.14 both reject it. The functional case runs in 4 s.

A unit test now also asserts `ignore_compatibility=True` on the
`PackageFinder`, so the #458 guard no longer depends on live PyPI alone.
