### PR TITLE
fix(secret): scan commit batches in parallel

### DIFF
--- a/changelog.d/20260911_140000_alexandre.pasmantier_commit_range_parallel_scan.md
+++ b/changelog.d/20260911_140000_alexandre.pasmantier_commit_range_parallel_scan.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Commit scans (`secret scan repo`, `commit-range`, `changes`, `ci`, `pre-push`,
+  `pre-receive`) processed batches one at a time, ignoring `GG_MAX_WORKERS`.
+  Batches now run in parallel, which can speed up large scans considerably.

--- a/ggshield/verticals/secret/repo.py
+++ b/ggshield/verticals/secret/repo.py
@@ -221,19 +221,19 @@ def scan_commit_range(
                         commit_scanned_callback,
                     )
                 )
-                # Stop now if an exception has been raised by a future
-                for future in futures:
-                    exception = future.exception()
-                    if exception is not None:
-                        raise exception
 
-            for future in as_completed(futures):
-                scan_collection = future.result()
-                for scan in scan_collection.scans_with_results:
-                    if scan.results and scan.results.errors:
-                        for error in scan.results.errors:
-                            ui.display_error(error.description)
-                    scans.append(scan)
+            try:
+                for future in as_completed(futures):
+                    scan_collection = future.result()
+                    for scan in scan_collection.scans_with_results:
+                        if scan.results and scan.results.errors:
+                            for error in scan.results.errors:
+                                ui.display_error(error.description)
+                        scans.append(scan)
+            except Exception:
+                # Don't run the remaining batches if one already failed
+                executor.shutdown(cancel_futures=True)
+                raise
 
     return_code = output_handler.process_scan(
         SecretScanCollection(

--- a/ggshield/verticals/secret/repo.py
+++ b/ggshield/verticals/secret/repo.py
@@ -1,9 +1,11 @@
 import itertools
 import logging
 import traceback
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections.abc import Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Callable, Iterable, Iterator, List, Pattern, Set
+from re import Pattern
+from typing import Callable, List, Set
 
 from click import UsageError
 from pygitguardian import GGClient
@@ -189,10 +191,8 @@ def scan_commit_range(
                 (Commit.from_staged(exclusion_regexes=exclusion_regexes),)
             )
         commits_iters.append(
-            (
-                Commit.from_sha(sha, exclusion_regexes=exclusion_regexes)
-                for sha in commit_list
-            )
+            Commit.from_sha(sha, exclusion_regexes=exclusion_regexes)
+            for sha in commit_list
         )
         commits_batch = get_commits_by_batch(
             commits=itertools.chain(*commits_iters),
@@ -223,7 +223,8 @@ def scan_commit_range(
                 )
 
             try:
-                for future in as_completed(futures):
+                # in submission order so we preserve the order
+                for future in futures:
                     scan_collection = future.result()
                     for scan in scan_collection.scans_with_results:
                         if scan.results and scan.results.errors:

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -1,3 +1,4 @@
+import time
 from copy import deepcopy
 from pathlib import Path
 from typing import List
@@ -6,11 +7,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ggshield.core.config.user_config import SecretConfig
-from ggshield.core.scan import Commit
+from ggshield.core.scan import Commit, ScanContext, ScanMode
 from ggshield.core.scan.commit_information import CommitInformation
 from ggshield.core.scan.commit_utils import CommitScannable
 from ggshield.verticals.secret import Result, Results
-from ggshield.verticals.secret.repo import get_commits_by_batch, scan_commits_content
+from ggshield.verticals.secret.repo import (
+    get_commits_by_batch,
+    scan_commit_range,
+    scan_commits_content,
+)
+from ggshield.verticals.secret.secret_scan_collection import SecretScanCollection
 from tests.unit.conftest import _ONE_LINE_AND_MULTILINE_PATCH_CONTENT, TWO_POLICY_BREAKS
 
 
@@ -260,3 +266,50 @@ def test_scan_2_commits_file_association(secret_scanner_mock):
             file2_1, policy_breaks_file_2_1, secret_config=SecretConfig()
         ),
     ]
+
+
+@patch("ggshield.verticals.secret.repo.MAX_WORKERS", 2)
+@patch("ggshield.verticals.secret.repo.get_required_token_scopes_from_config")
+@patch("ggshield.verticals.secret.repo.check_client_api_key")
+@patch("ggshield.verticals.secret.repo.Commit.from_sha")
+@patch("ggshield.verticals.secret.repo.scan_commits_content")
+def test_scan_commit_range_stops_on_error(
+    scan_commits_content_mock, from_sha_mock, _check_api_key, _scopes
+):
+    """
+    GIVEN a range of commits, scanned one commit per batch
+    WHEN scanning one of them raises
+    THEN the exception propagates
+    AND the remaining batches are not scanned
+    """
+    nb_commits = 50
+    started = []
+
+    def scan(commits, *args):
+        started.append(commits)
+        if len(started) == 3:
+            raise RuntimeError("boom")
+        time.sleep(0.05)
+        return SecretScanCollection(id="batch", type="commit-range", scans=[])
+
+    scan_commits_content_mock.side_effect = scan
+    from_sha_mock.side_effect = lambda sha, exclusion_regexes: Commit(
+        sha=sha,
+        patch_parser=MagicMock(),
+        info=CommitInformation(author="", email="", date="", paths=[Path("f")]),
+    )
+    client = MagicMock()
+    client.secret_scan_preferences.maximum_documents_per_scan = 1
+
+    with pytest.raises(RuntimeError, match="boom"):
+        scan_commit_range(
+            client=client,
+            cache=MagicMock(),
+            commit_list=[f"sha{i}" for i in range(nb_commits)],
+            output_handler=MagicMock(),
+            exclusion_regexes=set(),
+            scan_context=ScanContext(scan_mode=ScanMode.PRE_RECEIVE, command_path="x"),
+            secret_config=SecretConfig(),
+        )
+
+    assert len(started) < nb_commits

--- a/tests/unit/verticals/secret/test_scan_repo.py
+++ b/tests/unit/verticals/secret/test_scan_repo.py
@@ -313,3 +313,47 @@ def test_scan_commit_range_stops_on_error(
         )
 
     assert len(started) < nb_commits
+
+
+@patch("ggshield.verticals.secret.repo.MAX_WORKERS", 2)
+@patch("ggshield.verticals.secret.repo.get_required_token_scopes_from_config")
+@patch("ggshield.verticals.secret.repo.check_client_api_key")
+@patch("ggshield.verticals.secret.repo.Commit.from_sha")
+@patch("ggshield.verticals.secret.repo.scan_commits_content")
+def test_scan_commit_range_scans_batches_in_parallel(
+    scan_commits_content_mock, from_sha_mock, _check_api_key, _scopes
+):
+    """
+    GIVEN 2 batches and 2 workers
+    WHEN scanning
+    THEN the second batch starts before the first one ends
+    """
+    events = []
+
+    def scan(commits, *args):
+        events.append("start")
+        time.sleep(0.1)
+        events.append("end")
+        return SecretScanCollection(id="batch", type="commit-range", scans=[])
+
+    scan_commits_content_mock.side_effect = scan
+    from_sha_mock.side_effect = lambda sha, exclusion_regexes: Commit(
+        sha=sha,
+        patch_parser=MagicMock(),
+        info=CommitInformation(author="", email="", date="", paths=[Path("f")]),
+    )
+    client = MagicMock()
+    client.secret_scan_preferences.maximum_documents_per_scan = 1
+
+    scan_commit_range(
+        client=client,
+        cache=MagicMock(),
+        commit_list=["sha1", "sha2"],
+        output_handler=MagicMock(),
+        exclusion_regexes=set(),
+        scan_context=ScanContext(scan_mode=ScanMode.PRE_RECEIVE, command_path="x"),
+        secret_config=SecretConfig(),
+    )
+
+    # Sequential scanning would give ["start", "end", "start", "end"]
+    assert events[:2] == ["start", "start"]


### PR DESCRIPTION
`scan_commit_range` was spawning a threadpool but was then blocking in between submitting batches:
```python
  with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
      futures = []
      for commits in commits_batch:
          futures.append(executor.submit(...))

          for future in futures:
              exception = future.exception()
              if exception is not None:
                  raise exception

      ...
``` 
and `future.exception()` actually blocks until the future is done.
Which really means we're submitting one batch, waiting for it to complete, submitting a second one, waiting for it to complete etc. which kind of defeats the purpose of the thread pool entirely 😅 

It looks like all ggshield commit scans (`repo`, `commit-range`, `changes`, `ci`, `pre-push`, `pre-receive`) run through this function so they all actually ran batches one at a time and ignored `GG_MAX_WORKERS`.

This seems to be the case since at least 2023 (10fef6f3e).

A quick fix is to submit everything upfront and check for exceptions separately (see code).

On a local bench (with a pretty extreme case) (100 batches, 0.3s fake API calls, and 20 workers) the total time goes from 28.6s down to 1.6s.