### PR TITLE
fix(client): stop retrying POST requests that time out reading the response

### DIFF
--- a/changelog.d/20260911_120000_benjamin.rigaud_no_retry_post_read_timeout.md
+++ b/changelog.d/20260911_120000_benjamin.rigaud_no_retry_post_read_timeout.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- A scan request that times out waiting for the server's response now fails immediately instead of being retried for several minutes. The server has already accepted the request by the time this happens, so retrying only made it redo the same (possibly large) scan up to six times while the user waited.

--- a/ggshield/cmd/auth/logout.py
+++ b/ggshield/cmd/auth/logout.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 import click
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, Timeout
 
 import ggshield.verticals.hmsl.utils as hmsl_utils
 from ggshield.cmd.utils.common_options import add_common_options
@@ -110,7 +110,9 @@ def revoke_token(config: Config, instance_url: str) -> None:
     )
     try:
         response = client.post(endpoint="token/revoke")
-    except ConnectionError:
+    except (ConnectionError, Timeout):
+        # A read timeout no longer reaches us as a ConnectionError now that
+        # POST read timeouts are not retried.
         raise UnexpectedError(CONNECTION_ERROR_MESSAGE)
 
     if response.status_code != 204:

--- a/ggshield/core/client.py
+++ b/ggshield/core/client.py
@@ -9,6 +9,7 @@ from pygitguardian import GGClient, GGClientCallbacks
 from pygitguardian.models import APITokensResponse, Detail, TokenScope
 from requests import Session
 from requests.adapters import HTTPAdapter
+from typing_extensions import Self
 
 from . import auth_check_cache, ui
 from .config import Config
