### PR TITLE
fix(ai-hook): replay the debounced verdict instead of falling silent

### DIFF
--- a/changelog.d/20260911_143000_achille.mascia_ai_hook_debounce_reuses_the_verdict.md
+++ b/changelog.d/20260911_143000_achille.mascia_ai_hook_debounce_reuses_the_verdict.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- When two ggshield AI hooks are configured for the same event, the second one no
+  longer exits without a verdict. Both now answer with the same decision, and the
+  event still costs a single scan.

--- a/rust/hook/src/debounce.rs
+++ b/rust/hook/src/debounce.rs
@@ -1,0 +1,172 @@
+//! Payload debounce: one scan per event, one verdict for every hook that asks.
+//!
+//! Some setups install hooks in several assistants' config formats, so one event
+//! reaches us twice with byte-identical stdin. The first invocation scans and
+//! stores what it emitted; the next one with the same payload replays it, so
+//! both hooks answer alike and the event still costs a single API call.
+//!
+//! Everything here fails towards *scanning*: an entry that cannot be read,
+//! trusted or parsed is a miss, and a miss scans. Silence is never an outcome.
+//!
+//! Constraint: the verdict is stored once the scan is done, so two invocations
+//! that overlap both scan. That costs a round trip and still leaves both with a
+//! verdict; only a lock held across the API call could collapse them.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::output::Emission;
+use crate::payload::sha256_hex;
+use ggshield_common::secure_file;
+use ggshield_config::config;
+
+/// Ours alone, unlike the clean-verdict cache: hooks.py keeps its own
+/// `latest_ai_hook.txt`, which holds a bare hash and no verdict to replay.
+const FILENAME: &str = "ai_hook_debounce.json";
+
+/// The hooks of one event fire within milliseconds of each other. Past a minute
+/// a replay would answer for content that has had time to change, so the entry
+/// expires and the next invocation scans.
+const TTL_SECONDS: i64 = 60;
+
+/// A block message embeds the redacted tool output, which some agents make
+/// arbitrarily large, and the cache dir is no place for megabytes. Over the cap
+/// nothing is stored: the next invocation scans, which costs a round trip rather
+/// than a lost verdict.
+const MAX_ENTRY_BYTES: usize = 256 * 1024;
+
+/// The last event's verdict. `stored_at` rather than an absolute expiry, so a
+/// future timestamp reads as *not fresh*.
+#[derive(Serialize, Deserialize)]
+struct Entry {
+    payload_hash: String,
+    stored_at: i64,
+    emission: Emission,
+}
+
+fn path() -> Option<PathBuf> {
+    config::cache_dir().map(|dir| dir.join(FILENAME))
+}
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// The debounce key: the raw payload, trimmed as hooks.py trims it.
+pub fn hash(stdin_content: &str) -> String {
+    sha256_hex(stdin_content.trim())
+}
+
+/// The verdict another invocation emitted for this very payload, if one is
+/// stored and still fresh.
+pub fn replay(hash: &str) -> Option<Emission> {
+    let raw = secure_file::read_if_trusted(&path()?)?;
+    let entry: Entry = serde_json::from_str(&raw).ok()?;
+    let age = now().checked_sub(entry.stored_at)?;
+    (entry.payload_hash == hash && (0..TTL_SECONDS).contains(&age)).then_some(entry.emission)
+}
+
+/// Remember what this payload was answered with. Best effort: a lost write
+/// costs the next hook a scan of its own.
+pub fn store(hash: &str, emission: &Emission) {
+    let Some(dir) = config::cache_dir() else {
+        return;
+    };
+    let Ok(json) = serde_json::to_string(&Entry {
+        payload_hash: hash.to_string(),
+        stored_at: now(),
+        emission: emission.clone(),
+    }) else {
+        return;
+    };
+    if json.len() > MAX_ENTRY_BYTES || secure_file::create_dir_private(&dir).is_err() {
+        return;
+    }
+    // Write beside the target and rename: two hooks for one event run in
+    // parallel, and rename within one directory is atomic, so neither ever reads
+    // half of the other's entry. The pid keeps them off each other's temp file.
+    let temp = dir.join(format!("{FILENAME}.{}.tmp", std::process::id()));
+    if secure_file::write_private(&temp, &json).is_err()
+        || std::fs::rename(&temp, dir.join(FILENAME)).is_err()
+    {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verdict_cache::with_cache_dir;
+    use serde_json::json;
+
+    fn emissions() -> [Emission; 3] {
+        [
+            Emission::Stdout(json!({"decision": "block", "reason": "nope"}), 0),
+            Emission::Stderr("nope".into(), 2),
+            Emission::Silent(0),
+        ]
+    }
+
+    /// GIVEN each of the three ways an adapter can answer
+    /// WHEN it is stored and replayed
+    /// THEN it comes back whole, exit code included, and only for its own payload.
+    #[test]
+    fn every_emission_round_trips_for_its_own_payload_only() {
+        let (_guard, _dir) = with_cache_dir();
+        for emission in emissions() {
+            store(&hash(" event "), &emission);
+            assert_eq!(replay(&hash("event")), Some(emission));
+            assert_eq!(replay(&hash("another event")), None);
+        }
+    }
+
+    /// GIVEN an entry older than the TTL, and one stamped in the future
+    /// WHEN it is replayed
+    /// THEN neither is reused, so the payload is scanned again.
+    #[test]
+    fn a_stale_or_future_entry_is_not_replayed() {
+        let (_guard, dir) = with_cache_dir();
+        for stored_at in [now() - TTL_SECONDS - 1, now() + 60] {
+            let entry = json!({
+                "payload_hash": hash("event"),
+                "stored_at": stored_at,
+                "emission": {"Silent": 0},
+            });
+            std::fs::write(dir.path().join(FILENAME), entry.to_string()).expect("write");
+            assert_eq!(replay(&hash("event")), None, "{stored_at}");
+        }
+    }
+
+    /// GIVEN a debounce file that is not an entry we wrote
+    /// WHEN it is replayed
+    /// THEN it answers "nothing stored", which means "scan".
+    #[test]
+    fn a_corrupt_entry_is_not_replayed() {
+        let (_guard, dir) = with_cache_dir();
+        for content in [
+            "not json",
+            "{}",
+            r#"{"payload_hash": "x", "stored_at": 0}"#,
+            r#"{"payload_hash": "x", "stored_at": 0, "emission": {"Nonsense": 1}}"#,
+        ] {
+            std::fs::write(dir.path().join(FILENAME), content).expect("write");
+            assert_eq!(replay("x"), None, "{content}");
+        }
+    }
+
+    /// GIVEN a verdict larger than the cap
+    /// WHEN it is stored
+    /// THEN nothing is kept, and the next invocation scans rather than replaying.
+    #[test]
+    fn an_oversize_verdict_is_not_stored() {
+        let (_guard, _dir) = with_cache_dir();
+        let huge = Emission::Stderr("x".repeat(MAX_ENTRY_BYTES + 1), 2);
+        store(&hash("event"), &huge);
+        assert_eq!(replay(&hash("event")), None);
+    }
+}

--- a/rust/hook/src/lib.rs
+++ b/rust/hook/src/lib.rs
@@ -13,6 +13,7 @@
 //! rather than guessing — see `config::dotenv_overrides()` and `user_config`.
 
 mod api;
+mod debounce;
 mod exclusion;
 mod message;
 mod notify;
@@ -28,7 +29,7 @@ use std::io::Read;
 use std::path::Path;
 
 use error::Error;
-use output::HookResult;
+use output::{Emission, HookResult};
 use payload::{EventType, Payload, Tool};
 
 /// `MAX_READ_SIZE` in ai_hook.py.
@@ -154,7 +155,8 @@ fn run(stdin_content: &str) -> Result<i32, Error> {
     let config = config::resolve()?;
     warn_if_insecure(&config);
     let exit_zero = config.user.exit_zero;
-    Ok(apply_exit_zero(scan(&config, stdin_content)?, exit_zero))
+    let emission = scan(&config, stdin_content)?;
+    Ok(apply_exit_zero(output::emit(emission), exit_zero))
 }
 
 /// The two warnings `create_session()` prints when TLS verification is disabled.
@@ -181,30 +183,42 @@ fn apply_exit_zero(code: i32, exit_zero: bool) -> i32 {
     if exit_zero && code == 1 { 0 } else { code }
 }
 
-fn scan(config: &config::Config, stdin_content: &str) -> Result<i32, Error> {
-    if !stdin_content.is_empty() && has_already_been_seen(stdin_content) {
-        return Ok(0);
+/// Decide what this event is answered with. The caller emits it, once.
+fn scan(config: &config::Config, stdin_content: &str) -> Result<Emission, Error> {
+    // An empty stdin has no verdict to share: it is rejected below.
+    let debounce_hash = (!stdin_content.is_empty()).then(|| debounce::hash(stdin_content));
+    if let Some(hash) = &debounce_hash
+        && let Some(emission) = debounce::replay(hash)
+    {
+        return Ok(emission);
     }
 
     let mut payloads = payload::parse(stdin_content)?;
     let (index, secrets) = scan_payloads(config, &mut payloads)?;
     let payload = &payloads[index];
 
-    if secrets.is_empty() {
-        return Ok(output::output_result(&HookResult::allow(payload)));
-    }
+    let result = if secrets.is_empty() {
+        HookResult::allow(payload)
+    } else {
+        let result = HookResult::block(
+            payload,
+            message::from_secrets(&secrets, payload),
+            secrets.len(),
+        );
+        // `has_secret_already_leaked()`: on PostToolUse the secret is already in
+        // the agent's context, so tell the user out-of-band. Best effort, and
+        // only for the invocation that scanned: one event, one banner.
+        if payload.event_type == EventType::PostToolUse {
+            notify(&result);
+        }
+        result
+    };
 
-    let result = HookResult::block(
-        payload,
-        message::from_secrets(&secrets, payload),
-        secrets.len(),
-    );
-    // `has_secret_already_leaked()`: on PostToolUse the secret is already in the
-    // agent's context, so tell the user out-of-band. Best effort.
-    if payload.event_type == EventType::PostToolUse {
-        notify(&result);
+    let emission = output::emission(&result);
+    if let Some(hash) = &debounce_hash {
+        debounce::store(hash, &emission);
     }
-    Ok(output::output_result(&result))
+    Ok(emission)
 }
 
 /// One payload still waiting for an API answer, and its cache key.
@@ -277,8 +291,8 @@ fn scan_payloads(
             None
         };
         // A Read resolves to the same document at PreToolUse and PostToolUse, so
-        // the second event is answered locally. `has_already_been_seen()` cannot:
-        // it debounces on raw stdin, which differs between the two.
+        // the second event is answered locally. The payload debounce cannot: it
+        // keys on raw stdin, which differs between the two.
         if let Some(key) = &key
             && verdict_cache::has_clean_verdict(key)
         {
@@ -473,28 +487,6 @@ fn is_path_binary(path: &Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
         .is_some_and(|ext| binary_extensions::BINARY_EXTENSIONS.contains(&ext))
-}
-
-/// `has_already_been_seen()`. Some setups install hooks from several assistants
-/// and invoke us twice with an identical payload.
-///
-/// No file lock, unlike Python's `filelock`: losing the race means both
-/// processes scan the same payload — slower, never less safe.
-fn has_already_been_seen(content: &str) -> bool {
-    let hash = payload::sha256_hex(content.trim());
-    let Some(dir) = config::cache_dir() else {
-        return false;
-    };
-    if std::fs::create_dir_all(&dir).is_err() {
-        return false;
-    }
-    let path = dir.join("latest_ai_hook.txt");
-    let stored = std::fs::read_to_string(&path).unwrap_or_default();
-    if stored == hash {
-        return true;
-    }
-    let _ = std::fs::write(&path, &hash);
-    false
 }
 
 /// `_send_secret_notification()`. Best effort; every failure is swallowed so the
@@ -941,6 +933,58 @@ mod tests {
             Ok(Err(Error::Invalid(message))) => assert_eq!(message, "Unrecognized agent"),
             other => panic!("expected an Invalid rejection, got {other:?}"),
         }
+    }
+
+    /// A Claude Code PreToolUse event, as an agent writes it to our stdin.
+    fn claude_bash_event(command: &str) -> String {
+        serde_json::json!({
+            "session_id": "abc",
+            "transcript_path": "/Users/x/.claude/projects/p/abc.jsonl",
+            "cwd": "/tmp",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        })
+        .to_string()
+    }
+
+    /// GIVEN two ggshield hooks configured for one event, so the same payload
+    /// reaches us twice
+    /// WHEN each invocation decides what to answer
+    /// THEN both answer the same verdict, and only the first one scans.
+    #[test]
+    fn a_second_hook_replays_the_verdict_rather_than_falling_silent() {
+        let (_guard, _dir) = verdict_cache::with_cache_dir();
+        let (url, recorded) = mock_api(MockLimits::default());
+        let config = test_config(url);
+        let event = claude_bash_event(&format!("aws configure set key {SECRET}"));
+
+        let first = scan(&config, &event).expect("first");
+        let second = scan(&config, &event).expect("second");
+
+        // A block, so the clean-verdict cache plays no part: the request count
+        // below is the debounce's alone.
+        assert!(matches!(first, Emission::Stdout(..)), "{first:?}");
+        assert_eq!(first, second);
+        assert_eq!(recorded.batches.lock().expect("lock").len(), 1);
+    }
+
+    /// GIVEN a stored verdict that cannot be parsed
+    /// WHEN the same payload reaches us again
+    /// THEN it is scanned again, and answered with the same verdict.
+    #[test]
+    fn an_unreadable_stored_verdict_falls_back_to_scanning() {
+        let (_guard, dir) = verdict_cache::with_cache_dir();
+        let (url, recorded) = mock_api(MockLimits::default());
+        let config = test_config(url);
+        let event = claude_bash_event(&format!("aws configure set key {SECRET}"));
+
+        let first = scan(&config, &event).expect("first");
+        std::fs::write(dir.path().join("ai_hook_debounce.json"), "{ truncated").expect("write");
+        let second = scan(&config, &event).expect("second");
+
+        assert_eq!(first, second);
+        assert_eq!(recorded.batches.lock().expect("lock").len(), 2);
     }
 
     /// GIVEN `exit_zero`

--- a/rust/hook/src/output.rs
+++ b/rust/hook/src/output.rs
@@ -55,6 +55,10 @@ impl<'a> HookResult<'a> {
 /// What an adapter decided to emit: a JSON document on stdout, (Codex's
 /// unknown-event branch) a bare message on stderr, or (Vibe's passthrough)
 /// nothing at all.
+///
+/// Serializable because the payload debounce stores one, so a second hook fired
+/// for the same event replays the same verdict.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Emission {
     Stdout(Value, i32),
     Stderr(String, i32),
@@ -251,7 +255,13 @@ pub fn emission(result: &HookResult) -> Emission {
 
 /// Prints the verdict and returns the process exit code.
 pub fn output_result(result: &HookResult) -> i32 {
-    match emission(result) {
+    emit(emission(result))
+}
+
+/// Prints one emission, whether it was just decided or replayed from the
+/// debounce, and returns the process exit code.
+pub fn emit(emission: Emission) -> i32 {
+    match emission {
         Emission::Stdout(value, code) => {
             println!("{value}");
             code

--- a/rust/tests/equivalence.py
+++ b/rust/tests/equivalence.py
@@ -38,8 +38,9 @@ Every payload fixture is copied from tests/unit/verticals/ai/test_hooks.py, so
 the shapes are the ones ggshield's own tests consider realistic.
 
 Both sides get a *fresh* cache dir per run, otherwise the payload debounce
-(`has_already_been_seen`) makes the second implementation exit silently and the
-comparison is meaningless.
+answers a repeated payload from what the previous run left behind (silently in
+Python, by replaying the stored verdict in Rust) and the comparison is
+meaningless.
 """
 
 import json


### PR DESCRIPTION
Independent of the detection PRs. A user with both a global and a project-level ggshield hook has a project-level configuration that silently does nothing.

Two hooks configured for one event receive the same stdin. The debounce keyed on that payload alone, so the first invocation answered and the second exited 0 with no output at all. Which verdict survived depended on which binary happened to run first, which matters when the two are not the same build or the same `.gitguardian.yaml` exclusions. Nothing errored and nothing warned.

The debounce now stores the emission the first invocation printed, exit code included, and a second invocation with the same payload replays it. Both hooks answer alike and the event still costs one scan, which was the point of the debounce in the first place.

Measured against the released build on the same payload twice:

```
released:  run 1 -> 1355 bytes    run 2 -> 0 bytes
this PR:   run 1 -> 1355 bytes    run 2 -> 1355 bytes, identical
```

Four decisions worth a reviewer's attention. The entry expires after **60 seconds**, where the old debounce had no expiry at all, because the hooks of one event fire milliseconds apart and past a minute a replay could answer for content that has had time to change. The serialized entry is capped at **256 KiB**, above which nothing is stored so the next invocation simply scans: a wasted round trip, never a lost verdict. It lives in a **file of our own** rather than Python's `latest_ai_hook.txt`, which holds a bare hash with no verdict to replay. And every failure path, corrupt entry included, falls back to scanning rather than to silence.

One known ceiling, documented in the module: the verdict is stored after the scan, so two invocations that genuinely overlap in time both scan. One extra API call, both still get a verdict. Collapsing that would mean the second hook blocking on the first one's network round trip, which was judged not worth the latency and deadlock risk.

The equivalence gate is unaffected, 2 known divergences and 0 unexpected, and the `cache` and `cache-interop` matrices still pass. Python keeps the old behaviour and still falls silent on a second identical payload, but the harness never sends one twice in a workdir so no divergence appears.

Found while live-testing Cursor for NHI-2007, where it made a correct implementation look broken and cost a debugging round.

NHI-2023