@@ -32,6 +33,34 @@ _RETRY_ALLOWED_METHODS = frozenset(
 _RETRY_STATUS_FORCELIST = frozenset({502, 503, 504})
 
 
+class _RetryWithoutPostReadTimeout(urllib3.Retry):
+    """urllib3.Retry, but a read timeout on a POST is never retried.
+
+    A read timeout means the server already accepted the request and is
+    still working on it (e.g. an expensive scan); retrying only makes it
+    redo that work. Connection resets reach us as ProtocolError, not
+    ReadTimeoutError, so they still go through the normal retry path.
+    """
+
+    def increment(
+        self,
+        method: Optional[str] = None,
+        url: Optional[str] = None,
+        response: Optional[Any] = None,
+        error: Optional[Exception] = None,
+        _pool: Optional[Any] = None,
+        _stacktrace: Optional[Any] = None,
+    ) -> Self:
+        if (
+            error is not None
+            and method is not None
+            and method.upper() == "POST"
+            and isinstance(error, urllib3.exceptions.ReadTimeoutError)
+        ):
+            raise error
+        return super().increment(method, url, response, error, _pool, _stacktrace)
+
+
 class RetryProfile(Enum):
     """HTTP retry policy applied to the requests Session."""
 
@@ -50,14 +79,14 @@ class RetryProfile(Enum):
 
 def _build_retry(profile: RetryProfile) -> urllib3.Retry:
     if profile is RetryProfile.PRE_RECEIVE:
-        return urllib3.Retry(
+        return _RetryWithoutPostReadTimeout(
             total=1,
             backoff_factor=0,
             backoff_jitter=0,
             status_forcelist=_RETRY_STATUS_FORCELIST,
             allowed_methods=_RETRY_ALLOWED_METHODS,
         )
-    return urllib3.Retry(
+    return _RetryWithoutPostReadTimeout(
         total=5,
         backoff_factor=0.5,
         backoff_max=8,

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -4,7 +4,7 @@ import socket
 import struct
 import threading
 from contextlib import contextmanager
-from typing import Any, Iterator, List, Tuple, Type
+from typing import Any, Callable, Iterator, List, Tuple, Type
 from unittest.mock import Mock, patch
 
 import click
@@ -461,87 +461,65 @@ def test_create_session_with_self_signed_option(allow_self_signed: bool):
         assert session.verify is True
 
 
-# --- Real-server tests for the POST/read-timeout retry behaviour below.
-#
-# These spin up an actual local TCP/HTTP server instead of mocking exceptions,
-# so the full requests -> urllib3 -> Retry stack is exercised, not just the
-# code we wrote.
-
-
-# CI runs pytest with --disable-socket. The tests below talk to a server they
-# start themselves, so each one allows sockets again, restricted to loopback.
+# The tests below drive a real local server rather than mocking exceptions, so
+# the whole requests -> urllib3 -> Retry stack is exercised. pytest-socket's
+# allow_hosts marker keeps them to loopback; do not add enable_socket, which
+# short-circuits that check and opens the socket completely.
 
 
 @contextmanager
-def _hanging_server() -> Iterator[Tuple[int, List[str]]]:
-    """A server that accepts connections but never replies, to trigger a
-    genuine read timeout. Returns (port, attempts), where attempts grows by
-    one connection accepted."""
+def _raw_server(
+    handle: Callable[[socket.socket], None]
+) -> Iterator[Tuple[int, List[str]]]:
+    """Serve raw connections with `handle`, yielding (port, attempts).
+
+    `attempts` gains one entry per connection accepted, which is how the tests
+    count retries.
+    """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("127.0.0.1", 0))
     sock.listen(20)
+    sock.settimeout(0.2)
     port = sock.getsockname()[1]
     attempts: List[str] = []
     stop = threading.Event()
 
     def serve() -> None:
         while not stop.is_set():
-            sock.settimeout(0.2)
             try:
                 conn, _ = sock.accept()
             except socket.timeout:
                 continue
             attempts.append("connection")
-            try:
-                conn.settimeout(5)
-                conn.recv(65536)  # read the request, then go silent
-            except OSError:
-                pass
+            handle(conn)
 
     thread = threading.Thread(target=serve, daemon=True)
     thread.start()
     try:
         yield port, attempts
     finally:
+        # Join before closing: closing the listening socket while accept() is
+        # blocked on it raises OSError in the thread.
         stop.set()
+        thread.join(timeout=5)
         sock.close()
 
 
-@contextmanager
-def _reset_server() -> Iterator[Tuple[int, List[str]]]:
-    """A server that accepts a connection and immediately resets it, the
-    scenario PR #1218 added POST to allowed_methods for."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(20)
-    port = sock.getsockname()[1]
-    attempts: List[str] = []
-    stop = threading.Event()
-
-    def serve() -> None:
-        while not stop.is_set():
-            sock.settimeout(0.2)
-            try:
-                conn, _ = sock.accept()
-            except socket.timeout:
-                continue
-            attempts.append("connection")
-            # SO_LINGER with a zero timeout makes close() send a RST
-            # instead of a clean FIN, i.e. a connection reset.
-            conn.setsockopt(
-                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
-            )
-            conn.close()
-
-    thread = threading.Thread(target=serve, daemon=True)
-    thread.start()
+def _read_then_go_silent(conn: socket.socket) -> None:
+    """Take the request and never answer, to cause a real read timeout."""
     try:
-        yield port, attempts
-    finally:
-        stop.set()
-        sock.close()
+        conn.settimeout(5)
+        conn.recv(65536)
+    except OSError:
+        pass
+
+
+def _reset(conn: socket.socket) -> None:
+    """Reset the connection instead of answering."""
+    # SO_LINGER with a zero timeout makes close() send a RST rather than a FIN.
+    conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+    conn.close()
 
 
 @contextmanager
@@ -551,6 +529,12 @@ def _status_server(status_code: int) -> Iterator[Tuple[int, List[str]]]:
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def _reply(self) -> None:
+            # Read the body before answering. Closing a socket that still holds
+            # unread data sends a RST, and Windows then drops the response the
+            # client had already received.
+            remaining = int(self.headers.get("Content-Length") or 0)
+            while remaining > 0:
+                remaining -= len(self.rfile.read(min(remaining, 65536)))
             attempts.append(self.command)
             self.send_response(status_code)
             self.send_header("Content-Length", "0")
@@ -574,13 +558,13 @@ def _status_server(status_code: int) -> Iterator[Tuple[int, List[str]]]:
     finally:
         server.shutdown()
         thread.join(timeout=5)
+        server.server_close()
 
 
+@pytest.mark.allow_hosts(["127.0.0.1"])
 @pytest.mark.parametrize(
     "retry_profile", [RetryProfile.DEFAULT, RetryProfile.PRE_RECEIVE]
 )
-@pytest.mark.enable_socket
-@pytest.mark.allow_hosts(["127.0.0.1"])
 def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
     """
     GIVEN a server that accepts the connection but never replies
@@ -590,7 +574,7 @@ def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
     A read timeout means the server already has the request and is working
     on it, so retrying would only make it redo that work.
     """
-    with _hanging_server() as (port, attempts):
+    with _raw_server(_read_then_go_silent) as (port, attempts):
         session = create_session(retry_profile=retry_profile)
         with pytest.raises(requests.exceptions.ReadTimeout):
             session.post(
@@ -599,7 +583,6 @@ def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
         assert len(attempts) == 1
 
 
-@pytest.mark.enable_socket
 @pytest.mark.allow_hosts(["127.0.0.1"])
 def test_get_read_timeout_is_still_retried():
     """
@@ -607,7 +590,7 @@ def test_get_read_timeout_is_still_retried():
     WHEN a GET request hits the read timeout
     THEN it is retried (the fix only exempts POST)
     """
-    with _hanging_server() as (port, attempts):
+    with _raw_server(_read_then_go_silent) as (port, attempts):
         # PRE_RECEIVE (total=1) keeps the test fast: one retry is enough to
         # prove the request is retried at all.
         session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
@@ -616,7 +599,6 @@ def test_get_read_timeout_is_still_retried():
         assert len(attempts) == 2
 
 
-@pytest.mark.enable_socket
 @pytest.mark.allow_hosts(["127.0.0.1"])
 def test_post_connection_reset_is_still_retried():
     """
@@ -627,7 +609,7 @@ def test_post_connection_reset_is_still_retried():
     Regression guard for PR #1218, which added POST to allowed_methods so
     connection resets on POST get retried.
     """
-    with _reset_server() as (port, attempts):
+    with _raw_server(_reset) as (port, attempts):
         session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
         with pytest.raises(requests.exceptions.ConnectionError):
             session.post(
@@ -636,9 +618,8 @@ def test_post_connection_reset_is_still_retried():
         assert len(attempts) == 2
 
 
-@pytest.mark.parametrize("status_code", [502, 503, 504])
-@pytest.mark.enable_socket
 @pytest.mark.allow_hosts(["127.0.0.1"])
+@pytest.mark.parametrize("status_code", [502, 503, 504])
 def test_post_status_forcelist_is_still_retried(status_code: int):
     """
     GIVEN a server that always answers with a status in the forcelist

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -468,6 +468,10 @@ def test_create_session_with_self_signed_option(allow_self_signed: bool):
 # code we wrote.
 
 
+# CI runs pytest with --disable-socket. The tests below talk to a server they
+# start themselves, so each one allows sockets again, restricted to loopback.
+
+
 @contextmanager
 def _hanging_server() -> Iterator[Tuple[int, List[str]]]:
     """A server that accepts connections but never replies, to trigger a
@@ -575,6 +579,8 @@ def _status_server(status_code: int) -> Iterator[Tuple[int, List[str]]]:
 @pytest.mark.parametrize(
     "retry_profile", [RetryProfile.DEFAULT, RetryProfile.PRE_RECEIVE]
 )
+@pytest.mark.enable_socket
+@pytest.mark.allow_hosts(["127.0.0.1"])
 def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
     """
     GIVEN a server that accepts the connection but never replies
@@ -593,6 +599,8 @@ def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
         assert len(attempts) == 1
 
 
+@pytest.mark.enable_socket
+@pytest.mark.allow_hosts(["127.0.0.1"])
 def test_get_read_timeout_is_still_retried():
     """
     GIVEN the same server that never replies
@@ -608,6 +616,8 @@ def test_get_read_timeout_is_still_retried():
         assert len(attempts) == 2
 
 
+@pytest.mark.enable_socket
+@pytest.mark.allow_hosts(["127.0.0.1"])
 def test_post_connection_reset_is_still_retried():
     """
     GIVEN a server that resets the connection instead of replying
@@ -627,6 +637,8 @@ def test_post_connection_reset_is_still_retried():
 
 
 @pytest.mark.parametrize("status_code", [502, 503, 504])
+@pytest.mark.enable_socket
+@pytest.mark.allow_hosts(["127.0.0.1"])
 def test_post_status_forcelist_is_still_retried(status_code: int):
     """
     GIVEN a server that always answers with a status in the forcelist

--- a/tests/unit/core/test_client.py
+++ b/tests/unit/core/test_client.py
@@ -1,5 +1,10 @@
+import http.server
 import os
-from typing import Type
+import socket
+import struct
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator, List, Tuple, Type
 from unittest.mock import Mock, patch
 
 import click
@@ -454,3 +459,184 @@ def test_create_session_with_self_signed_option(allow_self_signed: bool):
         assert session.verify is False
     else:
         assert session.verify is True
+
+
+# --- Real-server tests for the POST/read-timeout retry behaviour below.
+#
+# These spin up an actual local TCP/HTTP server instead of mocking exceptions,
+# so the full requests -> urllib3 -> Retry stack is exercised, not just the
+# code we wrote.
+
+
+@contextmanager
+def _hanging_server() -> Iterator[Tuple[int, List[str]]]:
+    """A server that accepts connections but never replies, to trigger a
+    genuine read timeout. Returns (port, attempts), where attempts grows by
+    one connection accepted."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(20)
+    port = sock.getsockname()[1]
+    attempts: List[str] = []
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            sock.settimeout(0.2)
+            try:
+                conn, _ = sock.accept()
+            except socket.timeout:
+                continue
+            attempts.append("connection")
+            try:
+                conn.settimeout(5)
+                conn.recv(65536)  # read the request, then go silent
+            except OSError:
+                pass
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield port, attempts
+    finally:
+        stop.set()
+        sock.close()
+
+
+@contextmanager
+def _reset_server() -> Iterator[Tuple[int, List[str]]]:
+    """A server that accepts a connection and immediately resets it, the
+    scenario PR #1218 added POST to allowed_methods for."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(20)
+    port = sock.getsockname()[1]
+    attempts: List[str] = []
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            sock.settimeout(0.2)
+            try:
+                conn, _ = sock.accept()
+            except socket.timeout:
+                continue
+            attempts.append("connection")
+            # SO_LINGER with a zero timeout makes close() send a RST
+            # instead of a clean FIN, i.e. a connection reset.
+            conn.setsockopt(
+                socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+            )
+            conn.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield port, attempts
+    finally:
+        stop.set()
+        sock.close()
+
+
+@contextmanager
+def _status_server(status_code: int) -> Iterator[Tuple[int, List[str]]]:
+    """A server that always answers with status_code."""
+    attempts: List[str] = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def _reply(self) -> None:
+            attempts.append(self.command)
+            self.send_response(status_code)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._reply()
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._reply()
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass  # keep test output clean
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, attempts
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize(
+    "retry_profile", [RetryProfile.DEFAULT, RetryProfile.PRE_RECEIVE]
+)
+def test_post_read_timeout_is_not_retried(retry_profile: RetryProfile):
+    """
+    GIVEN a server that accepts the connection but never replies
+    WHEN a POST request hits the read timeout
+    THEN only one attempt is made, and a requests.exceptions.ReadTimeout is raised
+
+    A read timeout means the server already has the request and is working
+    on it, so retrying would only make it redo that work.
+    """
+    with _hanging_server() as (port, attempts):
+        session = create_session(retry_profile=retry_profile)
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            session.post(
+                f"http://127.0.0.1:{port}/v1/multiscan", json={}, timeout=(5, 0.2)
+            )
+        assert len(attempts) == 1
+
+
+def test_get_read_timeout_is_still_retried():
+    """
+    GIVEN the same server that never replies
+    WHEN a GET request hits the read timeout
+    THEN it is retried (the fix only exempts POST)
+    """
+    with _hanging_server() as (port, attempts):
+        # PRE_RECEIVE (total=1) keeps the test fast: one retry is enough to
+        # prove the request is retried at all.
+        session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get(f"http://127.0.0.1:{port}/v1/foo", timeout=(5, 0.2))
+        assert len(attempts) == 2
+
+
+def test_post_connection_reset_is_still_retried():
+    """
+    GIVEN a server that resets the connection instead of replying
+    WHEN a POST request is sent
+    THEN it is still retried the full number of times
+
+    Regression guard for PR #1218, which added POST to allowed_methods so
+    connection resets on POST get retried.
+    """
+    with _reset_server() as (port, attempts):
+        session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.post(
+                f"http://127.0.0.1:{port}/v1/multiscan", json={}, timeout=(5, 0.2)
+            )
+        assert len(attempts) == 2
+
+
+@pytest.mark.parametrize("status_code", [502, 503, 504])
+def test_post_status_forcelist_is_still_retried(status_code: int):
+    """
+    GIVEN a server that always answers with a status in the forcelist
+    WHEN a POST request is sent
+    THEN it is still retried the full number of times
+    """
+    with _status_server(status_code) as (port, attempts):
+        session = create_session(retry_profile=RetryProfile.PRE_RECEIVE)
+        with pytest.raises(requests.exceptions.RetryError):
+            session.post(
+                f"http://127.0.0.1:{port}/v1/multiscan", json={}, timeout=(5, 5)
+            )
+        assert len(attempts) == 2


### PR DESCRIPTION
## Problem

When a scan request hits the client's read timeout, ggshield sends it again, up to five more times. That is the wrong move for a read timeout: the server has already accepted the request and is still working on it, so each retry only asks it to redo the same work. The user waits over six minutes before the command finally fails, and a large scan is run six times instead of once.

The retry policy came from #1218, which added POST to `allowed_methods` so that a connection reset mid-scan would recover. `read` was left unset, and urllib3 defaults it to `None`, which means read timeouts count against the same budget.

## What this changes

Read timeouts on POST now surface immediately, on the first attempt.

Everything else behaves as before:

- connection resets on POST are still retried, which is what #1218 was for
- read timeouts on GET and the other idempotent methods are still retried
- 502, 503 and 504 responses are still retried

`Retry(read=0)` would not work here: urllib3 reports a connection reset as a `ProtocolError`, which it classifies as a read error, so that setting would have switched off the #1218 behaviour too. Instead `Retry.increment` is overridden to re-raise only `ReadTimeoutError`, and only for POST.

`auth logout` caught only `ConnectionError` around the token revoke call, which is how an exhausted read timeout used to arrive. It now catches `Timeout` as well, so the message pointing at connectivity is still the one shown.

## How it was verified

The tests drive real local servers rather than mocks, and count the connections the server actually accepts:

| Scenario | Expected | Result |
|---|---|---|
| POST, server never replies | 1 attempt, `ReadTimeout` raised | passes on both retry profiles |
| GET, server never replies | still retried | passes |
| POST, server resets the connection | still retried in full | passes |
| POST, server returns 502 / 503 / 504 | still retried in full | passes |

Three things about the test servers came out of review and are worth calling out, since they are the kind of thing that comes back:

- The status server answered without reading the request body. Closing a socket that still holds unread data sends a RST, and Windows then discards the response the client had already received, which is what made the 502 case red there and green everywhere else.
- Closing the listening socket while the serving thread sat in `accept()` raised `OSError` in that thread. `--disable-pytest-warnings` hid it in CI. The thread is joined first now.
- `enable_socket` takes precedence over `allow_hosts` in pytest-socket: `pytest_runtest_setup()` enables the socket and returns before it looks at the host list. With both markers a connect to a public address goes through, so the loopback restriction the comment promised was not in force. Only `allow_hosts` remains, which works with or without `--disable-socket`.

`pytest tests/unit --disable-socket`: 2730 passed, 1 skipped. The four tests were also run ten times with `PytestUnhandledThreadExceptionWarning` raised as an error, with no failures.

The error the user sees is unchanged in shape and still maps to exit code 4: `Scanning failed: HTTPSConnectionPool(...): Read timed out. (read timeout=60)`.

One note for reviewers: the `pyright` pre-commit hook was skipped on these commits. It fails the same way on unmodified `main`, reporting import-resolution errors across the whole codebase, because pyright does not pick up the project virtualenv without an explicit `venvPath` in `[tool.pyright]`. With the interpreter set it reports 0 errors on this branch. Worth its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
